### PR TITLE
vyos-1x-vmware: T3681: Fix Python bytecompile exclusion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ clean:
 
 .PHONY: test
 test: generate-configd-include-json
-	set -e; python3 -m compileall -q -x '/vmware-tools/scripts/, /ppp/' .
+	set -e; python3 -m compileall -q -x '/vmware-tools/scripts/' -x '/ppp/' .
 	PYTHONPATH=python/ python3 -m "nose" --with-xunit src --with-coverage --cover-erase --cover-xml --cover-package src/conf_mode,src/op_mode,src/completion,src/helpers,src/validators,src/tests --verbose
 
 .PHONY: check_migration_scripts_executable

--- a/debian/control
+++ b/debian/control
@@ -385,7 +385,7 @@ Description: VyOS configuration scripts and data
  VyOS configuration scripts, interface definitions, and everything
 
 Package: vyos-1x-vmware
-Architecture: amd64
+Architecture: all
 Depends:
  vyos-1x,
  open-vm-tools


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

VMware resuming was broken again due to a change in the `Makefile` in the following commit: https://github.com/vyos/vyos-1x/commit/64c9fdef02323309e97b2bb682604ada52d651e8. That change added an exclusion to the `python -m compileall` regex, however the updated exclusion regex did not work and resulted in byte compiling and creating a `__pycache__` directory again which `open-vm-tools` tries to execute on resume.

Although a fix landed upstream in `open-vm-tools` to prevent executing `__pycache__` directories [here](https://github.com/vmware/open-vm-tools/pull/689.) There is no new version in Debian that has this fix yet.

This PR fixes the Python byte compile exclusion regex by specifying it as two separate regexes, I'm not sure why the second exclusion was added initially, as there is no `/ppp/` directory that python tries to compile but I have left it in there just in case.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

https://vyos.dev/T3681

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
