### PR TITLE
node_exporter: T7416: Add missing backslash in node_exporter.service

### DIFF
--- a/data/templates/prometheus/node_exporter.service.j2
+++ b/data/templates/prometheus/node_exporter.service.j2
@@ -9,6 +9,11 @@ After=network.target
 User=node_exporter
 {% endif %}
 ExecStart={{ vrf_command }}/usr/sbin/node_exporter \
+{% if collectors is vyos_defined %}
+{%     if collectors.textfile is vyos_defined %}
+        --collector.textfile.directory=/run/node_exporter/collector \
+{%     endif %}
+{% endif %}
 {% if listen_address is vyos_defined %}
 {%     for address in listen_address %}
         --web.listen-address={{ address }}:{{ port }}
@@ -16,10 +21,6 @@ ExecStart={{ vrf_command }}/usr/sbin/node_exporter \
 {% else %}
         --web.listen-address=:{{ port }}
 {% endif %}
-{% if collectors is vyos_defined %}
-{%     if collectors.textfile is vyos_defined %}
-        --collector.textfile.directory=/run/node_exporter/collector
-{%     endif %}
-{% endif %}
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Fixes missing trailing backslash in node_exporter.service template. Ensures proper loading of collectors when collectors.textfile is defined.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7416

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# show service monitoring |commands
set prometheus node-exporter collectors textfile
set prometheus node-exporter listen-address '127.0.0.1'
```
and the systemd unit file:
```
[Service]
User=node_exporter
ExecStart=/usr/sbin/node_exporter \
        --web.listen-address=127.0.0.1:9100
        --collector.textfile.directory=/run/node_exporter/collector

root@vyos:/# ps -ef |grep node_exporter 
node_ex+ 2337282       1  0 15:53 ?        00:00:00 /usr/sbin/node_exporter --web.listen-address=127.0.0.1:9100
```
after this patch:

```
[Service]
User=node_exporter
ExecStart=/usr/sbin/node_exporter \
        --collector.textfile.directory=/run/node_exporter/collector \
        --web.listen-address=127.0.0.1:9100

vyos@vyos# sudo ps -ef |grep node_exporter 
node_ex+ 2340103       1  0 16:30 ?        00:00:00 /usr/sbin/node_exporter --collector.textfile.directory=/run/node_exporter/collector --web.listen-address=127.0.0.1:9100
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
