### PR TITLE
router-advert: T7389: Duplicate prefix safeguard

### DIFF
--- a/data/templates/router-advert/radvd.conf.j2
+++ b/data/templates/router-advert/radvd.conf.j2
@@ -57,12 +57,20 @@ interface {{ iface }} {
     };
 {%             endfor %}
 {%         endif %}
-{%         if iface_config.auto_ignore is vyos_defined %}
+{%         if iface_config.prefix is vyos_defined and "::/64" in iface_config.prefix %}
+{%             if iface_config.auto_ignore is vyos_defined or iface_config.prefix | count > 1 %}
     autoignoreprefixes {
-{%             for auto_ignore_prefix in iface_config.auto_ignore %}
+{%                 if iface_config.auto_ignore is vyos_defined %}
+{%                     for auto_ignore_prefix in (iface_config.auto_ignore + iface_config.prefix | list) | reject("eq", "::/64") | unique %}
         {{ auto_ignore_prefix }};
-{%             endfor %}
+{%                     endfor %}
+{%                 else %}
+{%                     for auto_ignore_prefix in iface_config.prefix | reject("eq", "::/64") %}
+        {{ auto_ignore_prefix }};
+{%                     endfor %}
+{%                 endif %}
     };
+{%             endif %}
 {%         endif %}
 {%         if iface_config.prefix is vyos_defined %}
 {%             for prefix, prefix_options in iface_config.prefix.items() %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The radvd auto-ignore CLI syntax has been added to VyOS, but a further enhancement could also be added to prevent duplicate prefix advertisements altogether.

For additional context, please see the previous `auto-ignore` CLI PR: https://github.com/vyos/vyos-1x/pull/4463

The merged PR linked above implements the new CLI syntax for `auto-ignore`. This PR introduces a further enhancement to prevent duplicate advertisements when an administrator overrides a prefix on an interface that has been configured with the special `::/64` wildcard prefix.

As an extra safeguard, I propose the following:

When configuring `set service router-advert` for an interface - if the wildcard prefix `::/64` is used AND the administrator overrides a prefix, that overridden prefix should be immediately inserted into the

```
autoignoreprefixes {
};
```

block in /run/radvd/radvd.conf, **regardless** of whether or not the administrator also creates an `auto-ignore` config in the CLI. This would prevent the possibility of the prefix being accidentally advertised twice in the RA, if the administrator forgets to create the `auto-ignore` rule.


Otherwise, the administrator would need to remember to configure auto-ignore at the CLI for every prefix they are overriding configuration for.

For example, suppose I have the following addresses assigned to eth1:

2001:db8::1/64
fd00::1/64
fd01::1/64

If I run the following:

```
# Configure the wildcard prefix
set service router-advert interfaces eth1 prefix ::/64

# Override config for the fd00::/64 prefix
set service router-advert interface eth1 prefix fd00::/64 preferred-lifetime '5555'
set service router-advert interface eth1 prefix fd00::/64 valid-lifetime '9999'
```

After running these commands, VyOS should immediately add the fd00::/64 prefix to autoignoreprefixes in radvd.conf. The resulting radvd.conf should be:

```
### Autogenerated by service_router-advert.py ###

interface eth1 {
    IgnoreIfMissing on;
    AdvDefaultPreference medium;
    MaxRtrAdvInterval 600;
    AdvReachableTime 0;
    AdvIntervalOpt on;
    AdvSendAdvert on;
    AdvOtherConfigFlag off;
    AdvRetransTimer 0;
    AdvCurHopLimit 64;
    autoignoreprefixes {
        fd00::/64;
    };
    prefix ::/64 {
        AdvAutonomous on;
        AdvValidLifetime 2592000;
        AdvOnLink on;
        AdvPreferredLifetime 14400;
        DeprecatePrefix off;
        DecrementLifetimes off;
    };
    prefix fd00::/64 {
        AdvAutonomous on;
        AdvValidLifetime 9999;
        AdvOnLink on;
        AdvPreferredLifetime 5555;
        DeprecatePrefix off;
        DecrementLifetimes off;
    };
};
```

This should happen immediately when the overridden advertisement is added on eth1, since it also contains the wildcard prefix. It should happen automatically without my having to remember to run: `set service router-advert interfaces eth1 auto-ignore fd00::/64`

Otherwise, if I forgot to do this, the result would be duplicate fd00::/64 prefixes being advertised in the RA:

![wireshark-before-aip-duplicate](https://github.com/user-attachments/assets/0aadb039-e387-4d76-bcf8-2af2f405453b)


In my opinion, an RA with duplicate prefixes should never be possible, especially on an enterprise router. I couldn't find a relevant section in any RFC that outlines whether duplicate prefix advertisements are permissible or not. But I can't even imagine a use case or scenario where that would be desirable, as it causes unpredictable behavior in clients.

If these radvd.conf entries were inserted automatically, the admin wouldn't need to worry about it.

In fact, the only time the admin would ever need to manually use the `auto-ignore` CLI syntax is when they specifically want the wildcard to IGNORE a prefix altogether instead of overriding it. To me, this makes 100% perfect sense based on the wording of the radvd syntax for "auto ignore prefixes".


After overriding a prefix advertisement, VyOS should add the entries to autoignoreprefixes block in radvd.conf, but NOT ADD `auto-ignore XXX::/64` to the CLI config tree. Otherwise, the admin could remove the `auto-ignore` CLI config (either accidentally or otherwise) and cause duplicate prefixes to be advertised.

Instead, the overidden prefix will ALWAYS exist in radvd.conf autoignoreprefixes block, regardless of whether an `auto-ignore` CLI config has been manually added. And it will remain there unless and until the administrator deletes the override (or deletes the wildcard prefix).

When generating the autoignoreprefixes block in radvd.conf, VyOS currently just uses all of the `auto-ignore` config nodes created by the administrator in the CLI.

Instead, it should be generated programmatically from the set union between `auto-ignore` CLI nodes AND overridden prefixes, so that each prefix is guaranteed to be only listed once in the autoignoreprefixes block.

It's important to note that this is NOT a bug in VyOS - this behavior is reproducible in pretty much any router OS that uses older versions of radvd as the back-end for generating RA packets. I was actually able to produce duplicate-prefix RAs in an EdgeRouter. As much as I love EdgeOS, with the seemingly slow pace of development in EdgeMAX, I'm not confident that Ubiquiti will ever get around to fixing this problem - but I digress.

This enhancement will make it effectively impossible to configure router advertisements with duplicate prefixes, whether accidentally or intentionally.

I'm open to other suggestions though. Please feel free to share your thoughts or critique.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Make radvd's new "auto ignore prefixes" feature the default behavior for overridden prefixes

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7389

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

On a clean install of VyOS in VirtualBox, configure eth1 as a simulated LAN interface:

```
set interfaces ethernet eth1 address '2001:db8::1/64'
set interfaces ethernet eth1 address 'fd00::1/64'
set interfaces ethernet eth1 address 'fd01::1/64'
```

Configure router advertisements with the wildcard prefix and some arbitrary lifetimes:

```
set service router-advert interface eth1 prefix ::/64
set service router-advert interface eth1 prefix ::/64 preferred-lifetime '7777'
set service router-advert interface eth1 prefix ::/64 valid-lifetime '8888'
```

Now override the `fd00::/64` prefix with different lifetimes:
```
set service router-advert interface eth1 prefix fd00::/64 preferred-lifetime '5555'
set service router-advert interface eth1 prefix fd00::/64 valid-lifetime '9999'
```

The resulting `/run/radvd/radvd.conf` file should now contain:
```
### Autogenerated by service_router-advert.py ###

interface eth1 {
    IgnoreIfMissing on;
    AdvDefaultPreference medium;
    MaxRtrAdvInterval 600;
    AdvReachableTime 0;
    AdvIntervalOpt on;
    AdvSendAdvert on;
    AdvOtherConfigFlag off;
    AdvRetransTimer 0;
    AdvCurHopLimit 64;
    autoignoreprefixes {
        fd00::/64;
    };
    prefix ::/64 {
        AdvAutonomous on;
        AdvValidLifetime 8888;
        AdvOnLink on;
        AdvPreferredLifetime 7777;
        DeprecatePrefix off;
        DecrementLifetimes off;
    };
    prefix fd00::/64 {
        AdvAutonomous on;
        AdvValidLifetime 9999;
        AdvOnLink on;
        AdvPreferredLifetime 5555;
        DeprecatePrefix off;
        DecrementLifetimes off;
    };
};
```

Now let's exclude a prefix instead of overriding it. Exclude the `fd01::/64` prefix using the new CLI syntax:

```
set service router-advert interface eth1 auto-ignore 'fd01::/64'
```

The resulting `/run/radvd/radvd.conf` file should now contain:
```
### Autogenerated by service_router-advert.py ###

interface eth1 {
    IgnoreIfMissing on;
    AdvDefaultPreference medium;
    MaxRtrAdvInterval 600;
    AdvReachableTime 0;
    AdvIntervalOpt on;
    AdvSendAdvert on;
    AdvOtherConfigFlag off;
    AdvRetransTimer 0;
    AdvCurHopLimit 64;
    autoignoreprefixes {
        fd01::/64;
        fd00::/64;
    };
    prefix ::/64 {
        AdvAutonomous on;
        AdvValidLifetime 8888;
        AdvOnLink on;
        AdvPreferredLifetime 7777;
        DeprecatePrefix off;
        DecrementLifetimes off;
    };
    prefix fd00::/64 {
        AdvAutonomous on;
        AdvValidLifetime 9999;
        AdvOnLink on;
        AdvPreferredLifetime 5555;
        DeprecatePrefix off;
        DecrementLifetimes off;
    };
};
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
