### PR TITLE
op-mode: T7542: add support for "standalone" behavior of operational mode tag nodes

### DIFF
--- a/schema/op-mode-definition.rnc
+++ b/schema/op-mode-definition.rnc
@@ -1,6 +1,6 @@
 #    interface_definition.rnc: VyConf reference tree XML grammar
 #
-#    Copyright (C) 2014. 2017 VyOS maintainers and contributors <maintainers@vyos.net>
+#    Copyright (C) 2014-2025 VyOS maintainers and contributors <maintainers@vyos.net>
 #
 #    This library is free software; you can redistribute it and/or
 #    modify it under the terms of the GNU Lesser General Public
@@ -37,13 +37,27 @@ node = element node
 }
 
 # Tag nodes are containers for nodes without predefined names, like network interfaces
-# or user names (e.g. "interfaces ethernet eth0" or "user jrandomhacker")
-# Tag nodes may contain node and leafNode elements, and also nameConstraint tags
-# They must not contain other tag nodes
+# or user names (e.g. "show interfaces ethernet ethX").
+# Operational mode tag nodes can be parents to other tag nodes,
+# like in "ping <host> count <packets>".
+#
+# Some commands can be called either with or without arguments,
+# like "show interfaces ethernet eth0" (show info for eth0 only)
+# or "show interfaces ethernet" (show info about all ethernet interfaces).
+# That case is handled using the <standalone> element
 tagNode = element tagNode
 {
     nodeNameAttr,
-    (properties? & children? & command?)
+    (properties? & standalone? & children? & command?)
+}
+
+# The <standalone> element is only used inside tag nodes
+# to define their behavior when they are called without arguments
+# It can provide a help string and a command.
+# Everything else is handled in the <tagNode> itself.
+standalone = element standalone
+{
+    help & command
 }
 
 # Leaf nodes are terminal configuration nodes that can't have children,

--- a/schema/op-mode-definition.rng
+++ b/schema/op-mode-definition.rng
@@ -3,7 +3,7 @@
   <!--
        interface_definition.rnc: VyConf reference tree XML grammar
     
-       Copyright (C) 2014. 2017 VyOS maintainers and contributors <maintainers@vyos.net>
+       Copyright (C) 2014-2025 VyOS maintainers and contributors <maintainers@vyos.net>
     
        This library is free software; you can redistribute it and/or
        modify it under the terms of the GNU Lesser General Public
@@ -59,9 +59,14 @@
   </define>
   <!--
     Tag nodes are containers for nodes without predefined names, like network interfaces
-    or user names (e.g. "interfaces ethernet eth0" or "user jrandomhacker")
-    Tag nodes may contain node and leafNode elements, and also nameConstraint tags
-    They must not contain other tag nodes
+    or user names (e.g. "show interfaces ethernet ethX").
+    Operational mode tag nodes can be parents to other tag nodes,
+    like in "ping <host> count <packets>".
+    
+    Some commands can be called either with or without arguments,
+    like "show interfaces ethernet eth0" (show info for eth0 only)
+    or "show interfaces ethernet" (show info about all ethernet interfaces).
+    That case is handled using the <standalone> element
   -->
   <define name="tagNode">
     <element name="tagNode">
@@ -71,11 +76,28 @@
           <ref name="properties"/>
         </optional>
         <optional>
+          <ref name="standalone"/>
+        </optional>
+        <optional>
           <ref name="children"/>
         </optional>
         <optional>
           <ref name="command"/>
         </optional>
+      </interleave>
+    </element>
+  </define>
+  <!--
+    The <standalone> element is only used inside tag nodes
+    to define their behavior when they are called without arguments
+    It can provide a help string and a command.
+    Everything else is handled in the <tagNode> itself.
+  -->
+  <define name="standalone">
+    <element name="standalone">
+      <interleave>
+        <ref name="help"/>
+        <ref name="command"/>
       </interleave>
     </element>
   </define>
@@ -139,10 +161,11 @@
   <!--
     completionHelp tags contain information about allowed values of a node that is used for generating
     tab completion in the CLI frontend and drop-down lists in GUI frontends
-    It is only meaninful for leaf nodes
+    It is only meaningful for leaf nodes
     Allowed values can be given as a fixed list of values (e.g. <list>foo bar baz</list>),
     as a configuration path (e.g. <path>interfaces ethernet</path>),
-    or as a path to a script file that generates the list (e.g. <script>/usr/lib/foo/list-things</script>
+    as a path to a script file that generates the list (e.g. <script>/usr/lib/foo/list-things</script>,
+    or to enable built-in image path completion (<imagePath/>).
   -->
   <define name="completionHelp">
     <element name="completionHelp">

--- a/scripts/build-command-op-templates
+++ b/scripts/build-command-op-templates
@@ -124,6 +124,26 @@ def get_properties(p):
 
     return props
 
+def get_standalone(s):
+    standalone = {}
+
+    if s is None:
+        return {}
+
+    # Get the help string
+    try:
+        standalone["help"] = s.find("help").text
+    except:
+        standalone["help"] = "No help available"
+
+    # Get the command -- it's required by the schema
+    try:
+        standalone["command"] = s.find("command")
+    except:
+        raise AssertionError("Found a <standalone> node without <command>")
+
+    return standalone
+
 
 def make_node_def(props, command):
     # XXX: replace with a template processor if it grows
@@ -150,6 +170,7 @@ def process_node(n, tmpl_dir):
     my_tmpl_dir = copy.copy(tmpl_dir)
 
     props_elem = n.find("properties")
+    standalone_elem = n.find("standalone")
     children = n.find("children")
     command = n.find("command")
     name = n.get("name")
@@ -163,6 +184,7 @@ def process_node(n, tmpl_dir):
     os.makedirs(make_path(my_tmpl_dir), exist_ok=True)
 
     props = get_properties(props_elem)
+    standalone = get_standalone(standalone_elem)
 
     nodedef_path = os.path.join(make_path(my_tmpl_dir), "node.def")
     if node_type == "node":
@@ -189,7 +211,10 @@ def process_node(n, tmpl_dir):
         # does not exist at all.
         if not os.path.exists(nodedef_path) or os.path.getsize(nodedef_path) == 0:
             with open(nodedef_path, "w") as f:
-                f.write('help: {0}\n'.format(props['help']))
+                if standalone:
+                    f.write(make_node_def(standalone, standalone["command"]))
+                else:
+                    f.write('help: {0}\n'.format(props['help']))
 
         # Create the inner node.tag part
         my_tmpl_dir.append("node.tag")


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

There are operational mode commands that can be called either with an argument or without. For example, `show interfaces ethernet` (show information about all Ethernet interfaces) and `show interfaces ethernet eth0` (only show information for `eth0`).

The old way to handle that was to create a `<node>` and a `<tagNode>` with the same name ("ethernet" for the example above) — the `<node>` would handle the call to `show interfaces ethernet` and the `<tagNode>` would handle the case with `ethX`.

That was a pretty nasty exploit of the way the old CLI backend works and causes multiple problems: from unnecessarily verbose XML files with a lot of duplication to big difficulties with implementing a new command lookup algorithm and a documentation generator (outlined in T7541).

There are two possible ways to think about such commands that can be called with or without arguments.

The first way is that `show interfaces ethernet` is like a normal node — it has a meaning of its own and can be called without an argument, but shares a property with tag nodes — it can also take an argument. In that approach, normal nodes need a way to include anonymous children to account for variable arguments. That was my initial idea that created significant  difficulties with the JSON representation that would be used for command lookup — how to mark a child node as that anonymous child? I was thinking of using some reserved name for that purpose like `"!tag"` (since `!` is not used in command names).

However, later I realized that there was another way to think about those commands. `show interfaces ethernet` is a tag node that shares a property with normal nodes — it has a special behavior when it's called without an argument. Most tag nodes command tell the user that an argument is required, this one show information for all Ethernet interfaces. That means that is just needs a way to define that behavior. And in practice that behavior is just a help string and a command.

This PR adds a new `<standalone>` element that can be included in `<tagNode>` to give it a help string and a command to call when it's executed without arguments:

```
<tagNode name="foo">
  <properties> ... </properties>
  <command>the command to run when the node is called with an argument</command>
  <standalone>
    <help>outer node help string</help>
    <command>command to run when the node is called without an argument</command>
  </standalone>
</tagNode>
```

That change is fully compatible with the old schema.

So far, commands are mandatory for standalone elements because I couldn't think of a case where it makes sense to add it just for the help strings. That restriction can be trivially relaxed later.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
