### PR TITLE
nat66: T7051: snat group as destination

### DIFF
--- a/interface-definitions/nat66.xml.in
+++ b/interface-definitions/nat66.xml.in
@@ -53,6 +53,7 @@
                     </properties>
                   </leafNode>
                   #include <include/nat-port.xml.i>
+                  #include <include/firewall/source-destination-group-ipv6.xml.i>
                 </children>
               </node>
               <node name="source">

--- a/smoketest/scripts/cli/test_nat66.py
+++ b/smoketest/scripts/cli/test_nat66.py
@@ -227,6 +227,35 @@ class TestNAT66(VyOSUnitTestSHIM.TestCase):
 
         self.verify_nftables(nftables_search, 'ip6 vyos_nat')
 
+    def test_source_nat66_network_group(self):
+        address_group = 'smoketest_addr'
+        address_group_member = 'fc00::1'
+        network_group = 'smoketest_net'
+        network_group_member = 'fc00::/64'
+        translation_prefix = 'fc01::/64'
+
+        self.cli_set(['firewall', 'group', 'ipv6-address-group', address_group, 'address', address_group_member])
+        self.cli_set(['firewall', 'group', 'ipv6-network-group', network_group, 'network', network_group_member])
+
+        self.cli_set(src_path + ['rule', '1', 'destination', 'group', 'address-group', address_group])
+        self.cli_set(src_path + ['rule', '1', 'translation', 'address', translation_prefix])
+
+        self.cli_set(src_path + ['rule', '2', 'destination', 'group', 'network-group', network_group])
+        self.cli_set(src_path + ['rule', '2', 'translation', 'address', translation_prefix])
+
+        self.cli_commit()
+
+        nftables_search = [
+            [f'set A6_{address_group}'],
+            [f'elements = {{ {address_group_member} }}'],
+            [f'set N6_{network_group}'],
+            [f'elements = {{ {network_group_member} }}'],
+            ['ip6 daddr', f'@A6_{address_group}', 'snat prefix to fc01::/64'],
+            ['ip6 daddr', f'@N6_{network_group}', 'snat prefix to fc01::/64']
+        ]
+
+        self.verify_nftables(nftables_search, 'ip6 vyos_nat')
+
     def test_nat66_no_rules(self):
         # T3206: deleting all rules but keep the direction 'destination' or
         # 'source' resulteds in KeyError: 'rule'.

--- a/src/conf_mode/nat66.py
+++ b/src/conf_mode/nat66.py
@@ -92,6 +92,10 @@ def verify(nat):
             if prefix != None:
                 if not is_ipv6(prefix):
                     raise ConfigError(f'{err_msg} source-prefix not specified')
+                
+            if 'destination' in config and 'group' in config['destination']:
+                if len({'address_group', 'network_group', 'domain_group'} & set(config['destination']['group'])) > 1:
+                    raise ConfigError('Only one address-group, network-group or domain-group can be specified')
 
     if dict_search('destination.rule', nat):
         for rule, config in dict_search('destination.rule', nat).items():


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add CLI config node for "group" when configuring NAT66 source

Ensure there is only one group in NAT66 source rule config

Add smoketest to cover new group usage in source NAT66 rules
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6679 - Implements destination groups for NAT66.

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Create some IPv6 network-groups as an example:

```
set firewall group ipv6-network-group ULA network 'fd00::/64'
set firewall group ipv6-network-group ULA2 network 'fd88::/64'
```

Configure SNAT using IPv6 network groups:

```
set nat66 source rule 10 destination group network-group 'ULA'
set nat66 source rule 10 translation address 'masquerade'

set nat66 source rule 20 destination group network-group 'ULA2'
set nat66 source rule 20 translation address 'fd99::/64'
```

Smoketest output:

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_nat66.py
test_destination_nat66 (__main__.TestNAT66.test_destination_nat66) ... ok
test_destination_nat66_network_group (__main__.TestNAT66.test_destination_nat66_network_group) ... ok
test_destination_nat66_prefix (__main__.TestNAT66.test_destination_nat66_prefix) ... ok
test_destination_nat66_protocol (__main__.TestNAT66.test_destination_nat66_protocol) ... ok
test_destination_nat66_without_translation_address (__main__.TestNAT66.test_destination_nat66_without_translation_address) ... ok
test_nat66_no_rules (__main__.TestNAT66.test_nat66_no_rules) ... ok
test_source_nat66 (__main__.TestNAT66.test_source_nat66) ... ok
test_source_nat66_address (__main__.TestNAT66.test_source_nat66_address) ... ok
test_source_nat66_network_group (__main__.TestNAT66.test_source_nat66_network_group) ... ok
test_source_nat66_protocol (__main__.TestNAT66.test_source_nat66_protocol) ... ok
test_source_nat66_required_translation_prefix (__main__.TestNAT66.test_source_nat66_required_translation_prefix) ... ok

----------------------------------------------------------------------
Ran 11 tests in 36.652s

OK
vyos@vyos:~$
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
