### PR TITLE
firewall: T7318: Add support for nftables map

### DIFF
--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -34,6 +34,93 @@ table ip6 raw {
 delete table ip vyos_filter
 {% endif %}
 table ip vyos_filter {
+
+{% if group.ipv4_map is vyos_defined %}
+{%     for map_name, map_conf in group.ipv4_map.items() %}
+{%         set ns = namespace(type_components=[], element_components=[]) %}
+{%         if map_conf.parameters.inbound_interface is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['ifname'] %}
+{%         endif %}
+{%         if map_conf.parameters.outbound_interface is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['ifname'] %}
+{%         endif %}
+{%         if map_conf.parameters.source_address is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['ipv4_addr'] %}
+{%         endif %}
+{%         if map_conf.parameters.destination_address is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['ipv4_addr'] %}
+{%         endif %}
+{%         if map_conf.parameters.source_port is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['inet_service'] %}
+{%         endif %}
+{%         if map_conf.parameters.destination_port is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['inet_service'] %}
+{%         endif %}
+{%         if map_conf.parameters.protocol_udp is vyos_defined or map_conf.parameters.protocol_tcp is vyos_defined or map_conf.parameters.protocol_icmp is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['inet_proto'] %}
+{%         endif %}
+{%         if map_conf.parameters.icmp_type is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['icmp_type'] %}
+{%         endif %}
+{%         if map_conf.parameters.icmp_code is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['icmp_code'] %}
+{%         endif %}
+    map MAP_{{ map_name }} {
+        type {{ ns.type_components | join(' . ') }} : verdict
+        flags interval
+        counter
+{%         if map_conf.rule is vyos_defined %}
+        elements = {
+{%             for rule_id, rule_conf in map_conf.rule.items() if rule_conf.disable is not vyos_defined %}
+{%                 set ns.element_components = [] %}
+{%                 if map_conf.parameters.inbound_interface is vyos_defined and rule_conf.inbound_interface.name is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + [rule_conf.inbound_interface.name] %}
+{%                 endif %}
+{%                 if map_conf.parameters.outbound_interface is vyos_defined and rule_conf.outbound_interface.name is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + [rule_conf.outbound_interface.name] %}
+{%                 endif %}
+{%                 if map_conf.parameters.source_address is vyos_defined and rule_conf.source.address is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + [rule_conf.source.address] %}
+{%                 endif %}
+{%                 if map_conf.parameters.destination_address is vyos_defined and rule_conf.destination.address is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + [rule_conf.destination.address] %}
+{%                 endif %}
+{%                 if map_conf.parameters.source_port is vyos_defined and rule_conf.source.port is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + [rule_conf.source.port] %}
+{%                 endif %}
+{%                 if map_conf.parameters.destination_port is vyos_defined and rule_conf.destination.port is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + [rule_conf.destination.port] %}
+{%                 endif %}
+{%                 if map_conf.parameters.protocol_udp is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + ['udp'] %}
+{%                 elif map_conf.parameters.protocol_tcp is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + ['tcp'] %}
+{%                 elif map_conf.parameters.protocol_icmp is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + ['icmp'] %}
+{%                 endif %}
+{%                 if map_conf.parameters.icmp_type is vyos_defined and rule_conf.icmp.type is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + [rule_conf.icmp.type] %}
+{%                 endif %}
+{%                 if map_conf.parameters.icmp_code is vyos_defined and rule_conf.icmp.code is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + [rule_conf.icmp.code] %}
+{%                 endif %}
+{%                 if rule_conf.action == 'jump' %}
+            {{ ns.element_components | join(' . ') }} : jump NAME_{{ rule_conf.jump_target }}
+{%                 elif rule_conf.action == 'goto' %}
+            {{ ns.element_components | join(' . ') }} : goto NAME_{{ rule_conf.jump_target }}
+{%                 else %}
+            {{ ns.element_components | join(' . ') }} : {{ rule_conf.action }}
+{%                 endif %}
+{%                 if not loop.last %}
+            ,
+{%                 endif %}
+{%             endfor %}
+        }
+{%         endif %}
+    }
+{%     endfor %}
+{% endif %}
+
 {% if ipv4 is vyos_defined %}
 {%     if flowtable is vyos_defined %}
 {%         for name, flowtable_conf in flowtable.items() %}
@@ -187,6 +274,93 @@ table ip vyos_filter {
 delete table ip6 vyos_filter
 {% endif %}
 table ip6 vyos_filter {
+
+{% if group.ipv6_map is vyos_defined %}
+{%     for map_name, map_conf in group.ipv6_map.items() %}
+{%         set ns = namespace(type_components=[], element_components=[]) %}
+{%         if map_conf.parameters.inbound_interface is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['ifname'] %}
+{%         endif %}
+{%         if map_conf.parameters.outbound_interface is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['ifname'] %}
+{%         endif %}
+{%         if map_conf.parameters.source_address is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['ipv6_addr'] %}
+{%         endif %}
+{%         if map_conf.parameters.destination_address is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['ipv6_addr'] %}
+{%         endif %}
+{%         if map_conf.parameters.source_port is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['inet_service'] %}
+{%         endif %}
+{%         if map_conf.parameters.destination_port is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['inet_service'] %}
+{%         endif %}
+{%         if map_conf.parameters.protocol_udp is vyos_defined or map_conf.parameters.protocol_tcp is vyos_defined or map_conf.parameters.protocol_icmp is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['inet_proto'] %}
+{%         endif %}
+{%         if map_conf.parameters.icmp_type is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['icmpv6_type'] %}
+{%         endif %}
+{%         if map_conf.parameters.icmp_code is vyos_defined %}
+{%             set ns.type_components = ns.type_components + ['icmpv6_code'] %}
+{%         endif %}
+    map MAP6_{{ map_name }} {
+        type {{ ns.type_components | join(' . ') }} : verdict
+        flags interval
+        counter
+{%         if map_conf.rule is vyos_defined %}
+        elements = {
+{%             for rule_id, rule_conf in map_conf.rule.items() if rule_conf.disable is not vyos_defined %}
+{%                 set ns.element_components = [] %}
+{%                 if map_conf.parameters.inbound_interface is vyos_defined and rule_conf.inbound_interface.name is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + [rule_conf.inbound_interface.name] %}
+{%                 endif %}
+{%                 if map_conf.parameters.outbound_interface is vyos_defined and rule_conf.outbound_interface.name is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + [rule_conf.outbound_interface.name] %}
+{%                 endif %}
+{%                 if map_conf.parameters.source_address is vyos_defined and rule_conf.source.address is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + [rule_conf.source.address] %}
+{%                 endif %}
+{%                 if map_conf.parameters.destination_address is vyos_defined and rule_conf.destination.address is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + [rule_conf.destination.address] %}
+{%                 endif %}
+{%                 if map_conf.parameters.source_port is vyos_defined and rule_conf.source.port is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + [rule_conf.source.port] %}
+{%                 endif %}
+{%                 if map_conf.parameters.destination_port is vyos_defined and rule_conf.destination.port is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + [rule_conf.destination.port] %}
+{%                 endif %}
+{%                 if map_conf.parameters.protocol_udp is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + ['udp'] %}
+{%                 elif map_conf.parameters.protocol_tcp is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + ['tcp'] %}
+{%                 elif map_conf.parameters.protocol_icmp is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + ['icmpv6'] %}
+{%                 endif %}
+{%                 if map_conf.parameters.icmp_type is vyos_defined and rule_conf.icmpv6.type is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + [rule_conf.icmpv6.type] %}
+{%                 endif %}
+{%                 if map_conf.parameters.icmp_code is vyos_defined and rule_conf.icmpv6.code is vyos_defined %}
+{%                     set ns.element_components = ns.element_components + [rule_conf.icmpv6.code] %}
+{%                 endif %}
+{%                 if rule_conf.action == 'jump' %}
+            {{ ns.element_components | join(' . ') }} : jump NAME6_{{ rule_conf.jump_target }}
+{%                 elif rule_conf.action == 'goto' %}
+            {{ ns.element_components | join(' . ') }} : goto NAME6_{{ rule_conf.jump_target }}
+{%                 else %}
+            {{ ns.element_components | join(' . ') }} : {{ rule_conf.action }}
+{%                 endif %}
+{%                 if not loop.last %}
+            ,
+{%                 endif %}
+{%             endfor %}
+        }
+{%         endif %}
+    }
+{%     endfor %}
+{% endif %}
+
 {% if ipv6 is vyos_defined %}
 {%     if flowtable is vyos_defined %}
 {%         for name, flowtable_conf in flowtable.items() %}

--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -173,6 +173,247 @@
               #include <include/generic-description.xml.i>
             </children>
           </tagNode>
+          <tagNode name="ipv4-map">
+            <properties>
+              <help>Firewall ipv4-map</help>
+            </properties>
+            <children>
+              #include <include/generic-description.xml.i>
+              <node name="parameters">
+                <properties>
+                  <help>Define allowed parameters in map</help>
+                </properties>
+                <children>
+                  <leafNode name="source-address">
+                    <properties>
+                      <help>Allow source address as parameter</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="destination-address">
+                    <properties>
+                      <help>Allow destination address as parameter</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="source-port">
+                    <properties>
+                      <help>Allow source port as parameter</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="destination-port">
+                    <properties>
+                      <help>Allow destination port as parameter</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="inbound-interface">
+                    <properties>
+                      <help>Allow inbound interface as parameter</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="outbound-interface">
+                    <properties>
+                      <help>Allow outbound interface as parameter</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="icmp-type">
+                    <properties>
+                      <help>Allow ICMP type as parameter</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="icmp-code">
+                    <properties>
+                      <help>Allow ICMP code as parameter</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="protocol-icmp">
+                    <properties>
+                      <help>Define protocol parameter as ICMP</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="protocol-tcp">
+                    <properties>
+                      <help>Define protocol parameter as TCP</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="protocol-udp">
+                    <properties>
+                      <help>Define protocol parameter as UDP</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+
+                </children>
+              </node>
+              <tagNode name="rule">
+                <properties>
+                  <help>IPv4 Map rule number</help>
+                </properties>
+                <children>
+                  #include <include/generic-description.xml.i>
+                  #include <include/firewall/action-map.xml.i>
+                  #include <include/generic-disable-node.xml.i>
+                  #include <include/firewall/inbound-interface-no-group.xml.i>
+                  #include <include/firewall/outbound-interface-no-group.xml.i>
+                  #include <include/firewall/icmp.xml.i>
+                  <leafNode name="jump-target">
+                    <properties>
+                      <help>Set jump target. Action jump must be defined to use this setting</help>
+                      <completionHelp>
+                        <path>firewall ipv4 name</path>
+                      </completionHelp>
+                    </properties>
+                  </leafNode>
+                  <node name="source">
+                    <properties>
+                      <help>Source parameters</help>
+                    </properties>
+                    <children>
+                      #include <include/firewall/address-or-mask.xml.i>
+                      #include <include/firewall/port-range.xml.i>
+                    </children>
+                  </node>
+                  <node name="destination">
+                    <properties>
+                      <help>Destination parameters</help>
+                    </properties>
+                    <children>
+                      #include <include/firewall/address-or-mask.xml.i>
+                      #include <include/firewall/port-range.xml.i>
+                    </children>
+                  </node>
+                </children>
+              </tagNode>
+            </children>
+          </tagNode>
+          <tagNode name="ipv6-map">
+            <properties>
+              <help>Firewall ipv6-map</help>
+            </properties>
+            <children>
+              #include <include/generic-description.xml.i>
+              <node name="parameters">
+                <properties>
+                  <help>Define allowed parameters in map</help>
+                </properties>
+                <children>
+                  <leafNode name="source-address">
+                    <properties>
+                      <help>Allow source address as parameter</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="destination-address">
+                    <properties>
+                      <help>Allow destination address as parameter</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="source-port">
+                    <properties>
+                      <help>Allow source port as parameter</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="destination-port">
+                    <properties>
+                      <help>Allow destination port as parameter</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="inbound-interface">
+                    <properties>
+                      <help>Allow inbound interface as parameter</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="outbound-interface">
+                    <properties>
+                      <help>Allow outbound interface as parameter</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="icmp-type">
+                    <properties>
+                      <help>Allow ICMP type as parameter</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="icmp-code">
+                    <properties>
+                      <help>Allow ICMP code as parameter</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="protocol-icmp">
+                    <properties>
+                      <help>Define protocol parameter as ICMP</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="protocol-tcp">
+                    <properties>
+                      <help>Define protocol parameter as TCP</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="protocol-udp">
+                    <properties>
+                      <help>Define protocol parameter as UDP</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+              <tagNode name="rule">
+                <properties>
+                  <help>IPv6 Map rule number</help>
+                </properties>
+                <children>
+                  #include <include/generic-description.xml.i>
+                  #include <include/firewall/action-map.xml.i>
+                  #include <include/generic-disable-node.xml.i>
+                  #include <include/firewall/inbound-interface-no-group.xml.i>
+                  #include <include/firewall/outbound-interface-no-group.xml.i>
+                  #include <include/firewall/icmpv6.xml.i>
+                  <leafNode name="jump-target">
+                    <properties>
+                      <help>Set jump target. Action jump must be defined to use this setting</help>
+                      <completionHelp>
+                        <path>firewall ipv4 name</path>
+                      </completionHelp>
+                    </properties>
+                  </leafNode>
+                  <node name="source">
+                    <properties>
+                      <help>Source parameters</help>
+                    </properties>
+                    <children>
+                      #include <include/firewall/address-or-mask-ipv6.xml.i>
+                      #include <include/firewall/port-range.xml.i>
+                    </children>
+                  </node>
+                  <node name="destination">
+                    <properties>
+                      <help>Destination parameters</help>
+                    </properties>
+                    <children>
+                      #include <include/firewall/address-or-mask-ipv6.xml.i>
+                      #include <include/firewall/port-range.xml.i>
+                    </children>
+                  </node>
+                </children>
+              </tagNode>
+            </children>
+          </tagNode>
           <tagNode name="ipv6-address-group">
             <properties>
               <help>Firewall ipv6-address-group</help>

--- a/interface-definitions/include/firewall/action-forward.xml.i
+++ b/interface-definitions/include/firewall/action-forward.xml.i
@@ -3,11 +3,15 @@
   <properties>
     <help>Rule action</help>
     <completionHelp>
-      <list>accept continue jump reject return drop queue offload synproxy</list>
+      <list>accept apply-map continue jump reject return drop queue offload synproxy</list>
     </completionHelp>
     <valueHelp>
       <format>accept</format>
       <description>Accept matching entries</description>
+    </valueHelp>
+    <valueHelp>
+      <format>apply-map</format>
+      <description>Apply map to rule</description>
     </valueHelp>
     <valueHelp>
       <format>continue</format>
@@ -42,7 +46,7 @@
       <description>Synproxy connections</description>
     </valueHelp>
     <constraint>
-      <regex>(accept|continue|jump|reject|return|drop|queue|offload|synproxy)</regex>
+      <regex>(accept|apply-map|continue|jump|reject|return|drop|queue|offload|synproxy)</regex>
     </constraint>
   </properties>
 </leafNode>

--- a/interface-definitions/include/firewall/action-map.xml.i
+++ b/interface-definitions/include/firewall/action-map.xml.i
@@ -1,0 +1,37 @@
+<!-- include start from firewall/action-map.xml.i -->
+<leafNode name="action">
+  <properties>
+    <help>Rule action</help>
+    <completionHelp>
+      <list>accept continue drop goto jump return</list>
+    </completionHelp>
+    <valueHelp>
+      <format>accept</format>
+      <description>Accept matching entries</description>
+    </valueHelp>
+    <valueHelp>
+      <format>continue</format>
+      <description>Continue parsing next rule</description>
+    </valueHelp>
+    <valueHelp>
+      <format>drop</format>
+      <description>Drop matching entries</description>
+    </valueHelp>
+    <valueHelp>
+      <format>goto</format>
+      <description>Go to another chain</description>
+    </valueHelp>
+    <valueHelp>
+      <format>jump</format>
+      <description>Jump to another chain</description>
+    </valueHelp>
+    <valueHelp>
+      <format>return</format>
+      <description>Return from the current chain and continue at the next rule of the last chain</description>
+    </valueHelp>
+    <constraint>
+      <regex>(accept|continue|drop|goto|jump|return)</regex>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/firewall/action.xml.i
+++ b/interface-definitions/include/firewall/action.xml.i
@@ -3,11 +3,15 @@
   <properties>
     <help>Rule action</help>
     <completionHelp>
-      <list>accept continue jump reject return drop queue offload synproxy</list>
+      <list>accept apply-map continue jump reject return drop queue offload synproxy</list>
     </completionHelp>
     <valueHelp>
       <format>accept</format>
       <description>Accept matching entries</description>
+    </valueHelp>
+    <valueHelp>
+      <format>apply-map</format>
+      <description>Apply map to rule</description>
     </valueHelp>
     <valueHelp>
       <format>continue</format>
@@ -42,7 +46,7 @@
       <description>Synproxy connections</description>
     </valueHelp>
     <constraint>
-      <regex>(accept|continue|jump|reject|return|drop|queue|offload|synproxy)</regex>
+      <regex>(accept|apply-map|continue|jump|reject|return|drop|queue|offload|synproxy)</regex>
     </constraint>
   </properties>
 </leafNode>

--- a/interface-definitions/include/firewall/address-or-mask-ipv6.xml.i
+++ b/interface-definitions/include/firewall/address-or-mask-ipv6.xml.i
@@ -1,0 +1,19 @@
+<!-- include start from firewall/address-or-mask-ipv6.xml.i -->
+<leafNode name="address">
+  <properties>
+    <help>IP address or Subnet</help>
+    <valueHelp>
+      <format>ipv6</format>
+      <description>IP address to match</description>
+    </valueHelp>
+    <valueHelp>
+      <format>ipv6net</format>
+      <description>Subnet to match</description>
+    </valueHelp>
+    <constraint>
+      <validator name="ipv6-address"/>
+      <validator name="ipv6-prefix"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/firewall/address-or-mask.xml.i
+++ b/interface-definitions/include/firewall/address-or-mask.xml.i
@@ -1,0 +1,19 @@
+<!-- include start from firewall/address.xml.i -->
+<leafNode name="address">
+  <properties>
+    <help>IP address or subnet</help>
+    <valueHelp>
+      <format>ipv4</format>
+      <description>IPv4 address to match</description>
+    </valueHelp>
+    <valueHelp>
+      <format>ipv4net</format>
+      <description>IPv4 prefix to match</description>
+    </valueHelp>
+    <constraint>
+      <validator name="ipv4-address"/>
+      <validator name="ipv4-prefix"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/firewall/ipv4-custom-name.xml.i
+++ b/interface-definitions/include/firewall/ipv4-custom-name.xml.i
@@ -41,7 +41,7 @@
         #include <include/firewall/set-packet-modifications-mark.xml.i>
         #include <include/firewall/set-packet-modifications-tcp-mss.xml.i>
         #include <include/firewall/set-packet-modifications-ttl.xml.i>
-
+        #include <include/firewall/ipv4-map.xml.i>
       </children>
     </tagNode>
   </children>

--- a/interface-definitions/include/firewall/ipv4-hook-forward.xml.i
+++ b/interface-definitions/include/firewall/ipv4-hook-forward.xml.i
@@ -36,6 +36,7 @@
             #include <include/firewall/set-packet-modifications-mark.xml.i>
             #include <include/firewall/set-packet-modifications-tcp-mss.xml.i>
             #include <include/firewall/set-packet-modifications-ttl.xml.i>
+            #include <include/firewall/ipv4-map.xml.i>
           </children>
         </tagNode>
       </children>

--- a/interface-definitions/include/firewall/ipv4-hook-input.xml.i
+++ b/interface-definitions/include/firewall/ipv4-hook-input.xml.i
@@ -28,6 +28,7 @@
             #include <include/firewall/common-rule-ipv4.xml.i>
             #include <include/firewall/inbound-interface.xml.i>
             #include <include/firewall/match-ipsec-in.xml.i>
+            #include <include/firewall/ipv4-map.xml.i>
           </children>
         </tagNode>
       </children>

--- a/interface-definitions/include/firewall/ipv4-hook-output.xml.i
+++ b/interface-definitions/include/firewall/ipv4-hook-output.xml.i
@@ -33,6 +33,7 @@
             #include <include/firewall/set-packet-modifications-mark.xml.i>
             #include <include/firewall/set-packet-modifications-tcp-mss.xml.i>
             #include <include/firewall/set-packet-modifications-ttl.xml.i>
+            #include <include/firewall/ipv4-map.xml.i>
           </children>
         </tagNode>
       </children>

--- a/interface-definitions/include/firewall/ipv4-map.xml.i
+++ b/interface-definitions/include/firewall/ipv4-map.xml.i
@@ -1,0 +1,10 @@
+<!-- include start from firewall/ipv4-map.xml.i -->
+<leafNode name="map">
+    <properties>
+    <help>Map of defined parameters</help>
+    <completionHelp>
+        <path>firewall group ipv4-map</path>
+    </completionHelp>
+    </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/firewall/ipv6-custom-name.xml.i
+++ b/interface-definitions/include/firewall/ipv6-custom-name.xml.i
@@ -41,6 +41,7 @@
         #include <include/firewall/set-packet-modifications-mark.xml.i>
         #include <include/firewall/set-packet-modifications-tcp-mss.xml.i>
         #include <include/firewall/set-packet-modifications-hop-limit.xml.i>
+        #include <include/firewall/ipv6-map.xml.i>
       </children>
     </tagNode>
   </children>

--- a/interface-definitions/include/firewall/ipv6-hook-forward.xml.i
+++ b/interface-definitions/include/firewall/ipv6-hook-forward.xml.i
@@ -36,6 +36,7 @@
             #include <include/firewall/set-packet-modifications-mark.xml.i>
             #include <include/firewall/set-packet-modifications-tcp-mss.xml.i>
             #include <include/firewall/set-packet-modifications-hop-limit.xml.i>
+            #include <include/firewall/ipv6-map.xml.i>
           </children>
         </tagNode>
       </children>

--- a/interface-definitions/include/firewall/ipv6-hook-input.xml.i
+++ b/interface-definitions/include/firewall/ipv6-hook-input.xml.i
@@ -28,6 +28,7 @@
             #include <include/firewall/common-rule-ipv6.xml.i>
             #include <include/firewall/inbound-interface.xml.i>
             #include <include/firewall/match-ipsec-in.xml.i>
+            #include <include/firewall/ipv6-map.xml.i>
           </children>
         </tagNode>
       </children>

--- a/interface-definitions/include/firewall/ipv6-hook-output.xml.i
+++ b/interface-definitions/include/firewall/ipv6-hook-output.xml.i
@@ -33,6 +33,7 @@
             #include <include/firewall/set-packet-modifications-mark.xml.i>
             #include <include/firewall/set-packet-modifications-tcp-mss.xml.i>
             #include <include/firewall/set-packet-modifications-hop-limit.xml.i>
+            #include <include/firewall/ipv6-map.xml.i>
           </children>
         </tagNode>
       </children>

--- a/interface-definitions/include/firewall/ipv6-map.xml.i
+++ b/interface-definitions/include/firewall/ipv6-map.xml.i
@@ -1,0 +1,10 @@
+<!-- include start from firewall/ipv6-map.xml.i -->
+<leafNode name="map">
+    <properties>
+    <help>Map of defined parameters</help>
+    <completionHelp>
+        <path>firewall group ipv6-map</path>
+    </completionHelp>
+    </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/firewall/port-range.xml.i
+++ b/interface-definitions/include/firewall/port-range.xml.i
@@ -1,0 +1,22 @@
+<!-- include start from firewall/port-range.xml.i -->
+<leafNode name="port">
+  <properties>
+    <help>Port</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>Named port (any name in /etc/services, e.g., http)</description>
+    </valueHelp>
+    <valueHelp>
+      <format>u32:1-65535</format>
+      <description>Numbered port</description>
+    </valueHelp>
+    <valueHelp>
+      <format>&lt;start-end&gt;</format>
+      <description>Numbered port range (e.g. 1001-1005)</description>
+    </valueHelp>
+    <constraint>
+      <validator name="port-range"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -534,10 +534,10 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
 
         # Add inbound interface if specified
         if 'param_inbound_interface' in rule_conf:
-            map_expr.append(f'iifname')
+            map_expr.append('iifname')
         # Add outbound interface if specified
         if 'param_outbound_interface' in rule_conf:
-            map_expr.append(f'oifname')
+            map_expr.append('oifname')
         # Add source address if specified
         if 'param_source_address' in rule_conf:
             map_expr.append(f'{ip_name} saddr')

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -468,14 +468,14 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
             output.append('gre version 1')
 
         if gre_key:
-            # The offset of the key within the packet shifts depending on the C-flag. 
-            # nftables cannot handle complex enough expressions to match multiple 
+            # The offset of the key within the packet shifts depending on the C-flag.
+            # nftables cannot handle complex enough expressions to match multiple
             # offsets based on bitfields elsewhere.
-            # We enforce a specific match for the checksum flag in validation, so the 
-            # gre_flags dict will always have a 'checksum' key when gre_key is populated. 
-            if not gre_flags['checksum']: 
+            # We enforce a specific match for the checksum flag in validation, so the
+            # gre_flags dict will always have a 'checksum' key when gre_key is populated.
+            if not gre_flags['checksum']:
                 # No "unset" child node means C is set, we offset key lookup +32 bits
-                output.append(f'@th,64,32 == {gre_key}')                
+                output.append(f'@th,64,32 == {gre_key}')
             else:
                 output.append(f'@th,32,32 == {gre_key}')
 
@@ -522,6 +522,49 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
             ether_type = ether_type_mapping.get(ether_type, ether_type)
             output.append(f'vlan type {operator} {ether_type}')
 
+    if 'map' in rule_conf:
+        ip_version = '6' if ip_name == 'ip6' else ''
+        icmp_version = 'icmpv6' if ip_name == 'ip6' else 'icmp'
+        map_name = rule_conf['map']
+        map_expr = []
+        proto = ""
+
+        if 'param_protocol' in rule_conf:
+            proto = rule_conf['param_protocol']
+
+        # Add inbound interface if specified
+        if 'param_inbound_interface' in rule_conf:
+            map_expr.append(f'iifname')
+        # Add outbound interface if specified
+        if 'param_outbound_interface' in rule_conf:
+            map_expr.append(f'oifname')
+        # Add source address if specified
+        if 'param_source_address' in rule_conf:
+            map_expr.append(f'{ip_name} saddr')
+        # Add destination address if specified
+        if 'param_destination_address' in rule_conf:
+            map_expr.append(f'{ip_name} daddr')
+        # Add source port if specified
+        if 'param_source_port' in rule_conf:
+            map_expr.append(f'{proto} sport')
+        # Add destination port if specified
+        if 'param_destination_port' in rule_conf:
+            map_expr.append(f'{proto} dport')
+        # Add protocol if specified
+        if proto:
+            map_expr.append('meta l4proto')
+        # Add icmp type if specified
+        if 'param_icmp_type' in rule_conf:
+            map_expr.append(f'{icmp_version} type')
+        # Add icmp code if specified
+        if 'param_icmp_code' in rule_conf:
+            map_expr.append(f'{icmp_version} code')
+
+        # Create rule expression
+        if map_expr:
+            output.append(f'{" . ".join(map_expr)} vmap @MAP{ip_version}_{map_name}')
+
+
     if 'log' in rule_conf:
         action = rule_conf['action'] if 'action' in rule_conf else 'accept'
         #output.append(f'log prefix "[{fw_name[:19]}-{rule_id}-{action[:1].upper()}]"')
@@ -545,7 +588,8 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
                     log_snaplen = rule_conf['log_options']['snapshot_length']
                     output.append(f'snaplen {log_snaplen}')
 
-    output.append('counter')
+    if rule_conf['action'] != 'apply-map':
+        output.append('counter')
 
     if 'add_address_to_group' in rule_conf:
         for side in ['destination_address', 'source_address']:
@@ -601,6 +645,9 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
         if rule_conf['action'] == 'offload':
             offload_target = rule_conf['offload_target']
             output.append(f'flow add @VYOS_FLOWTABLE_{offload_target}')
+        elif rule_conf['action'] == 'apply-map':
+            # Action is applied directly in the map
+            pass
         else:
             output.append(f'{rule_conf["action"]}')
 
@@ -634,7 +681,7 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
     return " ".join(output)
 
 def parse_gre_flags(flags, force_keyed=False):
-    flag_map = { # nft does not have symbolic names for these. 
+    flag_map = { # nft does not have symbolic names for these.
         'checksum': 1<<0,
         'routing':  1<<1,
         'key':      1<<2,
@@ -645,7 +692,7 @@ def parse_gre_flags(flags, force_keyed=False):
     include = 0
     exclude = 0
     for fl_name, fl_state in flags.items():
-        if not fl_state: 
+        if not fl_state:
             include |= flag_map[fl_name]
         else: # 'unset' child tag
             exclude |= flag_map[fl_name]

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -588,7 +588,7 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
                     log_snaplen = rule_conf['log_options']['snapshot_length']
                     output.append(f'snaplen {log_snaplen}')
 
-    if rule_conf['action'] != 'apply-map':
+    if rule_conf.get('action') != 'apply-map':
         output.append('counter')
 
     if 'add_address_to_group' in rule_conf:

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -376,6 +376,251 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         self.verify_nftables(nftables_search, 'ip vyos_filter')
 
+    def test_ipv4_map(self):
+        # Test parameters not configured
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
+
+        #  Test failure of both tcp and udp
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'source-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'protocol-tcp'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'protocol-udp'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
+
+        # Test protocol not in parameters
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'source-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'destination-port'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
+
+        # Test action not in rule
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'source-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'protocol-tcp'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'destination', 'port', '2'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
+
+        # Test action jump but no jump-target; works for goto as well
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'source-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'protocol-tcp'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'action', 'jump'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'destination', 'port', '2'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
+
+        # Test jump-target in rule but action is not jump; works for goto as well
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'source-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'protocol-tcp'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'action', 'accept'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'destination', 'port', '2'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'jump-target', 'test-filter'])
+        self.cli_set(['firewall', 'ipv4', 'name', 'test-filter'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
+
+        # Test parameter configured but not set in rules
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'source-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'protocol-tcp'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'action', 'accept'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'source', 'port', '1'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
+
+        # Test field configured in rules but not in parameters
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'source-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'protocol-tcp'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'action', 'accept'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'destination', 'port', '2'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'destination', 'address', '1.1.1.1'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
+
+        # Test success
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'source-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'parameters', 'protocol-tcp'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'action', 'accept'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '1', 'destination', 'port', '2'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '2', 'action', 'drop'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '2', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '2', 'destination', 'port', '3'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '3', 'action', 'return'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '3', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '3', 'destination', 'port', '4'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '4', 'action', 'continue'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '4', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '4', 'destination', 'port', '5'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '5', 'action', 'goto'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '5', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '5', 'destination', 'port', '6'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '5', 'jump-target', 'test-filter1'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '6', 'action', 'jump'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '6', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '6', 'destination', 'port', '7'])
+        self.cli_set(['firewall', 'group', 'ipv4-map', 'test-map', 'rule', '6', 'jump-target', 'test-filter2'])
+        self.cli_set(['firewall', 'ipv4', 'name', 'test-filter1'])
+        self.cli_set(['firewall', 'ipv4', 'name', 'test-filter2'])
+        self.cli_set(['firewall', 'ipv4', 'output', 'filter', 'rule', '10', 'action', 'apply-map'])
+        self.cli_set(['firewall', 'ipv4', 'output', 'filter', 'rule', '10', 'map', 'test-map'])
+        self.cli_commit()
+
+        nftables_search = [
+            [f'type inet_service . inet_service . inet_proto : verdict'],
+            ['1 . 2 . tcp counter packets 0 bytes 0 : accept'],
+            ['1 . 3 . tcp counter packets 0 bytes 0 : drop'],
+            ['1 . 4 . tcp counter packets 0 bytes 0 : return'],
+            ['1 . 5 . tcp counter packets 0 bytes 0 : continue'],
+            ['1 . 6 . tcp counter packets 0 bytes 0 : goto NAME_test-filter1'],
+            ['1 . 7 . tcp counter packets 0 bytes 0 : jump NAME_test-filter2'],
+            [f'tcp sport . tcp dport . meta l4proto vmap @MAP_test-map comment "ipv4-OUT-filter-10"']
+        ]
+
+        self.verify_nftables(nftables_search, 'ip vyos_filter')
+
+
+    def test_ipv6_map(self):
+        # Test parameters not configured
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
+
+        #  Test failure of both tcp and udp
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'source-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'protocol-tcp'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'protocol-udp'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
+
+        # Test protocol not in parameters
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'source-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'destination-port'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
+
+        # Test action not in rule
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'source-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'protocol-tcp'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'destination', 'port', '2'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
+
+        # Test action jump but no jump-target; works for goto as well
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'source-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'protocol-tcp'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'action', 'jump'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'destination', 'port', '2'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
+
+        # Test jump-target in rule but action is not jump; works for goto as well
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'source-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'protocol-tcp'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'action', 'accept'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'destination', 'port', '2'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'jump-target', 'test-filter'])
+        self.cli_set(['firewall', 'ipv4', 'name', 'test-filter'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
+
+        # Test parameter configured but not set in rules
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'source-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'protocol-tcp'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'action', 'accept'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'source', 'port', '1'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
+
+        # Test field configured in rules but not in parameters
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'source-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'protocol-tcp'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'action', 'accept'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'destination', 'port', '2'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'destination', 'address', '2001::1'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_discard()
+
+        # Test success
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'source-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'parameters', 'protocol-tcp'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'action', 'accept'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '1', 'destination', 'port', '2'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '2', 'action', 'drop'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '2', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '2', 'destination', 'port', '3'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '3', 'action', 'return'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '3', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '3', 'destination', 'port', '4'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '4', 'action', 'continue'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '4', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '4', 'destination', 'port', '5'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '5', 'action', 'goto'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '5', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '5', 'destination', 'port', '6'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '5', 'jump-target', 'test-filter1'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '6', 'action', 'jump'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '6', 'source', 'port', '1'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '6', 'destination', 'port', '7'])
+        self.cli_set(['firewall', 'group', 'ipv6-map', 'test-map', 'rule', '6', 'jump-target', 'test-filter2'])
+        self.cli_set(['firewall', 'ipv6', 'name', 'test-filter1'])
+        self.cli_set(['firewall', 'ipv6', 'name', 'test-filter2'])
+        self.cli_set(['firewall', 'ipv6', 'output', 'filter', 'rule', '10', 'action', 'apply-map'])
+        self.cli_set(['firewall', 'ipv6', 'output', 'filter', 'rule', '10', 'map', 'test-map'])
+        self.cli_commit()
+
+        nftables_search = [
+            [f'type inet_service . inet_service . inet_proto : verdict'],
+            ['1 . 2 . tcp counter packets 0 bytes 0 : accept'],
+            ['1 . 3 . tcp counter packets 0 bytes 0 : drop'],
+            ['1 . 4 . tcp counter packets 0 bytes 0 : return'],
+            ['1 . 5 . tcp counter packets 0 bytes 0 : continue'],
+            ['1 . 6 . tcp counter packets 0 bytes 0 : goto NAME6_test-filter1'],
+            ['1 . 7 . tcp counter packets 0 bytes 0 : jump NAME6_test-filter2'],
+            [f'tcp sport . tcp dport . meta l4proto vmap @MAP6_test-map comment "ipv6-OUT-filter-10"']
+        ]
+
+        self.verify_nftables(nftables_search, 'ip6 vyos_filter')
+
 
     def test_ipv4_mask(self):
         name = 'smoketest-mask'

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -240,7 +240,7 @@ def verify_rule(firewall, family, hook, priority, rule_id, rule_conf):
     if 'action' not in rule_conf:
         raise ConfigError('Rule action must be defined')
 
-    if 'apply-map' in rule_conf['action']:
+    if 'apply-map' in rule_conf.get('action'):
         # check if map is configured
         if 'map' not in rule_conf:
             raise ConfigError('map is a required field when using apply-map')
@@ -282,7 +282,7 @@ def verify_rule(firewall, family, hook, priority, rule_id, rule_conf):
 
     if 'map' in rule_conf:
         # Check if map is defined with action apply-map
-        if 'apply-map' not in rule_conf['action']:
+        if 'apply-map' not in rule_conf.get('action'):
             raise ConfigError('Action apply-map is required when using map')
 
     if 'jump' in rule_conf['action'] and 'jump_target' not in rule_conf:

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -160,44 +160,38 @@ def get_config(config=None):
     # When applying a map to a rule, the values within parameters need to be preserved
     # for execution of the rule in a chain. These values are lost once the rule enters
     # /python/vyos/firewall.py. This stores those values in the rule under the param_ prefix
-    if firewall.get('group', {}).get('ipv4_map', {}) or firewall.get('group', {}).get('ipv6_map', {}):
-        for family in ['ipv4', 'ipv6']:
-            if family in firewall:
-                for chain in ['name','forward','input','output']:
-                    if chain in firewall[family]:
-                        for priority, priority_conf in firewall[family][chain].items():
-                            if 'rule' in priority_conf:
-                                for rule_id, rule_conf in priority_conf['rule'].items():
-                                    if 'map' in rule_conf:
-                                        map_name = rule_conf['map']
-                                        map_family = f'{family}_map'
+    if firewall.get("group", {}).keys() & {"ipv4_map", "ipv6_map"}:
+        _PARAM_MAP = {
+            "protocol_tcp": ("param_protocol", "tcp"),
+            "protocol_udp": ("param_protocol", "udp"),
+            "protocol_icmp": ("param_protocol", "icmp"),
+            "icmp_type": ("param_icmp_type", {}),
+            "icmp_code": ("param_icmp_code", {}),
+            "source_address": ("param_source_address", {}),
+            "destination_address": ("param_destination_address", {}),
+            "source_port": ("param_source_port", {}),
+            "destination_port": ("param_destination_port", {}),
+            "inbound_interface": ("param_inbound_interface", {}),
+            "outbound_interface": ("param_outbound_interface", {}),
+        }
+        for family in ("ipv4", "ipv6"):
+            family_conf = firewall.get(family, {})
+            group_map = firewall.get("group", {}).get(f"{family}_map", {})
 
-                                        if firewall.get('group', {}).get(map_family, {}).get(map_name, {}).get('parameters'):
-                                            param_path = firewall['group'][map_family][map_name]['parameters']
-                                            rule_path = firewall[family][chain][priority]['rule'][rule_id]
+            for chain_conf in (
+                family_conf.get(c, {}) for c in ("name", "forward", "input", "output")
+            ):
+                for priority_conf in chain_conf.values():
+                    rule_dict = priority_conf.get("rule", {})
+                    for rule_conf in rule_dict.values():
+                        params = group_map.get(rule_conf.get("map"), {}).get("parameters", ())
+                        if not params:
+                            continue
 
-                                            if 'protocol_tcp' in param_path:
-                                                rule_path['param_protocol'] = 'tcp'
-                                            if 'protocol_udp' in param_path:
-                                              rule_path['param_protocol'] = 'udp'
-                                            if 'protocol_icmp' in param_path:
-                                                rule_path['param_protocol'] = 'icmp'
-                                                if 'icmp_type' in param_path:
-                                                    rule_path['param_icmp_type'] = {}
-                                                if 'icmp_code' in param_path:
-                                                    rule_path['param_icmp_code'] = {}
-                                            if 'source_address' in param_path:
-                                                rule_path['param_source_address'] = {}
-                                            if 'destination_address' in param_path:
-                                                rule_path['param_destination_address'] = {}
-                                            if 'source_port' in param_path:
-                                                rule_path['param_source_port'] = {}
-                                            if 'destination_port' in param_path:
-                                                rule_path['param_destination_port'] = {}
-                                            if 'inbound_interface' in param_path:
-                                                rule_path['param_inbound_interface'] = {}
-                                            if 'outbound_interface' in param_path:
-                                                rule_path['param_outbound_interface'] = {}
+                        # only loop over params that actually appear in both param‐map and the config
+                        for key in set(params) & _PARAM_MAP.keys():
+                            dest_field, value = _PARAM_MAP[key]
+                            rule_conf[dest_field] = value
 
     set_dependents('conntrack', conf)
 
@@ -246,10 +240,9 @@ def verify_rule(firewall, family, hook, priority, rule_id, rule_conf):
             raise ConfigError('map is a required field when using apply-map')
 
         # check if map exists
-        if not firewall.get('group', {}).get(f'{family}_map', {}).get(rule_conf['map']):
+        map_conf = firewall.get("group", {}).get(f"{family}_map", {}).get(rule_conf["map"])
+        if not map_conf:
             raise ConfigError(f'{family}-map "{rule_conf["map"]}" does not exist')
-        else:
-            map_conf = firewall.get('group', {}).get(f'{family}_map', {}).get(rule_conf['map'])
 
         # Check if icmp is configured in both chain rule and map rule
         if 'icmp' in rule_conf:
@@ -514,31 +507,32 @@ def verify(firewall):
         for map_family in ['ipv4_map', 'ipv6_map']:
             for map_name, map_conf in firewall['group'].get(map_family, {}).items():
                 # Check if the map has parameters
-                if not map_conf.get('parameters'):
+                map_conf_parameters = map_conf.get('parameters', {})
+                if not map_conf_parameters:
                     raise ConfigError(f'{map_family} "{map_name}" must have parameters defined')
 
                 # If either source port or destination port is defined, then protocol must be defined
-                if ('source_port' in map_conf.get('parameters', {}) or 'destination_port' in map_conf.get('parameters', {})) and not ('protocol_tcp' in map_conf['parameters'] or 'protocol_udp' in map_conf['parameters']):
+                if ('source_port' in map_conf_parameters or 'destination_port' in map_conf_parameters) and not ('protocol_tcp' in map_conf_parameters or 'protocol_udp' in map_conf_parameters):
                     raise ConfigError(f'{map_family} \"{map_name}\" must have a protocol defined if source port or destination port is defined')
 
                 # If protocol is defined, then source port or destination port must be defined
-                if ('protocol_tcp' in map_conf.get('parameters', {}) or 'protocol_udp' in map_conf.get('parameters', {})) and not ('source_port' in map_conf['parameters'] or 'destination_port' in map_conf['parameters']):
+                if ('protocol_tcp' in map_conf_parameters or 'protocol_udp' in map_conf_parameters) and not ('source_port' in map_conf_parameters or 'destination_port' in map_conf_parameters):
                     raise ConfigError(f'{map_family} \"{map_name}\" must have a source port or destination port defined if protocol is defined')
 
                 # Check if more than one protocol is defined
-                if len({k: v for k, v in map_conf.get('parameters', {}).items() if 'protocol_' in k}) > 1:
+                if len({k: v for k, v in map_conf_parameters.items() if 'protocol_' in k}) > 1:
                     raise ConfigError(f'{map_family} "{map_name}" cannot have more than one protocol defined')
 
-                if ('icmp_type' in map_conf.get('parameters') or 'icmp_code' in map_conf.get('parameters')) and not 'protocol_icmp' in map_conf.get('parameters'):
+                if ('icmp_type' in map_conf_parameters or 'icmp_code' in map_conf_parameters) and not 'protocol_icmp' in map_conf_parameters:
                     raise ConfigError(f'{map_family} "{map_name}" must have a protocol icmp defined if icmp type or code is defined')
 
                 rule_list = []
 
                 # Bug in nft versions < 1.1.0; no error handling for concatenating more than 512-bytes
-                if len(map_conf['parameters']) > 5:
+                if len(map_conf_parameters) > 5:
                     raise ConfigError(f'{map_family} "{map_name}" cannot have more than 5 parameters defined')
 
-                param_list = [k for k in map_conf['parameters'] if "protocol" not in k]
+                param_list = [k for k in map_conf_parameters if "protocol" not in k]
 
                 # Create list of parameters that are configured in the rules
                 for rule_id, rule_conf in map_conf.get('rule', {}).items():

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -157,6 +157,48 @@ def get_config(config=None):
                 if local_zone in zone_conf['from']:
                     local_zone_conf['from_local'][zone] = zone_conf['from'][local_zone]
 
+    # When applying a map to a rule, the values within parameters need to be preserved
+    # for execution of the rule in a chain. These values are lost once the rule enters
+    # /python/vyos/firewall.py. This stores those values in the rule under the param_ prefix
+    if firewall.get('group', {}).get('ipv4_map', {}) or firewall.get('group', {}).get('ipv6_map', {}):
+        for family in ['ipv4', 'ipv6']:
+            if family in firewall:
+                for chain in ['name','forward','input','output']:
+                    if chain in firewall[family]:
+                        for priority, priority_conf in firewall[family][chain].items():
+                            if 'rule' in priority_conf:
+                                for rule_id, rule_conf in priority_conf['rule'].items():
+                                    if 'map' in rule_conf:
+                                        map_name = rule_conf['map']
+                                        map_family = f'{family}_map'
+
+                                        if firewall.get('group', {}).get(map_family, {}).get(map_name, {}).get('parameters'):
+                                            param_path = firewall['group'][map_family][map_name]['parameters']
+                                            rule_path = firewall[family][chain][priority]['rule'][rule_id]
+
+                                            if 'protocol_tcp' in param_path:
+                                                rule_path['param_protocol'] = 'tcp'
+                                            if 'protocol_udp' in param_path:
+                                              rule_path['param_protocol'] = 'udp'
+                                            if 'protocol_icmp' in param_path:
+                                                rule_path['param_protocol'] = 'icmp'
+                                                if 'icmp_type' in param_path:
+                                                    rule_path['param_icmp_type'] = {}
+                                                if 'icmp_code' in param_path:
+                                                    rule_path['param_icmp_code'] = {}
+                                            if 'source_address' in param_path:
+                                                rule_path['param_source_address'] = {}
+                                            if 'destination_address' in param_path:
+                                                rule_path['param_destination_address'] = {}
+                                            if 'source_port' in param_path:
+                                                rule_path['param_source_port'] = {}
+                                            if 'destination_port' in param_path:
+                                                rule_path['param_destination_port'] = {}
+                                            if 'inbound_interface' in param_path:
+                                                rule_path['param_inbound_interface'] = {}
+                                            if 'outbound_interface' in param_path:
+                                                rule_path['param_outbound_interface'] = {}
+
     set_dependents('conntrack', conf)
 
     return firewall
@@ -198,6 +240,51 @@ def verify_rule(firewall, family, hook, priority, rule_id, rule_conf):
     if 'action' not in rule_conf:
         raise ConfigError('Rule action must be defined')
 
+    if 'apply-map' in rule_conf['action']:
+        # check if map is configured
+        if 'map' not in rule_conf:
+            raise ConfigError('map is a required field when using apply-map')
+
+        # check if map exists
+        if not firewall.get('group', {}).get(f'{family}_map', {}).get(rule_conf['map']):
+            raise ConfigError(f'{family}-map "{rule_conf["map"]}" does not exist')
+        else:
+            map_conf = firewall.get('group', {}).get(f'{family}_map', {}).get(rule_conf['map'])
+
+        # Check if icmp is configured in both chain rule and map rule
+        if 'icmp' in rule_conf:
+            if 'protocol_icmp' in map_conf.get('parameters'):
+                raise ConfigError(f'ICMP cannot be configured in both chain rule and map rule')
+
+        # Check if inbound/outbound_interface is configured in both chain rule and map rule
+        if 'inbound_interface' in rule_conf:
+            if 'inbound_interface' in map_conf.get('parameters'):
+                raise ConfigError(f'Inbound interface cannot be configured in both chain rule and map rule')
+        if 'outbound_interface' in rule_conf:
+            if 'outbound_interface' in map_conf.get('parameters'):
+                raise ConfigError(f'Outbound interface cannot be configured in both chain rule and map rule')
+
+        # Check if source values are configured in rule; not allowed in apply-map
+        if 'source' in rule_conf:
+            raise ConfigError('Source value is not supported for apply-map; configure in map parameters')
+
+        # Check if destination values are configured in rule; not allowed in apply-map
+        if 'destination' in rule_conf:
+            raise ConfigError('Destination value is not supported for apply-map; configure in map parameters')
+
+        # Check if protocol values are configured in rule; not allowed in apply-map
+        if 'protocol' in rule_conf:
+            raise ConfigError('Protocol value is not supported for apply-map; configure in map parameters')
+
+        # Check if jump-target is defined; must be defined in map if using apply-map
+        if 'jump_target' in rule_conf:
+            raise ConfigError('jump-target cannot be defined in this rule; apply in map instead')
+
+    if 'map' in rule_conf:
+        # Check if map is defined with action apply-map
+        if 'apply-map' not in rule_conf['action']:
+            raise ConfigError('Action apply-map is required when using map')
+
     if 'jump' in rule_conf['action'] and 'jump_target' not in rule_conf:
         raise ConfigError('Action set to jump, but no jump-target specified')
 
@@ -205,7 +292,7 @@ def verify_rule(firewall, family, hook, priority, rule_id, rule_conf):
         if 'jump' not in rule_conf['action']:
             raise ConfigError('jump-target defined, but action jump needed and it is not defined')
         target = rule_conf['jump_target']
-        if hook != 'name': # This is a bit clumsy, but consolidates a chunk of code. 
+        if hook != 'name': # This is a bit clumsy, but consolidates a chunk of code.
             verify_jump_target(firewall, hook, target, family, recursive=True)
         else:
             verify_jump_target(firewall, hook, target, family, recursive=False)
@@ -268,12 +355,12 @@ def verify_rule(firewall, family, hook, priority, rule_id, rule_conf):
 
             if dict_search_args(rule_conf, 'gre', 'flags', 'checksum') is None:
                 # There is no builtin match in nftables for the GRE key, so we need to do a raw lookup.
-                # The offset of the key within the packet shifts depending on the C-flag. 
-                # 99% of the time, nobody will have checksums enabled - it's usually a manual config option. 
-                # We can either assume it is unset unless otherwise directed 
+                # The offset of the key within the packet shifts depending on the C-flag.
+                # 99% of the time, nobody will have checksums enabled - it's usually a manual config option.
+                # We can either assume it is unset unless otherwise directed
                 # (confusing, requires doco to explain why it doesn't work sometimes)
-                # or, demand an explicit selection to be made for this specific match rule. 
-                # This check enforces the latter. The user is free to create rules for both cases. 
+                # or, demand an explicit selection to be made for this specific match rule.
+                # This check enforces the latter. The user is free to create rules for both cases.
                 raise ConfigError('Matching GRE tunnel key requires an explicit checksum flag match. For most cases, use "gre flags checksum unset"')
 
             if dict_search_args(rule_conf, 'gre', 'flags', 'key', 'unset') is not None:
@@ -286,7 +373,7 @@ def verify_rule(firewall, family, hook, priority, rule_id, rule_conf):
                 if gre_inner_value < 0 or gre_inner_value > 65535:
                     raise ConfigError('inner-proto outside valid ethertype range 0-65535')
             except ValueError:
-                pass # Symbolic constant, pre-validated before reaching here. 
+                pass # Symbolic constant, pre-validated before reaching here.
 
     tcp_flags = dict_search_args(rule_conf, 'tcp', 'flags')
     if tcp_flags:
@@ -423,6 +510,106 @@ def verify_hardware_offload(ifname):
         raise ConfigError(f'Interface "{ifname}" requires "offload hw-tc-offload"')
 
 def verify(firewall):
+    if 'ipv4_map' in firewall.get('group', {}) or 'ipv6_map' in firewall.get('group', {}):
+        for map_family in ['ipv4_map', 'ipv6_map']:
+            for map_name, map_conf in firewall['group'].get(map_family, {}).items():
+                # Check if the map has parameters
+                if not map_conf.get('parameters'):
+                    raise ConfigError(f'{map_family} "{map_name}" must have parameters defined')
+
+                # If either source port or destination port is defined, then protocol must be defined
+                if ('source_port' in map_conf.get('parameters', {}) or 'destination_port' in map_conf.get('parameters', {})) and not ('protocol_tcp' in map_conf['parameters'] or 'protocol_udp' in map_conf['parameters']):
+                    raise ConfigError(f'{map_family} \"{map_name}\" must have a protocol defined if source port or destination port is defined')
+
+                # If protocol is defined, then source port or destination port must be defined
+                if ('protocol_tcp' in map_conf.get('parameters', {}) or 'protocol_udp' in map_conf.get('parameters', {})) and not ('source_port' in map_conf['parameters'] or 'destination_port' in map_conf['parameters']):
+                    raise ConfigError(f'{map_family} \"{map_name}\" must have a source port or destination port defined if protocol is defined')
+
+                # Check if more than one protocol is defined
+                if len({k: v for k, v in map_conf.get('parameters', {}).items() if 'protocol_' in k}) > 1:
+                    raise ConfigError(f'{map_family} "{map_name}" cannot have more than one protocol defined')
+
+                if ('icmp_type' in map_conf.get('parameters') or 'icmp_code' in map_conf.get('parameters')) and not 'protocol_icmp' in map_conf.get('parameters'):
+                    raise ConfigError(f'{map_family} "{map_name}" must have a protocol icmp defined if icmp type or code is defined')
+
+                rule_list = []
+
+                # Bug in nft versions < 1.1.0; no error handling for concatenating more than 512-bytes
+                if len(map_conf['parameters']) > 5:
+                    raise ConfigError(f'{map_family} "{map_name}" cannot have more than 5 parameters defined')
+
+                param_list = [k for k in map_conf['parameters'] if "protocol" not in k]
+
+                # Create list of parameters that are configured in the rules
+                for rule_id, rule_conf in map_conf.get('rule', {}).items():
+                    # Check if the rule has an action defined
+                    if 'action' not in rule_conf:
+                        raise ConfigError(f'{map_name} - Rule {rule_id}: must have an action defined')
+
+                    # Check if inbound/outbound_interface is not empty
+                    if 'inbound_interface' in rule_conf:
+                        if 'name' not in rule_conf['inbound_interface']:
+                            raise ConfigError(f'{map_name} - Rule {rule_id}: must have an interface name defined for inbound_interface')
+                    if 'outbound_interface' in rule_conf:
+                        if 'name' not in rule_conf['outbound_interface']:
+                            raise ConfigError(f'{map_name} - Rule {rule_id}: must have an interface name defined for outbound_interface')
+
+                    # Check if icmp is configured in the rules
+                    icmp_family = "icmpv6" if map_family == "ipv6_map" else "icmp"
+                    if icmp_family in rule_conf:
+                        # Check if icmp is an empty dictionary
+                        if 'type' not in rule_conf[icmp_family] and 'type_name' not in rule_conf[icmp_family]:
+                            raise ConfigError(f'{map_name} - Rule {rule_id}: must have an icmp type defined; protocol icmp is inherited from the parameters')
+                        if 'protocol_icmp' not in map_conf.get('parameters', {}):
+                            raise ConfigError(f'{map_name} - Rule {rule_id}: protocol icmp must be a parameter if rule matches icmp')
+
+                    # Check if the rule has a jump-target defined if action is jump/goto
+                    if rule_conf['action'] == 'jump' or rule_conf['action'] == 'goto':
+                        if 'jump_target' not in rule_conf:
+                            raise ConfigError(f'{map_name} - Rule {rule_id}: must have a jump-target defined if action is jump/goto')
+
+                    # Check if the rule has a jump-target defined if action is not jump/goto
+                    if 'jump_target' in rule_conf and rule_conf['action'] not in ['jump', 'goto']:
+                        raise ConfigError(f'{map_name} - Rule {rule_id}: cannot have a jump-target defined if action is not jump/goto')
+
+                    # Check if the jump-target exists
+                    if rule_conf.get('jump_target'):
+                        if rule_conf['jump_target'] not in firewall.get(map_family[:4], {}).get('name', []):
+                            raise ConfigError(f'{map_name} - Rule {rule_id}: jump-target "{rule_conf["jump_target"]}" does not exist')
+
+                    # Get list of fields that are configured in the rules
+                    if rule_conf.get('source', {}).get('address'):
+                        rule_list.append('source_address')
+                    if rule_conf.get('destination', {}).get('address'):
+                        rule_list.append('destination_address')
+                    if rule_conf.get('source', {}).get('port'):
+                        rule_list.append('source_port')
+                    if rule_conf.get('destination', {}).get('port'):
+                            rule_list.append('destination_port')
+                    if rule_conf.get(icmp_family):
+                        if rule_conf.get(icmp_family).get('type') or rule_conf.get(icmp_family).get('type_name'):
+                            rule_list.append('icmp_type')
+                        if rule_conf.get(icmp_family).get('code'):
+                            rule_list.append('icmp_code')
+                    if rule_conf.get('inbound_interface', {}).get('name'):
+                        rule_list.append('inbound_interface')
+                    if rule_conf.get('outbound_interface', {}).get('name'):
+                        rule_list.append('outbound_interface')
+
+                    # Cannot have a rule with only action defined
+                    if not rule_list and rule_conf.get('action'):
+                        raise ConfigError(f'{map_name} - Rule {rule_id}: Must have fields configured')
+
+                    # Check for items that are configured in the rules but not defined in the parameters
+                    for item in rule_list:
+                        if item not in param_list:
+                            raise ConfigError(f'{map_name} - Rule {rule_id}: {item.replace("_", " ")} not a defined parameter')
+
+                    # Check for items that are defined in the parameters but not configured in the rules
+                    for item in param_list:
+                        if item not in rule_list:
+                            raise ConfigError(f'{map_name} - Rule {rule_id}: {item.replace("_", " ")} is a required parameter')
+
     if 'flowtable' in firewall:
         for flowtable, flowtable_conf in firewall['flowtable'].items():
             if 'interface' not in flowtable_conf:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
This change will add the ability to configure nft maps in VyOS. This can radically improve the speed of rule processing in deployments with a large number of firewall rules, since rules are not evaluated sequentially, but against a hashmap.

### Syntax:
#### Add parameters
```
set firewall group ipv4-map test parameters source-address	
set firewall group ipv4-map test parameters destination-address	
set firewall group ipv4-map test parameters destination-port
set firewall group ipv4-map test parameters protocol-tcp
```
#### Add rules
```
set firewall group ipv4-map test rule 10 action 'accept'
set firewall group ipv4-map test rule 10 destination address '10.0.5.0/24'
set firewall group ipv4-map test rule 10 destination port '179'
set firewall group ipv4-map test rule 10 source address '0.0.0.0/0'

set firewall group ipv4-map test rule 20 action 'drop'
set firewall group ipv4-map test rule 20 destination address '10.0.5.0/24'
set firewall group ipv4-map test rule 20 destination port '3389'
set firewall group ipv4-map test rule 20 source address '0.0.0.0/0'
```
After committing these, the map will be applied. You can verify in nftables:
```
vyos@cli-dev# sudo nft list map vyos_filter MAP_test
table ip vyos_filter {
        map MAP_test {
                type ipv4_addr . ipv4_addr . inet_service . inet_proto : verdict
                flags interval
                counter
                elements = { 0.0.0.0/0 . 10.0.5.0/24 . 179 . tcp counter packets 0 bytes 0 : accept,
                             0.0.0.0/0 . 10.0.5.0/24 . 3389 . tcp counter packets 0 bytes 0 : drop }
        }
}
```
#### Apply map to a rule
```
set firewall ipv4 output filter rule 10 action 'apply-map'
set firewall ipv4 output filter rule 10 map 'test'
```
After applying the map, you can see the applied rule in nftables:
```
vyos@cli-dev# sudo nft list chain vyos_filter VYOS_OUTPUT_filter
table ip vyos_filter {
        chain VYOS_OUTPUT_filter {
                type filter hook output priority filter; policy accept;
                ip saddr . ip daddr . tcp dport . meta l4proto vmap @MAP_test comment "ipv4-OUT-filter-10"
                counter packets 50 bytes 8588 accept comment "OUT-filter default-action accept"
        }
}
```
Or with the normal `show firewall` commands:
```
vyos@cli-dev# run show firewall ipv4 output filter
Ruleset Information

---------------------------------
ipv4 Firewall "output filter"

Rule     Action     Protocol      Packets    Bytes  Conditions
-------  ---------  ----------  ---------  -------  -------------------------------------------------------------
10       apply-map  all                 0        0  ip saddr . ip daddr . tcp dport . meta l4proto vmap @MAP_test
default  accept     all               501    74416
```
Packet/Byte counts can be viewed directly in the map:
```
vyos@cli-dev# sudo nft list map vyos_filter MAP_test
table ip vyos_filter {
        map MAP_test {
                type ipv4_addr . ipv4_addr . inet_service . inet_proto : verdict
                flags interval
                counter
                elements = { 0.0.0.0/0 . 10.0.5.0/24 . 179 . tcp counter packets 22 bytes 1320 : accept,
                             0.0.0.0/0 . 10.0.5.0/24 . 3389 . tcp counter packets 0 bytes 0 : drop }
        }
}
```
The map can be searched for matched traffic with this (an op mode command will be added after this is merged):
```
vyos@cli-dev# sudo nft get element ip vyos_filter MAP_test { 10.0.95.207 . 10.0.5.1 . 179 . tcp }
table ip vyos_filter {
        map MAP_test {
                type ipv4_addr . ipv4_addr . inet_service . inet_proto : verdict
                flags interval
                elements = { 0.0.0.0/0 . 10.0.5.0/24 . 179 . tcp counter packets 32 bytes 1920 : accept }
        }
}
```
#### Possible parameters:
```
   destination-address  Allow destination address as parameter
   destination-port     Allow destination port as parameter
   icmp-code            Allow ICMP code as parameter
   icmp-type            Allow ICMP type as parameter
   inbound-interface    Allow inbound interface as parameter
   outbound-interface   Allow outbound interface as parameter
   protocol-icmp        Define protocol parameter as ICMP
   protocol-tcp         Define protocol parameter as TCP
   protocol-udp         Define protocol parameter as UDP
   source-address       Allow source address as parameter
   source-port          Allow source port as parameter
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7318

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
test_ipv4_map (__main__.TestFirewall.test_ipv4_map) ... ok
test_ipv6_map (__main__.TestFirewall.test_ipv6_map) ... ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
