### PR TITLE
T7382: adds podman log driver configuration option

### DIFF
--- a/data/templates/container/containers.conf.j2
+++ b/data/templates/container/containers.conf.j2
@@ -172,7 +172,11 @@ default_sysctls = [
 
 # Logging driver for the container. Available options: k8s-file and journald.
 #
+{% if log_driver is vyos_defined %}
+log_driver = "{{ log_driver }}"
+{% else %}
 #log_driver = "k8s-file"
+{% endif %}
 
 # Maximum size allowed for the container log file. Negative numbers indicate
 # that no size limit is imposed. If positive, it must be >= 8192 to match or

--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -621,6 +621,25 @@
           </node>
         </children>
       </tagNode>
+      <leafNode name="log-driver">
+        <properties>
+          <help>Configure container log driver</help>
+          <completionHelp>
+            <list>k8s-file journald</list>
+          </completionHelp>
+          <valueHelp>
+            <format>k8s-file</format>
+            <description>Logs to plain-text json file</description>
+          </valueHelp>
+          <valueHelp>
+            <format>journald</format>
+            <description>Logs to systemd's journal</description>
+          </valueHelp>
+          <constraint>
+            <regex>(k8s-file|journald)</regex>
+          </constraint>
+        </properties>
+      </leafNode>
     </children>
   </node>
 </interfaceDefinition>

--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -95,6 +95,14 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         tmp = cmd(f'sudo podman exec -it {cont_name} sysctl kernel.msgmax')
         self.assertEqual(tmp, 'kernel.msgmax = 4096')
 
+    def test_log_driver(self):
+        self.cli_set(base_path + ['log-driver', 'journald'])
+
+        self.cli_commit()
+
+        tmp = cmd('podman info --format "{{ .Host.LogDriver }}"')
+        self.assertEqual(tmp, 'journald')
+
     def test_name_server(self):
         cont_name = 'dns-test'
         net_name = 'net-test'

--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -33,10 +33,12 @@ PROCESS_PIDFILE = '/run/vyos-container-{0}.service.pid'
 busybox_image = 'busybox:stable'
 busybox_image_path = '/usr/share/vyos/busybox-stable.tar'
 
+
 def cmd_to_json(command):
     c = cmd(command + ' --format=json')
     data = json.loads(c)[0]
     return data
+
 
 class TestContainer(VyOSUnitTestSHIM.TestCase):
     @classmethod
@@ -73,13 +75,26 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         cont_name = 'c1'
 
         self.cli_set(['interfaces', 'ethernet', 'eth0', 'address', '10.0.2.15/24'])
-        self.cli_set(['protocols', 'static', 'route', '0.0.0.0/0', 'next-hop', '10.0.2.2'])
+        self.cli_set(
+            ['protocols', 'static', 'route', '0.0.0.0/0', 'next-hop', '10.0.2.2']
+        )
         self.cli_set(['system', 'name-server', '1.1.1.1'])
         self.cli_set(['system', 'name-server', '8.8.8.8'])
 
         self.cli_set(base_path + ['name', cont_name, 'image', busybox_image])
         self.cli_set(base_path + ['name', cont_name, 'allow-host-networks'])
-        self.cli_set(base_path + ['name', cont_name, 'sysctl', 'parameter', 'kernel.msgmax', 'value', '4096'])
+        self.cli_set(
+            base_path
+            + [
+                'name',
+                cont_name,
+                'sysctl',
+                'parameter',
+                'kernel.msgmax',
+                'value',
+                '4096',
+            ]
+        )
 
         # commit changes
         self.cli_commit()
@@ -113,7 +128,17 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
 
         self.cli_set(base_path + ['name', cont_name, 'image', busybox_image])
         self.cli_set(base_path + ['name', cont_name, 'name-server', name_server])
-        self.cli_set(base_path + ['name', cont_name, 'network', net_name, 'address', str(ip_interface(prefix).ip + 2)])
+        self.cli_set(
+            base_path
+            + [
+                'name',
+                cont_name,
+                'network',
+                net_name,
+                'address',
+                str(ip_interface(prefix).ip + 2),
+            ]
+        )
 
         # verify() - name server has no effect when container network has dns enabled
         with self.assertRaises(ConfigSessionError):
@@ -154,7 +179,17 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         for ii in range(1, 6):
             name = f'{base_name}-{ii}'
             self.cli_set(base_path + ['name', name, 'image', busybox_image])
-            self.cli_set(base_path + ['name', name, 'network', net_name, 'address', str(ip_interface(prefix).ip + ii)])
+            self.cli_set(
+                base_path
+                + [
+                    'name',
+                    name,
+                    'network',
+                    net_name,
+                    'address',
+                    str(ip_interface(prefix).ip + ii),
+                ]
+            )
 
         # verify() - first IP address of a prefix can not be used by a container
         with self.assertRaises(ConfigSessionError):
@@ -171,8 +206,14 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         for ii in range(2, 6):
             name = f'{base_name}-{ii}'
             c = cmd_to_json(f'sudo podman container inspect {name}')
-            self.assertEqual(c['NetworkSettings']['Networks'][net_name]['Gateway']  , str(ip_interface(prefix).ip + 1))
-            self.assertEqual(c['NetworkSettings']['Networks'][net_name]['IPAddress'], str(ip_interface(prefix).ip + ii))
+            self.assertEqual(
+                c['NetworkSettings']['Networks'][net_name]['Gateway'],
+                str(ip_interface(prefix).ip + 1),
+            )
+            self.assertEqual(
+                c['NetworkSettings']['Networks'][net_name]['IPAddress'],
+                str(ip_interface(prefix).ip + ii),
+            )
 
     def test_ipv6_network(self):
         prefix = '2001:db8::/64'
@@ -184,7 +225,17 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         for ii in range(1, 6):
             name = f'{base_name}-{ii}'
             self.cli_set(base_path + ['name', name, 'image', busybox_image])
-            self.cli_set(base_path + ['name', name, 'network', net_name, 'address', str(ip_interface(prefix).ip + ii)])
+            self.cli_set(
+                base_path
+                + [
+                    'name',
+                    name,
+                    'network',
+                    net_name,
+                    'address',
+                    str(ip_interface(prefix).ip + ii),
+                ]
+            )
 
         # verify() - first IP address of a prefix can not be used by a container
         with self.assertRaises(ConfigSessionError):
@@ -201,8 +252,14 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         for ii in range(2, 6):
             name = f'{base_name}-{ii}'
             c = cmd_to_json(f'sudo podman container inspect {name}')
-            self.assertEqual(c['NetworkSettings']['Networks'][net_name]['IPv6Gateway']      , str(ip_interface(prefix).ip + 1))
-            self.assertEqual(c['NetworkSettings']['Networks'][net_name]['GlobalIPv6Address'], str(ip_interface(prefix).ip + ii))
+            self.assertEqual(
+                c['NetworkSettings']['Networks'][net_name]['IPv6Gateway'],
+                str(ip_interface(prefix).ip + 1),
+            )
+            self.assertEqual(
+                c['NetworkSettings']['Networks'][net_name]['GlobalIPv6Address'],
+                str(ip_interface(prefix).ip + ii),
+            )
 
     def test_dual_stack_network(self):
         prefix4 = '192.0.2.0/24'
@@ -216,8 +273,28 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         for ii in range(1, 6):
             name = f'{base_name}-{ii}'
             self.cli_set(base_path + ['name', name, 'image', busybox_image])
-            self.cli_set(base_path + ['name', name, 'network', net_name, 'address', str(ip_interface(prefix4).ip + ii)])
-            self.cli_set(base_path + ['name', name, 'network', net_name, 'address', str(ip_interface(prefix6).ip + ii)])
+            self.cli_set(
+                base_path
+                + [
+                    'name',
+                    name,
+                    'network',
+                    net_name,
+                    'address',
+                    str(ip_interface(prefix4).ip + ii),
+                ]
+            )
+            self.cli_set(
+                base_path
+                + [
+                    'name',
+                    name,
+                    'network',
+                    net_name,
+                    'address',
+                    str(ip_interface(prefix6).ip + ii),
+                ]
+            )
 
         # verify() - first IP address of a prefix can not be used by a container
         with self.assertRaises(ConfigSessionError):
@@ -235,10 +312,22 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         for ii in range(2, 6):
             name = f'{base_name}-{ii}'
             c = cmd_to_json(f'sudo podman container inspect {name}')
-            self.assertEqual(c['NetworkSettings']['Networks'][net_name]['IPv6Gateway']      , str(ip_interface(prefix6).ip + 1))
-            self.assertEqual(c['NetworkSettings']['Networks'][net_name]['GlobalIPv6Address'], str(ip_interface(prefix6).ip + ii))
-            self.assertEqual(c['NetworkSettings']['Networks'][net_name]['Gateway']          , str(ip_interface(prefix4).ip + 1))
-            self.assertEqual(c['NetworkSettings']['Networks'][net_name]['IPAddress']        , str(ip_interface(prefix4).ip + ii))
+            self.assertEqual(
+                c['NetworkSettings']['Networks'][net_name]['IPv6Gateway'],
+                str(ip_interface(prefix6).ip + 1),
+            )
+            self.assertEqual(
+                c['NetworkSettings']['Networks'][net_name]['GlobalIPv6Address'],
+                str(ip_interface(prefix6).ip + ii),
+            )
+            self.assertEqual(
+                c['NetworkSettings']['Networks'][net_name]['Gateway'],
+                str(ip_interface(prefix4).ip + 1),
+            )
+            self.assertEqual(
+                c['NetworkSettings']['Networks'][net_name]['IPAddress'],
+                str(ip_interface(prefix4).ip + ii),
+            )
 
     def test_no_name_server(self):
         prefix = '192.0.2.0/24'
@@ -250,7 +339,17 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
 
         name = f'{base_name}-2'
         self.cli_set(base_path + ['name', name, 'image', busybox_image])
-        self.cli_set(base_path + ['name', name, 'network', net_name, 'address', str(ip_interface(prefix).ip + 2)])
+        self.cli_set(
+            base_path
+            + [
+                'name',
+                name,
+                'network',
+                net_name,
+                'address',
+                str(ip_interface(prefix).ip + 2),
+            ]
+        )
         self.cli_commit()
 
         n = cmd_to_json(f'sudo podman network inspect {net_name}')
@@ -266,7 +365,17 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
 
         name = f'{base_name}-2'
         self.cli_set(base_path + ['name', name, 'image', busybox_image])
-        self.cli_set(base_path + ['name', name, 'network', net_name, 'address', str(ip_interface(prefix).ip + 2)])
+        self.cli_set(
+            base_path
+            + [
+                'name',
+                name,
+                'network',
+                net_name,
+                'address',
+                str(ip_interface(prefix).ip + 2),
+            ]
+        )
         self.cli_commit()
 
         n = cmd_to_json(f'sudo podman network inspect {net_name}')
@@ -306,11 +415,14 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Query API about running containers
-        tmp = cmd("sudo curl --unix-socket /run/podman/podman.sock -H 'content-type: application/json' -sf http://localhost/containers/json")
+        tmp = cmd(
+            "sudo curl --unix-socket /run/podman/podman.sock -H 'content-type: application/json' -sf http://localhost/containers/json"
+        )
         tmp = json.loads(tmp)
 
         # We expect the same amount of containers from the API that we started above
         self.assertEqual(len(container_list), len(tmp))
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Change summary
Adds option to configure podmans log driver

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T7382

## Related PR(s)
* vyos/vyos-documentation/#1625


## How to test / Smoketest result
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_container.py
test_api_socket (__main__.TestContainer.test_api_socket) ... ok
test_basic (__main__.TestContainer.test_basic) ... ok
test_cpu_limit (__main__.TestContainer.test_cpu_limit) ... ok
test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... ok
test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... ok
test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... ok
test_log_driver (__main__.TestContainer.test_log_driver) ... ok
test_name_server (__main__.TestContainer.test_name_server) ... ok
test_network_mtu (__main__.TestContainer.test_network_mtu) ... ok
test_no_name_server (__main__.TestContainer.test_no_name_server) ... ok
test_uid_gid (__main__.TestContainer.test_uid_gid) ... ok
```

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
