### PR TITLE
ospf: T7383: Fixed unconfigured redistribution of nhrp into ospf

### DIFF
--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -92,7 +92,7 @@ def get_frrender_dict(conf, argv=None) -> dict:
             if dict_search(f'area.{area_num}.area_type.nssa', ospf) is None:
                 del default_values['area'][area_num]['area_type']['nssa']
 
-        for protocol in ['babel', 'bgp', 'connected', 'isis', 'kernel', 'rip', 'static']:
+        for protocol in ['babel', 'bgp', 'connected', 'isis', 'kernel', 'nhrp', 'rip', 'static']:
             if dict_search(f'redistribute.{protocol}', ospf) is None:
                 del default_values['redistribute'][protocol]
         if not bool(default_values['redistribute']):


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Fixed unconfigured redistribution of nhrp into ospf.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
 * https://vyos.dev/T7383

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Smoketests
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_ospf.py
test_ospf_01_defaults (__main__.TestProtocolsOSPF.test_ospf_01_defaults) ... ok
test_ospf_02_simple (__main__.TestProtocolsOSPF.test_ospf_02_simple) ... ok
test_ospf_03_access_list (__main__.TestProtocolsOSPF.test_ospf_03_access_list) ... ok
test_ospf_04_default_originate (__main__.TestProtocolsOSPF.test_ospf_04_default_originate) ... ok
test_ospf_05_options (__main__.TestProtocolsOSPF.test_ospf_05_options) ... ok
test_ospf_06_neighbor (__main__.TestProtocolsOSPF.test_ospf_06_neighbor) ... ok
test_ospf_07_redistribute (__main__.TestProtocolsOSPF.test_ospf_07_redistribute) ... ok
test_ospf_08_virtual_link (__main__.TestProtocolsOSPF.test_ospf_08_virtual_link) ... ok
test_ospf_09_interface_configuration (__main__.TestProtocolsOSPF.test_ospf_09_interface_configuration) ... ok
test_ospf_11_interface_area (__main__.TestProtocolsOSPF.test_ospf_11_interface_area) ... ok
test_ospf_12_vrfs (__main__.TestProtocolsOSPF.test_ospf_12_vrfs) ... ok
test_ospf_13_export_list (__main__.TestProtocolsOSPF.test_ospf_13_export_list) ... ok
test_ospf_14_segment_routing_configuration (__main__.TestProtocolsOSPF.test_ospf_14_segment_routing_configuration) ... ok
test_ospf_15_ldp_sync (__main__.TestProtocolsOSPF.test_ospf_15_ldp_sync) ... ok
test_ospf_16_graceful_restart (__main__.TestProtocolsOSPF.test_ospf_16_graceful_restart) ... ok
test_ospf_17_duplicate_area_network (__main__.TestProtocolsOSPF.test_ospf_17_duplicate_area_network) ... ok

----------------------------------------------------------------------
Ran 16 tests in 282.847s

OK
vyos@vyos:~$

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
