### PR TITLE
QoS: T7415: Fix tcp flags matching

### DIFF
--- a/interface-definitions/include/qos/tcp-flags.xml.i
+++ b/interface-definitions/include/qos/tcp-flags.xml.i
@@ -1,21 +1,21 @@
 <!-- include start from qos/tcp-flags.xml.i -->
-<leafNode name="tcp">
+<node name="tcp">
   <properties>
     <help>TCP Flags matching</help>
-    <completionHelp>
-      <list>ack syn</list>
-    </completionHelp>
-    <valueHelp>
-      <format>ack</format>
-      <description>Match TCP ACK</description>
-    </valueHelp>
-    <valueHelp>
-      <format>syn</format>
-      <description>Match TCP SYN</description>
-    </valueHelp>
-    <constraint>
-      <regex>(ack|syn)</regex>
-    </constraint>
   </properties>
-</leafNode>
+  <children>
+    <leafNode name="ack">
+      <properties>
+        <help>Match TCP ACK</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+    <leafNode name="syn">
+      <properties>
+        <help>Match TCP SYN</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+  </children>
+</node>
 <!-- include end -->

--- a/interface-definitions/include/qos/tcp-flags.xml.i
+++ b/interface-definitions/include/qos/tcp-flags.xml.i
@@ -1,21 +1,21 @@
 <!-- include start from qos/tcp-flags.xml.i -->
-<node name="tcp">
+<leafNode name="tcp">
   <properties>
     <help>TCP Flags matching</help>
+    <completionHelp>
+      <list>ack syn</list>
+    </completionHelp>
+    <valueHelp>
+      <format>ack</format>
+      <description>Match TCP ACK</description>
+    </valueHelp>
+    <valueHelp>
+      <format>syn</format>
+      <description>Match TCP SYN</description>
+    </valueHelp>
+    <constraint>
+      <regex>(ack|syn)</regex>
+    </constraint>
   </properties>
-  <children>
-    <leafNode name="ack">
-      <properties>
-        <help>Match TCP ACK</help>
-        <valueless/>
-      </properties>
-    </leafNode>
-    <leafNode name="syn">
-      <properties>
-        <help>Match TCP SYN</help>
-        <valueless/>
-      </properties>
-    </leafNode>
-  </children>
-</node>
+</leafNode>
 <!-- include end -->

--- a/src/conf_mode/qos.py
+++ b/src/conf_mode/qos.py
@@ -85,7 +85,13 @@ def _clean_conf_dict(conf):
         }
     """
     if isinstance(conf, dict):
-        return {node: _clean_conf_dict(val) for node, val in conf.items() if val != {} and _clean_conf_dict(val) != {}}
+        preserve_empty_nodes = {'syn', 'ack'}
+
+        return {
+            node: _clean_conf_dict(val)
+            for node, val in conf.items()
+            if (val != {} and _clean_conf_dict(val) != {}) or node in preserve_empty_nodes
+        }
     else:
         return conf
 


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
This fixes incorrect behavior in T7415. The qos.py conf-mode script cleans empty dictionaries. Since the `ack` and `syn` entries were not values, but valueless leafnodes themselves, it caused the entries to not be applied.

This moves the `syn` and `ack` to values under the `tcp` leafnode.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7415

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Configure QoS policy:
```
set qos interface eth1 egress 'EGRESS-QOS'
set qos policy shaper EGRESS-QOS bandwidth '20gbit'
set qos policy shaper EGRESS-QOS class 2 bandwidth '20%'
set qos policy shaper EGRESS-QOS class 2 ceiling '100%'
set qos policy shaper EGRESS-QOS class 2 description 'TEST'
set qos policy shaper EGRESS-QOS class 2 match-group 'qACK'
set qos policy shaper EGRESS-QOS class 2 priority '0'
set qos policy shaper EGRESS-QOS class 2 queue-type 'fair-queue'
set qos policy shaper EGRESS-QOS default bandwidth '43%'
set qos policy shaper EGRESS-QOS default ceiling '100%'
set qos policy shaper EGRESS-QOS default priority '7'
set qos policy shaper EGRESS-QOS default queue-type 'random-detect'
set qos policy shaper EGRESS-QOS description 'test1'
set qos traffic-match-group qACK match ACK ip tcp 'ack'
set qos traffic-match-group qACK match SYNACK ip tcp 'syn'
```
Verify counters with `show qos shaper`:
```
vyos@cli-dev# run show qos shaper
--------------------------------------------------------------------------------
Interface: eth1
Policy Name: EGRESS-QOS

Class    Type      Bandwidth    Max. BW     Bytes    Pkts    Drops    Queued
-------  ------  -----------  ---------  --------  ------  -------  --------
root     htb       20.000 Gb  20.000 Gb  7.560 KB      50        0         0
2        sfq        4.000 Gb   1.000 Gb  7.266 KB      47        0         0
default  red        8.600 Gb  20.000 Gb    294  B       3        0         0
```
Verify `tc filter`:
```
vyos@cli-dev# sudo tc filter show dev eth1
filter parent 1: protocol all pref 49151 u32 chain 0
filter parent 1: protocol all pref 49151 u32 chain 0 fh 801: ht divisor 1
filter parent 1: protocol all pref 49151 u32 chain 0 fh 801::800 order 2048 key ht 801 bkt 0 flowid 1:2 not_in_hw
  match 00020000/00020000 at 32
        action order 1:  police 0x1 rate 200Mbit burst 15325b mtu 2Kb action reclassify overhead 0b
        ref 1 bind 1

filter parent 1: protocol all pref 49152 u32 chain 0
filter parent 1: protocol all pref 49152 u32 chain 0 fh 800: ht divisor 1
filter parent 1: protocol all pref 49152 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 flowid 1:2 not_in_hw
  match 00100000/00100000 at 32
```
Smoketest results:
```
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... ok
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok
test_12_shaper_with_red_queue (__main__.TestQoS.test_12_shaper_with_red_queue) ... ok
test_13_shaper_delete_only_rule (__main__.TestQoS.test_13_shaper_delete_only_rule) ... ok
test_14_policy_limiter_marked_traffic (__main__.TestQoS.test_14_policy_limiter_marked_traffic) ... ok
test_15_traffic_match_group (__main__.TestQoS.test_15_traffic_match_group) ... ok
test_16_wrong_traffic_match_group (__main__.TestQoS.test_16_wrong_traffic_match_group) ... ok
test_17_cake_updates (__main__.TestQoS.test_17_cake_updates) ... ok
test_18_priority_queue_default (__main__.TestQoS.test_18_priority_queue_default) ... ok
test_19_priority_queue_default_random_detect (__main__.TestQoS.test_19_priority_queue_default_random_detect) ... ok
test_20_round_robin_policy_default (__main__.TestQoS.test_20_round_robin_policy_default) ... ok
test_21_shaper_hfsc (__main__.TestQoS.test_21_shaper_hfsc) ... ok
test_22_rate_control_default (__main__.TestQoS.test_22_rate_control_default) ... ok
test_23_policy_limiter_iif_filter (__main__.TestQoS.test_23_policy_limiter_iif_filter) ... ok
test_24_policy_shaper_match_ether (__main__.TestQoS.test_24_policy_shaper_match_ether) ... ok

----------------------------------------------------------------------
Ran 24 tests in 493.018s
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
