### PR TITLE
dhcp: T6068: Fix Kea HA duplicate peer names causing configuration fa…

### DIFF
--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -850,8 +850,24 @@ def kea_high_availability_json(config):
         peer1_role = 'standby' if ha_mode == 'hot-standby' else 'secondary'
         peer2_role = 'primary'
 
+    # FIX: Use config['name'] for this server instead of hostname
+    this_server_name = config['name']
+
+    # FIX: Derive remote peer name to avoid duplicates
+    if this_server_name == 'backup':
+        remote_peer_name = 'main'
+    elif this_server_name == 'main':
+        remote_peer_name = 'backup'
+    elif this_server_name == 'secondary':
+        remote_peer_name = 'primary'
+    elif this_server_name == 'primary':
+        remote_peer_name = 'secondary'
+    else:
+        # Fallback: append suffix to differentiate
+        remote_peer_name = f"{this_server_name}-peer"
+
     data = {
-        'this-server-name': os.uname()[1],
+        'this-server-name': this_server_name,
         'mode': ha_mode,
         'heartbeat-delay': 10000,
         'max-response-delay': 10000,
@@ -859,13 +875,13 @@ def kea_high_availability_json(config):
         'max-unacked-clients': 0,
         'peers': [
         {
-            'name': os.uname()[1],
+            'name': this_server_name,
             'url': f'http://{source_addr}:647/',
             'role': peer1_role,
             'auto-failover': True
         },
         {
-            'name': config['name'],
+            'name': remote_peer_name,
             'url': f'http://{remote_addr}:647/',
             'role': peer2_role,
             'auto-failover': True


### PR DESCRIPTION
# dhcp: T6068: Fix Kea HA duplicate peer names causing configuration failure

Replace os.uname()[1] usage with config['name'] and add peer name derivation logic to ensure unique peer names in HA configuration. Fixes "peer with name already specified" error that prevented HA from working.

## Change summary
Fixes a bug in the Kea DHCP High Availability configuration where duplicate peer names caused HA to fail with "peer with name 'X' already specified" error. The issue occurred when both `os.uname()[1]` (hostname) and `config['name']` resolved to the same value.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T6068

## Related PR(s)
None

## How to test / Smoketest result

### Problem Reproduction:
```bash
set service dhcp-server high-availability mode 'active-passive'
set service dhcp-server high-availability name 'backup'
set service dhcp-server high-availability remote '192.168.1.11'
set service dhcp-server high-availability source-address '192.168.1.12'
set service dhcp-server high-availability status 'secondary'
commit