### PR TITLE
syslog: T7367: ensure rsyslog is registered as default systemd syslog service

### DIFF
--- a/debian/vyos-1x.links
+++ b/debian/vyos-1x.links
@@ -1,3 +1,2 @@
 /etc/netplug/linkup.d/vyos-python-helper /etc/netplug/linkdown.d/vyos-python-helper
 /usr/libexec/vyos/system/standalone_root_pw_reset /opt/vyatta/sbin/standalone_root_pw_reset
-/lib/systemd/system/rsyslog.service /etc/systemd/system/syslog.service

--- a/python/vyos/defaults.py
+++ b/python/vyos/defaults.py
@@ -43,7 +43,7 @@ directories = {
 }
 
 systemd_services = {
-    'rsyslog' : 'rsyslog.service',
+    'syslog' : 'syslog.service',
     'snmpd' : 'snmpd.service',
 }
 

--- a/smoketest/scripts/cli/test_system_syslog.py
+++ b/smoketest/scripts/cli/test_system_syslog.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import unittest
 
 from base_vyostest_shim import VyOSUnitTestSHIM
@@ -58,6 +59,11 @@ class TestRSYSLOGService(VyOSUnitTestSHIM.TestCase):
         # delete testing SYSLOG config
         self.cli_delete(base_path)
         self.cli_commit()
+
+        # The default syslog implementation should make syslog.service a
+        # symlink to itself
+        self.assertEqual(os.readlink('/etc/systemd/system/syslog.service'),
+                         '/lib/systemd/system/rsyslog.service')
 
         # Check for running process
         self.assertFalse(process_named_running(PROCESS_NAME))

--- a/src/conf_mode/system_host-name.py
+++ b/src/conf_mode/system_host-name.py
@@ -175,7 +175,7 @@ def apply(config):
 
     # Restart services that use the hostname
     if hostname_new != hostname_old:
-        tmp = systemd_services['rsyslog']
+        tmp = systemd_services['syslog']
         call(f'systemctl restart {tmp}')
 
     # If SNMP is running, restart it too

--- a/src/conf_mode/system_syslog.py
+++ b/src/conf_mode/system_syslog.py
@@ -35,7 +35,7 @@ rsyslog_conf = '/run/rsyslog/rsyslog.conf'
 logrotate_conf = '/etc/logrotate.d/vyos-rsyslog'
 
 systemd_socket = 'syslog.socket'
-systemd_service = systemd_services['rsyslog']
+systemd_service = systemd_services['syslog']
 
 def get_config(config=None):
     if config:

--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -460,6 +460,14 @@ start ()
     nfct helper add tns inet6 tcp
     nft --file /usr/share/vyos/vyos-firewall-init.conf || log_failure_msg "could not initiate firewall rules"
 
+    # Ensure rsyslog is the default syslog daemon
+    SYSTEMD_SYSLOG="/etc/systemd/system/syslog.service"
+    SYSTEMD_RSYSLOG="/lib/systemd/system/rsyslog.service"
+    if [ ! -L ${SYSTEMD_SYSLOG} ] || [ "$(readlink -f ${SYSTEMD_SYSLOG})" != "${SYSTEMD_RSYSLOG}" ]; then
+        ln -sf ${SYSTEMD_RSYSLOG} ${SYSTEMD_SYSLOG}
+        systemctl daemon-reload
+    fi
+
     # As VyOS does not execute commands that are not present in the CLI we call
     # the script by hand to have a single source for the login banner and MOTD
     ${vyos_conf_scripts_dir}/system_syslog.py || log_failure_msg "could not reset syslog"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The default syslog implementation should make syslog.service a symlink to itself, so that this socket activates the right actual syslog service.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7367

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/951

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_syslog.py
test_basic (__main__.TestRSYSLOGService.test_basic) ... ok
test_console (__main__.TestRSYSLOGService.test_console) ... ok
test_remote (__main__.TestRSYSLOGService.test_remote) ... ok
test_vrf_source_address (__main__.TestRSYSLOGService.test_vrf_source_address) ... ok

----------------------------------------------------------------------
Ran 4 tests in 13.359s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
