### PR TITLE
haproxy: T7429: remove unsupported logging facility and log level

### DIFF
--- a/interface-definitions/include/haproxy/logging.xml.i
+++ b/interface-definitions/include/haproxy/logging.xml.i
@@ -4,7 +4,137 @@
     <help>Logging parameters</help>
   </properties>
   <children>
-    #include <include/syslog-facility.xml.i>
+    <tagNode name="facility">
+      <properties>
+        <help>Facility for logging</help>
+        <completionHelp>
+          <list>auth cron daemon kern lpr mail news syslog user uucp local0 local1 local2 local3 local4 local5 local6 local7</list>
+        </completionHelp>
+        <constraint>
+          <regex>(auth|cron|daemon|kern|lpr|mail|news|syslog|user|uucp|local0|local1|local2|local3|local4|local5|local6|local7)</regex>
+        </constraint>
+        <constraintErrorMessage>Invalid facility type</constraintErrorMessage>
+        <valueHelp>
+          <format>auth</format>
+          <description>Authentication and authorization</description>
+        </valueHelp>
+        <valueHelp>
+          <format>cron</format>
+          <description>Cron daemon</description>
+        </valueHelp>
+        <valueHelp>
+          <format>daemon</format>
+          <description>System daemons</description>
+        </valueHelp>
+        <valueHelp>
+          <format>kern</format>
+          <description>Kernel</description>
+        </valueHelp>
+        <valueHelp>
+          <format>lpr</format>
+          <description>Line printer spooler</description>
+        </valueHelp>
+        <valueHelp>
+          <format>mail</format>
+          <description>Mail subsystem</description>
+        </valueHelp>
+        <valueHelp>
+          <format>news</format>
+          <description>USENET subsystem</description>
+        </valueHelp>
+        <valueHelp>
+          <format>syslog</format>
+          <description>Authentication and authorization</description>
+        </valueHelp>
+        <valueHelp>
+          <format>user</format>
+          <description>Application processes</description>
+        </valueHelp>
+        <valueHelp>
+          <format>uucp</format>
+          <description>UUCP subsystem</description>
+        </valueHelp>
+        <valueHelp>
+          <format>local0</format>
+          <description>Local facility 0</description>
+        </valueHelp>
+        <valueHelp>
+          <format>local1</format>
+          <description>Local facility 1</description>
+        </valueHelp>
+        <valueHelp>
+          <format>local2</format>
+          <description>Local facility 2</description>
+        </valueHelp>
+        <valueHelp>
+          <format>local3</format>
+          <description>Local facility 3</description>
+        </valueHelp>
+        <valueHelp>
+          <format>local4</format>
+          <description>Local facility 4</description>
+        </valueHelp>
+        <valueHelp>
+          <format>local5</format>
+          <description>Local facility 5</description>
+        </valueHelp>
+        <valueHelp>
+          <format>local6</format>
+          <description>Local facility 6</description>
+        </valueHelp>
+        <valueHelp>
+          <format>local7</format>
+          <description>Local facility 7</description>
+        </valueHelp>
+      </properties>
+      <children>
+        <leafNode name="level">
+          <properties>
+            <help>Logging level</help>
+            <completionHelp>
+              <list>emerg alert crit err warning notice info debug</list>
+            </completionHelp>
+            <valueHelp>
+              <format>emerg</format>
+              <description>Emergency messages</description>
+            </valueHelp>
+            <valueHelp>
+              <format>alert</format>
+              <description>Urgent messages</description>
+            </valueHelp>
+            <valueHelp>
+              <format>crit</format>
+              <description>Critical messages</description>
+            </valueHelp>
+            <valueHelp>
+              <format>err</format>
+              <description>Error messages</description>
+            </valueHelp>
+            <valueHelp>
+              <format>warning</format>
+              <description>Warning messages</description>
+            </valueHelp>
+            <valueHelp>
+              <format>notice</format>
+              <description>Messages for further investigation</description>
+            </valueHelp>
+            <valueHelp>
+              <format>info</format>
+              <description>Informational messages</description>
+            </valueHelp>
+            <valueHelp>
+              <format>debug</format>
+              <description>Debug messages</description>
+            </valueHelp>
+            <constraint>
+              <regex>(emerg|alert|crit|err|warning|notice|info|debug)</regex>
+            </constraint>
+            <constraintErrorMessage>Invalid loglevel</constraintErrorMessage>
+          </properties>
+          <defaultValue>err</defaultValue>
+        </leafNode>
+      </children>
+    </tagNode>
   </children>
 </node>
 <!-- include end -->

--- a/interface-definitions/include/version/reverseproxy-version.xml.i
+++ b/interface-definitions/include/version/reverseproxy-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/reverseproxy-version.xml.i -->
-<syntaxVersion component='reverse-proxy' version='2'></syntaxVersion>
+<syntaxVersion component='reverse-proxy' version='3'></syntaxVersion>
 <!-- include end -->

--- a/smoketest/config-tests/basic-haproxy
+++ b/smoketest/config-tests/basic-haproxy
@@ -1,0 +1,46 @@
+set interfaces dummy dum0 address '172.18.254.203/32'
+set interfaces ethernet eth0 duplex 'auto'
+set interfaces ethernet eth0 speed 'auto'
+set interfaces ethernet eth0 vif 203 address '172.18.203.10/24'
+set interfaces ethernet eth1 duplex 'auto'
+set interfaces ethernet eth1 speed 'auto'
+set interfaces ethernet eth2 duplex 'auto'
+set interfaces ethernet eth2 speed 'auto'
+set load-balancing haproxy backend webserver logging facility daemon
+set load-balancing haproxy backend webserver logging facility user level 'info'
+set load-balancing haproxy backend webserver server web01 address '192.0.2.1'
+set load-balancing haproxy backend webserver server web01 port '443'
+set load-balancing haproxy backend webserver ssl no-verify
+set load-balancing haproxy global-parameters logging facility daemon
+set load-balancing haproxy global-parameters logging facility user level 'info'
+set load-balancing haproxy service frontend backend 'webserver'
+set load-balancing haproxy service frontend logging facility daemon
+set load-balancing haproxy service frontend logging facility user level 'info'
+set load-balancing haproxy service frontend port '443'
+set load-balancing haproxy service frontend ssl certificate 'dummy'
+set pki certificate dummy certificate 'MIIDsTCCApmgAwIBAgIUegVgO1wIN2v44trXZ+Kb1t48uL0wDQYJKoZIhvcNAQELBQAwVzELMAkGA1UEBhMCR0IxEzARBgNVBAgMClNvbWUtU3RhdGUxEjAQBgNVBAcMCVNvbWUtQ2l0eTENMAsGA1UECgwEVnlPUzEQMA4GA1UEAwwHdnlvcy5pbzAeFw0yNTA1MDUxODIzMTdaFw0yNjA1MDUxODIzMTdaMFcxCzAJBgNVBAYTAkdCMRMwEQYDVQQIDApTb21lLVN0YXRlMRIwEAYDVQQHDAlTb21lLUNpdHkxDTALBgNVBAoMBFZ5T1MxEDAOBgNVBAMMB3Z5b3MuaW8wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDEfMAwYLKKVhGlUXr9gkVC7uBi+0O9yyEgd5QzPByePXYw0FrSLWmLRfQuByFDPIVANcEa3FgIXIAeKmxItw7IhFRsG5soSOXXgBxdAH/qzEbWhwzgafnxZKJkmrQr8YA3IFtkFPr2+5s26WdjtwEM0tzIFkq6hmWSX1axUgvYlF2uCxjututMZ6I5JCa0uR3gBRuNONuGPH3Ko9zUEATffv53j9DbYVEM0lfVNewefPoVJmWz+oT0wP/kNx6tREf+aUAF4m+eBsqnggITftW2fyeFnoBPCcPp3HUgSwZhesunqz+YeW6Pk+WWb5vl+2QbMKKtz5qK6dI3q0z9yp4FAgMBAAGjdTBzMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMBMB0GA1UdDgQWBBSr4OYIWkb8UGuQnEFnjSbmvR+4vDAfBgNVHSMEGDAWgBSr4OYIWkb8UGuQnEFnjSbmvR+4vDANBgkqhkiG9w0BAQsFAAOCAQEAUmRWRPGXsvfuRT+53id3EufH1IJAdowrt6yBZsHobvqCXO2+YhG7oG6/UqUYiv5bHN5xEMQyWd7nyrLOUeFo2bpcMIOlpl6AoUIY65Gm2BqQ7FuPxLLO25RdpZ5WkMGX5kJsKY0/PcpamRKNz1khgFcRyxf9WGhCAIjDCWIWs8lkvPN3m75SFCW7MTuzzQOrzvI6nqqcHO4k8hRBznp26WLUW1rQKpNN09nZGOkeNYK5QbzKN/RUmtEHQZhlgLAIr09jUaA4RDLI1SdD6LR5nvpa9RJBTyS/kISF8BXKMgvUbDHN2nP+VUUrut2ZwoU+pxV4RVT2pS760HuYj4+sYQ=='
+set pki certificate dummy private key 'MIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQDEfMAwYLKKVhGlUXr9gkVC7uBi+0O9yyEgd5QzPByePXYw0FrSLWmLRfQuByFDPIVANcEa3FgIXIAeKmxItw7IhFRsG5soSOXXgBxdAH/qzEbWhwzgafnxZKJkmrQr8YA3IFtkFPr2+5s26WdjtwEM0tzIFkq6hmWSX1axUgvYlF2uCxjututMZ6I5JCa0uR3gBRuNONuGPH3Ko9zUEATffv53j9DbYVEM0lfVNewefPoVJmWz+oT0wP/kNx6tREf+aUAF4m+eBsqnggITftW2fyeFnoBPCcPp3HUgSwZhesunqz+YeW6Pk+WWb5vl+2QbMKKtz5qK6dI3q0z9yp4FAgMBAAECgf9plqCMg2pKEWRFl183bqWAm7lnLnsUOfABFNPYa3U+uKQUKZpboTBfzDfZqNak3XNQV0mTAR8pFfoMhQjQU9hUxH7ivjw1RUCHjixCF0vLBkTB34gL7FUbiEIFhR1NW3pCJY73OXOkIZG1Obh6Syb8KubDeu4bTmb90/TnDDAs6OYXJ5yo7ZDZLvLu5a3Dli+H4K5Qb5VJ74o/vtodBo3wmKBgy2Ey6JqF+y7/3HeE66rVhYNft5pURgemWnNYqh3oDTJASqpA/8n90o8ceYPVJugQ7029UiyTp0xgBRXFszgiYPkBlsNWB+9+ospopOmYU0owBykH+RtD/bQ0mwECgYEA4gxPdYbHg/GLihHrkv0t5V0pSEhBeBeTBdWG+P/6K90vXofpp7qISdOeYMGkh8mY+PfZNHksdu67d2ks5on5/dNf5YXWCm+LMMRiSsfOo11NISNdNHS6afqs18Wq1aKawv/rwotfxrakM4Gar692+jgz/l/X+FdOQwmE6uEus8ECgYEA3oW4eGtzGq28TiqyhTHduTkas0ckPWX8ulasyPnLxBKDNNohbXXpFIJIcrnl24QFJw3MJbo+R+OxZHgzPK8r64gIGVa7vLCR2fiU/RFoUa1Jo1pPOqXXWqf/Mvdokm2p0atrjRUX9VhjoFsDLcqTgAmfSCsVSqGucX6ER7Gy60UCgYAvmhoNjNFtFquk6rsqHAjTOTgdUaH/0S8T1nBy9SzQmeaEyKhKuvxCV78NbxnfwnNlUoQ6CZ50eTefINXkwn+TlTSnl/SIBA9SuLheOQ9p1ZcNeG4DQuWStcg6NBUSoghnMg+Ky2Di7slLU2qovpGWhcllMve/A1umwFVuRPdZwQKBgHS7mYYyd/Oq6HnpFDWjbzlXp5Yc3/oFooruJT5ZLHfzbjkvpRGTJW7I2dC1jMuXekx+hHXWOg3keI7IL7jJ/DRW7Ei+o0XdKuY57Y7ErwEJ8vNq0N1nWo4IS2wlNgp61PdVAdrFEgh3EexxUj2XY8FrSs/FKio4nxaS1Dn4EnAxAoGBAKqLvuPpmCMVwlIu57WGxL5d9i7EjIGY65l6HTKQYoHCzE51rkowH1La2fuUYz0IpExq2lcrLbOUtSyhXH7Zlktiz//Gu/P90SUfR/ZGcLeZi+EDyK2OctpnWBjs2Dmfg4D6vxk39yV8AB97pYG073GcJ/P54qRUuEitbpJwH+fB'
+set service ntp allow-client address '0.0.0.0/0'
+set service ntp allow-client address '::/0'
+set service ntp server 172.16.100.10
+set service ntp server 172.16.100.20
+set service ntp server 172.16.110.30
+set service ssh disable-host-validation
+set service ssh port '22'
+set system config-management commit-revisions '200'
+set system conntrack modules ftp
+set system conntrack modules h323
+set system conntrack modules nfs
+set system conntrack modules pptp
+set system conntrack modules sip
+set system conntrack modules sqlnet
+set system conntrack modules tftp
+set system console device ttyS0 speed '115200'
+set system host-name 'vyos'
+set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'
+set system login user vyos authentication plaintext-password ''
+set system name-server '172.16.254.30'
+set system option kernel disable-mitigations
+set system syslog local facility all level 'info'
+set system syslog local facility local7 level 'debug'
+set system time-zone 'Europe/Berlin'

--- a/smoketest/configs/basic-haproxy
+++ b/smoketest/configs/basic-haproxy
@@ -1,0 +1,153 @@
+interfaces {
+    dummy dum0 {
+        address "172.18.254.203/32"
+    }
+    ethernet eth0 {
+        duplex "auto"
+        speed "auto"
+        vif 203 {
+            address "172.18.203.10/24"
+        }
+    }
+    ethernet eth1 {
+        duplex "auto"
+        speed "auto"
+    }
+    ethernet eth2 {
+        duplex "auto"
+        speed "auto"
+    }
+}
+load-balancing {
+    reverse-proxy {
+        backend webserver {
+            logging {
+                facility all {
+                    level "all"
+                }
+                facility daemon {
+                    level "all"
+                }
+                facility user {
+                    level "info"
+                }
+            }
+            server web01 {
+                address "192.0.2.1"
+                port "443"
+            }
+            ssl {
+                no-verify
+            }
+        }
+        global-parameters {
+            logging {
+                facility all {
+                    level "all"
+                }
+                facility daemon {
+                    level "all"
+                }
+                facility user {
+                    level "info"
+                }
+            }
+        }
+        service frontend {
+            backend "webserver"
+            logging {
+                facility all {
+                    level "all"
+                }
+                facility daemon {
+                    level "all"
+                }
+                facility user {
+                    level "info"
+                }
+            }
+            port "443"
+            ssl {
+                certificate "dummy"
+            }
+        }
+    }
+}
+pki {
+    certificate dummy {
+        certificate "MIIDsTCCApmgAwIBAgIUegVgO1wIN2v44trXZ+Kb1t48uL0wDQYJKoZIhvcNAQELBQAwVzELMAkGA1UEBhMCR0IxEzARBgNVBAgMClNvbWUtU3RhdGUxEjAQBgNVBAcMCVNvbWUtQ2l0eTENMAsGA1UECgwEVnlPUzEQMA4GA1UEAwwHdnlvcy5pbzAeFw0yNTA1MDUxODIzMTdaFw0yNjA1MDUxODIzMTdaMFcxCzAJBgNVBAYTAkdCMRMwEQYDVQQIDApTb21lLVN0YXRlMRIwEAYDVQQHDAlTb21lLUNpdHkxDTALBgNVBAoMBFZ5T1MxEDAOBgNVBAMMB3Z5b3MuaW8wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDEfMAwYLKKVhGlUXr9gkVC7uBi+0O9yyEgd5QzPByePXYw0FrSLWmLRfQuByFDPIVANcEa3FgIXIAeKmxItw7IhFRsG5soSOXXgBxdAH/qzEbWhwzgafnxZKJkmrQr8YA3IFtkFPr2+5s26WdjtwEM0tzIFkq6hmWSX1axUgvYlF2uCxjututMZ6I5JCa0uR3gBRuNONuGPH3Ko9zUEATffv53j9DbYVEM0lfVNewefPoVJmWz+oT0wP/kNx6tREf+aUAF4m+eBsqnggITftW2fyeFnoBPCcPp3HUgSwZhesunqz+YeW6Pk+WWb5vl+2QbMKKtz5qK6dI3q0z9yp4FAgMBAAGjdTBzMAwGA1UdEwEB/wQCMAAwDgYDVR0PAQH/BAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMBMB0GA1UdDgQWBBSr4OYIWkb8UGuQnEFnjSbmvR+4vDAfBgNVHSMEGDAWgBSr4OYIWkb8UGuQnEFnjSbmvR+4vDANBgkqhkiG9w0BAQsFAAOCAQEAUmRWRPGXsvfuRT+53id3EufH1IJAdowrt6yBZsHobvqCXO2+YhG7oG6/UqUYiv5bHN5xEMQyWd7nyrLOUeFo2bpcMIOlpl6AoUIY65Gm2BqQ7FuPxLLO25RdpZ5WkMGX5kJsKY0/PcpamRKNz1khgFcRyxf9WGhCAIjDCWIWs8lkvPN3m75SFCW7MTuzzQOrzvI6nqqcHO4k8hRBznp26WLUW1rQKpNN09nZGOkeNYK5QbzKN/RUmtEHQZhlgLAIr09jUaA4RDLI1SdD6LR5nvpa9RJBTyS/kISF8BXKMgvUbDHN2nP+VUUrut2ZwoU+pxV4RVT2pS760HuYj4+sYQ=="
+        private {
+            key "MIIEuwIBADANBgkqhkiG9w0BAQEFAASCBKUwggShAgEAAoIBAQDEfMAwYLKKVhGlUXr9gkVC7uBi+0O9yyEgd5QzPByePXYw0FrSLWmLRfQuByFDPIVANcEa3FgIXIAeKmxItw7IhFRsG5soSOXXgBxdAH/qzEbWhwzgafnxZKJkmrQr8YA3IFtkFPr2+5s26WdjtwEM0tzIFkq6hmWSX1axUgvYlF2uCxjututMZ6I5JCa0uR3gBRuNONuGPH3Ko9zUEATffv53j9DbYVEM0lfVNewefPoVJmWz+oT0wP/kNx6tREf+aUAF4m+eBsqnggITftW2fyeFnoBPCcPp3HUgSwZhesunqz+YeW6Pk+WWb5vl+2QbMKKtz5qK6dI3q0z9yp4FAgMBAAECgf9plqCMg2pKEWRFl183bqWAm7lnLnsUOfABFNPYa3U+uKQUKZpboTBfzDfZqNak3XNQV0mTAR8pFfoMhQjQU9hUxH7ivjw1RUCHjixCF0vLBkTB34gL7FUbiEIFhR1NW3pCJY73OXOkIZG1Obh6Syb8KubDeu4bTmb90/TnDDAs6OYXJ5yo7ZDZLvLu5a3Dli+H4K5Qb5VJ74o/vtodBo3wmKBgy2Ey6JqF+y7/3HeE66rVhYNft5pURgemWnNYqh3oDTJASqpA/8n90o8ceYPVJugQ7029UiyTp0xgBRXFszgiYPkBlsNWB+9+ospopOmYU0owBykH+RtD/bQ0mwECgYEA4gxPdYbHg/GLihHrkv0t5V0pSEhBeBeTBdWG+P/6K90vXofpp7qISdOeYMGkh8mY+PfZNHksdu67d2ks5on5/dNf5YXWCm+LMMRiSsfOo11NISNdNHS6afqs18Wq1aKawv/rwotfxrakM4Gar692+jgz/l/X+FdOQwmE6uEus8ECgYEA3oW4eGtzGq28TiqyhTHduTkas0ckPWX8ulasyPnLxBKDNNohbXXpFIJIcrnl24QFJw3MJbo+R+OxZHgzPK8r64gIGVa7vLCR2fiU/RFoUa1Jo1pPOqXXWqf/Mvdokm2p0atrjRUX9VhjoFsDLcqTgAmfSCsVSqGucX6ER7Gy60UCgYAvmhoNjNFtFquk6rsqHAjTOTgdUaH/0S8T1nBy9SzQmeaEyKhKuvxCV78NbxnfwnNlUoQ6CZ50eTefINXkwn+TlTSnl/SIBA9SuLheOQ9p1ZcNeG4DQuWStcg6NBUSoghnMg+Ky2Di7slLU2qovpGWhcllMve/A1umwFVuRPdZwQKBgHS7mYYyd/Oq6HnpFDWjbzlXp5Yc3/oFooruJT5ZLHfzbjkvpRGTJW7I2dC1jMuXekx+hHXWOg3keI7IL7jJ/DRW7Ei+o0XdKuY57Y7ErwEJ8vNq0N1nWo4IS2wlNgp61PdVAdrFEgh3EexxUj2XY8FrSs/FKio4nxaS1Dn4EnAxAoGBAKqLvuPpmCMVwlIu57WGxL5d9i7EjIGY65l6HTKQYoHCzE51rkowH1La2fuUYz0IpExq2lcrLbOUtSyhXH7Zlktiz//Gu/P90SUfR/ZGcLeZi+EDyK2OctpnWBjs2Dmfg4D6vxk39yV8AB97pYG073GcJ/P54qRUuEitbpJwH+fB"
+        }
+    }
+}
+service {
+    ntp {
+        allow-client {
+            address "0.0.0.0/0"
+            address "::/0"
+        }
+        server 172.16.100.10 {
+        }
+        server 172.16.100.20 {
+        }
+        server 172.16.110.30 {
+        }
+    }
+    ssh {
+        disable-host-validation
+        port "22"
+    }
+}
+system {
+    config-management {
+        commit-revisions "200"
+    }
+    console {
+        device ttyS0 {
+            speed 115200
+        }
+    }
+    conntrack {
+        modules {
+            ftp
+            h323
+            nfs
+            pptp
+            sip
+            sqlnet
+            tftp
+        }
+    }
+    host-name vyos
+    login {
+        user vyos {
+            authentication {
+                encrypted-password $6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0
+                plaintext-password ""
+            }
+        }
+    }
+    name-server "172.16.254.30"
+    option {
+        kernel {
+            disable-mitigations
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level "info"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+    time-zone "Europe/Berlin"
+}
+
+
+// Warning: Do not remove the following line.
+// vyos-config-version: "bgp@5:broadcast-relay@1:cluster@2:config-management@1:conntrack@5:conntrack-sync@2:container@2:dhcp-relay@2:dhcp-server@8:dhcpv6-server@1:dns-dynamic@4:dns-forwarding@4:firewall@15:flow-accounting@1:https@6:ids@1:interfaces@32:ipoe-server@3:ipsec@13:isis@3:l2tp@9:lldp@2:mdns@1:monitoring@1:nat@8:nat66@3:ntp@3:openconnect@3:ospf@2:pim@1:policy@8:pppoe-server@10:pptp@5:qos@2:quagga@11:reverse-proxy@1:rip@1:rpki@2:salt@1:snmp@3:ssh@2:sstp@6:system@27:vrf@3:vrrp@4:vyos-accel-ppp@2:wanloadbalance@3:webproxy@2"
+// Release version: 1.4.1

--- a/src/migration-scripts/reverse-proxy/2-to-3
+++ b/src/migration-scripts/reverse-proxy/2-to-3
@@ -1,0 +1,66 @@
+# Copyright 2025 VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# T7429: logging facility "all" unavailable in code
+
+from vyos.configtree import ConfigTree
+
+base = ['load-balancing', 'haproxy']
+unsupported_facilities = ['all', 'authpriv', 'mark']
+
+def config_migrator(config, config_path: list) -> None:
+    if not config.exists(config_path):
+        return
+    # Remove unsupported backend HAProxy syslog facilities form CLI
+    # Works for both backend and service CLI nodes
+    for service_backend in config.list_nodes(config_path):
+        log_path = config_path + [service_backend, 'logging', 'facility']
+        if not config.exists(log_path):
+            continue
+        # Remove unsupported syslog facilities form CLI
+        for facility in config.list_nodes(log_path):
+            if facility in unsupported_facilities:
+                config.delete(log_path + [facility])
+                continue
+            # Remove unsupported facility log level form CLI. VyOS will fallback
+            # to default log level if not set
+            if config.exists(log_path + [facility, 'level']):
+                tmp = config.return_value(log_path + [facility, 'level'])
+                if tmp == 'all':
+                    config.delete(log_path + [facility, 'level'])
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(base):
+        # Nothing to do
+        return
+
+    # Remove unsupported syslog facilities form CLI
+    global_path = base + ['global-parameters', 'logging', 'facility']
+    if config.exists(global_path):
+        for facility in config.list_nodes(global_path):
+            if facility in unsupported_facilities:
+                config.delete(global_path + [facility])
+                continue
+            # Remove unsupported facility log level form CLI. VyOS will fallback
+            # to default log level if not set
+            if config.exists(global_path + [facility, 'level']):
+                tmp = config.return_value(global_path + [facility, 'level'])
+                if tmp == 'all':
+                    config.delete(global_path + [facility, 'level'])
+
+    # Remove unsupported backend HAProxy syslog facilities from CLI
+    config_migrator(config, base + ['backend'])
+    # Remove unsupported service HAProxy syslog facilities from CLI
+    config_migrator(config, base + ['service'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

VyOS 1.4.1 implemented support for logging facilities for HAProxy. The facilities got included from the syslog XML definition, which also added "virtual" or non existing facilities in HAProxy, namely: all, authpriv and mark.

If any of the above facilities is set, HAProxy will not start. The XML definition for syslog also came with an arbitrary log-level "all" that is also unsupported in HAProxy.

**NOTE:** this should be backported to VyOS 1.4.3 - it's a CLI change but the current available CLI will render the service unusable. To make the service work again one must delete the "bad" CLI nodes anyways.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7429

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
test_01_lb_reverse_proxy_domain (__main__.TestLoadBalancingReverseProxy.test_01_lb_reverse_proxy_domain) ... ok
test_02_lb_reverse_proxy_cert_not_exists (__main__.TestLoadBalancingReverseProxy.test_02_lb_reverse_proxy_cert_not_exists) ... ok
test_03_lb_reverse_proxy_ca_not_exists (__main__.TestLoadBalancingReverseProxy.test_03_lb_reverse_proxy_ca_not_exists) ... ok
test_04_lb_reverse_proxy_backend_ssl_no_verify (__main__.TestLoadBalancingReverseProxy.test_04_lb_reverse_proxy_backend_ssl_no_verify) ... ok
test_05_lb_reverse_proxy_backend_http_check (__main__.TestLoadBalancingReverseProxy.test_05_lb_reverse_proxy_backend_http_check) ... ok
test_06_lb_reverse_proxy_tcp_mode (__main__.TestLoadBalancingReverseProxy.test_06_lb_reverse_proxy_tcp_mode) ... ok
test_07_lb_reverse_proxy_http_response_headers (__main__.TestLoadBalancingReverseProxy.test_07_lb_reverse_proxy_http_response_headers) ... ok
test_08_lb_reverse_proxy_tcp_health_checks (__main__.TestLoadBalancingReverseProxy.test_08_lb_reverse_proxy_tcp_health_checks) ... ok
test_09_lb_reverse_proxy_logging (__main__.TestLoadBalancingReverseProxy.test_09_lb_reverse_proxy_logging) ... ok
test_10_lb_reverse_proxy_http_compression (__main__.TestLoadBalancingReverseProxy.test_10_lb_reverse_proxy_http_compression) ... ok
test_11_lb_haproxy_timeout (__main__.TestLoadBalancingReverseProxy.test_11_lb_haproxy_timeout) ... ok

----------------------------------------------------------------------
Ran 11 tests in 38.673s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
