### PR TITLE
T7528: only stop service if previously deployed

### DIFF
--- a/src/conf_mode/service_monitoring_prometheus.py
+++ b/src/conf_mode/service_monitoring_prometheus.py
@@ -64,18 +64,29 @@ def get_config(config=None):
                 with_recursive_defaults=True,
             )
 
-    tmp = is_node_changed(conf, base + ['node-exporter', 'vrf'])
-    if tmp:
+    # mark to stop services if they are removed
+    if not monitoring or 'node_exporter' not in monitoring:
+        if os.path.isfile(node_exporter_service_file):
+            monitoring.update({'node_exporter_stop_required': {}})
+
+    if not monitoring or 'frr_exporter' not in monitoring:
+        if os.path.isfile(frr_exporter_service_file):
+            monitoring.update({'frr_exporter_stop_required': {}})
+
+    if not monitoring or 'blackbox_exporter' not in monitoring:
+        if os.path.isfile(blackbox_exporter_service_file):
+            monitoring.update({'blackbox_exporter_stop_required': {}})
+
+    # mark to restart services if changed
+    if is_node_changed(conf, base + ['node-exporter', 'vrf']):
         monitoring.update({'node_exporter_restart_required': {}})
 
-    tmp = is_node_changed(conf, base + ['frr-exporter', 'vrf'])
-    if tmp:
+    if is_node_changed(conf, base + ['frr-exporter', 'vrf']):
         monitoring.update({'frr_exporter_restart_required': {}})
 
-    tmp = False
-    for node in ['vrf', 'config-file']:
-        tmp = tmp or is_node_changed(conf, base + ['blackbox-exporter', node])
-    if tmp:
+    if is_node_changed(conf, base + ['blackbox-exporter', 'vrf']) or is_node_changed(
+        conf, base + ['blackbox-exporter', 'conf-file']
+    ):
         monitoring.update({'blackbox_exporter_restart_required': {}})
 
     return monitoring
@@ -115,16 +126,19 @@ def generate(monitoring):
         # Delete systemd files
         if os.path.isfile(node_exporter_service_file):
             os.unlink(node_exporter_service_file)
+            monitoring.update({'node_exporter_stop_required': {}})
 
     if not monitoring or 'frr_exporter' not in monitoring:
         # Delete systemd files
         if os.path.isfile(frr_exporter_service_file):
             os.unlink(frr_exporter_service_file)
+            monitoring.update({'frr_exporter_stop_required': {}})
 
     if not monitoring or 'blackbox_exporter' not in monitoring:
         # Delete systemd files
         if os.path.isfile(blackbox_exporter_service_file):
             os.unlink(blackbox_exporter_service_file)
+            monitoring.update({'blackbox_exporter_stop_required': {}})
 
     if not monitoring:
         return None
@@ -173,11 +187,14 @@ def apply(monitoring):
     # Reload systemd manager configuration
     call('systemctl daemon-reload')
     if not monitoring or 'node_exporter' not in monitoring:
-        call(f'systemctl stop {node_exporter_systemd_service}')
+        if 'node_exporter_stop_required' in monitoring:
+            call(f'systemctl stop {node_exporter_systemd_service}')
     if not monitoring or 'frr_exporter' not in monitoring:
-        call(f'systemctl stop {frr_exporter_systemd_service}')
+        if 'frr_exporter_stop_required' in monitoring:
+            call(f'systemctl stop {frr_exporter_systemd_service}')
     if not monitoring or 'blackbox_exporter' not in monitoring:
-        call(f'systemctl stop {blackbox_exporter_systemd_service}')
+        if 'blackbox_exporter_stop_required' in monitoring:
+            call(f'systemctl stop {blackbox_exporter_systemd_service}')
 
     if not monitoring:
         return


### PR DESCRIPTION
## Change summary
Apply tries to stop services that weren't configured in the first place. Adding check to only try to stop services which were installed.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T7528

## Related PR(s)
* #4498

## How to test / Smoketest result
```
set interfaces dummy dum0 address '192.0.2.1/32'
set service monitoring prometheus node-exporter collectors textfile
set service monitoring prometheus node-exporter listen-address '192.0.2.1'
```
Verify logs not trying to stop in-existing vrr/blackbox exporter services


## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
