### PR TITLE
T7412: Allow privileged containers

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -75,6 +75,12 @@
               <multi/>
             </properties>
           </leafNode>
+          <leafNode name="privileged">
+             <properties>
+               <help>Grant root capabilities to the container</help>
+               <valueless/>
+             </properties>
+           </leafNode>
           <node name="sysctl">
             <properties>
               <help>Configure namespaced kernel parameters of the container</help>

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -324,6 +324,11 @@ def generate_run_arguments(name, container_config):
             cap = cap.upper().replace('-', '_')
             capabilities += f' --cap-add={cap}'
 
+    # Grant root capabilities to the container
+    privileged = ''
+    if 'privileged' in container_config:
+        privileged = '--privileged'
+
     # Add a host device to the container /dev/x:/dev/x
     device = ''
     if 'device' in container_config:
@@ -402,7 +407,7 @@ def generate_run_arguments(name, container_config):
         for ns in container_config['name_server']:
             name_server += f'--dns {ns}'
 
-    container_base_cmd = f'--detach --interactive --tty --replace {capabilities} --cpus {cpu_quota} {sysctl_opt} ' \
+    container_base_cmd = f'--detach --interactive --tty --replace {capabilities} {privileged} --cpus {cpu_quota} {sysctl_opt} ' \
                          f'--memory {memory}m --shm-size {shared_memory}m --memory-swap 0 --restart {restart} ' \
                          f'--name {name} {hostname} {device} {port} {name_server} {volume} {tmpfs} {env_opt} {label} {uid} {host_pid}'
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Add `--privileged` flag to Containers

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

https://vyos.dev/T7412

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Example Config

```
add container image docker.io/tynany/frr_exporter:v1.5.0
set container name frr-exporter allow-host-networks
set container name frr-exporter command '--no-collector.bfd --no-collector.ospf --collector.bgp --collector.bgp6 --collector.bgp.peer-descriptions --collector.bgp.peer-descriptions.plain-text --web.listen-address=localhost:9342'
set container name frr-exporter image 'docker.io/tynany/frr_exporter:v1.5.0'
set container name frr-exporter restart 'on-failure'
set container name frr-exporter volume sockets destination '/var/run/frr'
set container name frr-exporter volume sockets source '/var/run/frr'
```

When running the above, we can see if it is a privileged container

```
vyos@vyos# sudo podman inspect frr-exporter | jq '.[0].HostConfig.Privileged'
false

```

After adding the changes in this PR, we can add

```
set container name frr-exporter privileged
```

and see it is now a privileged container

```
vyos@vyos# sudo podman inspect frr-exporter | jq '.[0].HostConfig.Privileged'
true

vyos@vyos# cat /run/systemd/system/vyos-container-frr-exporter.service | grep --color privileged
        --detach --interactive --tty --replace  --privileged --cpus 0  --memory 512m --shm-size 64m --memory-swap 0 --restart on-failure --name frr-exporter      --volume /var/run/frr:/var/run/frr:rw,rprivate      --net host  docker.io/tynany/frr_exporter:v1.5.0 --no-collector.bfd --no-collector.ospf --collector.bgp --collector.bgp6 --collector.bgp.peer-descriptions --collector.bgp.peer-descriptions.plain-text --web.listen-address=localhost:9342
```


Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
