### PR TITLE
T7488: add utility for automatic rollback of section on apply stage error

### DIFF
--- a/python/vyos/configsession.py
+++ b/python/vyos/configsession.py
@@ -146,7 +146,7 @@ class ConfigSession(object):
     The write API of VyOS.
     """
 
-    def __init__(self, session_id, app=APP):
+    def __init__(self, session_id, app=APP, shared=False):
         """
          Creates a new config session.
 
@@ -187,7 +187,11 @@ class ConfigSession(object):
         else:
             self._vyconf_session = None
 
+        self.shared = shared
+
     def __del__(self):
+        if self.shared:
+            return
         if self._vyconf_session is None:
             try:
                 output = (

--- a/src/helpers/reset_section.py
+++ b/src/helpers/reset_section.py
@@ -29,6 +29,7 @@ from vyos.xml_ref import is_leaf
 
 
 CFG_GROUP = 'vyattacfg'
+DEBUG = False
 
 
 def type_str_to_list(value):
@@ -58,7 +59,10 @@ try:
     if is_leaf(path):
         sys.exit('path is leaf node: neither allowed nor useful')
 except ValueError:
-    sys.exit('nonexistent path: neither allowed nor useful')
+    if DEBUG:
+        sys.exit('nonexistent path: neither allowed nor useful')
+    else:
+        sys.exit()
 
 test = Config()
 in_session = test.in_session()

--- a/src/helpers/reset_section.py
+++ b/src/helpers/reset_section.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2025 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+
+import argparse
+import sys
+import os
+
+from vyos.configsession import ConfigSession
+from vyos.config import Config
+from vyos.configdiff import get_config_diff
+from vyos.xml_ref import is_leaf
+
+
+def type_str_to_list(value):
+    if isinstance(value, str):
+        return value.split()
+    raise argparse.ArgumentTypeError('path must be a whitespace separated string')
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('path', type=type_str_to_list, help='section to reload/rollback')
+parser.add_argument('--pid', help='pid of config session')
+
+group = parser.add_mutually_exclusive_group()
+group.add_argument('--reload', action='store_true', help='retry proposed commit')
+group.add_argument(
+    '--rollback', action='store_true', default=True, help='rollback to stable commit'
+)
+
+args = parser.parse_args()
+
+path = args.path
+reload = args.reload
+rollback = args.rollback
+pid = args.pid
+
+try:
+    if is_leaf(path):
+        sys.exit('path is leaf node: neither allowed nor useful')
+except ValueError:
+    sys.exit('nonexistent path: neither allowed nor useful')
+
+test = Config()
+if not test.in_session():
+    sys.exit('reset_section not available outside of a config session')
+
+diff = get_config_diff(test)
+if not diff.is_node_changed(path):
+    # No discrepancies at path after commit, hence no error to revert.
+    sys.exit()
+
+del diff
+del test
+
+
+session_id = int(pid) if pid else os.getppid()
+
+# check hint left by vyshim when ConfigError is from apply stage
+hint_name = f'/tmp/apply_{session_id}'
+if not os.path.exists(hint_name):
+    # no apply error; exit
+    sys.exit()
+else:
+    # cleanup hint and continue with reset
+    os.unlink(hint_name)
+
+session = ConfigSession(session_id, shared=True)
+
+session_env = session.get_session_env()
+config = Config(session_env)
+
+effective = not bool(reload)
+
+d = config.get_config_dict(path, effective=effective, get_first_key=True)
+
+session.discard()
+
+session.delete(path)
+session.commit()
+
+if not d:
+    # nothing more to do in either case of reload/rollback
+    sys.exit()
+
+session.set_section(path, d)
+session.commit()

--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -68,6 +68,7 @@ class Response(Enum):
     ERROR_COMMIT = 2
     ERROR_DAEMON = 4
     PASS = 8
+    ERROR_COMMIT_APPLY = 16
 
 
 vyos_conf_scripts_dir = directories['conf_mode']
@@ -142,8 +143,6 @@ def run_script(script_name, config, args) -> tuple[Response, str]:
     try:
         c = script.get_config(config)
         script.verify(c)
-        script.generate(c)
-        script.apply(c)
     except ConfigError as e:
         logger.error(e)
         return Response.ERROR_COMMIT, str(e)
@@ -151,6 +150,17 @@ def run_script(script_name, config, args) -> tuple[Response, str]:
         tb = traceback.format_exc()
         logger.error(tb)
         return Response.ERROR_COMMIT, tb
+
+    try:
+        script.generate(c)
+        script.apply(c)
+    except ConfigError as e:
+        logger.error(e)
+        return Response.ERROR_COMMIT_APPLY, str(e)
+    except Exception:
+        tb = traceback.format_exc()
+        logger.error(tb)
+        return Response.ERROR_COMMIT_APPLY, tb
 
     return Response.SUCCESS, ''
 

--- a/src/shim/vyshim.c
+++ b/src/shim/vyshim.c
@@ -18,8 +18,10 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <fcntl.h>
 #include <unistd.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <time.h>
 #include <stdint.h>
@@ -55,15 +57,17 @@ enum {
     SUCCESS =      1 << 0,
     ERROR_COMMIT = 1 << 1,
     ERROR_DAEMON = 1 << 2,
-    PASS =         1 << 3
+    PASS =         1 << 3,
+    ERROR_COMMIT_APPLY = 1 << 4
 };
 
 volatile int init_alarm = 0;
 volatile int timeout = 0;
 
-int initialization(void *);
+int initialization(void *, char *);
 int pass_through(char **, int);
 void timer_handler(int);
+void leave_hint(char *);
 
 double get_posix_clock_time(void);
 
@@ -94,8 +98,17 @@ int main(int argc, char* argv[])
     char *test = strstr(string_node_data, "VYOS_TAGNODE_VALUE");
     ex_index = test ? 2 : 1;
 
+    char *env_tmp = getenv("VYATTA_CONFIG_TMP");
+    if (env_tmp == NULL) {
+        fprintf(stderr, "Error: Environment variable VYATTA_CONFIG_TMP is not set.\n");
+        exit(EXIT_FAILURE);
+    }
+    char *pid_str = strdup(env_tmp);
+    strsep(&pid_str, "_");
+    debug_print("config session pid: %s\n", pid_str);
+
     if (access(COMMIT_MARKER, F_OK) != -1) {
-        init_timeout = initialization(requester);
+        init_timeout = initialization(requester, pid_str);
         if (!init_timeout) remove(COMMIT_MARKER);
     }
 
@@ -151,13 +164,19 @@ int main(int argc, char* argv[])
         ret = -1;
     }
 
+    if (err & ERROR_COMMIT_APPLY) {
+        debug_print("Received ERROR_COMMIT_APPLY\n");
+        leave_hint(pid_str);
+        ret = -1;
+    }
+
     zmq_close(requester);
     zmq_ctx_destroy(context);
 
     return ret;
 }
 
-int initialization(void* Requester)
+int initialization(void* Requester, char* pid_val)
 {
     char *active_str = NULL;
     size_t active_len = 0;
@@ -184,10 +203,6 @@ int initialization(void* Requester)
 
     double prev_time_value, time_value;
     double time_diff;
-
-    char *pid_val = getenv("VYATTA_CONFIG_TMP");
-    strsep(&pid_val, "_");
-    debug_print("config session pid: %s\n", pid_val);
 
     char *sudo_user = getenv("SUDO_USER");
     if (!sudo_user) {
@@ -336,6 +351,16 @@ void timer_handler(int signum)
     init_alarm = 1;
 
     return;
+}
+
+void leave_hint(char *pid_val)
+{
+    char tmp_str[16];
+    mode_t omask = umask(0);
+    snprintf(tmp_str, sizeof(tmp_str), "/tmp/apply_%s", pid_val);
+    open(tmp_str, O_CREAT|O_RDWR|O_TRUNC, 0666);
+    chown(tmp_str, 1002, 102);
+    umask(omask);
 }
 
 #ifdef _POSIX_MONOTONIC_CLOCK


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

This needs the corresponding PR for vyatta-cfg (https://github.com/vyos/vyatta-cfg/pull/102) to have effect within a config session. The _current_ PR will need to be merged first.

Provide a utility for automatic rollback of a config section in case of an apply stage error.
This is the required tool for the VPP restart work of PR https://github.com/vyos/vyos-vpp/pull/34

Under the modern backend, this will simply be a post-commit hook, however, for current use under the legacy backend, it requires some workarounds, notably because we are constrained by the legacy locking mechanism, which prevents a post commit hook from calling commit. This is already possible under vyconf which uses distinct locks for data vs. session.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/vyatta-cfg/pull/102
https://github.com/vyos/vyos-vpp/pull/34

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Tested by @natali-rs1985 in the context of https://github.com/vyos/vyos-vpp/pull/34

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
