### PR TITLE
T7484: Remove console ttyS0 section on ARM64 config.boot.default

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -97,6 +97,11 @@ override_dh_auto_install:
 	# Remove j2lint comments / linter configuration which would insert additional new-lines
 	find $(DIR)/$(VYOS_DATA_DIR) -name "*.j2" -type f | xargs sed -i -e '/^{#.*#}/d'
 
+ifeq ($(DEB_HOST_ARCH),arm64)
+	# T7484: On ARM64, remove the console ttyS0 section from default config, breaks if there is no such device
+	find $(DIR)/$(VYOS_DATA_DIR) -name "config.boot.default" -type f | xargs sed -i -e '/console {/,/^    }/d'
+endif
+
 	# Create localui dir
 	mkdir -p $(DIR)/$(VYOS_LOCALUI_DIR)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

On ARM64 the default VyOS config will break when booting the ISO when there is no serial device attached. This is also the case when you boot the KVM boot option.

For details on why this is, see the Phabricator task: https://vyos.dev/T7484

This change will modify the `config.boot.default` on ARM64 architecture to remove the following section from the config:

```json
    console {
        device ttyS0 {
            speed "115200"
        }
    }
```

This PR will remove this section from the `config.boot.default` on ARM64 architecture _only_. This will make the ISO bootable again without any errors and also installable without any errors on ARM64. Otherwise you have to use the mentioned workaround in the Phabricator task.

If one wants to have a serial device back, the user can always configure it again:

```shell
configure
set system console device ttyS0 speed 115200
commit
save
```

Note, I'm not sure if this is the best solution (I mentioned a few options in the Phabricator ticket), but I do think this is the most sane one for now.
I'm happy to go another route, so happy to receive any feedback/suggestions in this ticket or the Phabricator task.

I reckon it makes sense that if you boot the `KVM boot option` it shouldn't load any console options. But if you do boot the `Serial boot option` it should. Maybe that would be a better fix universally.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

https://vyos.dev/T7484

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Tested by building my own ISO via https://github.com/yunzheng/vyos-arm64-iso and booting it using VMWare Fusion on Apple Silicon.

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
