### PR TITLE
router-advert: T7380: Implement auto-ignore-prefix syntax for router advertisements

### DIFF
--- a/data/templates/router-advert/radvd.conf.j2
+++ b/data/templates/router-advert/radvd.conf.j2
@@ -21,13 +21,6 @@ interface {{ iface }} {
 {%         endif %}
     AdvIntervalOpt {{ 'off' if iface_config.no_send_interval is vyos_defined else 'on' }};
     AdvSendAdvert {{ 'off' if iface_config.no_send_advert is vyos_defined else 'on' }};
-{%         if iface_config.auto_ignore_prefix is vyos_defined %}
-    autoignoreprefixes {
-{%             for auto_ignore_prefix in iface_config.auto_ignore_prefix %}
-        {{ auto_ignore_prefix }};
-{%             endfor %}
-    };
-{%         endif %}
 {%         if iface_config.default_lifetime is vyos_defined %}
     AdvDefaultLifetime {{ iface_config.default_lifetime }};
 {%         endif %}
@@ -63,6 +56,13 @@ interface {{ iface }} {
         AdvValidLifetime {{ nat64prefix_options.valid_lifetime }};
     };
 {%             endfor %}
+{%         endif %}
+{%         if iface_config.auto_ignore_prefix is vyos_defined %}
+    autoignoreprefixes {
+{%             for auto_ignore_prefix in iface_config.auto_ignore_prefix %}
+        {{ auto_ignore_prefix }};
+{%             endfor %}
+    };
 {%         endif %}
 {%         if iface_config.prefix is vyos_defined %}
 {%             for prefix, prefix_options in iface_config.prefix.items() %}

--- a/data/templates/router-advert/radvd.conf.j2
+++ b/data/templates/router-advert/radvd.conf.j2
@@ -23,8 +23,8 @@ interface {{ iface }} {
     AdvSendAdvert {{ 'off' if iface_config.no_send_advert is vyos_defined else 'on' }};
 {%         if iface_config.auto_ignore_prefix is vyos_defined %}
     autoignoreprefixes {
-{%             for prefix in iface_config.auto_ignore_prefix.items() %}
-    {{ prefix }}
+{%             for auto_ignore_prefix in iface_config.auto_ignore_prefix %}
+    {{ auto_ignore_prefix }}
 {%             endfor %}
     }
 {%         endif %}

--- a/data/templates/router-advert/radvd.conf.j2
+++ b/data/templates/router-advert/radvd.conf.j2
@@ -24,7 +24,7 @@ interface {{ iface }} {
 {%         if iface_config.auto_ignore_prefix is vyos_defined %}
     autoignoreprefixes {
 {%             for auto_ignore_prefix in iface_config.auto_ignore_prefix %}
-    {{ auto_ignore_prefix }};
+        {{ auto_ignore_prefix }};
 {%             endfor %}
     }
 {%         endif %}

--- a/data/templates/router-advert/radvd.conf.j2
+++ b/data/templates/router-advert/radvd.conf.j2
@@ -21,6 +21,13 @@ interface {{ iface }} {
 {%         endif %}
     AdvIntervalOpt {{ 'off' if iface_config.no_send_interval is vyos_defined else 'on' }};
     AdvSendAdvert {{ 'off' if iface_config.no_send_advert is vyos_defined else 'on' }};
+{%         if iface_config.auto-ignore-prefix is vyos_defined %}
+    autoignoreprefixes {
+{%             for prefix in iface_config.auto-ignore-prefix.items() %}
+    {{ prefix }}
+{%             endfor %}
+    }
+{%         endif %}
 {%         if iface_config.default_lifetime is vyos_defined %}
     AdvDefaultLifetime {{ iface_config.default_lifetime }};
 {%         endif %}

--- a/data/templates/router-advert/radvd.conf.j2
+++ b/data/templates/router-advert/radvd.conf.j2
@@ -57,9 +57,9 @@ interface {{ iface }} {
     };
 {%             endfor %}
 {%         endif %}
-{%         if iface_config.auto_ignore_prefix is vyos_defined %}
+{%         if iface_config.auto_ignore is vyos_defined %}
     autoignoreprefixes {
-{%             for auto_ignore_prefix in iface_config.auto_ignore_prefix %}
+{%             for auto_ignore_prefix in iface_config.auto_ignore %}
         {{ auto_ignore_prefix }};
 {%             endfor %}
     };

--- a/data/templates/router-advert/radvd.conf.j2
+++ b/data/templates/router-advert/radvd.conf.j2
@@ -26,7 +26,7 @@ interface {{ iface }} {
 {%             for auto_ignore_prefix in iface_config.auto_ignore_prefix %}
         {{ auto_ignore_prefix }};
 {%             endfor %}
-    }
+    };
 {%         endif %}
 {%         if iface_config.default_lifetime is vyos_defined %}
     AdvDefaultLifetime {{ iface_config.default_lifetime }};

--- a/data/templates/router-advert/radvd.conf.j2
+++ b/data/templates/router-advert/radvd.conf.j2
@@ -21,9 +21,9 @@ interface {{ iface }} {
 {%         endif %}
     AdvIntervalOpt {{ 'off' if iface_config.no_send_interval is vyos_defined else 'on' }};
     AdvSendAdvert {{ 'off' if iface_config.no_send_advert is vyos_defined else 'on' }};
-{%         if iface_config.auto-ignore-prefix is vyos_defined %}
+{%         if iface_config.auto_ignore_prefix is vyos_defined %}
     autoignoreprefixes {
-{%             for prefix in iface_config.auto-ignore-prefix.items() %}
+{%             for prefix in iface_config.auto_ignore_prefix.items() %}
     {{ prefix }}
 {%             endfor %}
     }

--- a/data/templates/router-advert/radvd.conf.j2
+++ b/data/templates/router-advert/radvd.conf.j2
@@ -24,7 +24,7 @@ interface {{ iface }} {
 {%         if iface_config.auto_ignore_prefix is vyos_defined %}
     autoignoreprefixes {
 {%             for auto_ignore_prefix in iface_config.auto_ignore_prefix %}
-    {{ auto_ignore_prefix }}
+    {{ auto_ignore_prefix }};
 {%             endfor %}
     }
 {%         endif %}

--- a/debian/control
+++ b/debian/control
@@ -203,7 +203,7 @@ Depends:
   ndppd,
 # End "service ndp-proxy"
 # For "service router-advert"
-  radvd,
+  radvd (>= 2.20),
 # End "service route-advert"
 # For "load-balancing haproxy"
   haproxy,

--- a/interface-definitions/service_router-advert.xml.in
+++ b/interface-definitions/service_router-advert.xml.in
@@ -255,7 +255,7 @@
                   </leafNode>
                 </children>
               </tagNode>
-              <tagNode name="auto-ignore-prefix">
+              <leafNode name="auto-ignore-prefix">
                 <properties>
                   <help>IPv6 prefix to be excluded in Router Advertisements (RAs) - use in conjunction with the ::/64 wildcard prefix</help>
                   <valueHelp>
@@ -266,7 +266,7 @@
                     <validator name="ipv6-prefix"/>
                   </constraint>
                 </properties>
-              </tagNode>
+              </leafNode>
               <tagNode name="prefix">
                 <properties>
                   <help>IPv6 prefix to be advertised in Router Advertisements (RAs)</help>

--- a/interface-definitions/service_router-advert.xml.in
+++ b/interface-definitions/service_router-advert.xml.in
@@ -265,6 +265,7 @@
                   <constraint>
                     <validator name="ipv6-prefix"/>
                   </constraint>
+                  <multi/>
                 </properties>
               </leafNode>
               <tagNode name="prefix">

--- a/interface-definitions/service_router-advert.xml.in
+++ b/interface-definitions/service_router-advert.xml.in
@@ -255,6 +255,18 @@
                   </leafNode>
                 </children>
               </tagNode>
+              <tagNode name="auto-ignore-prefix">
+                <properties>
+                  <help>IPv6 prefix to be excluded in Router Advertisements (RAs) - use in conjunction with the ::/64 wildcard prefix</help>
+                  <valueHelp>
+                    <format>ipv6net</format>
+                    <description>IPv6 prefix to be excluded</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="ipv6-prefix"/>
+                  </constraint>
+                </properties>
+              </tagNode>
               <tagNode name="prefix">
                 <properties>
                   <help>IPv6 prefix to be advertised in Router Advertisements (RAs)</help>

--- a/interface-definitions/service_router-advert.xml.in
+++ b/interface-definitions/service_router-advert.xml.in
@@ -255,7 +255,7 @@
                   </leafNode>
                 </children>
               </tagNode>
-              <leafNode name="auto-ignore-prefix">
+              <leafNode name="auto-ignore">
                 <properties>
                   <help>IPv6 prefix to be excluded in Router Advertisements (RAs) - use in conjunction with the ::/64 wildcard prefix</help>
                   <valueHelp>

--- a/smoketest/scripts/cli/test_service_router-advert.py
+++ b/smoketest/scripts/cli/test_service_router-advert.py
@@ -252,6 +252,45 @@ class TestServiceRADVD(VyOSUnitTestSHIM.TestCase):
         tmp = get_config_value('AdvIntervalOpt')
         self.assertEqual(tmp, 'off')
 
+    def test_auto_ignore(self):
+        isp_prefix = '2001:db8::/64'
+        ula_prefixes = ['fd00::/64', 'fd01::/64']
+
+        self.cli_set(base_path + ['auto-ignore', isp_prefix])
+
+        for ula_prefix in ula_prefixes:
+            self.cli_set(base_path + ['auto-ignore', ula_prefix])
+        
+        # commit changes
+        self.cli_commit()
+        config = read_file(RADVD_CONF)
+
+        # ensure autoignoreprefixes block is generated in config file
+        tmp = f'autoignoreprefixes' + ' {'
+        self.assertIn(tmp, config)
+
+        # ensure all three prefixes are contained in the block
+        self.assertIn(f'        {isp_prefix};', config)
+        for ula_prefix in ula_prefixes:
+            self.assertIn(f'        {ula_prefix};', config)
+        
+        # remove a prefix and verify it's gone
+        self.cli_delete(base_path + ['auto-ignore', ula_prefixes[1]])
+        
+        self.cli_commit()
+        config = read_file(RADVD_CONF)
+
+        self.assertNotIn(f'        {ula_prefixes[1]};', config)
+
+        # remove the remaining two prefixes and verify the config block is gone
+        self.cli_delete(base_path + ['auto-ignore', ula_prefixes[0]])
+        self.cli_delete(base_path + ['auto-ignore', isp_prefix])
+
+        self.cli_commit()
+        config = read_file(RADVD_CONF)
+
+        tmp = f'autoignoreprefixes' + ' {'
+        self.assertNotIn(tmp, config)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/smoketest/scripts/cli/test_service_router-advert.py
+++ b/smoketest/scripts/cli/test_service_router-advert.py
@@ -282,6 +282,10 @@ class TestServiceRADVD(VyOSUnitTestSHIM.TestCase):
 
         self.assertNotIn(f'        {ula_prefixes[1]};', config)
 
+        # ensure remaining two prefixes are still present
+        self.assertIn(f'        {ula_prefixes[0]};', config)
+        self.assertIn(f'        {isp_prefix};', config)
+
         # remove the remaining two prefixes and verify the config block is gone
         self.cli_delete(base_path + ['auto-ignore', ula_prefixes[0]])
         self.cli_delete(base_path + ['auto-ignore', isp_prefix])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
radvd released a new feature, "auto ignore prefixes", which will be critically important for enterprise IPv6 deployments, or anywhere where internal ULAs are in use.

You can read all about how this functionality works in this merged PR conversation: https://github.com/radvd-project/radvd/pull/189

But to prevent link rot, I'll also explain its use case here:

When router advertisements are configured on an interface with multiple IPv6 prefixes, it is recommended that you configure your interface with the special wildcard prefix "::/64". The wildcard prefix will generate RAs for all prefixes including dynamic ones obtained from the ISP via DHCPv6-PD.

The downside is that RAs for all prefixes will have the same configuration. That is, they'll have the same flags and preferred/valid lifetimes. If you attempt to override these configuration settings for a specific prefix, the RA will contain a duplicate of the prefix - one with the general settings from the wildcard, and the other with your changes. This results in unpredictable client behavior.

"Auto ignore prefixes" solves this problem by allowing you to exclude certain prefixes from being auto-generated from the wildcard. This is useful for when you want to set different configuration options for different prefixes, or when you want to prevent the router from advertising a specific prefix altogether.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7380

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
**Demonstration**
On a clean install of VyOS rolling in VirtualBox, configure eth1 as a simulated LAN interface:

```
set interfaces ethernet eth1 address '2001:db8::1/64'
set interfaces ethernet eth1 address 'fd00::1/64'
set interfaces ethernet eth1 address 'fd01::1/64'
```

NOTE: `2001:db8::1` is a fake GUA for documentation purposes, but for this example, pretend it's a delegated ISP prefix.

Then configure router advertisements with the wildcard `::/64` prefix:

```
set service router-advert interface eth1 prefix ::/64
```

As expected, this generates an RA with all three prefixes:

![wireshark-initial-wildcard-cfg](https://github.com/user-attachments/assets/fbe0cc8e-e0ff-46e5-8207-fefd9d33fc7e)

Note, all three prefixes will have the same lifetimes and flags set. Let's attempt to override the settings for the `fd00::/64` prefix:

```
set service router-advert interface eth1 prefix fd00::/64 preferred-lifetime '5555'
set service router-advert interface eth1 prefix fd00::/64 valid-lifetime '9999'
```

As you can see below, this produces a problem. We now have duplicate advertisements for the same prefix, one with the general settings from the wildcard, and the other with our manual configuration. This will result in unpredictable client behavior:

![wireshark-before-aip-duplicate](https://github.com/user-attachments/assets/cb6ed33d-6503-460a-ab8b-562884c02a53)

Now let's remove the manual configuation and try out radvd's new "auto ignore prefixes" feature:

```
delete service router-advert interface eth1 prefix fd00::/64 preferred-lifetime '5555'
delete service router-advert interface eth1 prefix fd00::/64 valid-lifetime '9999'
delete service router-advert interface eth1 prefix fd00::/64

set service router-advert interface eth1 auto-ignore fd00::/64
set service router-advert interface eth1 auto-ignore fd01::/64
```

This produces the following in /run/radvd/radvd.conf:

```
### Autogenerated by service_router-advert.py ###

interface eth1 {
    IgnoreIfMissing on;
    AdvDefaultPreference medium;
    MaxRtrAdvInterval 600;
    AdvReachableTime 0;
    AdvIntervalOpt on;
    AdvSendAdvert on;
    AdvOtherConfigFlag off;
    AdvRetransTimer 0;
    AdvCurHopLimit 64;
    autoignoreprefixes {
        fd00::/64;
        fd01::/64;
    };
    prefix ::/64 {
        AdvAutonomous on;
        AdvValidLifetime 2592000;
        AdvOnLink on;
        AdvPreferredLifetime 14400;
        DeprecatePrefix off;
        DecrementLifetimes off;
    };
};
```

Now, only the dynamic ISP prefix is being advertised via the wildcard:

![wireshark-after-ignore-prefix](https://github.com/user-attachments/assets/f35afec6-5399-49bf-a975-7d7782716aeb)

If you still want to broadcast `fd00::/64` with your own settings, you can now do so manually:

```
set service router-advert interface eth1 prefix fd00::/64 preferred-lifetime '5555'
set service router-advert interface eth1 prefix fd00::/64 valid-lifetime '9999'
```

![wireshark-manual-config](https://github.com/user-attachments/assets/e88e05f9-87c3-4222-8c0a-c87716c6397e)

Now, `2001:db8::/64` and `fd00::/64` are both advertised once again. But this time, the `fd00::/64` prefix only appears once, and it contains our manual configuration. This achieves the desired result.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
