### PR TITLE
T7414: Fix conntrack ignore rules for using several ports

### DIFF
--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -728,7 +728,7 @@ def conntrack_rule(rule_conf, rule_id, action, ipv6=False):
                 if port[0] == '!':
                     operator = '!='
                     port = port[1:]
-                output.append(f'th {prefix}port {operator} {port}')
+                output.append(f'th {prefix}port {operator} {{ {port} }}')
 
             if 'group' in side_conf:
                 group = side_conf['group']

--- a/smoketest/scripts/cli/test_system_conntrack.py
+++ b/smoketest/scripts/cli/test_system_conntrack.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2024 VyOS maintainers and contributors
+# Copyright (C) 2021-2025 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -195,6 +195,8 @@ class TestSystemConntrack(VyOSUnitTestSHIM.TestCase):
     def test_conntrack_ignore(self):
         address_group = 'conntracktest'
         address_group_member = '192.168.0.1'
+        port_single = '53'
+        ports_multi = '500,4500'
         ipv6_address_group = 'conntracktest6'
         ipv6_address_group_member = 'dead:beef::1'
 
@@ -211,6 +213,14 @@ class TestSystemConntrack(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['ignore', 'ipv4', 'rule', '2', 'destination', 'group', 'address-group', address_group])
         self.cli_set(base_path + ['ignore', 'ipv4', 'rule', '2', 'protocol', 'all'])
 
+        self.cli_set(base_path + ['ignore', 'ipv4', 'rule', '3', 'source', 'address', '192.0.2.1'])
+        self.cli_set(base_path + ['ignore', 'ipv4', 'rule', '3', 'destination', 'port', ports_multi])
+        self.cli_set(base_path + ['ignore', 'ipv4', 'rule', '3', 'protocol', 'udp'])
+
+        self.cli_set(base_path + ['ignore', 'ipv4', 'rule', '4', 'source', 'address', '192.0.2.1'])
+        self.cli_set(base_path + ['ignore', 'ipv4', 'rule', '4', 'destination', 'port', port_single])
+        self.cli_set(base_path + ['ignore', 'ipv4', 'rule', '4', 'protocol', 'udp'])
+
         self.cli_set(base_path + ['ignore', 'ipv6', 'rule', '11', 'source', 'address', 'fe80::1'])
         self.cli_set(base_path + ['ignore', 'ipv6', 'rule', '11', 'destination', 'address', 'fe80::2'])
         self.cli_set(base_path + ['ignore', 'ipv6', 'rule', '11', 'destination', 'port', '22'])
@@ -226,7 +236,9 @@ class TestSystemConntrack(VyOSUnitTestSHIM.TestCase):
 
         nftables_search = [
             ['ip saddr 192.0.2.1', 'ip daddr 192.0.2.2', 'tcp dport 22', 'tcp flags & syn == syn', 'notrack'],
-            ['ip saddr 192.0.2.1', 'ip daddr @A_conntracktest', 'notrack']
+            ['ip saddr 192.0.2.1', 'ip daddr @A_conntracktest', 'notrack'],
+            ['ip saddr 192.0.2.1', 'udp dport { 500, 4500 }', 'notrack'],
+            ['ip saddr 192.0.2.1', 'udp dport 53', 'notrack']
         ]
 
         nftables6_search = [


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
If we use several port for the `conntrack ignore` there have to be used curly braces for nftables

Incorrect format: `dport  500,4500`
Correct format: `dport { 500, 4500 }`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7414

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
set system conntrack ignore ipv4 rule 1 destination address '192.0.2.0/24'
set system conntrack ignore ipv4 rule 1 destination port '500,4500'
set system conntrack ignore ipv4 rule 1 protocol 'udp'
commit

```
Before the fix:
```
vyos@vyos# commit

Failed to apply configuration: /run/nftables-ct.conf:8:59-61: Error:
Basetype of type internet network service is not bitmask         meta
l4proto udp ip daddr  192.0.2.0/24 th dport  500,4500 counter notrack
comment "ignore-1"
^^^

[[system conntrack]] failed
Commit failed
[edit]
vyos@vyos#

table ip vyos_conntrack {
    chain VYOS_CT_IGNORE {
        # rule-1 
        meta l4proto udp ip daddr  192.0.2.0/24 th dport  500,4500 counter notrack comment "ignore-1"
         return
    }
```

After the fix:
```
vyos@r14# sudo nft list table ip vyos_conntrack
table ip vyos_conntrack {
	chain VYOS_CT_IGNORE {
		ip daddr 192.0.2.0/24 udp dport { 500, 4500 } counter packets 0 bytes 0 notrack comment "ignore-1"
		return
	}

```

Smoketest:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_conntrack.py
test_conntrack_hash_size (__main__.TestSystemConntrack.test_conntrack_hash_size) ... ok
test_conntrack_ignore (__main__.TestSystemConntrack.test_conntrack_ignore) ... ok
test_conntrack_log (__main__.TestSystemConntrack.test_conntrack_log) ... ok
test_conntrack_module_enable (__main__.TestSystemConntrack.test_conntrack_module_enable) ... ok
test_conntrack_options (__main__.TestSystemConntrack.test_conntrack_options) ... ok
test_conntrack_timeout_custom (__main__.TestSystemConntrack.test_conntrack_timeout_custom) ... ok

----------------------------------------------------------------------
Ran 6 tests in 45.111s

OK
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
