### PR TITLE
smoketest: T7400: fix unbound variable when checking VXLAN remote and group settings

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_vxlan.py
+++ b/smoketest/scripts/cli/test_interfaces_vxlan.py
@@ -125,19 +125,17 @@ class VXLANInterfaceTest(BasicInterfaceTest.TestCase):
             'source-interface eth0',
             'vni 60'
         ]
-        params = []
         for option in options:
             opts = option.split()
-            params.append(opts[0])
-            self.cli_set(self._base_path + [ intf ] + opts)
+            self.cli_set(self._base_path + [intf] + opts)
 
-        with self.assertRaises(ConfigSessionError) as cm:
+        # verify() - Both group and remote cannot be specified
+        with self.assertRaises(ConfigSessionError):
             self.cli_commit()
 
-        exception = cm.exception
-        self.assertIn('Both group and remote cannot be specified', str(exception))
-        for param in params:
-            self.cli_delete(self._base_path + [intf, param])
+        # Remove blocking CLI option
+        self.cli_delete(self._base_path + [intf, 'group'])
+        self.cli_commit()
 
 
     def test_vxlan_external(self):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

```
FAIL: test_vxlan_group_remote_error (__main__.VXLANInterfaceTest.test_vxlan_group_remote_error) ---------------------------------------------------------------------- Traceback (most recent call last):
  File "/usr/libexec/vyos/tests/smoke/cli/test_interfaces_vxlan.py", line 139, in test_vxlan_group_remote_error
    self.assertIn('Both group and remote cannot be specified', str(exception))
AssertionError: 'Both group and remote cannot be specified' not found in '[[interfaces vxlan vxlan60]] failed\nCommit failed\n'
```

This happens because cm variable is accessed when no longer valid. Change behavior to match common smoketest style, check ConfigError exception - but do not check exception message. Fix the error and commit again.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7400

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4383

## How to test / Smoketest result

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_vxlan.py
test_add_multiple_ip_addresses (__main__.VXLANInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.VXLANInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.VXLANInterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.VXLANInterfaceTest.test_dhcp_client_options) ... skipped 'unsupported on interface family'
test_dhcp_disable_interface (__main__.VXLANInterfaceTest.test_dhcp_disable_interface) ... skipped 'unsupported on interface family'
test_dhcp_vrf (__main__.VXLANInterfaceTest.test_dhcp_vrf) ... skipped 'unsupported on interface family'
test_dhcpv6_client_options (__main__.VXLANInterfaceTest.test_dhcpv6_client_options) ... skipped 'unsupported on interface family'
test_dhcpv6_vrf (__main__.VXLANInterfaceTest.test_dhcpv6_vrf) ... skipped 'unsupported on interface family'
test_dhcpv6pd_auto_sla_id (__main__.VXLANInterfaceTest.test_dhcpv6pd_auto_sla_id) ... skipped 'unsupported on interface family'
test_dhcpv6pd_manual_sla_id (__main__.VXLANInterfaceTest.test_dhcpv6pd_manual_sla_id) ... skipped 'unsupported on interface family'
test_eapol (__main__.VXLANInterfaceTest.test_eapol) ... skipped 'unsupported on interface family'
test_interface_description (__main__.VXLANInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.VXLANInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.VXLANInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.VXLANInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.VXLANInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.VXLANInterfaceTest.test_ipv6_link_local_address) ... ok
test_move_interface_between_vrf_instances (__main__.VXLANInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.VXLANInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.VXLANInterfaceTest.test_span_mirror) ... skipped 'unsupported on interface family'
test_vif_8021q_interfaces (__main__.VXLANInterfaceTest.test_vif_8021q_interfaces) ... skipped 'unsupported on interface family'
test_vif_8021q_lower_up_down (__main__.VXLANInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'unsupported on interface family'
test_vif_8021q_mtu_limits (__main__.VXLANInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'unsupported on interface family'
test_vif_8021q_qos_change (__main__.VXLANInterfaceTest.test_vif_8021q_qos_change) ... skipped 'unsupported on interface family'
test_vif_s_8021ad_vlan_interfaces (__main__.VXLANInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'unsupported on interface family'
test_vif_s_protocol_change (__main__.VXLANInterfaceTest.test_vif_s_protocol_change) ... skipped 'unsupported on interface family'
test_vxlan_external (__main__.VXLANInterfaceTest.test_vxlan_external) ... ok
test_vxlan_group_remote_error (__main__.VXLANInterfaceTest.test_vxlan_group_remote_error) ... ok
test_vxlan_neighbor_suppress (__main__.VXLANInterfaceTest.test_vxlan_neighbor_suppress) ... ok
test_vxlan_parameters (__main__.VXLANInterfaceTest.test_vxlan_parameters) ... ok
test_vxlan_vlan_vni_mapping (__main__.VXLANInterfaceTest.test_vxlan_vlan_vni_mapping) ... ok
test_vxlan_vni_filter (__main__.VXLANInterfaceTest.test_vxlan_vni_filter) ... ok
test_vxlan_vni_filter_add_remove (__main__.VXLANInterfaceTest.test_vxlan_vni_filter_add_remove) ... ok

----------------------------------------------------------------------
Ran 33 tests in 299.501s

OK (skipped=15)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
