### PR TITLE
T7348: Add config CPU thread-count for accel-ppp services

### DIFF
--- a/interface-definitions/include/accel-ppp/thread-count.xml.i
+++ b/interface-definitions/include/accel-ppp/thread-count.xml.i
@@ -1,0 +1,27 @@
+<!-- include start from accel-ppp/thread-count.xml.i -->
+<leafNode name="thread-count">
+  <properties>
+    <help>Number of working threads</help>
+    <completionHelp>
+      <list>all half</list>
+    </completionHelp>
+    <valueHelp>
+      <format>all</format>
+      <description>Use all available CPU cores</description>
+    </valueHelp>
+    <valueHelp>
+      <format>half</format>
+      <description>Use half of available CPU cores</description>
+    </valueHelp>
+    <valueHelp>
+      <format>u32:1-512</format>
+      <description>Thread count</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-512"/>
+      <regex>(all|half)</regex>
+    </constraint>
+  </properties>
+  <defaultValue>all</defaultValue>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/service_ipoe-server.xml.in
+++ b/interface-definitions/service_ipoe-server.xml.in
@@ -237,6 +237,7 @@
           #include <include/accel-ppp/max-concurrent-sessions.xml.i>
           #include <include/accel-ppp/shaper.xml.i>
           #include <include/accel-ppp/snmp.xml.i>
+          #include <include/accel-ppp/thread-count.xml.i>
           #include <include/generic-description.xml.i>
           #include <include/name-server-ipv4-ipv6.xml.i>
           #include <include/accel-ppp/log.xml.i>

--- a/interface-definitions/service_pppoe-server.xml.in
+++ b/interface-definitions/service_pppoe-server.xml.in
@@ -175,6 +175,7 @@
           </node>
           #include <include/accel-ppp/shaper.xml.i>
           #include <include/accel-ppp/snmp.xml.i>
+          #include <include/accel-ppp/thread-count.xml.i>
           #include <include/accel-ppp/wins-server.xml.i>
           #include <include/generic-description.xml.i>
           #include <include/name-server-ipv4-ipv6.xml.i>

--- a/interface-definitions/vpn_l2tp.xml.in
+++ b/interface-definitions/vpn_l2tp.xml.in
@@ -137,6 +137,7 @@
               #include <include/accel-ppp/ppp-options.xml.i>
               #include <include/accel-ppp/shaper.xml.i>
               #include <include/accel-ppp/snmp.xml.i>
+              #include <include/accel-ppp/thread-count.xml.i>
               #include <include/accel-ppp/wins-server.xml.i>
               #include <include/generic-description.xml.i>
               #include <include/name-server-ipv4-ipv6.xml.i>

--- a/interface-definitions/vpn_pptp.xml.in
+++ b/interface-definitions/vpn_pptp.xml.in
@@ -53,6 +53,7 @@
               #include <include/accel-ppp/ppp-options.xml.i>
               #include <include/accel-ppp/shaper.xml.i>
               #include <include/accel-ppp/snmp.xml.i>
+              #include <include/accel-ppp/thread-count.xml.i>
               #include <include/accel-ppp/wins-server.xml.i>
               #include <include/generic-description.xml.i>
               #include <include/name-server-ipv4-ipv6.xml.i>

--- a/interface-definitions/vpn_sstp.xml.in
+++ b/interface-definitions/vpn_sstp.xml.in
@@ -50,6 +50,7 @@
           #include <include/accel-ppp/ppp-options.xml.i>
           #include <include/accel-ppp/shaper.xml.i>
           #include <include/accel-ppp/snmp.xml.i>
+          #include <include/accel-ppp/thread-count.xml.i>
           #include <include/accel-ppp/wins-server.xml.i>
           #include <include/generic-description.xml.i>
           #include <include/name-server-ipv4-ipv6.xml.i>

--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -661,6 +661,7 @@ def get_accel_dict(config, base, chap_secrets, with_pki=False):
     Return a dictionary with the necessary interface config keys.
     """
     from vyos.utils.cpu import get_core_count
+    from vyos.utils.cpu import get_half_cpus
     from vyos.template import is_ipv4
 
     dict = config.get_config_dict(base, key_mangling=('-', '_'),
@@ -670,7 +671,16 @@ def get_accel_dict(config, base, chap_secrets, with_pki=False):
                                   with_pki=with_pki)
 
     # set CPUs cores to process requests
-    dict.update({'thread_count' : get_core_count()})
+    match dict.get('thread_count'):
+        case 'all':
+            dict['thread_count'] = get_core_count()
+        case 'half':
+            dict['thread_count'] = get_half_cpus()
+        case str(x) if x.isdigit():
+            dict['thread_count'] = int(x)
+        case _:
+            dict['thread_count'] = get_core_count()
+
     # we need to store the path to the secrets file
     dict.update({'chap_secrets_file' : chap_secrets})
 

--- a/python/vyos/utils/cpu.py
+++ b/python/vyos/utils/cpu.py
@@ -26,6 +26,7 @@ It has special cases for x86_64 and MAY work correctly on other architectures,
 but nothing is certain.
 """
 
+import os
 import re
 
 def _read_cpuinfo():
@@ -114,3 +115,8 @@ def get_available_cpus():
     out = json.loads(cmd('lscpu --extended -b --json'))
 
     return out['cpus']
+
+
+def get_half_cpus():
+    """ return 1/2 of the numbers of available CPUs """
+    return max(1, os.cpu_count() // 2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Accel-ppp services should not use all CPU cores to process requests. At the moment accel-ppp services use all available CPU cores to process requests from the subscribers (establish/update session/etc). During mass connection of sessions, this can lead to the fact that it utilizes all CPU, and for other services like FRR, there is not enough CPU time to process their own stable work.

Services:
 - L2TP
 - SSTP
 - PPPoE
 - IPoE
 - PPtP

Add this option as configurable and use all cores if not set:

```
set service pppoe-server thread-count '2'
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Feature that fixes the bug

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7348

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Configure `thread-count` and check this value:
```
set service pppoe-server access-concentrator 'vyos-ac'
set service pppoe-server authentication any-login
set service pppoe-server authentication local-users username one password 'one'
set service pppoe-server authentication mode 'local'
set service pppoe-server client-ip-pool FIRST range '100.64.0.0/18'
set service pppoe-server default-pool 'FIRST'
set service pppoe-server gateway-address '100.64.0.1'
set service pppoe-server interface eth0
set service pppoe-server name-server '192.0.2.1'
set service pppoe-server name-server '192.0.2.2'
set service pppoe-server ppp-options disable-ccp
set service pppoe-server thread-count '1'


vyos@r14# cat /run/accel-pppd/pppoe.conf | grep core -B1 -A 2

[core]
thread-count=1

[edit]
vyos@r14# 



vyos@r14# delete service pppoe-server thread-count 
[edit]
vyos@r14# commit
[edit]
vyos@r14# 
[edit]
vyos@r14# cat /run/accel-pppd/pppoe.conf | grep core -B1 -A 2

[core]
thread-count=4

[edit]
vyos@r14# 


vyos@r14# set service pppoe-server thread-count all
[edit]
vyos@r14# commit
[edit]
vyos@r14# 
[edit]
vyos@r14# cat /run/accel-pppd/pppoe.conf | grep core -B1 -A 2

[core]
thread-count=4

[edit]
vyos@r14# 

[edit]
vyos@r14# set service pppoe-server thread-count half 
[edit]
vyos@r14# commit
[edit]
vyos@r14# 
[edit]
vyos@r14# cat /run/accel-pppd/pppoe.conf | grep core -B1 -A 2

[core]
thread-count=2

[edit]
vyos@r14# 

vyos@r14# set service pppoe-server thread-count 3
[edit]
vyos@r14# commit
[edit]
vyos@r14# 
[edit]
vyos@r14# cat /run/accel-pppd/pppoe.conf | grep core -B1 -A 2

[core]
thread-count=3

[edit]
vyos@r14# 

vyos@r14# del service pppoe-server thread-count 3
[edit]
vyos@r14# commit
[edit]
vyos@r14# cat /run/accel-pppd/pppoe.conf | grep core -B1 -A 2

[core]
thread-count=4

[edit]
vyos@r14# 
```



Smoketest:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py
test_accel_ipv4_pool (__main__.TestServicePPPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServicePPPoEServer.test_accel_ipv6_pool) ... ok
test_accel_limits (__main__.TestServicePPPoEServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestServicePPPoEServer.test_accel_local_authentication) ... ok
test_accel_log_level (__main__.TestServicePPPoEServer.test_accel_log_level) ... ok
test_accel_name_servers (__main__.TestServicePPPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServicePPPoEServer.test_accel_next_pool) ... ok
test_accel_ppp_options (__main__.TestServicePPPoEServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestServicePPPoEServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestServicePPPoEServer.test_accel_snmp) ... ok
test_accel_wins_server (__main__.TestServicePPPoEServer.test_accel_wins_server) ... ok
test_pppoe_limits (__main__.TestServicePPPoEServer.test_pppoe_limits) ... ok
test_pppoe_server_accept_service (__main__.TestServicePPPoEServer.test_pppoe_server_accept_service) ... ok
test_pppoe_server_any_login (__main__.TestServicePPPoEServer.test_pppoe_server_any_login) ... ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer.test_pppoe_server_authentication_protocols) ... ok
test_pppoe_server_pado_delay (__main__.TestServicePPPoEServer.test_pppoe_server_pado_delay) ... ok
test_pppoe_server_shaper (__main__.TestServicePPPoEServer.test_pppoe_server_shaper) ... ok
test_pppoe_server_vlan (__main__.TestServicePPPoEServer.test_pppoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 19 tests in 153.131s

OK
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
