### PR TITLE
smoketest: T7539: improve Kernel option check for WWAN

### DIFF
--- a/smoketest/scripts/system/test_kernel_options.py
+++ b/smoketest/scripts/system/test_kernel_options.py
@@ -143,5 +143,10 @@ class TestKernelModules(unittest.TestCase):
             tmp = re.findall(f'{option}=3', self._config_data)
             self.assertTrue(tmp)
 
+    def test_inotify_stackfs(self):
+        for option in ['CONFIG_INOTIFY_USER', 'CONFIG_INOTIFY_STACKFS']:
+            tmp = re.findall(f'{option}=y', self._config_data)
+            self.assertTrue(tmp)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/smoketest/scripts/system/test_kernel_options.py
+++ b/smoketest/scripts/system/test_kernel_options.py
@@ -148,5 +148,18 @@ class TestKernelModules(unittest.TestCase):
             tmp = re.findall(f'{option}=y', self._config_data)
             self.assertTrue(tmp)
 
+    def test_wwan(self):
+        for option in ['CONFIG_USB_NET_DRIVERS', 'CONFIG_USB_USBNET',
+                       'CONFIG_USB_NET_CDCETHER', 'CONFIG_USB_NET_HUAWEI_CDC_NCM',
+                       'CONFIG_USB_NET_CDC_MBIM', 'CONFIG_USB_NET_QMI_WWAN',
+                       'CONFIG_USB_SIERRA_NET', 'CONFIG_WWAN',
+                       'CONFIG_USB_SERIAL', 'CONFIG_USB_SERIAL_WWAN']:
+            tmp = re.findall(f'{option}=y', self._config_data)
+            self.assertTrue(tmp)
+
+        for option in ['CONFIG_WWAN_HWSIM', 'CONFIG_IOSM', 'CONFIG_MTK_T7XX']:
+            tmp = re.findall(f'{option}=m', self._config_data)
+            self.assertTrue(tmp)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Improve Kernel option check for WWAN using Smoketests

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7539

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/977

## How to test / Smoketest result

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/system/test_kernel_options.py
test_amd_pstate (__main__.TestKernelModules.test_amd_pstate) ... ok
test_bond_interface (__main__.TestKernelModules.test_bond_interface) ... ok
test_bridge_interface (__main__.TestKernelModules.test_bridge_interface) ... ok
test_container_cgroup_support (__main__.TestKernelModules.test_container_cgroup_support) ... ok
test_container_cpu (__main__.TestKernelModules.test_container_cpu) ... ok
test_dropmon_enabled (__main__.TestKernelModules.test_dropmon_enabled) ... ok
test_inotify_stackfs (__main__.TestKernelModules.test_inotify_stackfs) ... ok
test_ip_routing_support (__main__.TestKernelModules.test_ip_routing_support) ... ok
test_psample_enabled (__main__.TestKernelModules.test_psample_enabled) ... ok
test_qemu_support (__main__.TestKernelModules.test_qemu_support) ... ok
test_synproxy_enabled (__main__.TestKernelModules.test_synproxy_enabled) ... ok
test_vfio (__main__.TestKernelModules.test_vfio) ... ok
test_vmware_support (__main__.TestKernelModules.test_vmware_support) ... ok
test_wwan (__main__.TestKernelModules.test_wwan) ... ok

----------------------------------------------------------------------
Ran 14 tests in 0.015s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
