### PR TITLE
T7417: check existence of paths before set_tag/return_value in migration scripts vrf/1-to-2; vrf/2-to-3

### DIFF
--- a/src/migration-scripts/vrf/1-to-2
+++ b/src/migration-scripts/vrf/1-to-2
@@ -37,7 +37,10 @@ def migrate(config: ConfigTree) -> None:
         new_static_base = vrf_base + [vrf, 'protocols']
         config.set(new_static_base)
         config.copy(static_base, new_static_base + ['static'])
-        config.set_tag(new_static_base + ['static', 'route'])
+        if config.exists(new_static_base + ['static', 'route']):
+            config.set_tag(new_static_base + ['static', 'route'])
+        if config.exists(new_static_base + ['static', 'route6']):
+            config.set_tag(new_static_base + ['static', 'route6'])
 
     # Now delete the old configuration
     config.delete(base)

--- a/src/migration-scripts/vrf/2-to-3
+++ b/src/migration-scripts/vrf/2-to-3
@@ -76,7 +76,8 @@ def migrate(config: ConfigTree) -> None:
     # Get a list of all currently used VRFs and tables
     vrfs_current = {}
     for vrf in config.list_nodes(base):
-        vrfs_current[vrf] = int(config.return_value(base + [vrf, 'table']))
+        if config.exists(base + [vrf, 'table']):
+            vrfs_current[vrf] = int(config.return_value(base + [vrf, 'table']))
 
     # Check VRF names and table numbers
     name_regex = re.compile(r'^\d.*$')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

(1) the migration script
https://github.com/vyos/vyos-1x/blob/current/src/migration-scripts/vrf/1-to-2
ignores the possible path
`['vrf', 'name', tag-val-name, 'protocols', 'static', 'route6']`
and assumes
`['vrf', 'name', tag-val-name, 'protocols', 'static', 'route']
`
Add check for each case and conditionally set_tag.

(2) the migration script
https://github.com/vyos/vyos-1x/blob/current/src/migration-scripts/vrf/2-to-3
assumes the existence of table entries, however, these may not be present for the results of migration from
`['protocols', 'vrf', tag-val-name, 'static']`
in vrf/1-to-2.
The absence of table entries should not be a migration error, but should be left to be caught by the config script verification logic.

Add check for path
`['vrf', 'name', tag-value-name, 'table']`
before calling return_value.



The automatic backport to sagitta will report conflicts due to a difference in indentation, as a result of the revision of the migration system in current/circinus; a simple fix will repair the cherry-pick.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
