### PR TITLE
T7397: add "system kernel option quiet" to suppress boot messages

### DIFF
--- a/interface-definitions/system_option.xml.in
+++ b/interface-definitions/system_option.xml.in
@@ -69,6 +69,12 @@
                   </valueHelp>
                 </properties>
               </leafNode>
+              <leafNode name="quiet">
+                <properties>
+                  <help>Disable most log messages</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
               <node name="debug">
                 <properties>
                   <help>Dynamic debugging for kernel module</help>

--- a/smoketest/scripts/system/test_kernel_options.py
+++ b/smoketest/scripts/system/test_kernel_options.py
@@ -134,5 +134,14 @@ class TestKernelModules(unittest.TestCase):
             tmp = re.findall(f'{option}=y', self._config_data)
             self.assertTrue(tmp)
 
+    def test_amd_pstate(self):
+        # AMD pstate driver required as we have "set system option kernel amd-pstate-driver"
+        for option in ['CONFIG_X86_AMD_PSTATE']:
+            tmp = re.findall(f'{option}=y', self._config_data)
+            self.assertTrue(tmp)
+        for option in ['CONFIG_X86_AMD_PSTATE_DEFAULT_MODE']:
+            tmp = re.findall(f'{option}=3', self._config_data)
+            self.assertTrue(tmp)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/system_option.py
+++ b/src/conf_mode/system_option.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2019-2024 VyOS maintainers and contributors
+# Copyright (C) 2019-2025 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -136,6 +136,8 @@ def generate(options):
             mode = options['kernel']['amd_pstate_driver']
             cmdline_options.append(
                 f'initcall_blacklist=acpi_cpufreq_init amd_pstate={mode}')
+        if 'quiet' in options['kernel']:
+            cmdline_options.append('quiet')
     grub_util.update_kernel_cmdline_options(' '.join(cmdline_options))
 
     return None

--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -504,6 +504,8 @@ def get_cli_kernel_options(config_file: str) -> list:
         mode = kernel_options['amd-pstate-driver']
         cmdline_options.append(
             f'initcall_blacklist=acpi_cpufreq_init amd_pstate={mode}')
+    if 'quiet' in kernel_options:
+        cmdline_options.append('quiet')
 
     return cmdline_options
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Add option to limit the number of messages that are displayed on the console during the boot process and to persist this setting with image upgrades.

`set system option kernel quiet`


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7397

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-documentation/pull/1632

## How to test / Smoketest result

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_option.py
test_ctrl_alt_delete (__main__.TestSystemOption.test_ctrl_alt_delete) ... ok
test_kernel_options (__main__.TestSystemOption.test_kernel_options) ... ok
test_performance (__main__.TestSystemOption.test_performance) ... ok
test_reboot_on_panic (__main__.TestSystemOption.test_reboot_on_panic) ... ok
test_ssh_client_options (__main__.TestSystemOption.test_ssh_client_options) ... ok

----------------------------------------------------------------------
Ran 5 tests in 15.926s

OK
```

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/system/test_kernel_options.py
test_amd_pstate (__main__.TestKernelModules.test_amd_pstate) ... ok
test_bond_interface (__main__.TestKernelModules.test_bond_interface) ... ok
test_bridge_interface (__main__.TestKernelModules.test_bridge_interface) ... ok
test_container_cgroup_support (__main__.TestKernelModules.test_container_cgroup_support) ... ok
test_container_cpu (__main__.TestKernelModules.test_container_cpu) ... ok
test_dropmon_enabled (__main__.TestKernelModules.test_dropmon_enabled) ... ok
test_ip_routing_support (__main__.TestKernelModules.test_ip_routing_support) ... ok
test_psample_enabled (__main__.TestKernelModules.test_psample_enabled) ... ok
test_qemu_support (__main__.TestKernelModules.test_qemu_support) ... ok
test_synproxy_enabled (__main__.TestKernelModules.test_synproxy_enabled) ... ok
test_vfio (__main__.TestKernelModules.test_vfio) ... ok
test_vmware_support (__main__.TestKernelModules.test_vmware_support) ... ok

----------------------------------------------------------------------
Ran 12 tests in 0.012s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
