### PR TITLE
firewall: T7370: Add conntrack log commands

### DIFF
--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -52,7 +52,7 @@
           </leafNode>
           <node name="conntrack">
             <properties>
-              <help>Show log for Conntrack Events</help>
+              <help>Show log for conntrack events</help>
             </properties>
             <command>journalctl --no-hostname --boot -t vyos-conntrack-logger --grep='\[(NEW|UPDATE|DESTROY)\]'</command>
             <children>

--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -69,7 +69,7 @@
                   </leafNode>
                   <leafNode name="update">
                     <properties>
-                      <help>Show log for Conntrack Events</help>
+                      <help>Show log for conntrack events</help>
                     </properties>
                     <command>journalctl --no-hostname --boot -t vyos-conntrack-logger --grep='\[(UPDATE)\]'</command>
                   </leafNode>

--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -50,7 +50,7 @@
             </properties>
             <command>cat $(printf "%s\n" /var/log/messages* | sort -nr) | grep -e heartbeat -e cl_status -e mach_down -e ha_log</command>
           </leafNode>
-          <leafNode name="conntrack">
+          <node name="conntrack">
             <properties>
               <help>Show log for Conntrack Events</help>
             </properties>
@@ -82,7 +82,7 @@
                 </children>
               </node>
             </children>
-          </leafNode>
+          </node>
           <leafNode name="conntrack-sync">
             <properties>
               <help>Show log for Conntrack-sync</help>

--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -58,7 +58,7 @@
             <children>
               <node name="event">
                 <properties>
-                  <help>Show log for Conntrack Events</help>
+                  <help>Show log for conntrack events</help>
                 </properties>
                 <children>
                   <leafNode name="new">

--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -50,6 +50,39 @@
             </properties>
             <command>cat $(printf "%s\n" /var/log/messages* | sort -nr) | grep -e heartbeat -e cl_status -e mach_down -e ha_log</command>
           </leafNode>
+          <leafNode name="conntrack">
+            <properties>
+              <help>Show log for Conntrack Events</help>
+            </properties>
+            <command>journalctl --no-hostname --boot | egrep "vyos-conntrack-logger\[.*\]: \[(NEW|UPDATE|DESTROY)\]"</command>
+            <children>
+              <node name="event">
+                <properties>
+                  <help>Show log for Conntrack Events</help>
+                </properties>
+                <children>
+                  <leafNode name="new">
+                    <properties>
+                      <help>Show log for Conntrack Events</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot | egrep "vyos-conntrack-logger\[.*\]: \[(NEW)\]"</command>
+                  </leafNode>
+                  <leafNode name="update">
+                    <properties>
+                      <help>Show log for Conntrack Events</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot | egrep "vyos-conntrack-logger\[.*\]: \[(UPDATE)\]"</command>
+                  </leafNode>
+                  <leafNode name="destroy">
+                    <properties>
+                      <help>Show log for Conntrack Events</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot | egrep "vyos-conntrack-logger\[.*\]: \[(DESTROY)\]"</command>
+                  </leafNode>
+                </children>
+              </node>
+            </children>
+          </leafNode>
           <leafNode name="conntrack-sync">
             <properties>
               <help>Show log for Conntrack-sync</help>

--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -54,7 +54,7 @@
             <properties>
               <help>Show log for Conntrack Events</help>
             </properties>
-            <command>journalctl --no-hostname --boot | egrep "vyos-conntrack-logger\[.*\]: \[(NEW|UPDATE|DESTROY)\]"</command>
+            <command>journalctl --no-hostname --boot -t vyos-conntrack-logger --grep='\[(NEW|UPDATE|DESTROY)\]'</command>
             <children>
               <node name="event">
                 <properties>
@@ -65,19 +65,19 @@
                     <properties>
                       <help>Show log for Conntrack Events</help>
                     </properties>
-                    <command>journalctl --no-hostname --boot | egrep "vyos-conntrack-logger\[.*\]: \[(NEW)\]"</command>
+                    <command>journalctl --no-hostname --boot -t vyos-conntrack-logger --grep='\[(NEW)\]'</command>
                   </leafNode>
                   <leafNode name="update">
                     <properties>
                       <help>Show log for Conntrack Events</help>
                     </properties>
-                    <command>journalctl --no-hostname --boot | egrep "vyos-conntrack-logger\[.*\]: \[(UPDATE)\]"</command>
+                    <command>journalctl --no-hostname --boot -t vyos-conntrack-logger --grep='\[(UPDATE)\]'</command>
                   </leafNode>
                   <leafNode name="destroy">
                     <properties>
                       <help>Show log for Conntrack Events</help>
                     </properties>
-                    <command>journalctl --no-hostname --boot | egrep "vyos-conntrack-logger\[.*\]: \[(DESTROY)\]"</command>
+                    <command>journalctl --no-hostname --boot -t vyos-conntrack-logger --grep='\[(DESTROY)\]'</command>
                   </leafNode>
                 </children>
               </node>

--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -63,7 +63,7 @@
                 <children>
                   <leafNode name="new">
                     <properties>
-                      <help>Show log for Conntrack Events</help>
+                      <help>Show log for conntrack events</help>
                     </properties>
                     <command>journalctl --no-hostname --boot -t vyos-conntrack-logger --grep='\[(NEW)\]'</command>
                   </leafNode>


### PR DESCRIPTION

<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
The ability to view conntrack logs from the conntrack log daemon is missing. This PR adds the functionality.

Added the following commands:
```
show log conntrack
show log conntrack event new
show log conntrack event update
show log conntrack event destroy
```
<!-- All PR should follow this template to allow a clean and transparent review -->
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7370
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Enable conntrack logging for one or more events and generate traffic that will create an entry:
```
set system conntrack log event destroy
set system conntrack log event new
set system conntrack log event update
```
### Test the command:
```
vyos@vyos# run show log conntrack
Apr 16 19:49:05 vyos-conntrack-logger[4310]: [NEW]     514867617 icmp     1 30 src=10.5.0.1 dst=10.5.0.10 type=8 code=0 id=4397 [UNREPLIED] src=10.5.0.10 dst=10.5.0.1 type=0 code=0 id=4397
Apr 16 19:49:05 vyos-conntrack-logger[4312]: [UPDATE]  514867617 icmp     1 30 src=10.5.0.1 dst=10.5.0.10 type=8 code=0 id=4397 src=10.5.0.10 dst=10.5.0.1 type=0 code=0 id=4397
Apr 16 19:49:22 vyos-conntrack-logger[4311]: [DESTROY] 1519139135 udp      17 src=10.0.95.3 dst=255.255.255.255 sport=34734 dport=10001 [UNREPLIED] src=255.255.255.255 dst=10.0.95.3 sport=10001 dport=34734
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
