### PR TITLE
Revert "vyos-router: T7356: unset ANSI bold control character during boot"

### DIFF
--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -417,7 +417,6 @@ gen_duid ()
 
 start ()
 {
-    echo -e "Initializing VyOS router\033[0m"
     # reset and clean config files
     security_reset || log_failure_msg "security reset failed"
 
@@ -526,6 +525,7 @@ start ()
 
     cleanup_post_commit_hooks
 
+    log_daemon_msg "Starting VyOS router"
     disabled migrate || migrate_bootfile
 
     restore_if_missing_preconfig_script


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

This reverts commit ddca20df57008bd85b1363e089152e0ebf014f73.

By thinking about the issue again in another context I found the root cause - systemd. The issue ONLY appears on small terminals where systemd automatically truncates the lines to match the terminal width - so far so good. The BUG is, if truncation happens in the service name which is BOLD you're pretty much screwed, as truncation will not reset the color.

We can set `StatusUnitFormat=name` in `/etc/systemd/system.conf` which will not print the service long description to avoid truncation making the boot a little less verbose.

This is back to the roots - VyOS 1.3 only showed the service description but not the service name during system boot. 

https://www.freedesktop.org/software/systemd/man/latest/systemd-system.conf.html#StatusUnitFormat=

Before:

![image](https://github.com/user-attachments/assets/76dd5877-38b3-4f22-bdcb-770c725757da)

After

![image](https://github.com/user-attachments/assets/488b222a-2eb8-41cc-9cf9-d6810567656b)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7356

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-1x/pull/4492

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

