### PR TITLE
https: T7393: set listen-address bind fails silently without restart

### DIFF
--- a/src/conf_mode/service_https.py
+++ b/src/conf_mode/service_https.py
@@ -28,6 +28,7 @@ from vyos.configverify import verify_vrf
 from vyos.configverify import verify_pki_certificate
 from vyos.configverify import verify_pki_ca_certificate
 from vyos.configverify import verify_pki_dh_parameters
+from vyos.configdiff import get_config_diff
 from vyos.defaults import api_config_state
 from vyos.pki import wrap_certificate
 from vyos.pki import wrap_private_key
@@ -79,6 +80,14 @@ def get_config(config=None):
 
     # merge CLI and default dictionary
     https = config_dict_merge(default_values, https)
+
+    # some settings affecting nginx will require a restart:
+    # for example, a reload will not suffice when binding the listen address
+    # after nginx has started and dropped privileges; add flag here
+    diff = get_config_diff(conf)
+    children_changed = diff.node_changed_children(base)
+    https['nginx_restart_required'] = bool(set(children_changed) != set(['api']))
+
     return https
 
 def verify(https):
@@ -208,7 +217,10 @@ def apply(https):
     elif is_systemd_service_active(http_api_service_name):
         call(f'systemctl stop {http_api_service_name}')
 
-    call(f'systemctl reload-or-restart {https_service_name}')
+    if https['nginx_restart_required']:
+        call(f'systemctl restart {https_service_name}')
+    else:
+        call(f'systemctl reload-or-restart {https_service_name}')
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The config-mode script `service_https.py` apply stage calls `systemctl reload-or-restart` on the https server, however, some settings require an explicit restart or will silently fail, since nginx drops privileges after start up.

Distinguish cases where a service restart may be needed and check in apply stage.

Add smoketest.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
