### PR TITLE
T7386: firewall: Allow IPv6 member in firewall remote-groups

### DIFF
--- a/data/templates/firewall/nftables-defines.j2
+++ b/data/templates/firewall/nftables-defines.j2
@@ -44,6 +44,15 @@
     }
 {%         endfor %}
 {%     endif %}
+{%     if group.remote_group is vyos_defined and is_l3 and is_ipv6 %}
+{%         for name, name_config in group.remote_group.items() %}
+    set R6_{{ name }} {
+        type {{ ip_type }}
+        flags interval
+        auto-merge
+    }
+{%         endfor %}
+{%     endif %}
 {%     if group.mac_group is vyos_defined %}
 {%         for group_name, group_conf in group.mac_group.items() %}
 {%             set includes = group_conf.include if group_conf.include is vyos_defined else [] %}

--- a/interface-definitions/include/firewall/common-rule-ipv6.xml.i
+++ b/interface-definitions/include/firewall/common-rule-ipv6.xml.i
@@ -16,6 +16,7 @@
     #include <include/firewall/port.xml.i>
     #include <include/firewall/source-destination-group-ipv6.xml.i>
     #include <include/firewall/source-destination-dynamic-group-ipv6.xml.i>
+    #include <include/firewall/source-destination-remote-group.xml.i>
   </children>
 </node>
 <leafNode name="jump-target">
@@ -39,6 +40,7 @@
     #include <include/firewall/port.xml.i>
     #include <include/firewall/source-destination-group-ipv6.xml.i>
     #include <include/firewall/source-destination-dynamic-group-ipv6.xml.i>
+    #include <include/firewall/source-destination-remote-group.xml.i>
   </children>
 </node>
 <!-- include end -->

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -635,3 +635,19 @@ def is_valid_ipv4_address_or_range(addr: str) -> bool:
             return ip_network(addr).version == 4
     except:
         return False
+
+def is_valid_ipv6_address_or_range(addr: str) -> bool:
+    """
+    Validates if the provided address is a valid IPv4, CIDR or IPv4 range
+    :param addr: address to test
+    :return: bool: True if provided address is valid
+    """
+    from ipaddress import ip_network
+    try:
+        if '-' in addr: # If we are checking a range, validate both address's individually
+            split = addr.split('-')
+            return is_valid_ipv6_address_or_range(split[0]) and is_valid_ipv6_address_or_range(split[1])
+        else:
+            return ip_network(addr).version == 6
+    except:
+        return False

--- a/src/op_mode/firewall.py
+++ b/src/op_mode/firewall.py
@@ -18,12 +18,16 @@ import argparse
 import ipaddress
 import json
 import re
+from signal import signal, SIGPIPE, SIG_DFL
 import tabulate
 import textwrap
 
 from vyos.config import Config
 from vyos.utils.process import cmd
 from vyos.utils.dict import dict_search_args
+
+signal(SIGPIPE, SIG_DFL)
+
 
 def get_config_node(conf, node=None, family=None, hook=None, priority=None):
     if node == 'nat':

--- a/src/op_mode/firewall.py
+++ b/src/op_mode/firewall.py
@@ -648,12 +648,14 @@ def show_firewall_group(name=None):
                 references = find_references(group_type, remote_name)
                 row = [remote_name, textwrap.fill(remote_conf.get('description') or '', 50), group_type, '\n'.join(references) or 'N/D']
                 members = get_nftables_remote_group_members("ipv4", 'vyos_filter', f'R_{remote_name}')
+                members6 = get_nftables_remote_group_members("ipv6", 'vyos_filter', f'R6_{remote_name}')
 
                 if 'url' in remote_conf:
                     # display only the url if no members are found for both views
-                    if not members:
+                    if not members and not members6:
                         if args.detail:
-                            header_tail = ['Remote URL']
+                            header_tail = ['IPv6 Members', 'Remote URL']
+                            row.append('N/D')
                             row.append('N/D')
                             row.append(remote_conf['url'])
                         else:
@@ -662,8 +664,15 @@ def show_firewall_group(name=None):
                     else:
                         # display all table elements in detail view
                         if args.detail:
-                            header_tail = ['Remote URL']
-                            row += [' '.join(members)]
+                            header_tail = ['IPv6 Members', 'Remote URL']
+                            if members:
+                                row.append(' '.join(members))
+                            else:
+                                row.append('N/D')
+                            if members6:
+                                row.append(' '.join(members6))
+                            else:
+                                row.append('N/D')
                             row.append(remote_conf['url'])
                             rows.append(row)
                         else:

--- a/src/services/vyos-domain-resolver
+++ b/src/services/vyos-domain-resolver
@@ -28,7 +28,7 @@ from vyos.utils.commit import commit_in_progress
 from vyos.utils.dict import dict_search_args
 from vyos.utils.kernel import WIREGUARD_REKEY_AFTER_TIME
 from vyos.utils.file import makedir, chmod_775, write_file, read_file
-from vyos.utils.network import is_valid_ipv4_address_or_range
+from vyos.utils.network import is_valid_ipv4_address_or_range, is_valid_ipv6_address_or_range
 from vyos.utils.process import cmd
 from vyos.utils.process import run
 from vyos.xml_ref import get_defaults
@@ -143,10 +143,11 @@ def update_remote_group(config):
         for set_name, remote_config in remote_groups.items():
             if 'url' not in remote_config:
                 continue
-            nft_set_name = f'R_{set_name}'
+            nft_ip_set_name = f'R_{set_name}'
+            nft_ip6_set_name = f'R6_{set_name}'
 
             # Create list file if necessary
-            list_file = os.path.join(firewall_config_dir, f"{nft_set_name}.txt")
+            list_file = os.path.join(firewall_config_dir, f"{nft_ip_set_name}.txt")
             if not os.path.exists(list_file):
                 write_file(list_file, '', user="root", group="vyattacfg", mode=0o644)
 
@@ -159,16 +160,32 @@ def update_remote_group(config):
 
             # Read list file
             ip_list = []
+            ip6_list = []
+            invalid_list = []
             for line in read_file(list_file).splitlines():
                 line_first_word = line.strip().partition(' ')[0]
 
                 if is_valid_ipv4_address_or_range(line_first_word):
                     ip_list.append(line_first_word)
+                elif is_valid_ipv6_address_or_range(line_first_word):
+                    ip6_list.append(line_first_word)
+                else:
+                    if line_first_word[0].isalnum():
+                        invalid_list.append(line_first_word)
 
-            # Load tables
+            # Load ip tables
             for table in ipv4_tables:
-                if (table, nft_set_name) in valid_sets:
-                    conf_lines += nft_output(table, nft_set_name, ip_list)
+                if (table, nft_ip_set_name) in valid_sets:
+                    conf_lines += nft_output(table, nft_ip_set_name, ip_list)
+
+            # Load ip6 tables
+            for table in ipv6_tables:
+                if (table, nft_ip6_set_name) in valid_sets:
+                    conf_lines += nft_output(table, nft_ip6_set_name, ip6_list)
+
+            invalid_str = ", ".join(invalid_list)
+            if invalid_str:
+                logger.info(f'Invalid address for set {set_name}: {invalid_str}')
 
             count += 1
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
In the current implementation, firewall remote-groups support only IPv4 addresses, ranges, or prefixes. This PR extends that functionality to also support IPv6 addresses, ranges, and prefixes. Additionally, it updates the validation logic to log invalid IPv4 and IPv6 entries to the system log, while continuing to ignore comments in the downloaded file. Due to the potential for large output from group members, BrokenPipeError handling has been added to the op-mode show commands.

Lastly, all modified Python files were formatted with Ruff to ensure compliance with code standards.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
[https://vyos.dev/T7386](https://vyos.dev/T7386)

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
Documentation Update [PR 1634](https://github.com/vyos/vyos-documentation/pull/1634)

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_firewall.py
test_ipv4_remote_group (__main__.TestFirewall.test_ipv4_remote_group) ... ok
test_ipv6_remote_group (__main__.TestFirewall.test_ipv6_remote_group) ... ok
test_remote_group (__main__.TestFirewall.test_remote_group) ... ok
----------------------------------------------------------------------
Ran 28 tests in 114.552s
OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
