### PR TITLE
prometheus: T7435: Ensure only configured exporters are started

### DIFF
--- a/src/conf_mode/service_monitoring_prometheus.py
+++ b/src/conf_mode/service_monitoring_prometheus.py
@@ -48,9 +48,21 @@ def get_config(config=None):
     if not conf.exists(base):
         return None
 
-    monitoring = conf.get_config_dict(
-        base, key_mangling=('-', '_'), get_first_key=True, with_recursive_defaults=True
-    )
+    monitoring = {}
+    exporters = {
+        'node_exporter': base + ['node-exporter'],
+        'frr_exporter': base + ['frr-exporter'],
+        'blackbox_exporter': base + ['blackbox-exporter'],
+    }
+
+    for exporter_name, exporter_base in exporters.items():
+        if conf.exists(exporter_base):
+            monitoring[exporter_name] = conf.get_config_dict(
+                exporter_base,
+                key_mangling=('-', '_'),
+                get_first_key=True,
+                with_recursive_defaults=True,
+            )
 
     tmp = is_node_changed(conf, base + ['node-exporter', 'vrf'])
     if tmp:


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->


This PR fixes an issue where all Prometheus exporters (node_exporter, frr_exporter, blackbox_exporter) were started regardless of their configuration. The change ensures that only explicitly configured exporters are started.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7435

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Current configuration：
```
vyos@vyos# show |commands |grep 'monitoring prometheus'
set service monitoring prometheus node-exporter collectors textfile
set service monitoring prometheus node-exporter listen-address '127.0.0.1'
[edit]
```
Actual result:
```
vyos@vyos# sudo ps -ef |grep exporter
node_ex+ 1265448       1  0 16:17 ?        00:00:00 /usr/sbin/node_exporter --collector.textfile.directory=/run/node_exporter/collector --web.listen-address=127.0.0.1:9100
frr      1265454       1  0 16:17 ?        00:00:00 /usr/sbin/frr_exporter --web.listen-address=:9342
node_ex+ 1265462       1  0 16:17 ?        00:00:00 /usr/sbin/blackbox_exporter --web.listen-address=:9115 --config.file=/run/blackbox_exporter/config.yml
```
After this patch, only configured exporters are started：

```
vyos@vyos:~$ sudo python3 /usr/libexec/vyos/conf_mode/service_monitoring_prometheus.py
vyos@vyos:~$ sudo ps -ef |grep exporter
node_ex+ 1271272       1  0 16:37 ?        00:00:00 /usr/sbin/node_exporter --collector.textfile.directory=/run/node_exporter/collector --web.listen-address=127.0.0.1:9100
vyos     1271477 1183900  0 16:38 pts/2    00:00:00 grep exporter
vyos@vyos:~$
```
And the smoketest：
```
vyos@vyos:~$ sudo python3 /usr/libexec/vyos/tests//cli/test_service_monitoring_prometheus.py
test_01_node_exporter (__main__.TestMonitoringPrometheus.test_01_node_exporter) ... ok
test_02_frr_exporter (__main__.TestMonitoringPrometheus.test_02_frr_exporter) ... ok
test_03_blackbox_exporter (__main__.TestMonitoringPrometheus.test_03_blackbox_exporter) ... ok
test_04_blackbox_exporter_with_config (__main__.TestMonitoringPrometheus.test_04_blackbox_exporter_with_config) ... ok

----------------------------------------------------------------------
Ran 4 tests in 167.689s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
