### PR TITLE
Bridge: T7430: Add BPDU Guard and Root Guard support

### DIFF
--- a/interface-definitions/interfaces_bridge.xml.in
+++ b/interface-definitions/interfaces_bridge.xml.in
@@ -201,6 +201,18 @@
                       <valueless/>
                     </properties>
                   </leafNode>
+                  <leafNode name="bpdu-guard">
+                    <properties>
+                      <help>Enable BPDU Guard</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="root-guard">
+                    <properties>
+                      <help>Enable Root Guard</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
                 </children>
               </tagNode>
             </children>

--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -831,6 +831,12 @@
             </properties>
             <command>journalctl --no-hostname --boot --unit snmpd.service</command>
           </leafNode>
+          <leafNode name="spanning-tree">
+            <properties>
+              <help>Show log for Spanning Tree Protocol (STP)</help>
+            </properties>
+            <command>journalctl --dmesg --no-hostname --boot --grep='br[0-9].*(stp|bpdu|blocking|disabled|forwarding|listening|root port)'</command>
+          </leafNode>
           <node name="ssh">
             <properties>
               <help>Show log for Secure Shell (SSH)</help>

--- a/python/vyos/ifconfig/bridge.py
+++ b/python/vyos/ifconfig/bridge.py
@@ -376,6 +376,16 @@ class BridgeIf(Interface):
                 if 'priority' in interface_config:
                     lower.set_path_priority(interface_config['priority'])
 
+                # set BPDU guard
+                tmp = dict_search('bpdu_guard', interface_config)
+                value = '1' if (tmp != None) else '0'
+                lower.set_bpdu_guard(value)
+
+                # set root guard
+                tmp = dict_search('root_guard', interface_config)
+                value = '1' if (tmp != None) else '0'
+                lower.set_root_guard(value)
+
                 if 'enable_vlan' in config:
                     add_vlan = []
                     native_vlan_id = None

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -217,6 +217,16 @@ class Interface(Control):
             'location': '/sys/class/net/{ifname}/brport/priority',
             'errormsg': '{ifname} is not a bridge port member'
         },
+        'bpdu_guard': {
+            'validate': assert_boolean,
+            'location': '/sys/class/net/{ifname}/brport/bpdu_guard',
+            'errormsg': '{ifname} is not a bridge port member'
+        },
+        'root_guard': {
+            'validate': assert_boolean,
+            'location': '/sys/class/net/{ifname}/brport/root_block',
+            'errormsg': '{ifname} is not a bridge port member'
+        },
         'proxy_arp': {
             'validate': assert_boolean,
             'location': '/proc/sys/net/ipv4/conf/{ifname}/proxy_arp',
@@ -1105,6 +1115,28 @@ class Interface(Control):
         >>> Interface('eth0').set_path_priority(4)
         """
         self.set_interface('path_priority', priority)
+
+    def set_bpdu_guard(self, state):
+        """
+        Set BPDU guard state for a bridge port. When enabled, the port will be
+        disabled if it receives a BPDU packet.
+
+        Example:
+        >>> from vyos.ifconfig import Interface
+        >>> Interface('eth0').set_bpdu_guard(1)
+        """
+        self.set_interface('bpdu_guard', state)
+
+    def set_root_guard(self, state):
+        """
+        Set root guard state for a bridge port. When enabled, the port will be
+        disabled if it receives a superior BPDU that would make it a root port.
+
+        Example:
+        >>> from vyos.ifconfig import Interface
+        >>> Interface('eth0').set_root_guard(1)
+        """
+        self.set_interface('root_guard', state)
 
     def set_port_isolation(self, on_or_off):
         """

--- a/src/conf_mode/interfaces_bridge.py
+++ b/src/conf_mode/interfaces_bridge.py
@@ -167,6 +167,9 @@ def verify(bridge):
             if 'has_vrf' in interface_config:
                 raise ConfigError(error_msg + 'it has a VRF assigned!')
 
+            if 'bpdu_guard' in interface_config and 'root_guard' in interface_config:
+                raise ConfigError(error_msg + 'bpdu_guard and root_guard cannot be configured at the same time!')
+
             if 'enable_vlan' in bridge:
                 if 'has_vlan' in interface_config:
                     raise ConfigError(error_msg + 'it has VLAN subinterface(s) assigned!')

--- a/src/conf_mode/interfaces_bridge.py
+++ b/src/conf_mode/interfaces_bridge.py
@@ -168,7 +168,7 @@ def verify(bridge):
                 raise ConfigError(error_msg + 'it has a VRF assigned!')
 
             if 'bpdu_guard' in interface_config and 'root_guard' in interface_config:
-                raise ConfigError(error_msg + 'bpdu_guard and root_guard cannot be configured at the same time!')
+                raise ConfigError(error_msg + 'bpdu-guard and root-guard cannot be configured at the same time!')
 
             if 'enable_vlan' in bridge:
                 if 'has_vlan' in interface_config:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
This will add support for BPDU Guard and Root Guard to the bridge interface.

#### Syntax:

```
set interfaces bridge br0 member interface eth0 bpdu-guard
set interfaces bridge br0 member interface eth2 root-guard
```
Verification will come from:
`show bridge spanning-tree`
`show log spanning-tree`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7430
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
#### Configure a bridge with either root-guard or bpdu-guard:
```
set interfaces bridge br0 member interface eth0 root-guard
set interfaces bridge br0 stp
```
#### Verify op commands:
```
vyos@cli-dev# run show bridge spanning-tree
--------------------------------------------------------------------------------
Bridge interface br0 (DOWN):

Spanning Tree is Enabled
Bridge ID 96:ae:39:c4:52:05, Priority 32768
Root ID 96:ae:39:c4:52:05, Priority 32768 (This bridge is the root)
VLANs Disabled, Protocol 802.1Q

Interface    State      BPDU_Guard    Root_Guard    Learning
-----------  ---------  ------------  ------------  ----------
eth0         Listening  Disabled      Enabled       Enabled
```
#### View logs:
```
vyos@cli-dev# run show log spanning-tree
May 05 18:34:38 kernel: br0: BPDU received on blocked port 1(eth0)
May 05 18:35:25 kernel: br0: port 2(eth2) tried to become root port (blocked)
```
#### Smoketest:
test_bridge_root_bpdu_guard (__main__.BridgeInterfaceTest.test_bridge_root_bpdu_guard) ... ok

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
