### PR TITLE
openvpn: T7056: Raise error if non-TAP device is bridged

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_openvpn.py
+++ b/smoketest/scripts/cli/test_interfaces_openvpn.py
@@ -826,7 +826,6 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
         gw_subnet = "192.168.0.1"
 
         self.cli_set(['interfaces', 'bridge', br_if, 'member', 'interface', vtun_if])
-        self.cli_set(path + ['device-type', 'tap'])
         self.cli_set(path + ['encryption', 'data-ciphers', 'aes192'])
         self.cli_set(path + ['hash', auth_hash])
         self.cli_set(path + ['mode', 'server'])
@@ -840,6 +839,10 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
         self.cli_set(path + ['tls', 'certificate', 'ovpn_test'])
         self.cli_set(path + ['tls', 'dh-params', 'ovpn_test'])
 
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_set(path + ['device-type', 'tap'])
         self.cli_commit()
 
         config_file = f'/run/openvpn/{vtun_if}.conf'

--- a/src/conf_mode/interfaces_bridge.py
+++ b/src/conf_mode/interfaces_bridge.py
@@ -111,6 +111,11 @@ def get_config(config=None):
             elif interface.startswith('wlan') and interface_exists(interface):
                 set_dependents('wlan', conf, interface)
 
+            if interface.startswith('vtun'):
+                _, tmp_config = get_interface_dict(conf, ['interfaces', 'openvpn'], interface)
+                tmp = tmp_config.get('device_type') == 'tap'
+                bridge['member']['interface'][interface].update({'valid_ovpn' : tmp})
+
     # delete empty dictionary keys - no need to run code paths if nothing is there to do
     if 'member' in bridge:
         if 'interface' in bridge['member'] and len(bridge['member']['interface']) == 0:
@@ -177,6 +182,9 @@ def verify(bridge):
                 for option in ['allowed_vlan', 'native_vlan']:
                     if option in interface_config:
                         raise ConfigError('Can not use VLAN options on non VLAN aware bridge')
+
+            if interface.startswith('vtun') and not interface_config['valid_ovpn']:
+                raise ConfigError(error_msg + 'OpenVPN device-type must be set to "tap"')
 
     if 'enable_vlan' in bridge:
         if dict_search('vif.1', bridge):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Verify a bridged OpenVPN interface is set to TAP/L2 device type.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py
DEBUG - test_openvpn_client_interfaces (__main__.TestInterfacesOpenVPN.test_openvpn_client_interfaces) ... ok
DEBUG - test_openvpn_client_ip_version (__main__.TestInterfacesOpenVPN.test_openvpn_client_ip_version) ... ok
DEBUG - test_openvpn_client_verify (__main__.TestInterfacesOpenVPN.test_openvpn_client_verify) ... ok
DEBUG - test_openvpn_options (__main__.TestInterfacesOpenVPN.test_openvpn_options) ... ok
DEBUG - test_openvpn_server_ip_version (__main__.TestInterfacesOpenVPN.test_openvpn_server_ip_version) ... ok
DEBUG - test_openvpn_server_server_bridge (__main__.TestInterfacesOpenVPN.test_openvpn_server_server_bridge) ... ok
DEBUG - test_openvpn_server_subnet_topology (__main__.TestInterfacesOpenVPN.test_openvpn_server_subnet_topology) ... ok
DEBUG - test_openvpn_server_verify (__main__.TestInterfacesOpenVPN.test_openvpn_server_verify) ... ok
DEBUG - test_openvpn_site2site_interfaces_tun (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_interfaces_tun) ... ok
DEBUG - test_openvpn_site2site_ip_version (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_ip_version) ... ok
DEBUG - test_openvpn_site2site_verify (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_verify) ... ok
DEBUG - 
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 11 tests in 131.878s
DEBUG - 
DEBUG - OK
```

```
vyos@vyos# commit
[ interfaces bridge br268 ]
Can not add interface "vtun268" to bridge, OpenVPN device-type must be
set to "tap"
[[interfaces bridge br268]] failed
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
