### PR TITLE
vyos-1x-vmware: T3681: Remove extra -x flag from Python bytecompile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ clean:
 
 .PHONY: test
 test: generate-configd-include-json
-	set -e; python3 -m compileall -q -x '/vmware-tools/scripts/' -x '/ppp/' .
+	set -e; python3 -m compileall -q -x '/vmware-tools/scripts/' .
 	PYTHONPATH=python/ python3 -m "nose" --with-xunit src --with-coverage --cover-erase --cover-xml --cover-package src/conf_mode,src/op_mode,src/completion,src/helpers,src/validators,src/tests --verbose
 
 .PHONY: check_migration_scripts_executable


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

It seems there can be only one `-x` flag defined to `python3 -m compileall` command, so the second `-x /ppp/` overrides the first `-x /vmware-tools/scripts/`, meaning that https://github.com/vyos/vyos-1x/pull/4525 did not actually solve the issue :(

This extra PR removes the erroneous `-x /ppp/` flag.  With the `-x /ppp/` removed I can confirm the `__pycache__` is not there in the package.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

https://vyos.dev/T3681

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/vyos-1x/pull/4525

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

How to verify this PR after the package has been built:

```
$ dpkg -c vyos-1x-vmware_1.5dev0-3109-g08dc2e56b+dirty_all.deb
drwxr-xr-x root/root         0 2023-09-10 13:42 ./
drwxr-xr-x root/root         0 2023-09-10 13:42 ./etc/
drwxr-xr-x root/root         0 2023-09-10 13:42 ./etc/vmware-tools/
drwxr-xr-x root/root         0 2023-09-10 13:42 ./etc/vmware-tools/scripts/
drwxr-xr-x root/root         0 2023-09-10 13:42 ./etc/vmware-tools/scripts/resume-vm-default.d/
-rwxr-xr-x root/root      2079 2023-09-10 13:42 ./etc/vmware-tools/scripts/resume-vm-default.d/ether-resume.py
-rw-r--r-- root/root        33 2023-09-10 13:42 ./etc/vmware-tools/tools.conf
drwxr-xr-x root/root         0 2023-09-10 13:42 ./usr/
drwxr-xr-x root/root         0 2023-09-10 13:42 ./usr/share/
drwxr-xr-x root/root         0 2023-09-10 13:42 ./usr/share/doc/
drwxr-xr-x root/root         0 2023-09-10 13:42 ./usr/share/doc/vyos-1x-vmware/
-rw-r--r-- root/root       322 2023-09-10 13:42 ./usr/share/doc/vyos-1x-vmware/changelog.gz
-rw-r--r-- root/root      1261 2023-09-10 13:42 ./usr/share/doc/vyos-1x-vmware/copyright
```

There should be no `__pycache__` directory in the package.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
