### PR TITLE
T7458: Fix VPN IPsec unexpected passthrough logic bug

### DIFF
--- a/src/conf_mode/vpn_ipsec.py
+++ b/src/conf_mode/vpn_ipsec.py
@@ -727,7 +727,7 @@ def generate(ipsec):
                         for remote_prefix in remote_prefixes:
                             local_net = ipaddress.ip_network(local_prefix)
                             remote_net = ipaddress.ip_network(remote_prefix)
-                            if local_net.overlaps(remote_net):
+                            if local_net.subnet_of(remote_net):
                                 if passthrough is None:
                                     passthrough = []
                                 passthrough.append(local_prefix)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
VPN IPsec unexpected passthrough logic bug was introduced in this commit https://github.com/vyos/vyos-1x/commit/f480346bb8e934b1ce2e0fc3be23f7168273bba1 The correct behaviour of the `cidr_fit` was replaced with the incorrect `overlap`

This way, the passthrough option is used every time when networks overlap.

```
>>> from ipaddress import ip_network
>>>
>>> a = ip_network('192.0.2.0/24')
>>> b = ip_network('192.0.2.100/30')
>>>
>>> a.overlaps(b)
True
>>>
>>> b.overlaps(a)
True
>>>
```

But there should be `subnet_of`:
```
>>> a.subnet_of(b)
False
>>>
>>> b.subnet_of(a)
True
>>>
```


![topo-ipsec-ts](https://github.com/user-attachments/assets/a6f18a44-5db4-4e57-a716-678e90873242)

In configuration, it looks like
```
set vpn ipsec site-to-site peer RIGHT tunnel 0 local prefix '192.0.2.0/24'
set vpn ipsec site-to-site peer RIGHT tunnel 0 remote prefix '192.0.2.100/30'
```
The StrongSwan unexpected configuration:
```
            RIGHT-tunnel-0-passthrough {
                local_ts = 192.0.2.0/24
                remote_ts = 192.0.2.0/24
                start_action = trap
                mode = pass
            }
```

So all outgoing traffic to the 192.0.2.0/24 passes through the main routing table instead of out SA
We can see it here (**no out** packets):
```
vyos@r-left# sudo swanctl -l
RIGHT: #1, ESTABLISHED, IKEv2, 8f04aedee88d168b_i* e06c6f6c279b72f8_r
  local  '192.0.2.1' @ 192.0.2.1[4500]
  remote '192.0.2.6' @ 192.0.2.6[4500]
  AES_CBC-256/HMAC_SHA1_96/PRF_HMAC_SHA1/MODP_1024
  established 1970s ago, rekeying in 24320s
  RIGHT-tunnel-0: #1, reqid 1, INSTALLED, TUNNEL, ESP:AES_CBC-256/HMAC_SHA1_96
    installed 1970s ago, rekeying in 1045s, expires in 1631s
    in  cfe45694, 115500 bytes,  1375 packets,   284s ago
    out c2c9c529,      0 bytes,     0 packets
    local  192.0.2.0/24
    remote 192.0.2.100/30
[edit]
vyos@r-left#
```
Use `subnet_of` to fix this.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7458

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
VyOS configuration:
```
set interfaces ethernet eth0 address '192.0.2.1/30'
set interfaces ethernet eth1 address '192.0.2.254/25'
set system host-name 'r-left'
set vpn ipsec authentication psk PSK id '192.0.2.1'
set vpn ipsec authentication psk PSK id '192.0.2.6'
set vpn ipsec authentication psk PSK secret '1234567890'
set vpn ipsec esp-group ESP-group lifetime '3600'
set vpn ipsec esp-group ESP-group mode 'tunnel'
set vpn ipsec esp-group ESP-group pfs 'enable'
set vpn ipsec esp-group ESP-group proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-group proposal 1 hash 'sha1'
set vpn ipsec ike-group IKE-group key-exchange 'ikev2'
set vpn ipsec ike-group IKE-group lifetime '28800'
set vpn ipsec ike-group IKE-group proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE-group proposal 1 hash 'sha1'
set vpn ipsec interface 'eth0'
set vpn ipsec site-to-site peer RIGHT authentication local-id '192.0.2.1'
set vpn ipsec site-to-site peer RIGHT authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer RIGHT authentication remote-id '192.0.2.6'
set vpn ipsec site-to-site peer RIGHT connection-type 'initiate'
set vpn ipsec site-to-site peer RIGHT ike-group 'IKE-group'
set vpn ipsec site-to-site peer RIGHT local-address '192.0.2.1'
set vpn ipsec site-to-site peer RIGHT remote-address '192.0.2.6'
set vpn ipsec site-to-site peer RIGHT tunnel 0 esp-group 'ESP-group'
set vpn ipsec site-to-site peer RIGHT tunnel 0 local prefix '192.0.2.0/24'
set vpn ipsec site-to-site peer RIGHT tunnel 0 remote prefix '192.0.2.100/30'
```
Check strongswan.conf and get unexpected `passthrough` children connection
```
vyos@r-left# cat /etc/swanctl/swanctl.conf | grep passthrough -A5
            RIGHT-tunnel-0-passthrough {
                local_ts = 192.0.2.0/24
                remote_ts = 192.0.2.0/24
                start_action = trap
                mode = pass
            }
```

The `passthrough` should be used only if the local prefix is part of the subnet of the remote prefix
for example:
```
set vpn ipsec site-to-site peer RIGHT tunnel 1 esp-group 'ESP-group'
set vpn ipsec site-to-site peer RIGHT tunnel 1 local prefix '10.2.5.0/30'
set vpn ipsec site-to-site peer RIGHT tunnel 1 remote prefix '10.0.0.0/8'
```
Expected children:
```
            RIGHT-tunnel-1 {
                esp_proposals = aes256-sha1-modp1024
                life_time = 3600s
                local_ts = 10.2.5.0/30
                remote_ts = 10.0.0.0/8
                ipcomp = no
                mode = tunnel
                start_action = start
                close_action = none
                replay_window = 32
            }
            RIGHT-tunnel-1-passthrough {
                local_ts = 10.2.5.0/30
                remote_ts = 10.2.5.0/30
                start_action = trap
                mode = pass
            }

```

## Smoketest
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
test_dhcp_fail_handling (__main__.TestVPNIPsec.test_dhcp_fail_handling) ... ok
test_dmvpn (__main__.TestVPNIPsec.test_dmvpn) ... ok
test_flex_vpn_vips (__main__.TestVPNIPsec.test_flex_vpn_vips) ... ok
test_remote_access (__main__.TestVPNIPsec.test_remote_access) ... ok
test_remote_access_dhcp_fail_handling (__main__.TestVPNIPsec.test_remote_access_dhcp_fail_handling) ... ok
test_remote_access_eap_tls (__main__.TestVPNIPsec.test_remote_access_eap_tls) ... ok
test_remote_access_no_rekey (__main__.TestVPNIPsec.test_remote_access_no_rekey) ... ok
test_remote_access_pool_range (__main__.TestVPNIPsec.test_remote_access_pool_range) ... ok
test_remote_access_vti (__main__.TestVPNIPsec.test_remote_access_vti) ... ok
test_remote_access_x509 (__main__.TestVPNIPsec.test_remote_access_x509) ... ok
test_site_to_site (__main__.TestVPNIPsec.test_site_to_site) ... ok
test_site_to_site_vti (__main__.TestVPNIPsec.test_site_to_site_vti) ... ok
test_site_to_site_vti_ts_afi (__main__.TestVPNIPsec.test_site_to_site_vti_ts_afi) ... ok
test_site_to_site_x509 (__main__.TestVPNIPsec.test_site_to_site_x509) ... ok

----------------------------------------------------------------------
Ran 14 tests in 108.134s

OK
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
