### PR TITLE
T7423: Add kernel boot options isolcpus, hugepages, numa_balancing

### DIFF
--- a/interface-definitions/system_option.xml.in
+++ b/interface-definitions/system_option.xml.in
@@ -37,7 +37,145 @@
                <help>Kernel boot parameters</help>
              </properties>
              <children>
-               <leafNode name="disable-mitigations">
+              <node name="cpu">
+                <properties>
+                  <help>CPU settings</help>
+                </properties>
+                <children>
+                  <leafNode name="disable-nmi-watchdog">
+                    <properties>
+                      <help>Disable the NMI watchdog for detecting hard CPU lockups</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="isolate-cpus">
+                    <properties>
+                      <help>Isolate specified CPUs from the scheduler</help>
+                      <valueHelp>
+                        <format>u32:0-511</format>
+                        <description>CPU core</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>&lt;start-end&gt;</format>
+                        <description>CPU core range (examples: "1", "4-7", "1,2-5,7")</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="cpu"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="nohz-full">
+                    <properties>
+                      <help>Enable full tickless mode for specified CPUs</help>
+                      <valueHelp>
+                        <format>u32:0-511</format>
+                        <description>CPU core</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>&lt;start-end&gt;</format>
+                        <description>CPU core range (examples: "1", "4-7", "1,2-5,7")</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="cpu"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="rcu-no-cbs">
+                    <properties>
+                      <help>Offload Read-Copy-Update (RCU) callback processing to specified CPUs</help>
+                      <valueHelp>
+                        <format>u32:0-511</format>
+                        <description>CPU core</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>&lt;start-end&gt;</format>
+                        <description>CPU core range (examples: "1", "4-7", "1,2-5,7")</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="cpu"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+              <node name="memory">
+                <properties>
+                  <help>Memory settings</help>
+                </properties>
+                <children>
+                  <leafNode name="disable-numa-balancing">
+                    <properties>
+                      <help>Disable automatic NUMA memory balancing</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="default-hugepage-size">
+                    <properties>
+                      <help>Set default hugepage size (e.g., 2M, 1G)</help>
+                      <completionHelp>
+                        <list>2M 1G</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>2M</format>
+                        <description>2 megabytes</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>1G</format>
+                        <description>1 gigabyte</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>(2M|1G)</regex>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <tagNode name="hugepage-size">
+                    <properties>
+                      <help>Set hugepage size for allocation (e.g., 2M, 1G)</help>
+                      <completionHelp>
+                        <list>2M 1G</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>2M</format>
+                        <description>2 megabytes</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>1G</format>
+                        <description>1 gigabyte</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>(2M|1G)</regex>
+                      </constraint>
+                    </properties>
+                    <children>
+                      <leafNode name="hugepage-count">
+                        <properties>
+                          <help>Allocate number of hugepages for system use</help>
+                          <valueHelp>
+                            <format>u32</format>
+                            <description>Number of hugepages</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-100000"/>
+                          </constraint>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </tagNode>
+                </children>
+              </node>
+              <leafNode name="disable-hpet">
+                 <properties>
+                   <help>Disable High Precision Event Timer (HPET)</help>
+                   <valueless/>
+                 </properties>
+               </leafNode>
+              <leafNode name="disable-mce">
+                 <properties>
+                   <help>Disable Machine Check Exceptions (MCE) reporting and handling</help>
+                   <valueless/>
+                 </properties>
+               </leafNode>
+              <leafNode name="disable-mitigations">
                  <properties>
                    <help>Disable all optional CPU mitigations</help>
                    <valueless/>
@@ -67,6 +205,12 @@
                     <format>guided</format>
                     <description>The firmware controls performance states guided by the system governor</description>
                   </valueHelp>
+                </properties>
+              </leafNode>
+              <leafNode name="disable-softlockup">
+                <properties>
+                  <help>Disable soft lockup detector for kernel threads</help>
+                  <valueless/>
                 </properties>
               </leafNode>
               <leafNode name="quiet">

--- a/smoketest/scripts/cli/test_system_option.py
+++ b/smoketest/scripts/cli/test_system_option.py
@@ -102,9 +102,28 @@ class TestSystemOption(VyOSUnitTestSHIM.TestCase):
 
     def test_kernel_options(self):
         amd_pstate_mode = 'active'
+        isolate_cpus = '1,2,3'
+        nohz_full = '2'
+        rcu_no_cbs = '1,2,4-5'
+        default_hp_size = '2M'
+        hp_size_1g = '1G'
+        hp_size_2m = '2M'
+        hp_count_1g = '2'
+        hp_count_2m = '512'
 
+        self.cli_set(['system', 'option', 'kernel', 'cpu', 'disable-nmi-watchdog'])
+        self.cli_set(['system', 'option', 'kernel', 'cpu', 'isolate-cpus', isolate_cpus])
+        self.cli_set(['system', 'option', 'kernel', 'cpu', 'nohz-full', nohz_full])
+        self.cli_set(['system', 'option', 'kernel', 'cpu', 'rcu-no-cbs', rcu_no_cbs])
+        self.cli_set(['system', 'option', 'kernel', 'disable-hpet'])
+        self.cli_set(['system', 'option', 'kernel', 'disable-mce'])
         self.cli_set(['system', 'option', 'kernel', 'disable-mitigations'])
         self.cli_set(['system', 'option', 'kernel', 'disable-power-saving'])
+        self.cli_set(['system', 'option', 'kernel', 'disable-softlockup'])
+        self.cli_set(['system', 'option', 'kernel', 'memory', 'disable-numa-balancing'])
+        self.cli_set(['system', 'option', 'kernel', 'memory', 'default-hugepage-size', default_hp_size])
+        self.cli_set(['system', 'option', 'kernel', 'memory', 'hugepage-size', hp_size_1g, 'hugepage-count', hp_count_1g])
+        self.cli_set(['system', 'option', 'kernel', 'memory', 'hugepage-size', hp_size_2m, 'hugepage-count', hp_count_2m])
         self.cli_set(['system', 'option', 'kernel', 'quiet'])
 
         self.cli_set(['system', 'option', 'kernel', 'amd-pstate-driver', amd_pstate_mode])
@@ -121,6 +140,17 @@ class TestSystemOption(VyOSUnitTestSHIM.TestCase):
         self.assertIn(' mitigations=off', tmp)
         self.assertIn(' intel_idle.max_cstate=0 processor.max_cstate=1', tmp)
         self.assertIn(' quiet', tmp)
+        self.assertIn(' nmi_watchdog=0', tmp)
+        self.assertIn(' hpet=disable', tmp)
+        self.assertIn(' mce=off', tmp)
+        self.assertIn(' nosoftlockup', tmp)
+        self.assertIn(f' isolcpus={isolate_cpus}', tmp)
+        self.assertIn(f' nohz_full={nohz_full}', tmp)
+        self.assertIn(f' rcu_nocbs={rcu_no_cbs}', tmp)
+        self.assertIn(f' default_hugepagesz={default_hp_size}', tmp)
+        self.assertIn(f' hugepagesz={hp_size_1g} hugepages={hp_count_1g}', tmp)
+        self.assertIn(f' hugepagesz={hp_size_2m} hugepages={hp_count_2m}', tmp)
+        self.assertIn(' numa_balancing=disable', tmp)
 
         if cpu_vendor == 'AuthenticAMD':
             self.assertIn(f' initcall_blacklist=acpi_cpufreq_init amd_pstate={amd_pstate_mode}', tmp)

--- a/src/conf_mode/system_option.py
+++ b/src/conf_mode/system_option.py
@@ -127,6 +127,9 @@ def generate(options):
     # occurance is used for having the appropriate options passed to GRUB
     # when re-configuring options on the CLI.
     cmdline_options = []
+    kernel_opts = options.get('kernel', {})
+    k_cpu_opts = kernel_opts.get('cpu', {})
+    k_memory_opts = kernel_opts.get('memory', {})
     if 'kernel' in options:
         if 'disable_mitigations' in options['kernel']:
             cmdline_options.append('mitigations=off')
@@ -138,6 +141,48 @@ def generate(options):
                 f'initcall_blacklist=acpi_cpufreq_init amd_pstate={mode}')
         if 'quiet' in options['kernel']:
             cmdline_options.append('quiet')
+
+    if 'disable_hpet' in kernel_opts:
+        cmdline_options.append('hpet=disable')
+
+    if 'disable_mce' in kernel_opts:
+        cmdline_options.append('mce=off')
+
+    if 'disable_softlockup' in kernel_opts:
+        cmdline_options.append('nosoftlockup')
+
+    # CPU options
+    isol_cpus = k_cpu_opts.get('isolate_cpus')
+    if isol_cpus:
+        cmdline_options.append(f'isolcpus={isol_cpus}')
+
+    nohz_full = k_cpu_opts.get('nohz_full')
+    if nohz_full:
+        cmdline_options.append(f'nohz_full={nohz_full}')
+
+    rcu_nocbs = k_cpu_opts.get('rcu_no_cbs')
+    if rcu_nocbs:
+        cmdline_options.append(f'rcu_nocbs={rcu_nocbs}')
+
+    if 'disable_nmi_watchdog' in k_cpu_opts:
+        cmdline_options.append('nmi_watchdog=0')
+
+    # Memory options
+    if 'disable_numa_balancing' in k_memory_opts:
+        cmdline_options.append('numa_balancing=disable')
+
+    default_hp_size = k_memory_opts.get('default_hugepage_size')
+    if default_hp_size:
+        cmdline_options.append(f'default_hugepagesz={default_hp_size}')
+
+    hp_sizes = k_memory_opts.get('hugepage_size')
+    if hp_sizes:
+        for size, settings in hp_sizes.items():
+            cmdline_options.append(f'hugepagesz={size}')
+            count = settings.get('hugepage_count')
+            if count:
+                cmdline_options.append(f'hugepages={count}')
+
     grub_util.update_kernel_cmdline_options(' '.join(cmdline_options))
 
     return None

--- a/src/validators/cpu
+++ b/src/validators/cpu
@@ -1,0 +1,43 @@
+#!/usr/bin/python3
+
+import re
+import sys
+
+MAX_CPU = 511
+
+
+def validate_isolcpus(value):
+    pattern = re.compile(r'^(\d{1,3}(-\d{1,3})?)(,(\d{1,3}(-\d{1,3})?))*$')
+    if not pattern.fullmatch(value):
+        return False
+
+    flat_list = []
+    for part in value.split(','):
+        if '-' in part:
+            start, end = map(int, part.split('-'))
+            if start > end or start < 0 or end > MAX_CPU:
+                return False
+            flat_list.extend(range(start, end + 1))
+        else:
+            num = int(part)
+            if num < 0 or num > MAX_CPU:
+                return False
+            flat_list.append(num)
+
+    for i in range(1, len(flat_list)):
+        if flat_list[i] <= flat_list[i - 1]:
+            return False
+
+    return True
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python3 cpu.py <cpu_list>")
+        sys.exit(1)
+
+    input_value = sys.argv[1]
+    if validate_isolcpus(input_value):
+        sys.exit(0)
+    else:
+        sys.exit(1)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add kernel options that could be applied during boot:
 - isolcpus
 - nohz_full
 - rcu_nocbs
 - default_hugepagesz
 - hugepages
 - hugepagesz
 - numa_balancing
 - hpet
 - mce
 - nosoftlockup
 - nmi_watchdog

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7423

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

CLI:

```
set system option kernel cpu disable-nmi-watchdog
set system option kernel cpu isolate-cpus '1,2,4-5'
set system option kernel cpu nohz-full '1,2,4-5'
set system option kernel cpu rcu-no-cbs '1,2,4-5'
set system option kernel disable-hpet
set system option kernel disable-mce
set system option kernel disable-softlockup
set system option kernel memory default-hugepage-size '2M'
set system option kernel memory disable-numa-balancing
set system option kernel memory hugepage-size 1G hugepage-count '2'
set system option kernel memory hugepage-size 2M hugepage-count '512'
```
check options:
```
vyos@r14# cat /boot/grub/grub.cfg.d/vyos-versions/2025.04.29-0019-rolling.cfg | grep numa
    set boot_opts="boot=live rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/2025.04.29-0019-rolling hpet=disable mce=off nosoftlockup isolcpus=1,2,4-5 nohz_full=1,2,4-5 rcu_nocbs=1,2,4-5 nmi_watchdog=0 numa_balancing=disable default_hugepagesz=2M hugepagesz=1G hugepages=2 hugepagesz=2M hugepages=512"
[edit]
vyos@r14# 

```

Smoketest:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_option.py
test_ctrl_alt_delete (__main__.TestSystemOption.test_ctrl_alt_delete) ... ok
test_kernel_options (__main__.TestSystemOption.test_kernel_options) ... ok
test_performance (__main__.TestSystemOption.test_performance) ... ok
test_reboot_on_panic (__main__.TestSystemOption.test_reboot_on_panic) ... ok
test_ssh_client_options (__main__.TestSystemOption.test_ssh_client_options) ... ok

----------------------------------------------------------------------
Ran 5 tests in 36.935s

OK
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
