### PR TITLE
T7510: ospfd.frr.j2 ospf nssa translation error - fix template

### DIFF
--- a/data/templates/frr/ospfd.frr.j2
+++ b/data/templates/frr/ospfd.frr.j2
@@ -82,7 +82,7 @@ router ospf {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {%     for area_id, area_config in area.items() %}
 {%         if area_config.area_type is vyos_defined %}
 {%             for type, type_config in area_config.area_type.items() if type != 'normal' %}
- area {{ area_id }} {{ type }} {{ 'no-summary' if type_config.no_summary is vyos_defined }}
+ area {{ area_id }} {{ type }} {{ 'translate-' + type_config.translate if type_config.translate is vyos_defined }} {{ 'no-summary' if type_config.no_summary is vyos_defined }}
 {%                 if type_config.default_cost is vyos_defined %}
  area {{ area_id }} default-cost {{ type_config.default_cost }}
 {%                 endif %}

--- a/smoketest/scripts/cli/test_protocols_ospf.py
+++ b/smoketest/scripts/cli/test_protocols_ospf.py
@@ -574,5 +574,23 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'router ospf', frrconfig)
         self.assertIn(f' network {network} area {area1}', frrconfig)
 
+    def test_ospf_18_area_translate_no_summary(self):
+        area = '11'
+        area_type = 'nssa'
+        network = '100.64.0.0/10'
+
+        self.cli_set(base_path + ['area', area, 'area-type', area_type, 'no-summary'])
+        self.cli_set(base_path + ['area', area, 'area-type', area_type, 'translate', 'never'])
+        self.cli_set(base_path + ['area', area, 'network', network])
+
+        # commit changes
+        self.cli_commit()
+
+        # Verify FRR ospfd configuration
+        frrconfig = self.getFRRconfig('router ospf', endsection='^exit')
+        self.assertIn(f'router ospf', frrconfig)
+        self.assertIn(f' area {area} {area_type} translate-never no-summary', frrconfig)
+        self.assertIn(f' network {network} area {area}', frrconfig)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/src/conf_mode/protocols_ospf.py
+++ b/src/conf_mode/protocols_ospf.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2021-2024 VyOS maintainers and contributors
+# Copyright (C) 2021-2025 VyOS maintainers and contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as
@@ -17,6 +17,7 @@
 from sys import exit
 from sys import argv
 
+from vyos.base import Warning
 from vyos.config import Config
 from vyos.configverify import verify_common_route_maps
 from vyos.configverify import verify_route_map
@@ -62,6 +63,16 @@ def verify(config_dict):
     if 'area' in ospf:
           networks = []
           for area, area_config in ospf['area'].items():
+              # Implemented as warning to not break existing configurations
+              if area == '0' and dict_search('area_type.nssa', area_config) != None:
+                  Warning('You cannot configure NSSA to backbone!')
+              # Implemented as warning to not break existing configurations
+              if area == '0' and dict_search('area_type.stub', area_config) != None:
+                  Warning('You cannot configure STUB to backbone!')
+              # Implemented as warning to not break existing configurations
+              if len(area_config['area_type']) > 1:
+                  Warning(f'Only one area-type is supported for area "{area}"!')
+
               if 'import_list' in area_config:
                   acl_import = area_config['import_list']
                   if acl_import: verify_access_list(acl_import, ospf)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Hi, I have updated ospf frr template to fix nssa translation

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
Jinja2 template patching as suggested in the forum.
[https://forum.vyos.io/t/ospf-area-type-nssa-translate-never/16593/8](url)

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7510
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:/tmp$ sh conf commands | grep ospf
set protocols ospf area 0.0.0.10 area-type nssa translate 'never'
vyos@vyos:/tmp$ vtysh -e "show run ospfd no-header"
frr version 10.2.2
frr defaults traditional
hostname localhost
log syslog
log facility local7
hostname vyos
service integrated-vtysh-config
!
router ospf
 auto-cost reference-bandwidth 100
 timers throttle spf 200 1000 10000
 area 0.0.0.10 nssa translate-never
exit
!
end
vyos@vyos:/tmp$ conf 
WARNING: You are currently configuring a live-ISO environment, changes will not persist until installed
[edit]
vyos@vyos# set protocols ospf area 0.0.0.10 area-type nssa translate always 
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# exit
Warning: configuration changes have not been saved.
exit
vyos@vyos:/tmp$ vtysh -e "show run ospfd no-header"
frr version 10.2.2
frr defaults traditional
hostname localhost
log syslog
log facility local7
hostname vyos
service integrated-vtysh-config
!
router ospf
 auto-cost reference-bandwidth 100
 timers throttle spf 200 1000 10000
 area 0.0.0.10 nssa translate-always
exit
!
end
vyos@vyos:/tmp$ conf
WARNING: You are currently configuring a live-ISO environment, changes will not persist until installed
[edit]
vyos@vyos# del protocols ospf area 0.0.0.10 area-type nssa translate
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# exit
Warning: configuration changes have not been saved.
exit
vyos@vyos:/tmp$ vtysh -e "show run ospfd no-header"
frr version 10.2.2
frr defaults traditional
hostname localhost
log syslog
log facility local7
hostname vyos
service integrated-vtysh-config
!
router ospf
 auto-cost reference-bandwidth 100
 timers throttle spf 200 1000 10000
 area 0.0.0.10 nssa
exit
!
end
vyos@vyos:/tmp$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
