### PR TITLE
interface: T7375: cleanup SLAAC assigned address and default route after removing SLAAC CLI configuration

### DIFF
--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -1351,8 +1351,6 @@ class Interface(Control):
         # drop all interface addresses first
         self.flush_addrs()
 
-        ifname = self.ifname
-
         for bridge, bridge_config in bridge_dict.items():
             # add interface to bridge - use Section.klass to get BridgeIf class
             Section.klass(bridge)(bridge, create=True).add_port(self.ifname)
@@ -1368,7 +1366,7 @@ class Interface(Control):
             bridge_vlan_filter = Section.klass(bridge)(bridge, create=True).get_vlan_filter()
 
             if int(bridge_vlan_filter):
-                cur_vlan_ids = get_vlan_ids(ifname)
+                cur_vlan_ids = get_vlan_ids(self.ifname)
                 add_vlan = []
                 native_vlan_id = None
                 allowed_vlan_ids= []
@@ -1391,15 +1389,15 @@ class Interface(Control):
 
                 # Remove redundant VLANs from the system
                 for vlan in list_diff(cur_vlan_ids, add_vlan):
-                    cmd = f'bridge vlan del dev {ifname} vid {vlan} master'
+                    cmd = f'bridge vlan del dev {self.ifname} vid {vlan} master'
                     self._cmd(cmd)
 
                 for vlan in allowed_vlan_ids:
-                    cmd = f'bridge vlan add dev {ifname} vid {vlan} master'
+                    cmd = f'bridge vlan add dev {self.ifname} vid {vlan} master'
                     self._cmd(cmd)
                 # Setting native VLAN to system
                 if native_vlan_id:
-                    cmd = f'bridge vlan add dev {ifname} vid {native_vlan_id} pvid untagged master'
+                    cmd = f'bridge vlan add dev {self.ifname} vid {native_vlan_id} pvid untagged master'
                     self._cmd(cmd)
 
     def set_dhcp(self, enable: bool, vrf_changed: bool=False):
@@ -1478,12 +1476,11 @@ class Interface(Control):
         if enable not in [True, False]:
             raise ValueError()
 
-        ifname = self.ifname
         config_base = directories['dhcp6_client_dir']
-        config_file = f'{config_base}/dhcp6c.{ifname}.conf'
-        script_file = f'/etc/wide-dhcpv6/dhcp6c.{ifname}.script' # can not live under /run b/c of noexec mount option
-        systemd_override_file = f'/run/systemd/system/dhcp6c@{ifname}.service.d/10-override.conf'
-        systemd_service = f'dhcp6c@{ifname}.service'
+        config_file = f'{config_base}/dhcp6c.{self.ifname}.conf'
+        script_file = f'/etc/wide-dhcpv6/dhcp6c.{self.ifname}.script' # can not live under /run b/c of noexec mount option
+        systemd_override_file = f'/run/systemd/system/dhcp6c@{self.ifname}.service.d/10-override.conf'
+        systemd_service = f'dhcp6c@{self.ifname}.service'
 
         # Rendered client configuration files require additional settings
         config = deepcopy(self.config)

--- a/src/etc/sysctl.d/30-vyos-router.conf
+++ b/src/etc/sysctl.d/30-vyos-router.conf
@@ -83,6 +83,16 @@ net.ipv4.conf.default.ignore_routes_with_linkdown=1
 net.ipv6.conf.all.ignore_routes_with_linkdown=1
 net.ipv6.conf.default.ignore_routes_with_linkdown=1
 
+# Disable IPv6 interface autoconfigurationnable packet forwarding for IPv6
+net.ipv6.conf.all.autoconf=0
+net.ipv6.conf.default.autoconf=0
+net.ipv6.conf.*.autoconf=0
+
+# Disable IPv6 router advertisements
+net.ipv6.conf.all.accept_ra=0
+net.ipv6.conf.default.accept_ra=0
+net.ipv6.conf.*.accept_ra=0
+
 # Enable packet forwarding for IPv6
 net.ipv6.conf.all.forwarding=1
 

--- a/src/systemd/vyos.target
+++ b/src/systemd/vyos.target
@@ -1,3 +1,3 @@
 [Unit]
 Description=VyOS target
-After=multi-user.target vyos-grub-update.service
+After=multi-user.target vyos-grub-update.service systemd-sysctl.service


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

When SLAAC is enabled on an interface: `set interfaces ethernet eth0 vif 10 ipv6 address autoconf` it will assign an appropriate IPv6 address to the Kernel interface. When removing SLAAC from the CLI configuration the address and default route was not cleared. This has been fixed.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7375

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

### Manual Testing

Enable IPv6 address autoconfiguration (SLAAC)

```
set interfaces ethernet eth1 vif 1111 ipv6 address autoconf
commit
```

Show interfaces

```
vyos@vyos:~$ show int
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address                             MAC                VRF        MTU  S/L    Description
-----------  -------------------------------------  -----------------  -------  -----  -----  -------------
eth0         -                                      00:50:56:bf:c5:6d  default   1500  u/u
eth1         -                                      00:50:56:b3:38:c5  default   1500  u/u
eth1.1111    2001:db8:1111:0:250:56ff:feb3:38c5/64  00:50:56:b3:38:c5  default   1500  u/u
lo           127.0.0.1/8                            00:00:00:00:00:00  default  65536  u/u
             ::1/128
```

Show IPv6 routing entries

```
vyos@vyos:~$ show ipv6 route
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIPng, O - OSPFv3, I - IS-IS, B - BGP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

K>* ::/0 [0/1024] via fe80::250:56ff:feb3:cdba, eth1.1111, weight 1, 00:02:00
C>* 2001:db8:1111::/64 is directly connected, eth1.1111, weight 1, 00:01:58
K * 2001:db8:1111::/64 [0/256] is directly connected, eth1.1111, weight 1, 00:02:00
L>* 2001:db8:1111:0:250:56ff:feb3:38c5/128 is directly connected, eth1.1111, weight 1, 00:01:58
C * fe80::/64 is directly connected, eth1.1111, weight 1, 00:02:00
```

Remove IPv6 SLAAC configuration

```
del interfaces ethernet eth1 vif 1111 ipv6
commit
```

```
vyos@vyos:~$ show int
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address                             MAC                VRF        MTU  S/L    Description
-----------  -------------------------------------  -----------------  -------  -----  -----  -------------
eth0         -                                      00:50:56:bf:c5:6d  default   1500  u/u
eth1         -                                      00:50:56:b3:38:c5  default   1500  u/u
eth1.1111    -                                      00:50:56:b3:38:c5  default   1500  u/u
lo           127.0.0.1/8                            00:00:00:00:00:00  default  65536  u/u
             ::1/128
```

```
vyos@vyos:~$ show ipv6 route
Codes: K - kernel route, C - connected, L - local, S - static,
       R - RIPng, O - OSPFv3, I - IS-IS, B - BGP, N - NHRP,
       T - Table, v - VNC, V - VNC-Direct, A - Babel, F - PBR,
       f - OpenFabric, t - Table-Direct,
       > - selected route, * - FIB route, q - queued, r - rejected, b - backup
       t - trapped, o - offload failure

C * fe80::/64 is directly connected, eth1.1111, weight 1, 00:17:15
```

### Smoketest result

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_ethernet.py
test_add_multiple_ip_addresses (__main__.EthernetInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.EthernetInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.EthernetInterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.EthernetInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.EthernetInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.EthernetInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.EthernetInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.EthernetInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol (__main__.EthernetInterfaceTest.test_eapol) ... ok
test_ethtool_evpn_uplink_tracking (__main__.EthernetInterfaceTest.test_ethtool_evpn_uplink_tracking) ... ok
test_ethtool_flow_control (__main__.EthernetInterfaceTest.test_ethtool_flow_control) ... ok
test_ethtool_ring_buffer (__main__.EthernetInterfaceTest.test_ethtool_ring_buffer) ... ok
test_interface_description (__main__.EthernetInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.EthernetInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.EthernetInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.EthernetInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.EthernetInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.EthernetInterfaceTest.test_ipv6_link_local_address) ... ok
test_move_interface_between_vrf_instances (__main__.EthernetInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.EthernetInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_non_existing_interface (__main__.EthernetInterfaceTest.test_non_existing_interface) ... ok
test_offloading_rfs (__main__.EthernetInterfaceTest.test_offloading_rfs) ... ok
test_offloading_rps (__main__.EthernetInterfaceTest.test_offloading_rps) ... ok
test_span_mirror (__main__.EthernetInterfaceTest.test_span_mirror) ... ok
test_speed_duplex_verify (__main__.EthernetInterfaceTest.test_speed_duplex_verify) ... ok
test_switchdev (__main__.EthernetInterfaceTest.test_switchdev) ... ok
test_vif_8021q_interfaces (__main__.EthernetInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.EthernetInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.EthernetInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.EthernetInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.EthernetInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.EthernetInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 34 tests in 415.324s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
