### PR TITLE
T7492: Fix modem connection code

### DIFF
--- a/src/conf_mode/interfaces_wwan.py
+++ b/src/conf_mode/interfaces_wwan.py
@@ -29,6 +29,7 @@ from vyos.configverify import verify_vrf
 from vyos.configverify import verify_mtu_ipv6
 from vyos.ifconfig import WWANIf
 from vyos.utils.dict import dict_search
+from vyos.utils.network import is_wwan_connected
 from vyos.utils.process import cmd
 from vyos.utils.process import call
 from vyos.utils.process import DEVNULL
@@ -137,7 +138,7 @@ def apply(wwan):
                 break
             sleep(0.250)
 
-    if 'shutdown_required' in wwan:
+    if 'shutdown_required' in wwan or (not is_wwan_connected(wwan['ifname'])):
         # we only need the modem number. wwan0 -> 0, wwan1 -> 1
         modem = wwan['ifname'].lstrip('wwan')
         base_cmd = f'mmcli --modem {modem}'
@@ -159,7 +160,7 @@ def apply(wwan):
 
         return None
 
-    if 'shutdown_required' in wwan:
+    if 'shutdown_required' in wwan or (not is_wwan_connected(wwan['ifname'])):
         ip_type = 'ipv4'
         slaac = dict_search('ipv6.address.autoconf', wwan) != None
         if 'address' in wwan:


### PR DESCRIPTION
## Change summary
Added another possible condition to the flow through the config apply function so that interfaces will reconnect as expected, even when there has been no significant change to the contig tags.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T7492

## Related PR(s)
N/A

## How to test / Smoketest result
This change was tested on out testbed in our lab. This system is virtualised with a Sierra Wireless EM7421 LTE Modem passed through to the guest. The system was spun up and confirmed working, then the connect and disconnect methods were used as below:-

```
disconnect interface wwan0
connect interface wwan0
```

Previous broken behaviour: command would silently fail and not connect modem
New correct behaviour: If disconnected, the script wil attempt to connect the modem using mmcli

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
