### PR TITLE
policy: T5069: large-community-list regex validator disallows whitespace

### DIFF
--- a/src/validators/bgp-large-community-list
+++ b/src/validators/bgp-large-community-list
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2023 VyOS maintainers and contributors
+# Copyright (C) 2021-2025 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -17,18 +17,27 @@
 import re
 import sys
 
-pattern = '(.*):(.*):(.*)'
-allowedChars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', '+', '*', '?', '^', '$', '(', ')', '[', ']', '{', '}', '|', '\\', ':', '-' }
+allowedChars = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', '+', '*', '?', '^', '$', '(', ')', '[', ']', '{', '}', '|', '\\', ':', '-', '_', ' ' }
 
 if __name__ == '__main__':
     if len(sys.argv) != 2:
         sys.exit(1)
 
-    value = sys.argv[1].split(':')
-    if not len(value) == 3:
+    value = sys.argv[1]
+
+    # Require at least one well-formed large-community tuple in the pattern. 
+    tmp = value.split(':')
+    if len(tmp) < 3:
         sys.exit(1)
 
-    if not (re.match(pattern, sys.argv[1]) and set(sys.argv[1]).issubset(allowedChars)):
+    # Simple guard against invalid community & 1003.2 pattern chars
+    if not set(value).issubset(allowedChars):
+        sys.exit(1)
+
+    # Don't feed FRR badly formed regex
+    try:
+        re.compile(value)
+    except re.error:
         sys.exit(1)
 
     sys.exit(0)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
NOTE: Potentially hijacking an old ticket with a similar problem. 

T5816 improved 1.4/1.5's strict validation to allow full regex on a single large-community tuple. However, it is common to match multiple components of a large-community string via regex in earlier VyOS versions (not to mention Cisco IOS). T5816 is too strict about the form of the regex pattern, does not allow the common-separator wildcard '_' and whitespace, breaking old 1.3 configs and preventing simple pattern logic being used to match multiple communities. 

To resolve T5069's concerns and my own, this patch attempts to:
 * Perform basic, easy sanity checks that should always pass:
   * Contain at least one well-formed tuple
   * Permit only specific characters valid in community strings and POSIX regex
   * Rejecting obviously incorrect regular expressions, treating Python regex as a superset of POSIX
 * Run a final "sanity check" regex across the top, issue a warning if the overall pattern is not considered well formed

"Well formed" in this case would be one or more community segments roughly fitting the original check, separated by proper whitespace. "1:1:12:2:2" might be a mistake for "1:1:1 2:2:2", but there are still instances of useful patterns not following this form. 

Since there's no mechanism for providing warning feedback from a validator and validator output is thrown away unless an error, I've wrapped this in the console_warning() function and it just prints directly to the TTY. If this seems like overkill, if it could be more generally useful, or if there's a suitable mechanism I missed - I imagine validation success/warning/failure feedback could be useful at API level, not just CLI - let me know and I'll update it to match. 

If we retain the warning, I'll likely issue a followup patch for the documentation explaining the specific validation logic and what to check when the warning pops up. 

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T5069
* https://vyos.dev/T5816 - only for reference

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
# Example tests via CLI:
vyos@TEST-VYOS-LEFT# set policy large-community-list TEST rule 20 regex "1:1"

  
  
  
  Malformed large-community-list
  Value validation failed
  Set failed

[edit]
vyos@TEST-VYOS-LEFT# set policy large-community-list TEST rule 20 regex "1:1:1"
[edit]
vyos@TEST-VYOS-LEFT# set policy large-community-list TEST rule 20 regex "1:1:12:2:2"
WARNING: Regex does not follow expected form and may not match as expected.
[edit]
vyos@TEST-VYOS-LEFT# set policy large-community-list TEST rule 20 regex "1:1:1 2:2:2"
[edit]
vyos@TEST-VYOS-LEFT# set policy large-community-list TEST rule 20 regex "1:1:1_.*_2:2:2"
[edit]
vyos@TEST-VYOS-LEFT# set policy large-community-list TEST rule 20 regex "1:1:1_.*_2:2:2:"
WARNING: Regex does not follow expected form and may not match as expected.
[edit]
vyos@TEST-VYOS-LEFT# set policy large-community-list TEST rule 20 regex "1:1:1_.*(_2:2:2)"
[edit]
vyos@TEST-VYOS-LEFT# set policy large-community-list TEST rule 20 regex "1:1:1_.*(_2:2:2))"

  
  
  
  Malformed large-community-list
  Value validation failed
  Set failed

[edit]
```

I've checked that these compound matches are accepted by FRR and work in a production BGP environment as the older versions of FRR in 1.3 did. 

Smoketests, test_policy.py:
```
Ran 28 tests in 375.194s

OK
```

test_protocols_bgp.py:
```
Ran 30 tests in 438.052s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
