### PR TITLE
zebra: T7349: Added importing routes from non to the kernel routing table

### DIFF
--- a/data/templates/frr/zebra.route-map.frr.j2
+++ b/data/templates/frr/zebra.route-map.frr.j2
@@ -1,6 +1,12 @@
 !
 {{ 'no ' if disable_forwarding is vyos_defined }}{{ afi }} forwarding
 !
+{% if import_table is vyos_defined %}
+{%     for table_num, table_config in import_table.items() %}
+ip import-table {{ table_num }} {{ 'distance ' ~ table_config.distance if table_config.distance is vyos_defined }} {{ 'route-map ' ~ table_config.route_map if table_config.route_map is vyos_defined }}
+{%     endfor %}
+{% endif %}
+!
 {% if nht.no_resolve_via_default is vyos_defined %}
 no {{ afi }} nht resolve-via-default
 {% endif %}

--- a/interface-definitions/system_ip.xml.in
+++ b/interface-definitions/system_ip.xml.in
@@ -17,6 +17,33 @@
               #include <include/arp-ndp-table-size.xml.i>
             </children>
           </node>
+          <tagNode name="import-table">
+            <properties>
+              <help>Routing table for import</help>
+              <valueHelp>
+                <format>u32:1-252</format>
+                <description>Table number</description>
+              </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-252"/>
+                </constraint>
+            </properties>
+            <children>
+              <leafNode name="distance">
+                <properties>
+                  <help>Set distance for imported routes</help>
+                  <valueHelp>
+                    <format>u32:1-255</format>
+                    <description>Routing distance</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 1-255"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              #include <include/route-map.xml.i>
+            </children>
+          </tagNode>
           <leafNode name="disable-forwarding">
             <properties>
               <help>Disable IPv4 forwarding on all interfaces</help>

--- a/interface-definitions/system_ip.xml.in
+++ b/interface-definitions/system_ip.xml.in
@@ -29,18 +29,7 @@
                 </constraint>
             </properties>
             <children>
-              <leafNode name="distance">
-                <properties>
-                  <help>Set distance for imported routes</help>
-                  <valueHelp>
-                    <format>u32:1-255</format>
-                    <description>Routing distance</description>
-                  </valueHelp>
-                  <constraint>
-                    <validator name="numeric" argument="--range 1-255"/>
-                  </constraint>
-                </properties>
-              </leafNode>
+              #include <include/static/static-route-distance.xml.i>
               #include <include/route-map.xml.i>
             </children>
           </tagNode>

--- a/src/conf_mode/system_ip.py
+++ b/src/conf_mode/system_ip.py
@@ -53,6 +53,11 @@ def verify(config_dict):
         for protocol, protocol_options in opt['protocol'].items():
             if 'route_map' in protocol_options:
                 verify_route_map(protocol_options['route_map'], opt)
+
+    if dict_search('import_table', opt):
+        for table_num, import_config in opt['import_table'].items():
+            if dict_search('route_map', import_config):
+                verify_route_map(import_config['route_map'], opt)
     return
 
 def generate(config_dict):


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Added importing routes from non-kernel to the kernel routing table.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7349

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
This feature refers to the FRR function https://docs.frrouting.org/en/latest/zebra.html#zebra-table-import.
New CLI
```
vyos@vyos# set system ip import-table 20
Possible completions:
   distance             Set distance for imported routes
   route-map            Specify route-map name to use
```

Smoketests:
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_ip.py
test_system_ip_arp_table_size (__main__.TestSystemIP.test_system_ip_arp_table_size) ... ok
test_system_ip_forwarding (__main__.TestSystemIP.test_system_ip_forwarding) ... ok
test_system_ip_import_table (__main__.TestSystemIP.test_system_ip_import_table) ... ok
test_system_ip_multipath (__main__.TestSystemIP.test_system_ip_multipath) ... ok
test_system_ip_nht (__main__.TestSystemIP.test_system_ip_nht) ... ok
test_system_ip_protocol_non_existing_route_map (__main__.TestSystemIP.test_system_ip_protocol_non_existing_route_map) ... ok
test_system_ip_protocol_route_map (__main__.TestSystemIP.test_system_ip_protocol_route_map) ... ok

----------------------------------------------------------------------
Ran 7 tests in 34.285s

OK
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
