### PR TITLE
op-mode: T7560: add support for virtual tag nodes

### DIFF
--- a/op-mode-definitions/clear-ip.xml.in
+++ b/op-mode-definitions/clear-ip.xml.in
@@ -7,12 +7,6 @@
           <help>Clear Internet Protocol (IP) statistics or status</help>
         </properties>
         <children>
-          <node name="prefix-list">
-            <properties>
-              <help>Clear prefix-list statistics or status</help>
-            </properties>
-            <command>vtysh -c "$*"</command>
-          </node>
           <tagNode name="prefix-list">
             <properties>
               <help>Clear prefix-list statistics or status for specified word</help>
@@ -20,9 +14,13 @@
                 <list>&lt;WORD&gt;</list>
               </completionHelp>
             </properties>
+            <standalone>
+              <help>Clear prefix-list statistics or status</help>
+              <command>vtysh -c "$*"</command>
+            </standalone>
             <command>vtysh -c "$*"</command>
             <children>
-              <leafNode name="node.tag">
+              <virtualTagNode>
                 <properties>
                   <help>Clear prefix-list statistics or status for given word|network</help>
                   <completionHelp>
@@ -30,7 +28,7 @@
                   </completionHelp>
                 </properties>
                 <command>vtysh -c "$*"</command>
-              </leafNode>
+              </virtualTagNode>
             </children>
           </tagNode>
         </children>

--- a/op-mode-definitions/clear-ipv6.xml.in
+++ b/op-mode-definitions/clear-ipv6.xml.in
@@ -7,12 +7,6 @@
           <help>Clear Internet Protocol (IPv6) statistics or status</help>
         </properties>
         <children>
-          <node name="prefix-list">
-            <properties>
-              <help>Clear prefix-list statistics or status</help>
-            </properties>
-            <command>vtysh -c "$*"</command>
-          </node>
           <tagNode name="prefix-list">
             <properties>
               <help>Clear prefix-list statistics or status for specified word</help>
@@ -20,9 +14,13 @@
                 <list>WORD</list>
               </completionHelp>
             </properties>
+            <standalone>
+              <help>Clear prefix-list statistics or status</help>
+              <command>vtysh -c "$*"</command>
+            </standalone>
             <command>vtysh -c "$*"</command>
             <children>
-              <leafNode name="node.tag">
+              <virtualTagNode>
                 <properties>
                   <help>Clear prefix-list statistics or status for given word|network</help>
                   <completionHelp>
@@ -30,7 +28,7 @@
                   </completionHelp>
                 </properties>
                 <command>vtysh -c "$*"</command>
-              </leafNode>
+              </virtualTagNode>
             </children>
           </tagNode>
         </children>

--- a/op-mode-definitions/execute-port-scan.xml.in
+++ b/op-mode-definitions/execute-port-scan.xml.in
@@ -16,7 +16,7 @@
             </properties>
             <command>nmap -p- -T4 --max-retries=1 --host-timeout=30s "$4"</command>
             <children>
-              <leafNode name="node.tag">
+              <virtualTagNode>
                 <properties>
                   <help>Port scan options</help>
                   <completionHelp>
@@ -24,7 +24,7 @@
                   </completionHelp>
                 </properties>
                 <command>${vyos_op_scripts_dir}/execute_port-scan.py "${@:4}"</command>
-              </leafNode>
+              </virtualTagNode>
             </children>
           </tagNode>
         </children>

--- a/op-mode-definitions/firewall.xml.in
+++ b/op-mode-definitions/firewall.xml.in
@@ -7,43 +7,43 @@
           <help>Show firewall information</help>
         </properties>
         <children>
-          <tagNode name="group">
-            <properties>
-              <help>Show firewall group</help>
-              <completionHelp>
-                <path>firewall group address-group</path>
-                <path>firewall group network-group</path>
-                <path>firewall group port-group</path>
-                <path>firewall group domain-group</path>
-                <path>firewall group dynamic-group address-group</path>
-                <path>firewall group dynamic-group ipv6-address-group</path>
-                <path>firewall group interface-group</path>
-                <path>firewall group ipv6-address-group</path>
-                <path>firewall group ipv6-network-group</path>
-                <path>firewall group mac-group</path>
-                <path>firewall group network-group</path>
-                <path>firewall group port-group</path>
-                <path>firewall group remote-group</path>
-              </completionHelp>
-            </properties>
-            <children>
-              <leafNode name="detail">
-                <properties>
-                  <help>Show list view of firewall groups</help>
-                  <completionHelp>
-                    <path>firewall group detail</path>
-                  </completionHelp>
-                </properties>
-                <command>${vyos_op_scripts_dir}/firewall.py --action show_group --name $4 --detail $5</command>
-              </leafNode>
-            </children>
-            <command>${vyos_op_scripts_dir}/firewall.py --action show_group --name $4</command>
-          </tagNode>
           <node name="group">
             <properties>
               <help>Show firewall group</help>
             </properties>
             <children>
+              <virtualTagNode>
+                <properties>
+                  <help>Show firewall group</help>
+                  <completionHelp>
+                    <path>firewall group address-group</path>
+                    <path>firewall group network-group</path>
+                    <path>firewall group port-group</path>
+                    <path>firewall group domain-group</path>
+                    <path>firewall group dynamic-group address-group</path>
+                    <path>firewall group dynamic-group ipv6-address-group</path>
+                    <path>firewall group interface-group</path>
+                    <path>firewall group ipv6-address-group</path>
+                    <path>firewall group ipv6-network-group</path>
+                    <path>firewall group mac-group</path>
+                    <path>firewall group network-group</path>
+                    <path>firewall group port-group</path>
+                    <path>firewall group remote-group</path>
+                  </completionHelp>
+                </properties>
+                <children>
+                  <leafNode name="detail">
+                    <properties>
+                      <help>Show list view of firewall groups</help>
+                      <completionHelp>
+                        <path>firewall group detail</path>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/firewall.py --action show_group --name $4 --detail $5</command>
+                  </leafNode>
+                </children>
+                <command>${vyos_op_scripts_dir}/firewall.py --action show_group --name $4</command>
+              </virtualTagNode>
               <leafNode name="detail">
                 <properties>
                   <help>Show list view of firewall group</help>

--- a/op-mode-definitions/include/bgp/afi-common.xml.i
+++ b/op-mode-definitions/include/bgp/afi-common.xml.i
@@ -1,28 +1,4 @@
 <!-- included start from bgp/afi-common.xml.i -->
-<tagNode name="community">
-  <properties>
-    <help>Community number where AA and NN are (0-65535)</help>
-    <completionHelp>
-      <list>AA:NN</list>
-    </completionHelp>
-  </properties>
-  <children>
-    #include <include/bgp/exact-match.xml.i>
-  </children>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-</tagNode>
-<tagNode name="large-community">
-  <properties>
-    <help>Display routes matching the large-communities</help>
-    <completionHelp>
-      <list>AA:BB:CC</list>
-    </completionHelp>
-  </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-  <children>
-    #include <include/bgp/exact-match.xml.i>
-  </children>
-</tagNode>
 <tagNode name="large-community-list">
   <properties>
     <help>Display routes matching the large-community-list</help>

--- a/op-mode-definitions/include/bgp/afi-ipv4-ipv6-common.xml.i
+++ b/op-mode-definitions/include/bgp/afi-ipv4-ipv6-common.xml.i
@@ -4,6 +4,18 @@
     <help>Display routes matching the community</help>
   </properties>
   <children>
+    <virtualTagNode>
+      <properties>
+        <help>Community number where AA and NN are (0-65535)</help>
+        <completionHelp>
+          <list>AA:NN</list>
+        </completionHelp>
+      </properties>
+      <children>
+        #include <include/bgp/exact-match.xml.i>
+      </children>
+      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+    </virtualTagNode>
     <leafNode name="accept-own">
       <properties>
         <help>Should accept local VPN route if exported and imported into different VRF (well-known community)</help>
@@ -142,13 +154,21 @@
     <help>Show BGP routes matching the specified large-communities</help>
   </properties>
   <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+  <children>
+    <virtualTagNode>
+      <properties>
+        <help>Display routes matching the large-communities</help>
+        <completionHelp>
+          <list>AA:BB:CC</list>
+        </completionHelp>
+      </properties>
+      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+      <children>
+        #include <include/bgp/exact-match.xml.i>
+      </children>
+    </virtualTagNode>
+  </children>
 </node>
-<leafNode name="neighbors">
-  <properties>
-    <help>Detailed information on TCP and BGP neighbor connections</help>
-  </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-</leafNode>
 <tagNode name="neighbors">
   <properties>
     <help>Show BGP information for specified neighbor</help>
@@ -156,6 +176,10 @@
       <script>vtysh -c "$(IFS=$' '; echo "${COMP_WORDS[@]:0:${#COMP_WORDS[@]}-2} summary")" |  awk '/^[0-9a-f]/ {print $1}'</script>
     </completionHelp>
   </properties>
+  <standalone>
+    <help>Detailed information on TCP and BGP neighbor connections</help>
+    <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+  </standalone>
   <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
   <children>
     #include <include/bgp/advertised-routes.xml.i>

--- a/op-mode-definitions/include/bgp/afi-ipv4-ipv6-flowspec.xml.i
+++ b/op-mode-definitions/include/bgp/afi-ipv4-ipv6-flowspec.xml.i
@@ -1,16 +1,4 @@
 <!-- included start from bgp/afi-ipv4-ipv6-flowspec.xml.i -->
-<tagNode name="flowspec">
-  <properties>
-    <help>Network in the BGP routing table to display</help>
-    <completionHelp>
-      <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt; &lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
-    </completionHelp>
-  </properties>
-  <children>
-    #include <include/bgp/prefix-bestpath-multipath.xml.i>
-  </children>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-</tagNode>
 <node name="flowspec">
   <properties>
     <help>Flowspec Address Family modifier</help>
@@ -19,6 +7,18 @@
     #include <include/bgp/afi-common.xml.i>
     #include <include/bgp/afi-ipv4-ipv6-common.xml.i>
     #include <include/vtysh-generic-detail.xml.i>
+    <virtualTagNode>
+      <properties>
+        <help>Network in the BGP routing table to display</help>
+        <completionHelp>
+          <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt; &lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
+        </completionHelp>
+      </properties>
+      <children>
+        #include <include/bgp/prefix-bestpath-multipath.xml.i>
+      </children>
+      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+    </virtualTagNode>
   </children>
   <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
 </node>

--- a/op-mode-definitions/include/bgp/afi-ipv4-ipv6-vpn-rd.xml.i
+++ b/op-mode-definitions/include/bgp/afi-ipv4-ipv6-vpn-rd.xml.i
@@ -8,7 +8,7 @@
   </properties>
   <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
   <children>
-    <tagNode name="">
+    <virtualTagNode>
       <properties>
         <help>Show IP routes of specified prefix</help>
         <completionHelp>
@@ -16,7 +16,7 @@
         </completionHelp>
       </properties>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-    </tagNode>
+    </virtualTagNode>
   </children>
 </tagNode>
 <!-- included end -->

--- a/op-mode-definitions/include/bgp/afi-ipv4-ipv6-vpn.xml.i
+++ b/op-mode-definitions/include/bgp/afi-ipv4-ipv6-vpn.xml.i
@@ -1,16 +1,4 @@
 <!-- included start from bgp/afi-ipv4-ipv6-vpn.xml.i -->
-<tagNode name="vpn">
-  <properties>
-    <help>Network in the BGP routing table to display</help>
-    <completionHelp>
-      <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt; &lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
-    </completionHelp>
-  </properties>
-  <children>
-    #include <include/bgp/prefix-bestpath-multipath.xml.i>
-  </children>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-</tagNode>
 <node name="vpn">
   <properties>
     <help>VPN Address Family modifier</help>
@@ -19,6 +7,18 @@
     #include <include/bgp/afi-common.xml.i>
     #include <include/bgp/afi-ipv4-ipv6-common.xml.i>
     #include <include/bgp/afi-ipv4-ipv6-vpn-rd.xml.i>
+    <virtualTagNode>
+      <properties>
+        <help>Network in the BGP routing table to display</help>
+        <completionHelp>
+          <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt; &lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
+        </completionHelp>
+      </properties>
+      <children>
+        #include <include/bgp/prefix-bestpath-multipath.xml.i>
+      </children>
+      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+    </virtualTagNode>
   </children>
   <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
 </node>

--- a/op-mode-definitions/include/bgp/next-hop.xml.i
+++ b/op-mode-definitions/include/bgp/next-hop.xml.i
@@ -5,19 +5,19 @@
   </properties>
   <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
   <children>
+    <virtualTagNode>
+      <properties>
+        <help>IPv4/IPv6 nexthop address</help>
+        <completionHelp>
+          <list>&lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
+        </completionHelp>
+      </properties>
+      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+      <children>
+        #include <include/vtysh-generic-detail.xml.i>
+      </children>
+    </virtualTagNode>
     #include <include/vtysh-generic-detail.xml.i>
   </children>
 </node>
-<tagNode name="nexthop">
-  <properties>
-    <help>IPv4/IPv6 nexthop address</help>
-    <completionHelp>
-      <list>&lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
-    </completionHelp>
-  </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-  <children>
-    #include <include/vtysh-generic-detail.xml.i>
-  </children>
-</tagNode>
 <!-- included end -->

--- a/op-mode-definitions/include/bgp/show-bgp-common.xml.i
+++ b/op-mode-definitions/include/bgp/show-bgp-common.xml.i
@@ -1,23 +1,23 @@
 <!-- included start from bgp/show-bgp-common.xml.i -->
 #include <include/bgp/afi-common.xml.i>
 #include <include/bgp/afi-ipv4-ipv6-common.xml.i>
-<tagNode name="ipv4">
-  <properties>
-    <help>Network in the BGP routing table to display</help>
-    <completionHelp>
-      <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt; &lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
-    </completionHelp>
-  </properties>
-  <children>
-    #include <include/bgp/prefix-bestpath-multipath.xml.i>
-  </children>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-</tagNode>
 <node name="ipv4">
   <properties>
     <help>IPv4 Address Family</help>
   </properties>
   <children>
+    <virtualTagNode>
+      <properties>
+        <help>Network in the BGP routing table to display</help>
+        <completionHelp>
+          <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt; &lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
+        </completionHelp>
+      </properties>
+      <children>
+        #include <include/bgp/prefix-bestpath-multipath.xml.i>
+      </children>
+      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+    </virtualTagNode>
     #include <include/bgp/afi-common.xml.i>
     #include <include/bgp/afi-ipv4-ipv6-common.xml.i>
     #include <include/bgp/afi-ipv4-ipv6-flowspec.xml.i>
@@ -25,23 +25,23 @@
   </children>
   <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
 </node>
-<tagNode name="ipv6">
-  <properties>
-    <help>Network in the BGP routing table to display</help>
-    <completionHelp>
-      <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt; &lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
-    </completionHelp>
-  </properties>
-  <children>
-    #include <include/bgp/prefix-bestpath-multipath.xml.i>
-  </children>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-</tagNode>
 <node name="ipv6">
   <properties>
     <help>IPv6 Address Family</help>
   </properties>
   <children>
+    <virtualTagNode>
+      <properties>
+        <help>Network in the BGP routing table to display</help>
+          <completionHelp>
+          <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt; &lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
+        </completionHelp>
+        </properties>
+        <children>
+          #include <include/bgp/prefix-bestpath-multipath.xml.i>
+        </children>
+      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+    </virtualTagNode>
     #include <include/bgp/afi-common.xml.i>
     #include <include/bgp/afi-ipv4-ipv6-common.xml.i>
     #include <include/bgp/afi-ipv4-ipv6-vpn.xml.i>
@@ -53,21 +53,21 @@
     <help>Layer 2 Virtual Private Network</help>
   </properties>
   <children>
-    <tagNode name="evpn">
-      <properties>
-        <help>Network in the BGP routing table to display</help>
-        <completionHelp>
-          <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt; &lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
-        </completionHelp>
-      </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-    </tagNode>
     <node name="evpn">
       <properties>
         <help>Ethernet Virtual Private Network</help>
       </properties>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
       <children>
+        <virtualTagNode>
+          <properties>
+            <help>Network in the BGP routing table to display</help>
+            <completionHelp>
+              <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt; &lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
+            </completionHelp>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+        </virtualTagNode>
         #include <include/bgp/afi-common.xml.i>
         <node name="all">
           <properties>
@@ -188,13 +188,20 @@
             #include <include/vni-tagnode-all.xml.i>
           </children>
         </node>
-        #include <include/vni-tagnode.xml.i>
-        <leafNode name="vni">
+        <tagNode name="vni">
           <properties>
-            <help>VXLAN network identifier (VNI)</help>
+            <help>VXLAN network identifier (VNI) number</help>
+            <completionHelp>
+              <list>&lt;1-16777215&gt;</list>
+              <script>${vyos_completion_dir}/list_vni.sh</script>
+            </completionHelp>
           </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </leafNode>
+         <standalone>
+           <help>VXLAN network identifier (VNI)</help>
+           <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+         </standalone>
+         <command>${vyos_op_scripts_dir}/evpn.py show_evpn --command "$*"</command>
+        </tagNode>
       </children>
     </node>
   </children>

--- a/op-mode-definitions/include/bgp/show-ip-bgp-common.xml.i
+++ b/op-mode-definitions/include/bgp/show-ip-bgp-common.xml.i
@@ -37,18 +37,21 @@
       </properties>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
       <children>
+        <virtualTagNode>
+          <properties>
+            <help>Show BGP information for specified IP address or prefix</help>
+            <completionHelp>
+              <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt;</list>
+            </completionHelp>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+        </virtualTagNode>
         <leafNode name="cidr-only">
           <properties>
             <help>Display only routes with non-natural netmasks</help>
           </properties>
           <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
         </leafNode>
-        <node name="community">
-          <properties>
-            <help>Show BGP routes matching the communities</help>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </node>
         <tagNode name="community">
           <properties>
             <help>Display routes matching the specified communities</help>
@@ -56,6 +59,10 @@
               <list>&lt;AA:NN&gt; local-AS no-advertise no-export</list>
             </completionHelp>
           </properties>
+          <standalone>
+            <help>Show BGP routes matching the communities</help>
+            <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          </standalone>
           <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
         </tagNode>
         <tagNode name="community-list">
@@ -123,15 +130,6 @@
         </leafNode>
       </children>
     </node>
-    <tagNode name="unicast">
-      <properties>
-        <help>Show BGP information for specified IP address or prefix</help>
-        <completionHelp>
-          <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt;</list>
-        </completionHelp>
-      </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-    </tagNode>
   </children>
 </node>
 <leafNode name="large-community-info">

--- a/op-mode-definitions/include/isis-common.xml.i
+++ b/op-mode-definitions/include/isis-common.xml.i
@@ -4,19 +4,19 @@
     <help>Show IS-IS link state database</help>
   </properties>
   <children>
+    <virtualTagNode>
+      <properties>
+        <help>Show IS-IS link state database PDU</help>
+        <completionHelp>
+          <list>lsp-id detail</list>
+        </completionHelp>
+      </properties>
+      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+    </virtualTagNode>
     #include <include/vtysh-generic-detail.xml.i>
   </children>
   <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
 </node>
-<tagNode name="database">
-  <properties>
-    <help>Show IS-IS link state database PDU</help>
-    <completionHelp>
-      <list>lsp-id detail</list>
-    </completionHelp>
-  </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-</tagNode>
 <node name="fast-reroute">
   <properties>
     <help>Show IS-IS fast reroute/loop free alternate (lfa) information</help>
@@ -59,10 +59,10 @@
   </properties>
   <children>
     #include <include/vtysh-generic-detail.xml.i>
+    #include <include/vtysh-generic-interface-virtualTagNode.xml.i>
   </children>
   <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
 </node>
-#include <include/vtysh-generic-interface-tagNode.xml.i>
 <node name="mpls">
   <properties>
     <help>Show MPLS information</help>
@@ -82,13 +82,19 @@
       </properties>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
     </leafNode>
-    <leafNode name="interface">
+    <tagNode name="interface">
       <properties>
-        <help>Show interface information</help>
+        <help>Show information about specific interface</help>
+        <completionHelp>
+          <script>${vyos_completion_dir}/list_interfaces</script>
+        </completionHelp>
       </properties>
+      <standalone>
+        <help>Show interface information</help>
+        <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+      </standalone>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-    </leafNode>
-    #include <include/vtysh-generic-interface-tagNode.xml.i>
+    </tagNode>
   </children>
 </node>
 <node name="neighbor">
@@ -96,19 +102,19 @@
     <help>Show IS-IS neighbor adjacencies</help>
   </properties>
   <children>
+    <virtualTagNode>
+      <properties>
+        <help>Show specific IS-IS neighbor adjacency </help>
+        <completionHelp>
+          <list>system-id</list>
+        </completionHelp>
+      </properties>
+      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+    </virtualTagNode>
     #include <include/vtysh-generic-detail.xml.i>
   </children>
   <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
 </node>
-<tagNode name="neighbor">
-  <properties>
-    <help>Show specific IS-IS neighbor adjacency </help>
-    <completionHelp>
-      <list>system-id</list>
-    </completionHelp>
-  </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-</tagNode>
 <node name="route">
   <properties>
     <help>Show IS-IS routing table</help>

--- a/op-mode-definitions/include/ospf/common.xml.i
+++ b/op-mode-definitions/include/ospf/common.xml.i
@@ -17,6 +17,32 @@
       </properties>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
       <children>
+        <virtualTagNode>
+          <properties>
+            <help>Show IPv4 OSPF ASBR summary database information of given address</help>
+            <completionHelp>
+              <list>&lt;x.x.x.x&gt;</list>
+            </completionHelp>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          <children>
+            <tagNode name="adv-router">
+              <properties>
+                <help>Show IPv4 OSPF ASBR summary database of given address for given advertised router</help>
+                <completionHelp>
+                 <list>&lt;x.x.x.x&gt;</list>
+                </completionHelp>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </tagNode>
+            <leafNode name="self-originate">
+              <properties>
+                <help>Show summary of self-originate IPv4 OSPF ASBR database</help>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </leafNode>
+          </children>
+        </virtualTagNode>
         <tagNode name="adv-router">
           <properties>
             <help>Show IPv4 OSPF ASBR summary database for given address of advertised router</help>
@@ -26,50 +52,40 @@
           </properties>
           <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
         </tagNode>
-        <node name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF ASBR summary database for given address of advertised router</help>
-          </properties>
-        </node>
       </children>
     </node>
-    <tagNode name="asbr-summary">
-      <properties>
-        <help>Show IPv4 OSPF ASBR summary database information of given address</help>
-        <completionHelp>
-          <list>&lt;x.x.x.x&gt;</list>
-        </completionHelp>
-      </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-      <children>
-        <node name="adv-router">
-          <properties>
-            <help>Show advertising router link states</help>
-          </properties>
-        </node>
-        <tagNode name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF ASBR summary database of given address for given advertised router</help>
-            <completionHelp>
-             <list>&lt;x.x.x.x&gt;</list>
-            </completionHelp>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </tagNode>
-        <leafNode name="self-originate">
-          <properties>
-            <help>Show summary of self-originate IPv4 OSPF ASBR database</help>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </leafNode>
-      </children>
-    </tagNode>
     <node name="external">
       <properties>
         <help>Show IPv4 OSPF external database</help>
       </properties>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
       <children>
+        <virtualTagNode>
+          <properties>
+            <help>Show IPv4 OSPF external database information of specified IP address</help>
+            <completionHelp>
+              <list>&lt;x.x.x.x&gt;</list>
+            </completionHelp>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          <children>
+            <tagNode name="adv-router">
+              <properties>
+                <help>Show IPv4 OSPF external database of specified IP address for specified advertised router</help>
+                <completionHelp>
+                 <list>&lt;x.x.x.x&gt;</list>
+                </completionHelp>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </tagNode>
+            <leafNode name="self-originate">
+              <properties>
+                <help>Show self-originate IPv4 OSPF external database</help>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </leafNode>
+          </children>
+        </virtualTagNode>
         <tagNode name="adv-router">
           <properties>
             <help>Show IPv4 OSPF external database for specified IP address of advertised router</help>
@@ -79,44 +95,8 @@
           </properties>
           <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
         </tagNode>
-        <node name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF external database for specified IP address of advertised router</help>
-          </properties>
-        </node>
       </children>
     </node>
-    <tagNode name="external">
-      <properties>
-        <help>Show IPv4 OSPF external database information of specified IP address</help>
-        <completionHelp>
-          <list>&lt;x.x.x.x&gt;</list>
-        </completionHelp>
-      </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-      <children>
-        <node name="adv-router">
-          <properties>
-            <help>Show advertising router link states</help>
-          </properties>
-        </node>
-        <tagNode name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF external database of specified IP address for specified advertised router</help>
-            <completionHelp>
-             <list>&lt;x.x.x.x&gt;</list>
-            </completionHelp>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </tagNode>
-        <leafNode name="self-originate">
-          <properties>
-            <help>Show self-originate IPv4 OSPF external database</help>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </leafNode>
-      </children>
-    </tagNode>
     <leafNode name="max-age">
       <properties>
         <help>Show IPv4 OSPF max-age database</help>
@@ -129,6 +109,32 @@
       </properties>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
       <children>
+        <virtualTagNode>
+          <properties>
+            <help>Show IPv4 OSPF network database information of specified IP address</help>
+            <completionHelp>
+              <list>&lt;x.x.x.x&gt;</list>
+            </completionHelp>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          <children>
+            <tagNode name="adv-router">
+              <properties>
+                <help>Show IPv4 OSPF network database of specified IP address for specified advertised router</help>
+                <completionHelp>
+                 <list>&lt;x.x.x.x&gt;</list>
+                </completionHelp>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </tagNode>
+            <leafNode name="self-originate">
+              <properties>
+                <help>Show self-originate IPv4 OSPF network database</help>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </leafNode>
+          </children>
+        </virtualTagNode>
         <tagNode name="adv-router">
           <properties>
             <help>Show IPv4 OSPF network database for specified IP address of advertised router</help>
@@ -138,50 +144,40 @@
           </properties>
           <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
         </tagNode>
-        <node name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF network database for given address of advertised router</help>
-          </properties>
-        </node>
       </children>
     </node>
-    <tagNode name="network">
-      <properties>
-        <help>Show IPv4 OSPF network database information of specified IP address</help>
-        <completionHelp>
-          <list>&lt;x.x.x.x&gt;</list>
-        </completionHelp>
-      </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-      <children>
-        <node name="adv-router">
-          <properties>
-            <help>Show advertising router link states</help>
-          </properties>
-        </node>
-        <tagNode name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF network database of specified IP address for specified advertised router</help>
-            <completionHelp>
-             <list>&lt;x.x.x.x&gt;</list>
-            </completionHelp>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </tagNode>
-        <leafNode name="self-originate">
-          <properties>
-            <help>Show self-originate IPv4 OSPF network database</help>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </leafNode>
-      </children>
-    </tagNode>
     <node name="nssa-external">
       <properties>
         <help>Show IPv4 OSPF NSSA external database</help>
       </properties>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
       <children>
+        <virtualTagNode>
+          <properties>
+            <help>Show IPv4 OSPF NSSA external database information of specified IP address</help>
+            <completionHelp>
+              <list>&lt;x.x.x.x&gt;</list>
+            </completionHelp>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          <children>
+            <tagNode name="adv-router">
+              <properties>
+                <help>Show IPv4 OSPF NSSA external database of specified IP address for specified advertised router</help>
+                <completionHelp>
+                 <list>&lt;x.x.x.x&gt;</list>
+                </completionHelp>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </tagNode>
+            <leafNode name="self-originate">
+              <properties>
+                <help>Show self-originate IPv4 OSPF NSSA external database</help>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </leafNode>
+          </children>
+        </virtualTagNode>
         <tagNode name="adv-router">
           <properties>
             <help>Show IPv4 OSPF NSSA external database for specified IP address of advertised router</help>
@@ -191,50 +187,40 @@
           </properties>
           <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
         </tagNode>
-        <node name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF NSSA external database for specified IP address of advertised router</help>
-          </properties>
-        </node>
       </children>
     </node>
-    <tagNode name="nssa-external">
-      <properties>
-        <help>Show IPv4 OSPF NSSA external database information of specified IP address</help>
-        <completionHelp>
-          <list>&lt;x.x.x.x&gt;</list>
-        </completionHelp>
-      </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-      <children>
-        <node name="adv-router">
-          <properties>
-            <help>Show advertising router link states</help>
-          </properties>
-        </node>
-        <tagNode name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF NSSA external database of specified IP address for specified advertised router</help>
-            <completionHelp>
-             <list>&lt;x.x.x.x&gt;</list>
-            </completionHelp>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </tagNode>
-        <leafNode name="self-originate">
-          <properties>
-            <help>Show self-originate IPv4 OSPF NSSA external database</help>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </leafNode>
-      </children>
-    </tagNode>
     <node name="opaque-area">
       <properties>
         <help>Show IPv4 OSPF opaque-area database</help>
       </properties>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
       <children>
+        <virtualTagNode>
+          <properties>
+            <help>Show IPv4 OSPF opaque-area database information of specified IP address</help>
+            <completionHelp>
+              <list>&lt;x.x.x.x&gt;</list>
+            </completionHelp>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          <children>
+            <tagNode name="adv-router">
+              <properties>
+                <help>Show IPv4 OSPF opaque-area database of specified IP address for specified advertised router</help>
+                <completionHelp>
+                 <list>&lt;x.x.x.x&gt;</list>
+                </completionHelp>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </tagNode>
+            <leafNode name="self-originate">
+              <properties>
+                <help>Show self-originate IPv4 OSPF opaque-area database</help>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </leafNode>
+          </children>
+        </virtualTagNode>
         <tagNode name="adv-router">
           <properties>
             <help>Show IPv4 OSPF opaque-area database for specified IP address of advertised router</help>
@@ -244,50 +230,40 @@
           </properties>
           <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
         </tagNode>
-        <node name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF opaque-area database for specified IP address of advertised router</help>
-          </properties>
-        </node>
       </children>
     </node>
-    <tagNode name="opaque-area">
-      <properties>
-        <help>Show IPv4 OSPF opaque-area database information of specified IP address</help>
-        <completionHelp>
-          <list>&lt;x.x.x.x&gt;</list>
-        </completionHelp>
-      </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-      <children>
-        <node name="adv-router">
-          <properties>
-            <help>Show advertising router link states</help>
-          </properties>
-        </node>
-        <tagNode name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF opaque-area database of specified IP address for specified advertised router</help>
-            <completionHelp>
-             <list>&lt;x.x.x.x&gt;</list>
-            </completionHelp>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </tagNode>
-        <leafNode name="self-originate">
-          <properties>
-            <help>Show self-originate IPv4 OSPF opaque-area database</help>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </leafNode>
-      </children>
-    </tagNode>
     <node name="opaque-as">
       <properties>
         <help>Show IPv4 OSPF opaque-as database</help>
       </properties>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
       <children>
+        <virtualTagNode>
+          <properties>
+            <help>Show IPv4 OSPF opaque-as database information of specified IP address</help>
+            <completionHelp>
+              <list>&lt;x.x.x.x&gt;</list>
+            </completionHelp>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          <children>
+            <tagNode name="adv-router">
+              <properties>
+                <help>Show IPv4 OSPF opaque-as database of specified IP address for specified advertised router</help>
+                <completionHelp>
+                 <list>&lt;x.x.x.x&gt;</list>
+                </completionHelp>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </tagNode>
+            <leafNode name="self-originate">
+              <properties>
+                <help>Show self-originate IPv4 OSPF opaque-as database</help>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </leafNode>
+          </children>
+        </virtualTagNode>
         <tagNode name="adv-router">
           <properties>
             <help>Show IPv4 OSPF opaque-as database for specified IP address of advertised router</help>
@@ -297,50 +273,40 @@
           </properties>
           <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
         </tagNode>
-        <node name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF opaque-as database for specified IP address of advertised router</help>
-          </properties>
-        </node>
       </children>
     </node>
-    <tagNode name="opaque-as">
-      <properties>
-        <help>Show IPv4 OSPF opaque-as database information of specified IP address</help>
-        <completionHelp>
-          <list>&lt;x.x.x.x&gt;</list>
-        </completionHelp>
-      </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-      <children>
-        <node name="adv-router">
-          <properties>
-            <help>Show advertising router link states</help>
-          </properties>
-        </node>
-        <tagNode name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF opaque-as database of specified IP address for specified advertised router</help>
-            <completionHelp>
-             <list>&lt;x.x.x.x&gt;</list>
-            </completionHelp>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </tagNode>
-        <leafNode name="self-originate">
-          <properties>
-            <help>Show self-originate IPv4 OSPF opaque-as database</help>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </leafNode>
-      </children>
-    </tagNode>
     <node name="opaque-link">
       <properties>
         <help>Show IPv4 OSPF opaque-link database</help>
       </properties>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
       <children>
+        <virtualTagNode>
+          <properties>
+            <help>Show IPv4 OSPF opaque-link database information of specified IP address</help>
+            <completionHelp>
+              <list>&lt;x.x.x.x&gt;</list>
+            </completionHelp>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          <children>
+            <tagNode name="adv-router">
+              <properties>
+                <help>Show IPv4 OSPF opaque-link database of specified IP address for specified advertised router</help>
+                <completionHelp>
+                 <list>&lt;x.x.x.x&gt;</list>
+                </completionHelp>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </tagNode>
+            <leafNode name="self-originate">
+              <properties>
+                <help>Show self-originate IPv4 OSPF opaque-link database</help>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </leafNode>
+          </children>
+        </virtualTagNode>
         <tagNode name="adv-router">
           <properties>
             <help>Show IPv4 OSPF opaque-link database for specified IP address of advertised router</help>
@@ -350,50 +316,40 @@
           </properties>
           <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
         </tagNode>
-        <node name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF opaque-link database for specified IP address of advertised router</help>
-          </properties>
-        </node>
       </children>
     </node>
-    <tagNode name="opaque-link">
-      <properties>
-        <help>Show IPv4 OSPF opaque-link database information of specified IP address</help>
-        <completionHelp>
-          <list>&lt;x.x.x.x&gt;</list>
-        </completionHelp>
-      </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-      <children>
-        <node name="adv-router">
-          <properties>
-            <help>Show advertising router link states</help>
-          </properties>
-        </node>
-        <tagNode name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF opaque-link database of specified IP address for specified advertised router</help>
-            <completionHelp>
-             <list>&lt;x.x.x.x&gt;</list>
-            </completionHelp>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </tagNode>
-        <leafNode name="self-originate">
-          <properties>
-            <help>Show self-originate IPv4 OSPF opaque-link database</help>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </leafNode>
-      </children>
-    </tagNode>
     <node name="router">
       <properties>
         <help>Show IPv4 OSPF router database</help>
       </properties>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
       <children>
+        <virtualTagNode>
+          <properties>
+            <help>Show IPv4 OSPF router database information of specified IP address</help>
+            <completionHelp>
+              <list>&lt;x.x.x.x&gt;</list>
+            </completionHelp>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          <children>
+            <tagNode name="adv-router">
+              <properties>
+                <help>Show IPv4 OSPF router database of specified IP address for specified advertised router</help>
+                <completionHelp>
+                 <list>&lt;x.x.x.x&gt;</list>
+                </completionHelp>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </tagNode>
+            <leafNode name="self-originate">
+              <properties>
+                <help>Show self-originate IPv4 OSPF router database</help>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </leafNode>
+          </children>
+        </virtualTagNode>
         <tagNode name="adv-router">
           <properties>
             <help>Show IPv4 OSPF router database for specified IP address of advertised router</help>
@@ -403,44 +359,8 @@
           </properties>
           <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
         </tagNode>
-        <node name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF router database for specified IP address of advertised router</help>
-          </properties>
-        </node>
       </children>
     </node>
-    <tagNode name="router">
-      <properties>
-        <help>Show IPv4 OSPF router database information of specified IP address</help>
-        <completionHelp>
-          <list>&lt;x.x.x.x&gt;</list>
-        </completionHelp>
-      </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-      <children>
-        <node name="adv-router">
-          <properties>
-            <help>Show advertising router link states</help>
-          </properties>
-        </node>
-        <tagNode name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF router database of specified IP address for specified advertised router</help>
-            <completionHelp>
-             <list>&lt;x.x.x.x&gt;</list>
-            </completionHelp>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </tagNode>
-        <leafNode name="self-originate">
-          <properties>
-            <help>Show self-originate IPv4 OSPF router database</help>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </leafNode>
-      </children>
-    </tagNode>
     <leafNode name="self-originate">
       <properties>
         <help>Show IPv4 OSPF self-originate database</help>
@@ -453,6 +373,32 @@
       </properties>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
       <children>
+        <virtualTagNode>
+          <properties>
+            <help>Show IPv4 OSPF summary database information of specified IP address</help>
+            <completionHelp>
+              <list>&lt;x.x.x.x&gt;</list>
+            </completionHelp>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          <children>
+            <tagNode name="adv-router">
+              <properties>
+                <help>Show IPv4 OSPF summary database of specified IP address for specified advertised router</help>
+                <completionHelp>
+                 <list>&lt;x.x.x.x&gt;</list>
+                </completionHelp>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </tagNode>
+            <leafNode name="self-originate">
+              <properties>
+                <help>Show self-originate IPv4 OSPF summary database</help>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </leafNode>
+          </children>
+        </virtualTagNode>
         <tagNode name="adv-router">
           <properties>
             <help>Show IPv4 OSPF summary database for specified IP address of advertised router</help>
@@ -462,54 +408,24 @@
           </properties>
           <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
         </tagNode>
-        <node name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF summary database for specified IP address of advertised router</help>
-          </properties>
-        </node>
       </children>
     </node>
-    <tagNode name="summary">
-      <properties>
-        <help>Show IPv4 OSPF summary database information of specified IP address</help>
-        <completionHelp>
-          <list>&lt;x.x.x.x&gt;</list>
-        </completionHelp>
-      </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-      <children>
-        <node name="adv-router">
-          <properties>
-            <help>Show advertising router link states</help>
-          </properties>
-        </node>
-        <tagNode name="adv-router">
-          <properties>
-            <help>Show IPv4 OSPF summary database of specified IP address for specified advertised router</help>
-            <completionHelp>
-             <list>&lt;x.x.x.x&gt;</list>
-            </completionHelp>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </tagNode>
-        <leafNode name="self-originate">
-          <properties>
-            <help>Show self-originate IPv4 OSPF summary database</help>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </leafNode>
-      </children>
-    </tagNode>
   </children>
 </node>
 #include <include/ospf/graceful-restart.xml.i>
-<node name="interface">
+<tagNode name="interface">
   <properties>
-    <help>Show IPv4 OSPF interface information</help>
+    <help>Show information about specific interface</help>
+    <completionHelp>
+      <script>${vyos_completion_dir}/list_interfaces</script>
+    </completionHelp>
   </properties>
+  <standalone>
+    <help>Show IPv4 OSPF interface information</help>
+    <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+  </standalone>
   <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-</node>
-#include <include/vtysh-generic-interface-tagNode.xml.i>
+</tagNode>
 <node name="mpls">
   <properties>
     <help>Show MPLS information</help>
@@ -524,19 +440,19 @@
   </properties>
   <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
   <children>
+    <virtualTagNode>
+      <properties>
+        <help>Show IPv4 OSPF neighbor information for specified IP address or interface</help>
+        <completionHelp>
+          <list>&lt;x.x.x.x&gt;</list>
+          <script>${vyos_completion_dir}/list_interfaces</script>
+        </completionHelp>
+      </properties>
+      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+    </virtualTagNode>
     #include <include/frr-detail.xml.i>
   </children>
 </node>
-<tagNode name="neighbor">
-  <properties>
-    <help>Show IPv4 OSPF neighbor information for specified IP address or interface</help>
-    <completionHelp>
-      <list>&lt;x.x.x.x&gt;</list>
-      <script>${vyos_completion_dir}/list_interfaces</script>
-    </completionHelp>
-  </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-</tagNode>
 <node name="route">
   <properties>
     <help>Show IPv4 OSPF route information</help>

--- a/op-mode-definitions/include/ospfv3/border-routers.xml.i
+++ b/op-mode-definitions/include/ospfv3/border-routers.xml.i
@@ -5,16 +5,16 @@
   </properties>
   <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
   <children>
+    <virtualTagNode>
+      <properties>
+        <help>Border router ID</help>
+        <completionHelp>
+          <list>&lt;x.x.x.x&gt;</list>
+        </completionHelp>
+      </properties>
+      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+    </virtualTagNode>
     #include <include/frr-detail.xml.i>
   </children>
 </node>
-<tagNode name="border-routers">
-  <properties>
-    <help>Border router ID</help>
-    <completionHelp>
-      <list>&lt;x.x.x.x&gt;</list>
-    </completionHelp>
-  </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-</tagNode>
 <!-- included end -->

--- a/op-mode-definitions/include/ospfv3/database.xml.i
+++ b/op-mode-definitions/include/ospfv3/database.xml.i
@@ -21,7 +21,7 @@
         <help>Search by Any Link state Type</help>
       </properties>
       <children>
-        <tagNode name="any">
+        <virtualTagNode>
           <properties>
             <help>Search by Link state ID</help>
             <completionHelp>
@@ -32,31 +32,32 @@
             #include <include/frr-detail.xml.i>
             #include <include/ospfv3/dump.xml.i>
             #include <include/ospfv3/internal.xml.i>
+            #include <include/ospfv3/adv-router-id-node-tag.xml.i>
           </children>
-        </tagNode>
+        </virtualTagNode>
       </children>
     </node>
-    <tagNode name="any">
-      <properties>
-        <help>Search by Link state ID</help>
-        <completionHelp>
-          <list>&lt;x.x.x.x&gt;</list>
-        </completionHelp>
-      </properties>
-      <command>vtysh -c "show ipv6 ospf6 database * $6"</command>
-      <children>
-        #include <include/frr-detail.xml.i>
-        #include <include/ospfv3/dump.xml.i>
-        #include <include/ospfv3/internal.xml.i>
-        #include <include/ospfv3/adv-router-id-node-tag.xml.i>
-      </children>
-    </tagNode>
     <node name="as-external">
       <properties>
         <help>Show AS-External LSAs</help>
       </properties>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
       <children>
+        <virtualTagNode>
+          <properties>
+            <help>Search by Advertising Router IDs</help>
+            <completionHelp>
+              <list>&lt;x.x.x.x&gt;</list>
+            </completionHelp>
+          </properties>
+          <children>
+            #include <include/frr-detail.xml.i>
+            #include <include/ospfv3/dump.xml.i>
+            #include <include/ospfv3/internal.xml.i>
+            #include <include/ospfv3/self-originated.xml.i>
+            #include <include/ospfv3/adv-router-id-node-tag.xml.i>
+          </children>
+        </virtualTagNode>
         #include <include/ospfv3/adv-router.xml.i>
         <tagNode name="any">
           <properties>
@@ -79,21 +80,6 @@
         #include <include/ospfv3/self-originated.xml.i>
       </children>
     </node>
-    <tagNode name="as-external">
-      <properties>
-        <help>Search by Advertising Router IDs</help>
-        <completionHelp>
-          <list>&lt;x.x.x.x&gt;</list>
-        </completionHelp>
-      </properties>
-      <children>
-        #include <include/frr-detail.xml.i>
-        #include <include/ospfv3/dump.xml.i>
-        #include <include/ospfv3/internal.xml.i>
-        #include <include/ospfv3/self-originated.xml.i>
-        #include <include/ospfv3/adv-router-id-node-tag.xml.i>
-      </children>
-    </tagNode>
     #include <include/frr-detail.xml.i>
     #include <include/ospfv3/internal.xml.i>
     #include <include/ospfv3/linkstate-id.xml.i>
@@ -188,7 +174,7 @@
         #include <include/ospfv3/self-originated.xml.i>
       </children>
     </node>
-    <node name="node.tag">
+    <virtualTagNode>
       <properties>
         <help>Show LSAs</help>
       </properties>
@@ -202,7 +188,7 @@
         #include <include/ospfv3/linkstate-id-node-tag.xml.i>
         #include <include/ospfv3/self-originated.xml.i>
       </children>
-    </node>
+    </virtualTagNode>
     <node name="router">
       <properties>
         <help>Show router LSAs</help>

--- a/op-mode-definitions/include/ospfv3/interface.xml.i
+++ b/op-mode-definitions/include/ospfv3/interface.xml.i
@@ -5,71 +5,71 @@
   </properties>
   <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
   <children>
+    <virtualTagNode>
+      <properties>
+        <help>Specific insterface to examine</help>
+        <completionHelp>
+          <script>${vyos_completion_dir}/list_interfaces</script>
+        </completionHelp>
+      </properties>
+      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+      <children>
+        <node name="prefix">
+          <properties>
+            <help>Show connected prefixes to advertise</help>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          <children>
+            <virtualTagNode>
+              <properties>
+                <help>Show interface prefix route specific information</help>
+                <completionHelp>
+                  <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
+                </completionHelp>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+              <children>
+                #include <include/frr-detail.xml.i>
+                <node name="match">
+                  <properties>
+                    <help>Matched interface prefix information</help>
+                  </properties>
+                  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                </node>
+              </children>
+            </virtualTagNode>
+            #include <include/frr-detail.xml.i>
+          </children>
+        </node>
+      </children>
+    </virtualTagNode>
     <node name="prefix">
       <properties>
         <help>Show connected prefixes to advertise</help>
       </properties>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
       <children>
+        <virtualTagNode>
+          <properties>
+            <help>Show interface prefix route specific information</help>
+            <completionHelp>
+              <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
+            </completionHelp>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          <children>
+            #include <include/frr-detail.xml.i>
+            <node name="match">
+              <properties>
+                <help>Matched interface prefix information</help>
+              </properties>
+              <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            </node>
+          </children>
+        </virtualTagNode>
         #include <include/frr-detail.xml.i>
       </children>
     </node>
-    <tagNode name="prefix">
-      <properties>
-        <help>Show interface prefix route specific information</help>
-        <completionHelp>
-          <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
-        </completionHelp>
-      </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-      <children>
-        #include <include/frr-detail.xml.i>
-        <node name="match">
-          <properties>
-            <help>Matched interface prefix information</help>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </node>
-      </children>
-    </tagNode>
   </children>
 </node>
-<tagNode name="interface">
-  <properties>
-    <help>Specific insterface to examine</help>
-    <completionHelp>
-      <script>${vyos_completion_dir}/list_interfaces</script>
-    </completionHelp>
-  </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-  <children>
-    <node name="prefix">
-      <properties>
-        <help>Show connected prefixes to advertise</help>
-      </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-      <children>
-        #include <include/frr-detail.xml.i>
-      </children>
-    </node>
-    <tagNode name="prefix">
-      <properties>
-        <help>Show interface prefix route specific information</help>
-        <completionHelp>
-          <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
-        </completionHelp>
-      </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-      <children>
-        #include <include/frr-detail.xml.i>
-        <node name="match">
-          <properties>
-            <help>Matched interface prefix information</help>
-          </properties>
-          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </node>
-      </children>
-    </tagNode>
-  </children>
-</tagNode>
 <!-- included end -->

--- a/op-mode-definitions/include/ospfv3/linkstate-id-node-tag.xml.i
+++ b/op-mode-definitions/include/ospfv3/linkstate-id-node-tag.xml.i
@@ -1,5 +1,5 @@
 <!-- included start from ospfv3/linkstate-id-node-tag.xml.i -->
-<node name="node.tag">
+<virtualTagNode>
   <properties>
     <help>Search by Link state ID</help>
     <completionHelp>
@@ -13,5 +13,5 @@
     #include <include/ospfv3/internal.xml.i>
     #include <include/ospfv3/self-originated.xml.i>
   </children>
-</node>
+</virtualTagNode>
 <!-- included end -->

--- a/op-mode-definitions/include/ospfv3/linkstate.xml.i
+++ b/op-mode-definitions/include/ospfv3/linkstate.xml.i
@@ -13,7 +13,7 @@
         </completionHelp>
       </properties>
       <children>
-        <node name="node.tag">
+        <virtualTagNode>
           <properties>
             <help>Specify Link state ID as IPv4 address notation</help>
             <completionHelp>
@@ -21,7 +21,7 @@
             </completionHelp>
           </properties>
           <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        </node>
+        </virtualTagNode>
       </children>
     </tagNode>
     <tagNode name="router">

--- a/op-mode-definitions/include/ospfv3/route.xml.i
+++ b/op-mode-definitions/include/ospfv3/route.xml.i
@@ -5,6 +5,32 @@
   </properties>
   <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
   <children>
+    <virtualTagNode>
+      <properties>
+        <help>Show specified route/prefix information</help>
+        <completionHelp>
+          <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
+        </completionHelp>
+      </properties>
+      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+      <children>
+        <node name="longer">
+          <properties>
+            <help>Show routes longer than specified prefix</help>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+        </node>
+        <node name="match">
+          <properties>
+            <help>Show routes matching specified prefix</help>
+          </properties>
+          <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+          <children>
+            #include <include/frr-detail.xml.i>
+          </children>
+        </node>
+      </children>
+    </virtualTagNode>
     <node name="external-1">
       <properties>
         <help>Show Type-1 External route information</help>
@@ -50,30 +76,4 @@
     </node>
   </children>
 </node>
-<tagNode name="route">
-  <properties>
-    <help>Show specified route/prefix information</help>
-    <completionHelp>
-      <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
-    </completionHelp>
-  </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-  <children>
-    <node name="longer">
-      <properties>
-        <help>Show routes longer than specified prefix</help>
-      </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-    </node>
-    <node name="match">
-      <properties>
-        <help>Show routes matching specified prefix</help>
-      </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-      <children>
-        #include <include/frr-detail.xml.i>
-      </children>
-    </node>
-  </children>
-</tagNode>
 <!-- included end -->

--- a/op-mode-definitions/include/show-route-table.xml.i
+++ b/op-mode-definitions/include/show-route-table.xml.i
@@ -1,12 +1,7 @@
 <!-- included start from show-route-table.xml.i -->
-<node name="table">
-  <properties>
-    <help>Table to display</help>
-  </properties>
-</node>
 <tagNode name="table">
   <properties>
-    <help>The table number to display</help>
+    <help>Show routes in specific routing table</help>
     <completionHelp>
       <list>all</list>
       <path>protocols static table</path>

--- a/op-mode-definitions/include/show-route-tag.xml.i
+++ b/op-mode-definitions/include/show-route-tag.xml.i
@@ -1,12 +1,7 @@
 <!-- included start from show-route-tag.xml.i -->
-<node name="tag">
-  <properties>
-    <help>Show only routes with tag</help>
-  </properties>
-</node>
 <tagNode name="tag">
   <properties>
-    <help>Tag value</help>
+    <help>Show route with given tag</help>
     <completionHelp>
       <list>&lt;1-4294967295&gt;</list>
     </completionHelp>

--- a/op-mode-definitions/include/vtysh-generic-interface-virtualTagNode.xml
+++ b/op-mode-definitions/include/vtysh-generic-interface-virtualTagNode.xml
@@ -1,0 +1,11 @@
+<!-- included start from vtysh-generic-interface-virtualTagNode.xml.i -->
+<virtualTagNode>
+  <properties>
+    <help>Show information about specific interface</help>
+    <completionHelp>
+      <script>${vyos_completion_dir}/list_interfaces</script>
+    </completionHelp>
+  </properties>
+  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+</virtualTagNode>
+<!-- included end -->

--- a/op-mode-definitions/ipv4-route.xml.in
+++ b/op-mode-definitions/ipv4-route.xml.in
@@ -63,12 +63,6 @@
               <help>Reset IP route</help>
             </properties>
             <children>
-              <leafNode name= "cache">
-                <properties>
-                  <help>Flush the kernel route cache</help>
-                </properties>
-                <command>ip route flush cache</command>
-              </leafNode>
               <tagNode name="cache">
                 <properties>
                   <help>Flush the kernel route cache for a given route</help>
@@ -76,6 +70,10 @@
                     <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt;</list>
                   </completionHelp>
                 </properties>
+                <standalone>
+                  <help>Flush the kernel route cache</help>
+                  <command>ip route flush cache</command>
+                </standalone>
                 <command>ip route flush cache "$5"</command>
               </tagNode>
             </children>

--- a/op-mode-definitions/ipv6-route.xml.in
+++ b/op-mode-definitions/ipv6-route.xml.in
@@ -83,12 +83,6 @@
               <help>Reset IPv6 route</help>
             </properties>
             <children>
-              <leafNode name= "cache">
-                <properties>
-                  <help>Flush the kernel IPv6 route cache</help>
-                </properties>
-                <command>ip -f inet6 route flush cache</command>
-              </leafNode>
               <tagNode name="cache">
                 <properties>
                   <help>Flush the kernel IPv6 route cache for a given route</help>
@@ -96,6 +90,10 @@
                     <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
                   </completionHelp>
                 </properties>
+                <standalone>
+                  <help>Flush the kernel IPv6 route cache</help>
+                  <command>ip -f inet6 route flush cache</command>
+                </standalone>
                 <command>ip -f inet6 route flush cache "$5"</command>
               </tagNode>
             </children>

--- a/op-mode-definitions/monitor-command.xml.in
+++ b/op-mode-definitions/monitor-command.xml.in
@@ -2,26 +2,31 @@
 <interfaceDefinition>
   <node name="monitor">
     <children>
-      <tagNode name="command">
-        <properties>
-          <help>Monitor operational mode command (refreshes every 2 seconds)</help>
-        </properties>
-        <command>watch --no-title ${vyos_op_scripts_dir}/vyos-op-cmd-wrapper.sh ${@:3}</command>
-      </tagNode>
       <node name="command">
+        <properties>
+          <help>Monitor operational mode command output</help>
+        </properties>
         <children>
+          <virtualTagNode>
+            <properties>
+              <help>Monitor operational mode command (refreshes every 2 seconds)</help>
+            </properties>
+            <command>watch --no-title ${vyos_op_scripts_dir}/vyos-op-cmd-wrapper.sh ${@:3}</command>
+          </virtualTagNode>
           <node name="diff">
             <properties>
               <help>Show differences during each run</help>
             </properties>
+            <children>
+              <virtualTagNode>
+                <properties>
+                  <help>Monitor operational mode command (refreshes every 2 seconds)</help>
+                </properties>
+                <command>watch --no-title --differences ${vyos_op_scripts_dir}/vyos-op-cmd-wrapper.sh ${@:4}</command>
+              </virtualTagNode>
+            </children>
           </node>
-          <tagNode name="diff">
-            <properties>
-              <help>Monitor operational mode command (refreshes every 2 seconds)</help>
-            </properties>
-            <command>watch --no-title --differences ${vyos_op_scripts_dir}/vyos-op-cmd-wrapper.sh ${@:4}</command>
-          </tagNode>
-        </children>
+       </children>
       </node>
     </children>
   </node>

--- a/op-mode-definitions/monitor-protocol.xml.in
+++ b/op-mode-definitions/monitor-protocol.xml.in
@@ -35,12 +35,6 @@
                     </properties>
                     <command>vtysh -c "no debug bgp ${@:5}"</command>
                   </node>
-                  <node name="bestpath">
-                    <properties>
-                      <help>Disable BGP allow best path debugging</help>
-                    </properties>
-                    <command>vtysh -c "no debug bgp ${@:5}"</command>
-                  </node>
                   <tagNode name="bestpath">
                     <properties>
                       <help>Disable BGP bestpath IPv4 IPv6</help>
@@ -48,6 +42,10 @@
                         <list>&lt;x.x.x.x/x&gt; &lt;h:h:h:h:h:h:h:h/h&gt;</list>
                       </completionHelp>
                     </properties>
+                    <standalone>
+                      <help>Disable BGP allow best path debugging</help>
+                      <command>vtysh -c "no debug bgp ${@:5}"</command>
+                    </standalone>
                     <command>vtysh -c "no debug bgp ${@:5}"</command>
                   </tagNode>
                   <node name="flowspec">
@@ -155,12 +153,6 @@
                     </properties>
                     <command>vtysh -c "debug bgp ${@:5}"</command>
                   </node>
-                  <node name="bestpath">
-                    <properties>
-                      <help>Enable BGP allow best path debugging</help>
-                    </properties>
-                    <command>vtysh -c "debug bgp ${@:5}"</command>
-                  </node>
                   <tagNode name="bestpath">
                     <properties>
                       <help>Debug bestpath IPv4 IPv6</help>
@@ -168,6 +160,10 @@
                         <list>&lt;x.x.x.x/x&gt; &lt;h:h:h:h:h:h:h:h/h&gt;</list>
                       </completionHelp>
                     </properties>
+                    <standalone>
+                      <help>Enable BGP allow best path debugging</help>
+                      <command>vtysh -c "debug bgp ${@:5}"</command>
+                    </standalone>
                     <command>vtysh -c "debug bgp ${@:5}"</command>
                   </tagNode>
                   <node name="flowspec">

--- a/op-mode-definitions/mtr.xml.in
+++ b/op-mode-definitions/mtr.xml.in
@@ -11,7 +11,7 @@
         </properties>
         <command>${vyos_op_scripts_dir}/mtr.py ${@:3}</command>
         <children>
-          <leafNode name="node.tag">
+          <virtualTagNode>
             <properties>
               <help>Traceroute options</help>
               <completionHelp>
@@ -19,7 +19,7 @@
               </completionHelp>
             </properties>
             <command>${vyos_op_scripts_dir}/mtr.py ${@:3}</command>
-          </leafNode>
+          </virtualTagNode>
         </children>
       </tagNode>
     </children>
@@ -33,7 +33,7 @@
     </properties>
     <command>${vyos_op_scripts_dir}/mtr.py ${@:2}</command>
     <children>
-      <leafNode name="node.tag">
+      <virtualTagNode>
         <properties>
           <help>mtr options</help>
           <completionHelp>
@@ -41,7 +41,7 @@
           </completionHelp>
         </properties>
         <command>${vyos_op_scripts_dir}/mtr.py ${@:2}</command>
-      </leafNode>
+      </virtualTagNode>
     </children>
   </tagNode>
 </interfaceDefinition>

--- a/op-mode-definitions/openvpn.xml.in
+++ b/op-mode-definitions/openvpn.xml.in
@@ -39,91 +39,84 @@
             </properties>
             <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=openvpn</command>
             <children>
+              <leafNode name="client">
+                <properties>
+                  <help>Show tunnel status for OpenVPN client interfaces</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/openvpn.py show --mode client</command>
+              </leafNode>
+              <leafNode name="server">
+                <properties>
+                  <help>Show tunnel status for OpenVPN server interfaces</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/openvpn.py show --mode server</command>
+              </leafNode>
+              <leafNode name="site-to-site">
+                <properties>
+                  <help>Show tunnel status for OpenVPN site-to-site interfaces</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/openvpn.py show --mode site_to_site</command>
+              </leafNode>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed OpenVPN interface information</help>
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=openvpn</command>
               </leafNode>
-            </children>
-          </node>
-          <tagNode name="openvpn">
-            <properties>
-              <help>Show OpenVPN interface information</help>
-              <completionHelp>
-                <script>${vyos_completion_dir}/list_interfaces --type openvpn</script>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name=$4</command>
-            <children>
-              <tagNode name="user">
+              <virtualTagNode>
                 <properties>
-                  <help>Show OpenVPN interface users</help>
+                  <help>Show OpenVPN interface information</help>
                   <completionHelp>
-                    <script>${vyos_completion_dir}/list_openvpn_users.py --interface ${COMP_WORDS[3]}</script>
+                    <script>${vyos_completion_dir}/list_interfaces --type openvpn</script>
                   </completionHelp>
                 </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name=$4</command>
                 <children>
-                  <node name="mfa">
+                  <tagNode name="user">
                     <properties>
-                      <help>Show multi-factor authentication information</help>
+                      <help>Show OpenVPN interface users</help>
+                      <completionHelp>
+                        <script>${vyos_completion_dir}/list_openvpn_users.py --interface ${COMP_WORDS[3]}</script>
+                      </completionHelp>
                     </properties>
                     <children>
-                      <leafNode name="secret">
+                      <node name="mfa">
                         <properties>
-                          <help>Show multi-factor authentication secret</help>
+                          <help>Show multi-factor authentication information</help>
                         </properties>
-                        <command>${vyos_op_scripts_dir}/show_openvpn_mfa.py --user="$6" --intf="$4" --action=secret</command>
-                      </leafNode>
-                      <leafNode name="uri">
-                        <properties>
-                          <help>Show multi-factor authentication otpauth uri</help>
-                        </properties>
-                        <command>${vyos_op_scripts_dir}/show_openvpn_mfa.py --user="$6" --intf="$4" --action=uri</command>
-                      </leafNode>
-                      <leafNode name="qrcode">
-                        <properties>
-                          <help>Show multi-factor authentication QR code</help>
-                        </properties>
-                        <command>${vyos_op_scripts_dir}/show_openvpn_mfa.py --user="$6" --intf="$4" --action=qrcode</command>
-                      </leafNode>
+                        <children>
+                          <leafNode name="secret">
+                            <properties>
+                              <help>Show multi-factor authentication secret</help>
+                            </properties>
+                            <command>${vyos_op_scripts_dir}/show_openvpn_mfa.py --user="$6" --intf="$4" --action=secret</command>
+                          </leafNode>
+                          <leafNode name="uri">
+                            <properties>
+                              <help>Show multi-factor authentication otpauth uri</help>
+                            </properties>
+                            <command>${vyos_op_scripts_dir}/show_openvpn_mfa.py --user="$6" --intf="$4" --action=uri</command>
+                          </leafNode>
+                          <leafNode name="qrcode">
+                            <properties>
+                              <help>Show multi-factor authentication QR code</help>
+                            </properties>
+                            <command>${vyos_op_scripts_dir}/show_openvpn_mfa.py --user="$6" --intf="$4" --action=qrcode</command>
+                          </leafNode>
+                        </children>
+                      </node>
                     </children>
-                  </node>
+                  </tagNode>
+                  <leafNode name="brief">
+                    <properties>
+                      <help>Show summary of specified OpenVPN interface information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4"</command>
+                  </leafNode>
                 </children>
-              </tagNode>
-              <leafNode name="brief">
-                <properties>
-                  <help>Show summary of specified OpenVPN interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4"</command>
-              </leafNode>
+              </virtualTagNode>
             </children>
-          </tagNode>
-        </children>
-      </node>
-      <node name="openvpn">
-        <properties>
-          <help>Show OpenVPN information</help>
-        </properties>
-        <children>
-          <leafNode name="client">
-            <properties>
-              <help>Show tunnel status for OpenVPN client interfaces</help>
-            </properties>
-            <command>${vyos_op_scripts_dir}/openvpn.py show --mode client</command>
-          </leafNode>
-          <leafNode name="server">
-            <properties>
-              <help>Show tunnel status for OpenVPN server interfaces</help>
-            </properties>
-            <command>${vyos_op_scripts_dir}/openvpn.py show --mode server</command>
-          </leafNode>
-          <leafNode name="site-to-site">
-            <properties>
-              <help>Show tunnel status for OpenVPN site-to-site interfaces</help>
-            </properties>
-            <command>${vyos_op_scripts_dir}/openvpn.py show --mode site_to_site</command>
-          </leafNode>
+          </node>
         </children>
       </node>
     </children>

--- a/op-mode-definitions/ping.xml.in
+++ b/op-mode-definitions/ping.xml.in
@@ -9,7 +9,7 @@
     </properties>
     <command>${vyos_op_scripts_dir}/ping.py ${@:2}</command>
     <children>
-      <leafNode name="node.tag">
+      <virtualTagNode>
         <properties>
           <help>Ping options</help>
           <completionHelp>
@@ -17,7 +17,7 @@
           </completionHelp>
         </properties>
         <command>${vyos_op_scripts_dir}/ping.py ${@:2}</command>
-      </leafNode>
+      </virtualTagNode>
     </children>
   </tagNode>
 </interfaceDefinition>

--- a/op-mode-definitions/pki.xml.in
+++ b/op-mode-definitions/pki.xml.in
@@ -492,12 +492,6 @@
         </properties>
         <command>${vyos_op_scripts_dir}/pki.py show_all</command>
         <children>
-          <leafNode name="ca">
-            <properties>
-              <help>Show x509 CA certificates</help>
-            </properties>
-            <command>${vyos_op_scripts_dir}/pki.py show_certificate_authority</command>
-          </leafNode>
           <tagNode name="ca">
             <properties>
               <help>Show x509 CA certificate by name</help>
@@ -505,6 +499,10 @@
                 <path>pki ca</path>
               </completionHelp>
             </properties>
+            <standalone>
+              <help>Show x509 CA certificates</help>
+              <command>${vyos_op_scripts_dir}/pki.py show_certificate_authority</command>
+            </standalone>
             <command>${vyos_op_scripts_dir}/pki.py show_certificate_authority --name "$4"</command>
             <children>
               <leafNode name="pem">
@@ -515,12 +513,6 @@
               </leafNode>
             </children>
           </tagNode>
-          <leafNode name="certificate">
-            <properties>
-              <help>Show x509 certificates</help>
-            </properties>
-            <command>${vyos_op_scripts_dir}/pki.py show_certificate</command>
-          </leafNode>
           <tagNode name="certificate">
             <properties>
               <help>Show x509 certificate by name</help>
@@ -528,6 +520,10 @@
                 <path>pki certificate</path>
               </completionHelp>
             </properties>
+            <standalone>
+              <help>Show x509 certificates</help>
+              <command>${vyos_op_scripts_dir}/pki.py show_certificate</command>
+            </standalone>
             <command>${vyos_op_scripts_dir}/pki.py show_certificate --name "$4"</command>
             <children>
               <leafNode name="pem">
@@ -547,12 +543,6 @@
               </tagNode>
             </children>
           </tagNode>
-          <leafNode name="crl">
-            <properties>
-              <help>Show x509 certificate revocation lists</help>
-            </properties>
-            <command>${vyos_op_scripts_dir}/pki.py show_crl</command>
-          </leafNode>
           <tagNode name="crl">
             <properties>
               <help>Show x509 certificate revocation lists by CA name</help>
@@ -560,6 +550,10 @@
                 <path>pki ca</path>
               </completionHelp>
             </properties>
+            <standalone>
+              <help>Show x509 certificate revocation lists</help>
+              <command>${vyos_op_scripts_dir}/pki.py show_crl</command>
+            </standalone>
             <command>${vyos_op_scripts_dir}/pki.py show_crl --name "$4"</command>
             <children>
               <leafNode name="pem">

--- a/op-mode-definitions/reset-bgp.xml.in
+++ b/op-mode-definitions/reset-bgp.xml.in
@@ -7,6 +7,18 @@
           <help>Border Gateway Protocol (BGP) information</help>
         </properties>
         <children>
+          <virtualTagNode>
+            <properties>
+              <help>BGP IPv4/IPv6 neighbor to clear</help>
+              <completionHelp>
+                <script>${vyos_completion_dir}/list_bgp_neighbors.sh --both</script>
+              </completionHelp>
+            </properties>
+            <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            <children>
+              #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+            </children>
+          </virtualTagNode>
           <leafNode name="all">
             <properties>
               <help>Clear all peers</help>
@@ -37,20 +49,20 @@
               </leafNode>
               #include <include/bgp/reset-bgp-afi-common.xml.i>
               #include <include/bgp/reset-bgp-peer-group.xml.i>
+              <virtualTagNode>
+                <properties>
+                  <help>IPv4 neighbor to clear</help>
+                  <completionHelp>
+                    <script>${vyos_completion_dir}/list_bgp_neighbors.sh --ipv4</script>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                <children>
+                  #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
-          <tagNode name="ipv4">
-            <properties>
-              <help>IPv4 neighbor to clear</help>
-              <completionHelp>
-                <script>${vyos_completion_dir}/list_bgp_neighbors.sh --ipv4</script>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-            <children>
-              #include <include/bgp/reset-bgp-neighbor-options.xml.i>
-            </children>
-          </tagNode>
           <node name="ipv6">
             <properties>
               <help>IPv6 Address Family</help>
@@ -64,20 +76,20 @@
               </leafNode>
               #include <include/bgp/reset-bgp-afi-common.xml.i>
               #include <include/bgp/reset-bgp-peer-group.xml.i>
+              <virtualTagNode>
+                <properties>
+                  <help>IPv6 neighbor to clear</help>
+                  <completionHelp>
+                    <script>${vyos_completion_dir}/list_bgp_neighbors.sh --ipv6</script>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                <children>
+                  #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
-          <tagNode name="ipv6">
-            <properties>
-              <help>IPv6 neighbor to clear</help>
-              <completionHelp>
-                <script>${vyos_completion_dir}/list_bgp_neighbors.sh --ipv6</script>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-            <children>
-              #include <include/bgp/reset-bgp-neighbor-options.xml.i>
-            </children>
-          </tagNode>
           <node name="l2vpn">
             <properties>
               <help>Layer 2 Virtual Private Network Address Family</help>
@@ -96,20 +108,20 @@
                   </leafNode>
                   #include <include/bgp/reset-bgp-afi-common.xml.i>
                   #include <include/bgp/reset-bgp-peer-group.xml.i>
+                  <virtualTagNode>
+                    <properties>
+                      <help>BGP IPv4/IPv6 neighbor to clear</help>
+                      <completionHelp>
+                        <script>${vyos_completion_dir}/list_bgp_neighbors.sh --both</script>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                    <children>
+                      #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                    </children>
+                  </virtualTagNode>
                 </children>
               </node>
-              <tagNode name="evpn">
-                <properties>
-                  <help>BGP IPv4/IPv6 neighbor to clear</help>
-                  <completionHelp>
-                    <script>${vyos_completion_dir}/list_bgp_neighbors.sh --both</script>
-                  </completionHelp>
-                </properties>
-                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-                <children>
-                  #include <include/bgp/reset-bgp-neighbor-options.xml.i>
-                </children>
-              </tagNode>
             </children>
           </node>
           <tagNode name="vrf">
@@ -120,7 +132,7 @@
               </completionHelp>
             </properties>
             <children>
-              <node name="node.tag">
+              <virtualTagNode>
                 <properties>
                   <help>IPv4/IPv6 neighbor to clear</help>
                   <completionHelp>
@@ -131,7 +143,7 @@
                 <children>
                   #include <include/bgp/reset-bgp-neighbor-options.xml.i>
                 </children>
-              </node>
+              </virtualTagNode>
               <leafNode name="all">
                 <properties>
                   <help>Clear all peers</help>
@@ -162,20 +174,20 @@
                   </leafNode>
                   #include <include/bgp/reset-bgp-afi-common.xml.i>
                   #include <include/bgp/reset-bgp-peer-group-vrf.xml.i>
+                  <virtualTagNode>
+                    <properties>
+                      <help>IPv4 neighbor to clear</help>
+                      <completionHelp>
+                        <script>${vyos_completion_dir}/list_bgp_neighbors.sh --ipv4 --vrf ${COMP_WORDS[3]}</script>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                    <children>
+                      #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                    </children>
+                  </virtualTagNode>
                 </children>
               </node>
-              <tagNode name="ipv4">
-                <properties>
-                  <help>IPv4 neighbor to clear</help>
-                  <completionHelp>
-                    <script>${vyos_completion_dir}/list_bgp_neighbors.sh --ipv4 --vrf ${COMP_WORDS[3]}</script>
-                  </completionHelp>
-                </properties>
-                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-                <children>
-                  #include <include/bgp/reset-bgp-neighbor-options.xml.i>
-                </children>
-              </tagNode>
               <node name="ipv6">
                 <properties>
                   <help>IPv6 Address Family</help>
@@ -189,20 +201,20 @@
                   </leafNode>
                   #include <include/bgp/reset-bgp-afi-common.xml.i>
                   #include <include/bgp/reset-bgp-peer-group-vrf.xml.i>
+                  <virtualTagNode>
+                    <properties>
+                      <help>IPv6 neighbor to clear</help>
+                      <completionHelp>
+                        <script>${vyos_completion_dir}/list_bgp_neighbors.sh --ipv6 --vrf ${COMP_WORDS[3]}</script>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                    <children>
+                      #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                    </children>
+                  </virtualTagNode>
                 </children>
               </node>
-              <tagNode name="ipv6">
-                <properties>
-                  <help>IPv6 neighbor to clear</help>
-                  <completionHelp>
-                    <script>${vyos_completion_dir}/list_bgp_neighbors.sh --ipv6 --vrf ${COMP_WORDS[3]}</script>
-                  </completionHelp>
-                </properties>
-                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-                <children>
-                  #include <include/bgp/reset-bgp-neighbor-options.xml.i>
-                </children>
-              </tagNode>
               <node name="l2vpn">
                 <properties>
                   <help>Layer 2 Virtual Private Network Address Family</help>
@@ -221,38 +233,26 @@
                       </leafNode>
                       #include <include/bgp/reset-bgp-afi-common.xml.i>
                       #include <include/bgp/reset-bgp-peer-group-vrf.xml.i>
+                      <virtualTagNode>
+                        <properties>
+                          <help>BGP IPv4/IPv6 neighbor to clear</help>
+                          <completionHelp>
+                            <script>${vyos_completion_dir}/list_bgp_neighbors.sh --both --vrf ${COMP_WORDS[3]}</script>
+                          </completionHelp>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                        <children>
+                          #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                        </children>
+                      </virtualTagNode>
                     </children>
                   </node>
-                  <tagNode name="evpn">
-                    <properties>
-                      <help>BGP IPv4/IPv6 neighbor to clear</help>
-                      <completionHelp>
-                        <script>${vyos_completion_dir}/list_bgp_neighbors.sh --both --vrf ${COMP_WORDS[3]}</script>
-                      </completionHelp>
-                    </properties>
-                    <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-                    <children>
-                      #include <include/bgp/reset-bgp-neighbor-options.xml.i>
-                    </children>
-                  </tagNode>
                 </children>
               </node>
             </children>
           </tagNode>
         </children>
       </node>
-      <tagNode name="bgp">
-        <properties>
-          <help>BGP IPv4/IPv6 neighbor to clear</help>
-          <completionHelp>
-            <script>${vyos_completion_dir}/list_bgp_neighbors.sh --both</script>
-          </completionHelp>
-        </properties>
-        <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-        <children>
-          #include <include/bgp/reset-bgp-neighbor-options.xml.i>
-        </children>
-      </tagNode>
     </children>
   </node>
 </interfaceDefinition>

--- a/op-mode-definitions/reset-ip-bgp.xml.in
+++ b/op-mode-definitions/reset-ip-bgp.xml.in
@@ -9,28 +9,38 @@
               <help>Border Gateway Protocol (BGP) information</help>
             </properties>
             <children>
+              <virtualTagNode>
+                <properties>
+                  <help>BGP IPv4/IPv6 neighbor to clear</help>
+                  <completionHelp>
+                    <script>${vyos_completion_dir}/list_bgp_neighbors.sh --ipv4</script>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                <children>
+                  #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                </children>
+              </virtualTagNode>
               <leafNode name="all">
                 <properties>
                   <help>Clear all BGP peering sessions</help>
                 </properties>
                 <command>vtysh -c "clear bgp ipv4 *"</command>
               </leafNode>
-              <node name="dampening">
-                <properties>
-                  <help>Clear BGP route flap dampening information</help>
-                </properties>
-                <command>vtysh -c "clear ip bgp dampening"</command>
-              </node>
               <tagNode name="dampening">
                 <properties>
-                  <help>Clear BGP route flap dampening information for given host|network address</help>
+                  <help>Clear BGP route flap dampening information for given host ornetwork address</help>
                   <completionHelp>
                     <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt;</list>
                   </completionHelp>
                 </properties>
+                <standalone>
+                  <help>Clear BGP route flap dampening information</help>
+                  <command>vtysh -c "clear ip bgp dampening"</command>
+                </standalone>
                 <command>vtysh -c "clear ip bgp dampening $5"</command>
                 <children>
-                  <leafNode name="node.tag">
+                  <virtualTagNode>
                     <properties>
                       <help>Clear BGP route flap dampening information for given network address</help>
                       <completionHelp>
@@ -38,7 +48,7 @@
                       </completionHelp>
                     </properties>
                     <command>vtysh -c "clear ip bgp dampening $5 $6"</command>
-                  </leafNode>
+                  </virtualTagNode>
                 </children>
               </tagNode>
               #include <include/bgp/reset-bgp-afi-common.xml.i>
@@ -57,7 +67,7 @@
                     </properties>
                     <command>vtysh -c "clear bgp vrf $5 *"</command>
                   </leafNode>
-                  <leafNode name="node.tag">
+                  <virtualTagNode>
                     <properties>
                       <help>Clear BGP neighbor IP address</help>
                       <completionHelp>
@@ -65,24 +75,12 @@
                       </completionHelp>
                     </properties>
                     <command>vtysh -c "clear bgp vrf $5 $6"</command>
-                  </leafNode>
+                  </virtualTagNode>
                 </children>
               </tagNode>
             </children>
           </node>
-          <tagNode name="bgp">
-            <properties>
-              <help>BGP IPv4/IPv6 neighbor to clear</help>
-              <completionHelp>
-                <script>${vyos_completion_dir}/list_bgp_neighbors.sh --ipv4</script>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-            <children>
-              #include <include/bgp/reset-bgp-neighbor-options.xml.i>
-            </children>
-          </tagNode>
-        </children>
+       </children>
       </node>
     </children>
   </node>

--- a/op-mode-definitions/show-bridge.xml.in
+++ b/op-mode-definitions/show-bridge.xml.in
@@ -6,7 +6,57 @@
         <properties>
           <help>Show bridging information</help>
         </properties>
+        <command>${vyos_op_scripts_dir}/bridge.py show</command>
         <children>
+          <virtualTagNode>
+            <properties>
+              <help>Show bridge information for a given bridge interface</help>
+              <completionHelp>
+                <script>${vyos_completion_dir}/list_interfaces --type bridge</script>
+              </completionHelp>
+            </properties>
+            <command>bridge -c link show | grep "master $3"</command>
+            <children>
+              <node name="spanning-tree">
+                <properties>
+                  <help>View Spanning Tree info for specified bridges</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/stp.py show_stp --ifname=$3</command>
+                <children>
+                  <leafNode name="detail">
+                    <properties>
+                      <help>Show detailed Spanning Tree info for specified bridge</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/stp.py show_stp --ifname=$3 --detail</command>
+                  </leafNode>
+                </children>
+              </node>
+              <leafNode name="mdb">
+                <properties>
+                  <help>Displays the multicast group database for the bridge</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/bridge.py show_mdb --interface=$3</command>
+              </leafNode>
+              <leafNode name="fdb">
+                <properties>
+                  <help>Show the forwarding database of the bridge</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/bridge.py show_fdb --interface=$3</command>
+              </leafNode>
+              <leafNode name="detail">
+                <properties>
+                  <help>Display bridge interface details</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/bridge.py show_detail --interface=$3</command>
+              </leafNode>
+              <leafNode name="nexthop-group">
+                <properties>
+                  <help>Display bridge interface nexthop-group</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/bridge.py show_detail --nexthop-group --interface=$3</command>
+              </leafNode>
+            </children>
+          </virtualTagNode>
           <node name="spanning-tree">
             <properties>
               <help>View Spanning Tree info for all bridges</help>
@@ -43,59 +93,6 @@
           </leafNode>
         </children>
       </node>
-      <tagNode name="bridge">
-        <properties>
-          <help>Show bridge information for a given bridge interface</help>
-          <completionHelp>
-            <script>${vyos_completion_dir}/list_interfaces --type bridge</script>
-          </completionHelp>
-        </properties>
-        <command>bridge -c link show | grep "master $3"</command>
-        <standalone>
-          <help>Show bridge interface information</help>
-          <command>${vyos_op_scripts_dir}/bridge.py show</command>
-        </standalone>
-        <children>
-          <node name="spanning-tree">
-            <properties>
-              <help>View Spanning Tree info for specified bridges</help>
-            </properties>
-            <command>${vyos_op_scripts_dir}/stp.py show_stp --ifname=$3</command>
-            <children>
-              <leafNode name="detail">
-                <properties>
-                  <help>Show detailed Spanning Tree info for specified bridge</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/stp.py show_stp --ifname=$3 --detail</command>
-              </leafNode>
-            </children>
-          </node>
-          <leafNode name="mdb">
-            <properties>
-              <help>Displays the multicast group database for the bridge</help>
-            </properties>
-            <command>${vyos_op_scripts_dir}/bridge.py show_mdb --interface=$3</command>
-          </leafNode>
-          <leafNode name="fdb">
-            <properties>
-              <help>Show the forwarding database of the bridge</help>
-            </properties>
-            <command>${vyos_op_scripts_dir}/bridge.py show_fdb --interface=$3</command>
-          </leafNode>
-          <leafNode name="detail">
-            <properties>
-              <help>Display bridge interface details</help>
-            </properties>
-            <command>${vyos_op_scripts_dir}/bridge.py show_detail --interface=$3</command>
-          </leafNode>
-          <leafNode name="nexthop-group">
-            <properties>
-              <help>Display bridge interface nexthop-group</help>
-            </properties>
-            <command>${vyos_op_scripts_dir}/bridge.py show_detail --nexthop-group --interface=$3</command>
-          </leafNode>
-        </children>
-      </tagNode>
     </children>
   </node>
 </interfaceDefinition>

--- a/op-mode-definitions/show-evpn.xml.in
+++ b/op-mode-definitions/show-evpn.xml.in
@@ -11,30 +11,30 @@
             <properties>
               <help>Access VLANs</help>
             </properties>
-            <children>
+	        <children>
+              <virtualTagNode>
+                <properties>
+                  <help>Access VLANs interface name</help>
+                  <completionHelp>
+                    <script>${vyos_completion_dir}/list_interfaces --bridgeable --no-vlan-subinterfaces</script>
+                  </completionHelp>
+                </properties>
+                <children>
+                  <virtualTagNode>
+                    <properties>
+                      <help>VLAN ID</help>
+                      <completionHelp>
+                        <list>&lt;1-4094&gt;</list>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/evpn.py show_evpn --command "$*"</command>
+                  </virtualTagNode>
+                </children>
+              </virtualTagNode>
               #include <include/frr-detail.xml.i>
             </children>
             <command>${vyos_op_scripts_dir}/evpn.py show_evpn --command "$*"</command>
           </node>
-          <tagNode name="access-vlan">
-            <properties>
-              <help>Access VLANs interface name</help>
-              <completionHelp>
-                <script>${vyos_completion_dir}/list_interfaces --bridgeable --no-vlan-subinterfaces</script>
-              </completionHelp>
-            </properties>
-            <children>
-              <node name="node.tag">
-                <properties>
-                  <help>VLAN ID</help>
-                  <completionHelp>
-                    <list>&lt;1-4094&gt;</list>
-                  </completionHelp>
-                </properties>
-                <command>${vyos_op_scripts_dir}/evpn.py show_evpn --command "$*"</command>
-              </node>
-            </children>
-          </tagNode>
           <node name="arp-cache">
             <properties>
               <help>ARP and ND cache</help>
@@ -43,22 +43,22 @@
               #include <include/vni-tagnode-all.xml.i>
             </children>
           </node>
-          <tagNode name="es">
-            <properties>
-              <help>Show ESI information for specified ESI</help>
-              <completionHelp>
-                <list>&lt;esi&gt;</list>
-                <script>${vyos_completion_dir}/list_esi.sh</script>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/evpn.py show_evpn --command "$*"</command>
-          </tagNode>
           <node name="es">
             <properties>
               <help>Show ESI information</help>
             </properties>
             <command>${vyos_op_scripts_dir}/evpn.py show_evpn --command "$*"</command>
             <children>
+              <virtualTagNode>
+                <properties>
+                  <help>Show ESI information for specified ESI</help>
+                  <completionHelp>
+                    <list>&lt;esi&gt;</list>
+                    <script>${vyos_completion_dir}/list_esi.sh</script>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/evpn.py show_evpn --command "$*"</command>
+              </virtualTagNode>
               <leafNode name="detail">
                 <properties>
                   <help>Show ESI details</help>
@@ -106,13 +106,22 @@
               #include <include/vni-tagnode-all.xml.i>
             </children>
           </node>
-          #include <include/vni-tagnode.xml.i>
           <node name="vni">
             <properties>
               <help>Show VNI information</help>
             </properties>
             <command>${vyos_op_scripts_dir}/evpn.py show_evpn --command "$*"</command>
-            <children>
+	    <children>
+              <virtualTagNode>
+                <properties>
+                  <help>VXLAN network identifier (VNI) number</help>
+                  <completionHelp>
+                    <list>&lt;1-16777215&gt;</list>
+                    <script>${vyos_completion_dir}/list_vni.sh</script>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/evpn.py show_evpn --command "$*"</command>
+              </virtualTagNode>
               <leafNode name="detail">
                 <properties>
                   <help>Show VNI details</help>

--- a/op-mode-definitions/show-history.xml.in
+++ b/op-mode-definitions/show-history.xml.in
@@ -14,18 +14,17 @@
             </properties>
             <command>HISTTIMEFORMAT='%FT%T%z ' HISTFILE="$HOME/.bash_history" \set -o history; history 20</command>
           </leafNode>
+          <virtualTagNode>
+            <properties>
+              <help>Show last N commands in history</help>
+              <completionHelp>
+                <list>&lt;NUMBER&gt;</list>
+              </completionHelp>
+            </properties>
+            <command>HISTTIMEFORMAT='%FT%T%z ' HISTFILE="$HOME/.bash_history" \set -o history; history $3</command>
+          </virtualTagNode>
         </children>
       </node>
-
-      <tagNode name="history">
-        <properties>
-          <help>Show last N commands in history</help>
-          <completionHelp>
-            <list>&lt;NUMBER&gt;</list>
-          </completionHelp>
-        </properties>
-        <command>HISTTIMEFORMAT='%FT%T%z ' HISTFILE="$HOME/.bash_history" \set -o history; history $3</command>
-      </tagNode>
-    </children>
+   </children>
   </node>
 </interfaceDefinition>

--- a/op-mode-definitions/show-interfaces-bonding.xml.in
+++ b/op-mode-definitions/show-interfaces-bonding.xml.in
@@ -4,77 +4,11 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="bonding">
-            <properties>
-              <help>Show specified Bonding interface information</help>
-              <completionHelp>
-                <path>interfaces bonding</path>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=bonding</command>
-            <children>
-              <leafNode name="brief">
-                <properties>
-                  <help>Show summary of the specified bonding interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=bonding</command>
-              </leafNode>
-              <leafNode name="detail">
-                <properties>
-                  <help>Show detailed interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/show_bonding_detail.sh "$4"</command>
-              </leafNode>
-              <node name="lacp">
-                <properties>
-                  <help>Show LACP related info</help>
-                </properties>
-                <children>
-                  <leafNode name="detail">
-                    <properties>
-                      <help>Show LACP details</help>
-                    </properties>
-                    <command>${vyos_op_scripts_dir}/bonding.py show_lacp_detail --interface="$4" </command>
-                  </leafNode>
-                  <leafNode name="neighbors">
-                    <properties>
-                      <help>Show LACP Neighbors</help>
-                    </properties>
-                    <command>${vyos_op_scripts_dir}/bonding.py show_lacp_neighbors --interface="$4"</command>
-                  </leafNode>
-                </children>
-              </node>
-              <leafNode name="slaves">
-                <properties>
-                  <help>Show specified bonding interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/show-bond.py --interface "$4"</command>
-              </leafNode>
-              <tagNode name="vif">
-                <properties>
-                  <help>Show specified virtual network interface (vif) information</help>
-                  <completionHelp>
-                    <path>interfaces bonding ${COMP_WORDS[3]} vif</path>
-                  </completionHelp>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4.$6" --intf-type=bonding</command>
-                <children>
-                  <leafNode name="brief">
-                    <properties>
-                      <help>Show summary of specified virtual network interface (vif) information</help>
-                    </properties>
-                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4.$6" --intf-type=bonding</command>
-                  </leafNode>
-                </children>
-              </tagNode>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
           <node name="bonding">
             <properties>
-              <help>Show Bonding interface information</help>
+              <help>Show specified bonding interface information</help>
             </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=bonding</command>
+            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=bonding</command>
             <children>
               <leafNode name="detail">
                 <properties>
@@ -101,6 +35,71 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/show-bond.py --slaves</command>
               </leafNode>
+              <virtualTagNode>
+                <properties>
+                  <completionHelp>
+                    <path>interfaces bonding</path>
+                  </completionHelp>
+	        </properties>
+	        <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=bonding</command>
+                <children>
+                  <leafNode name="brief">
+                    <properties>
+                      <help>Show summary of the specified bonding interface information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=bonding</command>
+                  </leafNode>
+                  <leafNode name="detail">
+                    <properties>
+                      <help>Show detailed interface information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/show_bonding_detail.sh "$4"</command>
+                  </leafNode>
+                  <node name="lacp">
+                    <properties>
+                      <help>Show LACP related info</help>
+                    </properties>
+                    <children>
+                      <leafNode name="detail">
+                        <properties>
+                          <help>Show LACP details</help>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/bonding.py show_lacp_detail --interface="$4" </command>
+                      </leafNode>
+                      <leafNode name="neighbors">
+                        <properties>
+                          <help>Show LACP Neighbors</help>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/bonding.py show_lacp_neighbors --interface="$4"</command>
+                      </leafNode>
+                    </children>
+                  </node>
+                  <leafNode name="slaves">
+                    <properties>
+                      <help>Show specified bonding interface information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/show-bond.py --interface "$4"</command>
+                  </leafNode>
+                  <tagNode name="vif">
+                    <properties>
+                      <help>Show specified virtual network interface (vif) information</help>
+                      <completionHelp>
+                        <path>interfaces bonding ${COMP_WORDS[3]} vif</path>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4.$6" --intf-type=bonding</command>
+                    <children>
+                      <leafNode name="brief">
+                        <properties>
+                          <help>Show summary of specified virtual network interface (vif) information</help>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4.$6" --intf-type=bonding</command>
+                      </leafNode>
+                    </children>
+                  </tagNode>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-interfaces-bridge.xml.in
+++ b/op-mode-definitions/show-interfaces-bridge.xml.in
@@ -4,27 +4,9 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="bridge">
+         <node name="bridge">
             <properties>
-              <help>Show specified Bridge interface information</help>
-              <completionHelp>
-                <path>interfaces bridge</path>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=bridge</command>
-            <children>
-              <leafNode name="brief">
-                <properties>
-                  <help>Show summary of the specified bridge interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=bridge</command>
-              </leafNode>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
-          <node name="bridge">
-            <properties>
-              <help>Show Bridge interface information</help>
+              <help>Show bridge interface information</help>
             </properties>
             <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=bridge</command>
             <children>
@@ -34,6 +16,24 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=bridge</command>
               </leafNode>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specified bridge interface information</help>
+                  <completionHelp>
+                    <path>interfaces bridge</path>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=bridge</command>
+                <children>
+                  <leafNode name="brief">
+                    <properties>
+                      <help>Show summary of the specified bridge interface information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=bridge</command>
+                  </leafNode>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-interfaces-dummy.xml.in
+++ b/op-mode-definitions/show-interfaces-dummy.xml.in
@@ -4,27 +4,9 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="dummy">
+         <node name="dummy">
             <properties>
-              <help>Show specified Dummy interface information</help>
-              <completionHelp>
-                <path>interfaces dummy</path>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=dummy</command>
-            <children>
-              <leafNode name="brief">
-                <properties>
-                  <help>Show summary of the specified dummy interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=dummy</command>
-              </leafNode>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
-          <node name="dummy">
-            <properties>
-              <help>Show Dummy interface information</help>
+              <help>Show dummy interface information</help>
             </properties>
             <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=dummy</command>
             <children>
@@ -34,6 +16,24 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=dummy</command>
               </leafNode>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specified dummy interface information</help>
+                  <completionHelp>
+                    <path>interfaces dummy</path>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=dummy</command>
+                <children>
+                  <leafNode name="brief">
+                    <properties>
+                      <help>Show summary of the specified dummy interface information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=dummy</command>
+                  </leafNode>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-interfaces-ethernet.xml.in
+++ b/op-mode-definitions/show-interfaces-ethernet.xml.in
@@ -4,85 +4,84 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="ethernet">
-            <properties>
-              <help>Show specified Ethernet interface information</help>
-              <completionHelp>
-                <path>interfaces ethernet</path>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=ethernet</command>
-            <children>
-              <leafNode name="brief">
-                <properties>
-                  <help>Show summary of the specified ethernet interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=ethernet</command>
-              </leafNode>
-              <leafNode name="identify">
-                <properties>
-                  <help>Visually identify specified ethernet interface</help>
-                </properties>
-                <command>echo "Blinking interface $4 for 30 seconds."; ethtool --identify "$4" 30</command>
-              </leafNode>
-              <node name="physical">
-                <properties>
-                  <help>Show physical device information for specified ethernet interface</help>
-                </properties>
-                <command>ethtool "$4"; ethtool --show-ring "$4"; ethtool --driver "$4"</command>
-                <children>
-                  <leafNode name="offload">
-                    <properties>
-                      <help>Show physical device offloading capabilities</help>
-                    </properties>
-                    <command>ethtool --show-features "$4" | sed -e 1d -e '/fixed/d' -e 's/^\t*//g' -e 's/://' | column -t -s' '</command>
-                  </leafNode>
-                </children>
-              </node>
-              <leafNode name="statistics">
-                <properties>
-                  <help>Show physical device statistics for specified ethernet interface</help>
-                </properties>
-                <command>ethtool --statistics "$4"</command>
-              </leafNode>
-              <leafNode name="transceiver">
-                <properties>
-                  <help>Show transceiver information from modules (e.g SFP+, QSFP)</help>
-                </properties>
-                <command>ethtool --module-info "$4"</command>
-              </leafNode>
-              <tagNode name="vif">
-                <properties>
-                  <help>Show specified virtual network interface (vif) information</help>
-                  <completionHelp>
-                    <path>interfaces ethernet ${COMP_WORDS[3]} vif</path>
-                  </completionHelp>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4.$6" --intf-type=ethernet</command>
-                <children>
-                  <leafNode name="brief">
-                    <properties>
-                      <help>Show summary of specified virtual network interface (vif) information</help>
-                    </properties>
-                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4.$6" --intf-type=ethernet</command>
-                  </leafNode>
-                </children>
-              </tagNode>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
           <node name="ethernet">
             <properties>
-              <help>Show Ethernet interface information</help>
-            </properties>
+              <help>Show specified Ethernet interface information</help>
+           </properties>
             <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=ethernet</command>
-            <children>
+	    <children>
               <leafNode name="detail">
                 <properties>
                   <help>Show detailed ethernet interface information</help>
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=ethernet</command>
               </leafNode>
+              <virtualTagNode>
+	        <properties>
+		  <completionHelp>
+                    <path>interfaces ethernet</path>
+                  </completionHelp>
+	        </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=ethernet</command>
+                <children>
+                  <leafNode name="brief">
+                    <properties>
+                      <help>Show summary of the specified ethernet interface information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=ethernet</command>
+                  </leafNode>
+                  <leafNode name="identify">
+                    <properties>
+                      <help>Visually identify specified ethernet interface</help>
+                    </properties>
+                    <command>echo "Blinking interface $4 for 30 seconds."; ethtool --identify "$4" 30</command>
+                  </leafNode>
+                  <node name="physical">
+                    <properties>
+                      <help>Show physical device information for specified ethernet interface</help>
+                    </properties>
+                    <command>ethtool "$4"; ethtool --show-ring "$4"; ethtool --driver "$4"</command>
+                    <children>
+                      <leafNode name="offload">
+                        <properties>
+                          <help>Show physical device offloading capabilities</help>
+                        </properties>
+                        <command>ethtool --show-features "$4" | sed -e 1d -e '/fixed/d' -e 's/^\t*//g' -e 's/://' | column -t -s' '</command>
+                      </leafNode>
+                    </children>
+                  </node>
+                  <leafNode name="statistics">
+                    <properties>
+                      <help>Show physical device statistics for specified ethernet interface</help>
+                    </properties>
+                    <command>ethtool --statistics "$4"</command>
+                  </leafNode>
+                  <leafNode name="transceiver">
+                    <properties>
+                      <help>Show transceiver information from modules (e.g SFP+, QSFP)</help>
+                    </properties>
+                    <command>ethtool --module-info "$4"</command>
+                  </leafNode>
+                  <tagNode name="vif">
+                    <properties>
+                      <help>Show specified virtual network interface (vif) information</help>
+                      <completionHelp>
+                        <path>interfaces ethernet ${COMP_WORDS[3]} vif</path>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4.$6" --intf-type=ethernet</command>
+                    <children>
+                      <leafNode name="brief">
+                        <properties>
+                          <help>Show summary of specified virtual network interface (vif) information</help>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4.$6" --intf-type=ethernet</command>
+                      </leafNode>
+                    </children>
+                  </tagNode>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-interfaces-geneve.xml.in
+++ b/op-mode-definitions/show-interfaces-geneve.xml.in
@@ -4,25 +4,7 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="geneve">
-            <properties>
-              <help>Show specified GENEVE interface information</help>
-              <completionHelp>
-                <path>interfaces geneve</path>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=geneve</command>
-            <children>
-              <leafNode name="brief">
-                <properties>
-                  <help>Show summary of the specified GENEVE interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=geneve</command>
-              </leafNode>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
-          <node name="geneve">
+         <node name="geneve">
             <properties>
               <help>Show GENEVE interface information</help>
             </properties>
@@ -34,6 +16,24 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=geneve</command>
               </leafNode>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specified GENEVE interface information</help>
+                  <completionHelp>
+                    <path>interfaces geneve</path>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=geneve</command>
+                <children>
+                  <leafNode name="brief">
+                    <properties>
+                      <help>Show summary of the specified GENEVE interface information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=geneve</command>
+                  </leafNode>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-interfaces-input.xml.in
+++ b/op-mode-definitions/show-interfaces-input.xml.in
@@ -4,9 +4,23 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="input">
+          <node name="input">
             <properties>
-              <help>Show specified Input interface information</help>
+              <help>Show input (ifb) interface information</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=input</command>
+            <children>
+              <leafNode name="detail">
+                <properties>
+                  <help>Show detailed input interface information</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=input</command>
+              </leafNode>
+            </children>
+          </node>
+          <virtualTagNode>
+            <properties>
+              <help>Show specified input interface information</help>
               <completionHelp>
                 <path>interfaces input</path>
               </completionHelp>
@@ -21,21 +35,7 @@
               </leafNode>
               #include <include/show-interface-type-event-log.xml.i>
             </children>
-          </tagNode>
-          <node name="input">
-            <properties>
-              <help>Show Input (ifb) interface information</help>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=input</command>
-            <children>
-              <leafNode name="detail">
-                <properties>
-                  <help>Show detailed input interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=input</command>
-              </leafNode>
-            </children>
-          </node>
+          </virtualTagNode>
         </children>
       </node>
     </children>

--- a/op-mode-definitions/show-interfaces-l2tpv3.xml.in
+++ b/op-mode-definitions/show-interfaces-l2tpv3.xml.in
@@ -4,25 +4,7 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="l2tpv3">
-            <properties>
-              <help>Show specified L2TPv3 interface information</help>
-              <completionHelp>
-                <path>interfaces l2tpv3</path>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=l2tpv3</command>
-            <children>
-              <leafNode name="brief">
-                <properties>
-                  <help>Show summary of the specified L2TPv3 interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=l2tpv3</command>
-              </leafNode>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
-          <node name="l2tpv3">
+         <node name="l2tpv3">
             <properties>
               <help>Show L2TPv3 interface information</help>
             </properties>
@@ -34,6 +16,24 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=l2tpv3</command>
               </leafNode>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specified L2TPv3 interface information</help>
+                  <completionHelp>
+                    <path>interfaces l2tpv3</path>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=l2tpv3</command>
+                <children>
+                  <leafNode name="brief">
+                    <properties>
+                      <help>Show summary of the specified L2TPv3 interface information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=l2tpv3</command>
+                  </leafNode>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-interfaces-loopback.xml.in
+++ b/op-mode-definitions/show-interfaces-loopback.xml.in
@@ -4,25 +4,7 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="loopback">
-            <properties>
-              <help>Show specified Loopback interface information</help>
-              <completionHelp>
-                <path>interfaces loopback</path>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=loopback</command>
-            <children>
-              <leafNode name="brief">
-                <properties>
-                  <help>Show summary of the specified Loopback interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=loopback</command>
-              </leafNode>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
-          <node name="loopback">
+         <node name="loopback">
             <properties>
               <help>Show Loopback interface information</help>
             </properties>
@@ -34,6 +16,24 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=loopback</command>
               </leafNode>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specified Loopback interface information</help>
+                  <completionHelp>
+                    <path>interfaces loopback</path>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=loopback</command>
+                <children>
+                  <leafNode name="brief">
+                    <properties>
+                      <help>Show summary of the specified Loopback interface information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=loopback</command>
+                  </leafNode>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-interfaces-macsec.xml.in
+++ b/op-mode-definitions/show-interfaces-macsec.xml.in
@@ -19,21 +19,21 @@
                 </properties>
                 <command>ip -s macsec show</command>
               </leafNode>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specified MACsec interface information</help>
+                  <completionHelp>
+                    <path>interfaces macsec</path>
+                  </completionHelp>
+                </properties>
+                <command>ip macsec show $4</command>
+                <children>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>      
           </node>
-          <tagNode name="macsec">
-            <properties>
-              <help>Show specified MACsec interface information</help>
-              <completionHelp>
-                <path>interfaces macsec</path>
-              </completionHelp>
-            </properties>
-            <command>ip macsec show $4</command>
-            <children>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
-        </children>
+       </children>
       </node>
     </children>
   </node>

--- a/op-mode-definitions/show-interfaces-pppoe.xml.in
+++ b/op-mode-definitions/show-interfaces-pppoe.xml.in
@@ -4,34 +4,7 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="pppoe">
-            <properties>
-              <help>Show specified PPPoE interface information</help>
-              <completionHelp>
-                <path>interfaces pppoe</path>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=pppoe</command>
-            <children>
-              <leafNode name="log">
-                <properties>
-                  <help>Show specified PPPoE interface log</help>
-                </properties>
-                <command>journalctl --no-hostname --boot --follow --unit "ppp@$4".service</command>
-              </leafNode>
-              <leafNode name="statistics">
-                <properties>
-                  <help>Show specified PPPoE interface statistics</help>
-                  <completionHelp>
-                    <path>interfaces pppoe</path>
-                  </completionHelp>
-                </properties>
-                <command>${vyos_op_scripts_dir}/show_ppp_stats.sh "$4"</command>
-              </leafNode>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
-          <node name="pppoe">
+         <node name="pppoe">
             <properties>
               <help>Show PPPoE interface information</help>
             </properties>
@@ -43,6 +16,33 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=pppoe</command>
               </leafNode>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specified PPPoE interface information</help>
+                  <completionHelp>
+                    <path>interfaces pppoe</path>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=pppoe</command>
+                <children>
+                  <leafNode name="log">
+                    <properties>
+                      <help>Show specified PPPoE interface log</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot --follow --unit "ppp@$4".service</command>
+                  </leafNode>
+                  <leafNode name="statistics">
+                    <properties>
+                      <help>Show specified PPPoE interface statistics</help>
+                      <completionHelp>
+                        <path>interfaces pppoe</path>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/show_ppp_stats.sh "$4"</command>
+                  </leafNode>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-interfaces-pseudo-ethernet.xml.in
+++ b/op-mode-definitions/show-interfaces-pseudo-ethernet.xml.in
@@ -4,27 +4,9 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="pseudo-ethernet">
+         <node name="pseudo-ethernet">
             <properties>
-              <help>Show specified Pseudo-Ethernet/MACvlan interface information</help>
-              <completionHelp>
-                <path>interfaces pseudo-ethernet</path>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=pseudo-ethernet</command>
-            <children>
-              <leafNode name="brief">
-                <properties>
-                  <help>Show summary of the specified pseudo-ethernet/MACvlan interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=pseudo-ethernet</command>
-              </leafNode>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
-          <node name="pseudo-ethernet">
-            <properties>
-              <help>Show Pseudo-Ethernet/MACvlan interface information</help>
+              <help>Show pseudo-ethernet/MACvlan interface information</help>
             </properties>
             <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=pseudo-ethernet</command>
             <children>
@@ -34,6 +16,24 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=pseudo-ethernet</command>
               </leafNode>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specified pseudo-ethernet/MACvlan interface information</help>
+                  <completionHelp>
+                    <path>interfaces pseudo-ethernet</path>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=pseudo-ethernet</command>
+                <children>
+                  <leafNode name="brief">
+                    <properties>
+                      <help>Show summary of the specified pseudo-ethernet/MACvlan interface information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=pseudo-ethernet</command>
+                  </leafNode>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-interfaces-sstpc.xml.in
+++ b/op-mode-definitions/show-interfaces-sstpc.xml.in
@@ -4,34 +4,7 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="sstpc">
-            <properties>
-              <help>Show specified SSTP client interface information</help>
-              <completionHelp>
-                <path>interfaces sstpc</path>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=sstpc</command>
-            <children>
-              <leafNode name="log">
-                <properties>
-                  <help>Show specified SSTP client interface log</help>
-                </properties>
-                <command>journalctl --no-hostname --boot --follow --unit "ppp@$4".service</command>
-              </leafNode>
-              <leafNode name="statistics">
-                <properties>
-                  <help>Show specified SSTP client interface statistics</help>
-                  <completionHelp>
-                    <path>interfaces sstpc</path>
-                  </completionHelp>
-                </properties>
-                <command>${vyos_op_scripts_dir}/show_ppp_stats.sh "$4"</command>
-              </leafNode>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
-          <node name="sstpc">
+         <node name="sstpc">
             <properties>
               <help>Show SSTP client interface information</help>
             </properties>
@@ -43,6 +16,33 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=sstpc</command>
               </leafNode>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specified SSTP client interface information</help>
+                  <completionHelp>
+                    <path>interfaces sstpc</path>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=sstpc</command>
+                <children>
+                  <leafNode name="log">
+                    <properties>
+                      <help>Show specified SSTP client interface log</help>
+                    </properties>
+                    <command>journalctl --no-hostname --boot --follow --unit "ppp@$4".service</command>
+                  </leafNode>
+                  <leafNode name="statistics">
+                    <properties>
+                      <help>Show specified SSTP client interface statistics</help>
+                      <completionHelp>
+                        <path>interfaces sstpc</path>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/show_ppp_stats.sh "$4"</command>
+                  </leafNode>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-interfaces-tunnel.xml.in
+++ b/op-mode-definitions/show-interfaces-tunnel.xml.in
@@ -4,27 +4,9 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="tunnel">
+         <node name="tunnel">
             <properties>
-              <help>Show specified Tunnel interface information</help>
-              <completionHelp>
-                <path>interfaces tunnel</path>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=tunnel</command>
-            <children>
-              <leafNode name="brief">
-                <properties>
-                  <help>Show summary of the specified tunnel interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=tunnel</command>
-              </leafNode>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
-          <node name="tunnel">
-            <properties>
-              <help>Show Tunnel interface information</help>
+              <help>Show tunnel interface information</help>
             </properties>
             <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=tunnel</command>
             <children>
@@ -34,6 +16,24 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=tunnel</command>
               </leafNode>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specified tunnel interface information</help>
+                  <completionHelp>
+                    <path>interfaces tunnel</path>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=tunnel</command>
+                <children>
+                  <leafNode name="brief">
+                    <properties>
+                      <help>Show summary of the specified tunnel interface information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=tunnel</command>
+                  </leafNode>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-interfaces-virtual-ethernet.xml.in
+++ b/op-mode-definitions/show-interfaces-virtual-ethernet.xml.in
@@ -4,25 +4,7 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="virtual-ethernet">
-            <properties>
-              <help>Show specified virtual-ethernet interface information</help>
-              <completionHelp>
-                <path>interfaces virtual-ethernet</path>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=virtual-ethernet</command>
-            <children>
-              <leafNode name="brief">
-                <properties>
-                  <help>Show summary of the specified virtual-ethernet interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=virtual-ethernet</command>
-              </leafNode>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
-          <node name="virtual-ethernet">
+         <node name="virtual-ethernet">
             <properties>
               <help>Show virtual-ethernet interface information</help>
             </properties>
@@ -34,6 +16,24 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=virtual-ethernet</command>
               </leafNode>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specified virtual-ethernet interface information</help>
+                  <completionHelp>
+                    <path>interfaces virtual-ethernet</path>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=virtual-ethernet</command>
+                <children>
+                  <leafNode name="brief">
+                    <properties>
+                      <help>Show summary of the specified virtual-ethernet interface information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=virtual-ethernet</command>
+                  </leafNode>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-interfaces-vti.xml.in
+++ b/op-mode-definitions/show-interfaces-vti.xml.in
@@ -4,25 +4,7 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="vti">
-            <properties>
-              <help>Show specified VTI interface information</help>
-              <completionHelp>
-                <path>interfaces vti</path>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=vti</command>
-            <children>
-              <leafNode name="brief">
-                <properties>
-                  <help>Show summary of the specified vti interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=vti</command>
-              </leafNode>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
-          <node name="vti">
+         <node name="vti">
             <properties>
               <help>Show VTI interface information</help>
             </properties>
@@ -34,6 +16,24 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=vti</command>
               </leafNode>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specified VTI interface information</help>
+                  <completionHelp>
+                    <path>interfaces vti</path>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=vti</command>
+                <children>
+                  <leafNode name="brief">
+                    <properties>
+                      <help>Show summary of the specified vti interface information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=vti</command>
+                  </leafNode>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-interfaces-vxlan.xml.in
+++ b/op-mode-definitions/show-interfaces-vxlan.xml.in
@@ -4,25 +4,7 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="vxlan">
-            <properties>
-              <help>Show specified VXLAN interface information</help>
-              <completionHelp>
-                <path>interfaces vxlan</path>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=vxlan</command>
-            <children>
-              <leafNode name="brief">
-                <properties>
-                  <help>Show summary of the specified VXLAN interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=vxlan</command>
-              </leafNode>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
-          <node name="vxlan">
+         <node name="vxlan">
             <properties>
               <help>Show VXLAN interface information</help>
             </properties>
@@ -34,6 +16,24 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=vxlan</command>
               </leafNode>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specified VXLAN interface information</help>
+                  <completionHelp>
+                    <path>interfaces vxlan</path>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=vxlan</command>
+                <children>
+                  <leafNode name="brief">
+                    <properties>
+                      <help>Show summary of the specified VXLAN interface information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=vxlan</command>
+                  </leafNode>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-interfaces-wireguard.xml.in
+++ b/op-mode-definitions/show-interfaces-wireguard.xml.in
@@ -4,48 +4,6 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="wireguard">
-            <properties>
-              <help>Show specified WireGuard interface information</help>
-              <completionHelp>
-                <script>${vyos_completion_dir}/list_interfaces --type wireguard</script>
-              </completionHelp>
-            </properties>
-	        <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=wireguard</command>
-            <children>
-              <leafNode name="allowed-ips">
-                <properties>
-                  <help>Show all IP addresses allowed for the specified interface</help>
-                </properties>
-                <command>wg show "$4" allowed-ips</command>
-              </leafNode>
-              <leafNode name="endpoints">
-                <properties>
-                  <help>Show all endpoints for the specified interface</help>
-                </properties>
-                <command>wg show "$4" endpoints</command>
-              </leafNode>
-              <leafNode name="peers">
-                <properties>
-                  <help>Show all peer IDs for the specified interface</help>
-                </properties>
-                <command>wg show "$4" peers</command>
-              </leafNode>
-              <leafNode name="public-key">
-                <properties>
-                  <help>Show interface public-key</help>
-                </properties>
-                <command>wg show "$4" public-key</command>
-              </leafNode>
-              <leafNode name="summary">
-                <properties>
-                  <help>Shows current configuration and device information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces_wireguard.py show_summary --intf-name="$4"</command>
-              </leafNode>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
           <node name="wireguard">
             <properties>
               <help>Show WireGuard interface information</help>
@@ -58,6 +16,48 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=wireguard</command>
               </leafNode>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specified WireGuard interface information</help>
+                  <completionHelp>
+                    <script>${vyos_completion_dir}/list_interfaces --type wireguard</script>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=wireguard</command>
+                <children>
+                  <leafNode name="allowed-ips">
+                    <properties>
+                      <help>Show all IP addresses allowed for the specified interface</help>
+                    </properties>
+                    <command>wg show "$4" allowed-ips</command>
+                  </leafNode>
+                  <leafNode name="endpoints">
+                    <properties>
+                      <help>Show all endpoints for the specified interface</help>
+                    </properties>
+                    <command>wg show "$4" endpoints</command>
+                  </leafNode>
+                  <leafNode name="peers">
+                    <properties>
+                      <help>Show all peer IDs for the specified interface</help>
+                    </properties>
+                    <command>wg show "$4" peers</command>
+                  </leafNode>
+                  <leafNode name="public-key">
+                    <properties>
+                      <help>Show interface public-key</help>
+                    </properties>
+                    <command>wg show "$4" public-key</command>
+                  </leafNode>
+                  <leafNode name="summary">
+                    <properties>
+                      <help>Shows current configuration and device information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces_wireguard.py show_summary --intf-name="$4"</command>
+                  </leafNode>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-interfaces-wireless.xml.in
+++ b/op-mode-definitions/show-interfaces-wireless.xml.in
@@ -6,7 +6,7 @@
         <children>
           <node name="wireless">
             <properties>
-              <help>Show Wireless (WLAN) interface information</help>
+              <help>Show wireless (WLAN) interface information</help>
             </properties>
             <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-type=wireless</command>
             <children>
@@ -22,61 +22,61 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces_wireless.py show_info</command>
               </leafNode>
-            </children>
-          </node>
-          <tagNode name="wireless">
-            <properties>
-              <help>Show specified wireless interface information</help>
-              <completionHelp>
-                <script>${vyos_completion_dir}/list_interfaces --type wireless</script>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=wireless</command>
-            <children>
-              <leafNode name="brief">
+              <virtualTagNode>
                 <properties>
-                  <help>Show brief summary of the specified wireless interface</help>
+                  <help>Show specified wireless interface information</help>
+                  <completionHelp>
+                    <script>${vyos_completion_dir}/list_interfaces --type wireless</script>
+                  </completionHelp>
                 </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=wireless</command>
-              </leafNode>
-              <node name="scan">
-                <properties>
-                  <help>Scan for networks via specified wireless interface</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces_wireless.py show_scan --intf-name="$4"</command>
-                <children>
-                  <leafNode name="detail">
-                    <properties>
-                      <help>Show detailed scan results</help>
-                    </properties>
-                    <command>/sbin/iw dev "$4" scan ap-force</command>
-                  </leafNode>
-                </children>
-              </node>
-              <leafNode name="stations">
-                <properties>
-                  <help>Show specified Wireless interface information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces_wireless.py show_stations --intf-name="$4"</command>
-              </leafNode>
-              <tagNode name="vif">
-                <properties>
-                  <help>Show specified virtual network interface (vif) information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4.$6" --intf-type=wireless</command>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=wireless</command>
                 <children>
                   <leafNode name="brief">
                     <properties>
-                      <help>Show summary of specified virtual network interface (vif) information</help>
+                      <help>Show brief summary of the specified wireless interface</help>
                     </properties>
-                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4.$6" --intf-type=wireless</command>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=wireless</command>
                   </leafNode>
+                  <node name="scan">
+                    <properties>
+                      <help>Scan for networks via specified wireless interface</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces_wireless.py show_scan --intf-name="$4"</command>
+                    <children>
+                      <leafNode name="detail">
+                        <properties>
+                          <help>Show detailed scan results</help>
+                        </properties>
+                        <command>/sbin/iw dev "$4" scan ap-force</command>
+                      </leafNode>
+                    </children>
+                  </node>
+                  <leafNode name="stations">
+                    <properties>
+                      <help>Show specified wireless interface information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces_wireless.py show_stations --intf-name="$4"</command>
+                  </leafNode>
+                  <tagNode name="vif">
+                    <properties>
+                      <help>Show specified virtual network interface (vif) information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4.$6" --intf-type=wireless</command>
+                    <children>
+                      <leafNode name="brief">
+                        <properties>
+                          <help>Show summary of specified virtual network interface (vif) information</help>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4.$6" --intf-type=wireless</command>
+                      </leafNode>
+                    </children>
+                  </tagNode>
+                  #include <include/show-interface-type-event-log.xml.i>
                 </children>
-              </tagNode>
-              #include <include/show-interface-type-event-log.xml.i>
+              </virtualTagNode>
             </children>
-          </tagNode>
-        </children>
+          </node>
+       </children>
       </node>
     </children>
   </node>

--- a/op-mode-definitions/show-interfaces-wwan.xml.in
+++ b/op-mode-definitions/show-interfaces-wwan.xml.in
@@ -4,86 +4,7 @@
     <children>
       <node name="interfaces">
         <children>
-          <tagNode name="wwan">
-            <properties>
-              <help>Show specified Wireless Wire Area Network (WWAN) interface information</help>
-              <completionHelp>
-                <path>interfaces wwan</path>
-                <script>cd /sys/class/net; ls -d wwan*</script>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=wirelessmodem</command>
-            <children>
-              <leafNode name="capabilities">
-                <properties>
-                  <help>Show WWAN module capabilities</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --capabilities</command>
-              </leafNode>
-              <leafNode name="firmware">
-                <properties>
-                  <help>Show WWAN module firmware</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --firmware</command>
-              </leafNode>
-              <leafNode name="imei">
-                <properties>
-                  <help>Show WWAN module IMEI/ESN/MEID</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --imei</command>
-              </leafNode>
-              <leafNode name="imsi">
-                <properties>
-                  <help>Show WWAN module IMSI</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --imsi</command>
-              </leafNode>
-              <leafNode name="model">
-                <properties>
-                  <help>Show WWAN module manufacturer</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --model</command>
-              </leafNode>
-              <leafNode name="msisdn">
-                <properties>
-                  <help>Show WWAN module MSISDN</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --msisdn</command>
-              </leafNode>
-              <leafNode name="revision">
-                <properties>
-                  <help>Show WWAN module revision</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --revision</command>
-              </leafNode>
-              <leafNode name="signal">
-                <properties>
-                  <help>Show WWAN module RF signal info</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --signal</command>
-              </leafNode>
-              <leafNode name="sim">
-                <properties>
-                  <help>Show WWAN module connected SIM card information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --sim</command>
-              </leafNode>
-              <leafNode name="detail">
-                <properties>
-                  <help>Show WWAN module detailed information summary</help>
-                </properties>
-                <command>if cli-shell-api existsActive interfaces wwan $4; then mmcli --modem ${4#wwan}; else echo "Interface \"$4\" unconfigured!"; fi</command>
-              </leafNode>
-              <leafNode name="log">
-                <properties>
-                  <help>Show interface log for specified interface</help>
-                </properties>
-                <command>echo not implemented</command>
-              </leafNode>
-              #include <include/show-interface-type-event-log.xml.i>
-            </children>
-          </tagNode>
-          <node name="wwan">
+         <node name="wwan">
             <properties>
               <help>Show Wireless Modem (WWAN) interface information</help>
             </properties>
@@ -95,6 +16,85 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show --intf-type=wwan</command>
               </leafNode>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specified Wireless Wire Area Network (WWAN) interface information</help>
+                  <completionHelp>
+                    <path>interfaces wwan</path>
+                    <script>cd /sys/class/net; ls -d wwan*</script>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show --intf-name="$4" --intf-type=wirelessmodem</command>
+                <children>
+                  <leafNode name="capabilities">
+                    <properties>
+                      <help>Show WWAN module capabilities</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --capabilities</command>
+                  </leafNode>
+                  <leafNode name="firmware">
+                    <properties>
+                      <help>Show WWAN module firmware</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --firmware</command>
+                  </leafNode>
+                  <leafNode name="imei">
+                    <properties>
+                      <help>Show WWAN module IMEI/ESN/MEID</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --imei</command>
+                  </leafNode>
+                  <leafNode name="imsi">
+                    <properties>
+                      <help>Show WWAN module IMSI</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --imsi</command>
+                  </leafNode>
+                  <leafNode name="model">
+                    <properties>
+                      <help>Show WWAN module manufacturer</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --model</command>
+                  </leafNode>
+                  <leafNode name="msisdn">
+                    <properties>
+                      <help>Show WWAN module MSISDN</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --msisdn</command>
+                  </leafNode>
+                  <leafNode name="revision">
+                    <properties>
+                      <help>Show WWAN module revision</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --revision</command>
+                  </leafNode>
+                  <leafNode name="signal">
+                    <properties>
+                      <help>Show WWAN module RF signal info</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --signal</command>
+                  </leafNode>
+                  <leafNode name="sim">
+                    <properties>
+                      <help>Show WWAN module connected SIM card information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/show_wwan.py --interface=$4 --sim</command>
+                  </leafNode>
+                  <leafNode name="detail">
+                    <properties>
+                      <help>Show WWAN module detailed information summary</help>
+                    </properties>
+                    <command>if cli-shell-api existsActive interfaces wwan $4; then mmcli --modem ${4#wwan}; else echo "Interface \"$4\" unconfigured!"; fi</command>
+                  </leafNode>
+                  <leafNode name="log">
+                    <properties>
+                      <help>Show interface log for specified interface</help>
+                    </properties>
+                    <command>echo not implemented</command>
+                  </leafNode>
+                  #include <include/show-interface-type-event-log.xml.i>
+                </children>
+              </virtualTagNode>
             </children>
           </node>
         </children>

--- a/op-mode-definitions/show-interfaces.xml.in
+++ b/op-mode-definitions/show-interfaces.xml.in
@@ -26,34 +26,34 @@
             </properties>
             <command>${vyos_op_scripts_dir}/interfaces.py show_summary</command>
           </leafNode>
-          <tagNode name="kernel">
-            <properties>
-              <completionHelp>
-                <script>ip -j link show | jq -r '.[].ifname'</script>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --intf-name=$4</command>
-            <children>
-              <leafNode name="detail">
-                <properties>
-                  <help>Show system interface in JSON format</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --intf-name=$4 --detail</command>
-              </leafNode>
-              <leafNode name="json">
-                <properties>
-                  <help>Show system interface in JSON format</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --intf-name=$4 --raw</command>
-              </leafNode>
-            </children>
-          </tagNode>
           <node name="kernel">
             <properties>
               <help>Show all interfaces on this system</help>
             </properties>
             <command>${vyos_op_scripts_dir}/interfaces.py show_kernel</command>
             <children>
+              <virtualTagNode>
+                <properties>
+                  <completionHelp>
+                    <script>ip -j link show | jq -r '.[].ifname'</script>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --intf-name=$4</command>
+                <children>
+                  <leafNode name="detail">
+                    <properties>
+                      <help>Show system interface in JSON format</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --intf-name=$4 --detail</command>
+                  </leafNode>
+                  <leafNode name="json">
+                    <properties>
+                      <help>Show system interface in JSON format</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --intf-name=$4 --raw</command>
+                  </leafNode>
+                </children>
+              </virtualTagNode>
               <leafNode name="detail">
                 <properties>
                   <help>Show system interface in JSON format</help>

--- a/op-mode-definitions/show-ip-bgp.xml.in
+++ b/op-mode-definitions/show-ip-bgp.xml.in
@@ -11,12 +11,6 @@
             <command>vtysh -c "show ip bgp"</command>
             <children>
               #include <include/bgp/show-ip-bgp-common.xml.i>
-              <leafNode name="vrf">
-                <properties>
-                  <help>Show BGP VRF information</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-              </leafNode>
               <tagNode name="vrf">
                 <properties>
                   <help>Show BGP VRF related information</help>
@@ -25,6 +19,10 @@
                     <list>all</list>
                   </completionHelp>
                 </properties>
+                <standalone>
+                  <help>Show BGP VRF information</help>
+                  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                </standalone>
                 <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
                 <children>
                   #include <include/bgp/show-ip-bgp-common.xml.i>

--- a/op-mode-definitions/show-ip-route.xml.in
+++ b/op-mode-definitions/show-ip-route.xml.in
@@ -13,13 +13,24 @@
             </properties>
             <command>vtysh -c "show ip route"</command>
             <children>
-              #include <include/show-route-bgp.xml.i>
-              <node name="cache">
+              <virtualTagNode>
                 <properties>
-                  <help>Show kernel route cache</help>
+                  <help>Show IP routes of specified IP address or prefix</help>
+                  <completionHelp>
+                    <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt;</list>
+                  </completionHelp>
                 </properties>
-                <command>ip -s route list cache</command>
-              </node>
+                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                <children>
+                  <leafNode name="longer-prefixes">
+                    <properties>
+                      <help>Show longer prefixes of routes for specified prefix</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                  </leafNode>
+                </children>
+              </virtualTagNode>
+              #include <include/show-route-bgp.xml.i>
               <tagNode name="cache">
                 <properties>
                   <help>Show kernel route cache for a given route</help>
@@ -27,15 +38,13 @@
                     <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt;</list>
                   </completionHelp>
                 </properties>
+                <standalone>
+                  <help>Show kernel route cache</help>
+                  <command>ip -s route list cache</command>
+                </standalone>
                 <command>ip -s route list cache $5</command>
               </tagNode>
               #include <include/show-route-connected.xml.i>
-              <node name="forward">
-                <properties>
-                  <help>Show kernel route table</help>
-                </properties>
-                <command>ip route list</command>
-              </node>
               <tagNode name="forward">
                 <properties>
                   <help>Show kernel route table for a given route</help>
@@ -43,6 +52,10 @@
                     <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt;</list>
                   </completionHelp>
                 </properties>
+                <standalone>
+                  <help>Show kernel route table</help>
+                  <command>ip route list</command>
+                </standalone>
                 <command>ip -s route list $5</command>
               </tagNode>
               #include <include/show-route-isis.xml.i>
@@ -93,7 +106,7 @@
                   #include <include/show-route-static.xml.i>
                   #include <include/show-route-supernets-only.xml.i>
                   #include <include/show-route-tag.xml.i>
-                  <node name="node.tag">
+                  <virtualTagNode>
                     <properties>
                       <help>Show IP routes of specified IP address or prefix</help>
                       <completionHelp>
@@ -109,28 +122,11 @@
                         <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
                       </leafNode>
                     </children>
-                  </node>
+                  </virtualTagNode>
                 </children>
               </tagNode>
             </children>
           </node>
-          <tagNode name="route">
-            <properties>
-              <help>Show IP routes of specified IP address or prefix</help>
-              <completionHelp>
-                <list>&lt;x.x.x.x&gt; &lt;x.x.x.x/x&gt;</list>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-            <children>
-              <leafNode name="longer-prefixes">
-                <properties>
-                  <help>Show longer prefixes of routes for specified prefix</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-              </leafNode>
-            </children>
-          </tagNode>
         </children>
       </node>
     </children>

--- a/op-mode-definitions/show-ipv6-prefix-list.xml.in
+++ b/op-mode-definitions/show-ipv6-prefix-list.xml.in
@@ -13,6 +13,50 @@
             </properties>
             <command>vtysh -c "show ipv6 prefix-list"</command>
             <children>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specified IPv6 prefix-list</help>
+                  <completionHelp>
+                    <list>WORD</list>
+                  </completionHelp>
+                </properties>
+                <command>vtysh -c "show ipv6 prefix-list $4"</command>
+                <children>
+                  <virtualTagNode>
+                    <properties>
+                      <help>Show select prefix of specified IPv6 prefix-list</help>
+                      <completionHelp>
+                        <list>&lt;h:h:h:h:h:h:h:h/x&gt;</list>
+                      </completionHelp>
+                    </properties>
+                    <command>vtysh -c "show ipv6 prefix-list $4 $5"</command>
+                    <children>
+                      <node name="first-match">
+                        <properties>
+                          <help>Show first-match from select prefix of named IPv6 prefix-list</help>
+                        </properties>
+                        <command>vtysh -c "show ipv6 prefix-list $4 $5 first-match"</command>
+                      </node>
+                      <node name="longer">
+                        <properties>
+                          <help>Show longer match of select prefix from named IPv6 prefix-list</help>
+                        </properties>
+                        <command>vtysh -c "show ipv6 prefix-list $4 $5 longer"</command>
+                      </node>
+                    </children>
+                  </virtualTagNode>
+                  <tagNode name="seq">
+                    <properties>
+                      <help>Show specified sequence from specified IPv6 prefix-list</help>
+                    </properties>
+                    <standalone>
+                      <help>Show specified sequence from specified IPv6 prefix-list</help>
+                      <command>vtysh -c "show ipv6 prefix-list $4 seq"</command>
+                    </standalone>
+                    <command>vtysh -c "show ipv6 prefix-list $4 seq $6"</command>
+                  </tagNode>
+                </children>
+              </virtualTagNode>
               <tagNode name="detail">
                 <properties>
                   <help>Show detail of specified IPv6 prefix-list</help>
@@ -35,52 +79,6 @@
               </tagNode>
             </children>
           </node>
-          <tagNode name="prefix-list">
-            <properties>
-              <help>Show specified IPv6 prefix-list</help>
-              <completionHelp>
-                <list>WORD</list>
-              </completionHelp>
-            </properties>
-            <command>vtysh -c "show ipv6 prefix-list $4"</command>
-            <children>
-              <node name="node.tag">
-                <properties>
-                  <help>Show select prefix of specified IPv6 prefix-list</help>
-                  <completionHelp>
-                    <list>&lt;h:h:h:h:h:h:h:h/x&gt;</list>
-                  </completionHelp>
-                </properties>
-                <command>vtysh -c "show ipv6 prefix-list $4 $5"</command>
-                <children>
-                  <node name="first-match">
-                    <properties>
-                      <help>Show first-match from select prefix of named IPv6 prefix-list</help>
-                    </properties>
-                    <command>vtysh -c "show ipv6 prefix-list $4 $5 first-match"</command>
-                  </node>
-                  <node name="longer">
-                    <properties>
-                      <help>Show longer match of select prefix from named IPv6 prefix-list</help>
-                    </properties>
-                    <command>vtysh -c "show ipv6 prefix-list $4 $5 longer"</command>
-                  </node>
-                </children>
-              </node>
-              <node name="seq">
-                <properties>
-                  <help>Show specified sequence from specified IPv6 prefix-list</help>
-                </properties>
-                <command>vtysh -c "show ipv6 prefix-list $4 seq"</command>
-              </node>
-              <tagNode name="seq">
-                <properties>
-                  <help>Show specified sequence from specified IPv6 prefix-list</help>
-                </properties>
-                <command>vtysh -c "show ipv6 prefix-list $4 seq $6"</command>
-              </tagNode>
-            </children>
-          </tagNode>
         </children>
       </node>
     </children>

--- a/op-mode-definitions/show-ipv6-route.xml.in
+++ b/op-mode-definitions/show-ipv6-route.xml.in
@@ -13,13 +13,24 @@
             </properties>
             <command>vtysh -c "show ipv6 route"</command>
             <children>
-              #include <include/show-route-bgp.xml.i>
-              <node name="cache">
+              <virtualTagNode>
                 <properties>
-                  <help>Show kernel IPv6 route cache</help>
+                  <help>Show IPv6 routes of given address or prefix</help>
+                  <completionHelp>
+                    <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
+                  </completionHelp>
                 </properties>
-                <command>ip -s -f inet6 route list cache</command>
-              </node>
+                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                <children>
+                  <node name="longer-prefixes">
+                    <properties>
+                      <help>Show longer prefixes of routes for given prefix</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                  </node>
+                </children>
+              </virtualTagNode>
+              #include <include/show-route-bgp.xml.i>
               <tagNode name="cache">
                 <properties>
                   <help>Show kernel IPv6 route cache for a given route</help>
@@ -27,15 +38,13 @@
                     <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
                   </completionHelp>
                 </properties>
+                <standalone>
+                  <help>Show kernel IPv6 route cache</help>
+                  <command>ip -s -f inet6 route list cache</command>
+                </standalone>
                 <command>ip -s -f inet6 route list cache $5</command>
               </tagNode>
               #include <include/show-route-connected.xml.i>
-              <node name="forward">
-                <properties>
-                  <help>Show kernel IPv6 route table</help>
-                </properties>
-                <command>ip -f inet6 route list</command>
-              </node>
               <tagNode name="forward">
                 <properties>
                   <help>Show kernel IPv6 route table for a given route</help>
@@ -43,6 +52,10 @@
                     <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
                   </completionHelp>
                 </properties>
+                <standalone>
+                  <help>Show kernel IPv6 route table</help>
+                  <command>ip -f inet6 route list</command>
+                </standalone>
                 <command>ip -s -f inet6 route list $5</command>
               </tagNode>
               #include <include/show-route-isis.xml.i>
@@ -83,7 +96,7 @@
                     </properties>
                     <command>${vyos_op_scripts_dir}/route.py show_summary --family inet6 --vrf $5</command>
                   </node>
-                  <node name="node.tag">
+                  <virtualTagNode>
                     <properties>
                       <help>Show IPv6 routes of given address or prefix</help>
                       <completionHelp>
@@ -99,7 +112,7 @@
                         <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
                       </node>
                     </children>
-                  </node>
+                  </virtualTagNode>
                   #include <include/show-route-bgp.xml.i>
                   #include <include/show-route-connected.xml.i>
                   #include <include/show-route-isis.xml.i>
@@ -114,23 +127,6 @@
               </tagNode>
             </children>
           </node>
-          <tagNode name="route">
-            <properties>
-              <help>Show IPv6 routes of given address or prefix</help>
-              <completionHelp>
-                <list>&lt;h:h:h:h:h:h:h:h&gt; &lt;h:h:h:h:h:h:h:h/x&gt;</list>
-              </completionHelp>
-            </properties>
-            <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-            <children>
-              <node name="longer-prefixes">
-                <properties>
-                  <help>Show longer prefixes of routes for given prefix</help>
-                </properties>
-                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-              </node>
-            </children>
-          </tagNode>
         </children>
       </node>
     </children>

--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -5,21 +5,21 @@
       <help>Show system information</help>
     </properties>
     <children>
-      <tagNode name="log">
-        <properties>
-          <help>Show last number of messages in master logging buffer</help>
-          <completionHelp>
-            <list>&lt;1-9999&gt;</list>
-          </completionHelp>
-        </properties>
-        <command>if ${vyos_validators_dir}/numeric --range 1-9999 "$3"; then journalctl --no-hostname --boot --lines "$3"; fi</command>
-      </tagNode>
-      <node name="log">
+     <node name="log">
         <properties>
           <help>Show contents of current master logging buffer</help>
         </properties>
         <command>journalctl --no-hostname --boot</command>
         <children>
+          <virtualTagNode>
+            <properties>
+              <help>Show last number of messages in master logging buffer</help>
+              <completionHelp>
+                <list>&lt;1-9999&gt;</list>
+              </completionHelp>
+            </properties>
+            <command>if ${vyos_validators_dir}/numeric --range 1-9999 "$3"; then journalctl --no-hostname --boot --lines "$3"; fi</command>
+          </virtualTagNode>
           <leafNode name="audit">
             <properties>
               <help>Show audit logs</help>
@@ -858,14 +858,12 @@
                 <list>&lt;NUMBER&gt;</list>
               </completionHelp>
             </properties>
+            <standalone>
+              <help>Show last 10 lines of /var/log/messages file</help>
+              <command>tail -n 10 /var/log/messages</command>
+            </standalone>
             <command>tail -n "$4" /var/log/messages | ${VYATTA_PAGER:-cat}</command>
           </tagNode>
-          <node name="tail">
-            <properties>
-              <help>Show last 10 lines of /var/log/messages file</help>
-            </properties>
-            <command>tail -n 10 /var/log/messages</command>
-          </node>
           <leafNode name="vpn">
             <properties>
               <help>Show log for ALL Virtual Private Network services</help>

--- a/op-mode-definitions/show-mpls.xml.in
+++ b/op-mode-definitions/show-mpls.xml.in
@@ -18,6 +18,23 @@
                 </properties>
                 <command>vtysh -c "show mpls ldp binding"</command>
                 <children>
+                  <virtualTagNode>
+                    <properties>
+                      <help>LDP forwarding equivalence class</help>
+                      <completionHelp>
+                        <list>&lt;x.x.x.x/x&gt; &lt;h:h:h:h:h:h:h:h/h&gt;</list>
+                      </completionHelp>
+                    </properties>
+                    <command>vtysh -c "show mpls ldp binding $5"</command>
+                    <children>
+                      <leafNode name="detail">
+                        <properties>
+                          <help>Show detailed information</help>
+                        </properties>
+                        <command>vtysh -c "show mpls ldp binding $5 detail"</command>
+                      </leafNode>
+                    </children>
+                  </virtualTagNode>
                   <node name="detail">
                     <properties>
                       <help>Show detailed information</help>
@@ -116,23 +133,6 @@
                   </tagNode>
                 </children>
               </node>
-              <tagNode name="binding">
-                <properties>
-                  <help>LDP forwarding equivalence class</help>
-                  <completionHelp>
-                    <list>&lt;x.x.x.x/x&gt; &lt;h:h:h:h:h:h:h:h/h&gt;</list>
-                  </completionHelp>
-                </properties>
-                <command>vtysh -c "show mpls ldp binding $5"</command>
-                <children>
-                  <leafNode name="detail">
-                    <properties>
-                      <help>Show detailed information</help>
-                    </properties>
-                    <command>vtysh -c "show mpls ldp binding $5 detail"</command>
-                  </leafNode>
-                </children>
-              </tagNode>
               <node name="discovery">
                 <properties>
                   <help>Discovery hello information</help>
@@ -171,32 +171,32 @@
                     </properties>
                     <command>vtysh -c "show mpls ldp neighbor capabilities"</command>
                   </leafNode>
+                  <virtualTagNode>
+                    <properties>
+                      <help>LDP neighbor</help>
+                      <completionHelp>
+                        <list>&lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
+                        <script>vtysh -c "show mpls ldp neighbor" | awk '{print $2}' | egrep -v "ID"</script>
+                      </completionHelp>
+                    </properties>
+                    <command>vtysh -c "show mpls ldp neighbor $5"</command>
+                    <children>
+                      <leafNode name="detail">
+                        <properties>
+                          <help>Show detailed information</help>
+                        </properties>
+                        <command>vtysh -c "show mpls ldp neighbor $5 detail"</command>
+                      </leafNode>
+                      <leafNode name="capabilities">
+                        <properties>
+                          <help>Show neighbor capability information</help>
+                        </properties>
+                        <command>vtysh -c "show mpls ldp neighbor $5 capabilities"</command>
+                      </leafNode>
+                    </children>
+                  </virtualTagNode>
                 </children>
               </node>
-              <tagNode name="neighbor">
-                <properties>
-                  <help>LDP neighbor</help>
-                  <completionHelp>
-                    <list>&lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
-                    <script>vtysh -c "show mpls ldp neighbor" | awk '{print $2}' | egrep -v "ID"</script>
-                  </completionHelp>
-                </properties>
-                <command>vtysh -c "show mpls ldp neighbor $5"</command>
-                <children>
-                  <leafNode name="detail">
-                    <properties>
-                      <help>Show detailed information</help>
-                    </properties>
-                    <command>vtysh -c "show mpls ldp neighbor $5 detail"</command>
-                  </leafNode>
-                  <leafNode name="capabilities">
-                    <properties>
-                      <help>Show neighbor capability information</help>
-                    </properties>
-                    <command>vtysh -c "show mpls ldp neighbor $5 capabilities"</command>
-                  </leafNode>
-                </children>
-              </tagNode>
             </children>
           </node>
           <node name="pseudowire">

--- a/op-mode-definitions/show-openfabric.xml.in
+++ b/op-mode-definitions/show-openfabric.xml.in
@@ -24,11 +24,11 @@
               </completionHelp>
             </properties>
             <children>
+              #include <include/vtysh-generic-interface-virtualTagNode.xml.i>
               #include <include/vtysh-generic-detail.xml.i>
             </children>
             <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
           </node>
-          #include <include/vtysh-generic-interface-tagNode.xml.i>
           <node name="neighbor">
             <properties>
               <help>Show OpenFabric neighbor adjacencies</help>

--- a/op-mode-definitions/show-vrf.xml.in
+++ b/op-mode-definitions/show-vrf.xml.in
@@ -14,31 +14,31 @@
             </properties>
             <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
           </leafNode>
+          <virtualTagNode>
+            <properties>
+              <help>Show information on specific VRF instance</help>
+              <completionHelp>
+                <path>vrf name</path>
+              </completionHelp>
+            </properties>
+            <command>${vyos_op_scripts_dir}/vrf.py show --name="$3"</command>
+            <children>
+              <leafNode name="processes">
+                <properties>
+                  <help>Shows all process ids associated with VRF</help>
+                </properties>
+                <command>ip vrf pids "$3"</command>
+              </leafNode>
+              <leafNode name="vni">
+                <properties>
+                  <help>Show VXLAN VNI association</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+              </leafNode>
+            </children>
+          </virtualTagNode>
         </children>
       </node>
-      <tagNode name="vrf">
-        <properties>
-          <help>Show information on specific VRF instance</help>
-          <completionHelp>
-            <path>vrf name</path>
-          </completionHelp>
-        </properties>
-        <command>${vyos_op_scripts_dir}/vrf.py show --name="$3"</command>
-        <children>
-          <leafNode name="processes">
-            <properties>
-              <help>Shows all process ids associated with VRF</help>
-            </properties>
-            <command>ip vrf pids "$3"</command>
-          </leafNode>
-          <leafNode name="vni">
-            <properties>
-              <help>Show VXLAN VNI association</help>
-            </properties>
-            <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
-          </leafNode>
-        </children>
-      </tagNode>
-    </children>
+   </children>
   </node>
 </interfaceDefinition>

--- a/op-mode-definitions/terminal.xml.in
+++ b/op-mode-definitions/terminal.xml.in
@@ -74,12 +74,6 @@
               </tagNode>
             </children>
           </node>
-          <node name="pager">
-            <properties>
-              <help>Set terminal pager to default (less)</help>
-            </properties>
-            <command>VYATTA_PAGER=${_vyatta_default_pager}</command>
-          </node>
           <tagNode name="pager">
             <properties>
               <help>Set terminal pager</help>
@@ -87,6 +81,10 @@
                 <list>&lt;PROGRAM&gt;</list>
               </completionHelp>
             </properties>
+            <standalone>
+              <help>Set terminal pager to default (less)</help>
+              <command>VYATTA_PAGER=${_vyatta_default_pager}</command>
+            </standalone>
             <command>VYATTA_PAGER=$4</command>
           </tagNode>
           <tagNode name="length">

--- a/op-mode-definitions/traceroute.xml.in
+++ b/op-mode-definitions/traceroute.xml.in
@@ -9,7 +9,7 @@
     </properties>
     <command>${vyos_op_scripts_dir}/traceroute.py ${@:2}</command>
     <children>
-      <leafNode name="node.tag">
+      <virtualTagNode>
         <properties>
           <help>Traceroute options</help>
           <completionHelp>
@@ -17,7 +17,7 @@
           </completionHelp>
         </properties>
         <command>${vyos_op_scripts_dir}/traceroute.py ${@:2}</command>
-      </leafNode>
+      </virtualTagNode>
     </children>
   </tagNode>
 </interfaceDefinition>

--- a/op-mode-definitions/traffic-dump.xml.in
+++ b/op-mode-definitions/traffic-dump.xml.in
@@ -16,7 +16,7 @@
               </completionHelp>
             </properties>
             <children>
-              <leafNode name="node.tag">
+              <virtualTagNode>
                 <properties>
                   <help>Traffic capture options</help>
                   <completionHelp>
@@ -24,7 +24,7 @@
                   </completionHelp>
                 </properties>
                 <command>${vyos_op_scripts_dir}/tcpdump.py "${@:4}"</command>
-              </leafNode>
+              </virtualTagNode>
             </children>
           </tagNode>
         </children>

--- a/op-mode-definitions/vrrp.xml.in
+++ b/op-mode-definitions/vrrp.xml.in
@@ -2,31 +2,31 @@
 <interfaceDefinition>
   <node name="show">
     <children>
-      <tagNode name="vrrp">
-        <properties>
-          <help>Show specified VRRP (Virtual Router Redundancy Protocol) group information</help>
-        </properties>
-        <children>
-          <node name="statistics">
-            <properties>
-              <help>Show VRRP statistics</help>
-            </properties>
-            <command>${vyos_op_scripts_dir}/vrrp.py show_statistics --group-name="$3"</command>
-          </node>
-          <node name="detail">
-            <properties>
-              <help>Show detailed VRRP state information</help>
-            </properties>
-            <command>${vyos_op_scripts_dir}/vrrp.py show_detail --group-name="$3"</command>
-          </node>
-        </children>
-      </tagNode>
       <node name="vrrp">
         <properties>
           <help>Show VRRP (Virtual Router Redundancy Protocol) information</help>
         </properties>
         <command>${vyos_op_scripts_dir}/vrrp.py show_summary</command>
         <children>
+          <virtualTagNode>
+            <properties>
+              <help>Show specified VRRP (Virtual Router Redundancy Protocol) group information</help>
+            </properties>
+            <children>
+              <node name="statistics">
+                <properties>
+                  <help>Show VRRP statistics</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/vrrp.py show_statistics --group-name="$3"</command>
+              </node>
+              <node name="detail">
+                <properties>
+                  <help>Show detailed VRRP state information</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/vrrp.py show_detail --group-name="$3"</command>
+              </node>
+            </children>
+          </virtualTagNode>
           <node name="statistics">
             <properties>
               <help>Show VRRP statistics</help>

--- a/schema/op-mode-definition.rnc
+++ b/schema/op-mode-definition.rnc
@@ -60,6 +60,15 @@ standalone = element standalone
     help & command
 }
 
+# Virtual tag nodes provide a way to add a variable argument
+# to a command that also needs fixed arguments,
+# like "show ip route" that can take "show ip route bgp"
+# or a network and arguments after it, like "show ip route 10.0.0.0/8 longer-prefixes"
+virtualTagNode = element virtualTagNode
+{
+    (properties? & children? & command?)
+}
+
 # Leaf nodes are terminal configuration nodes that can't have children,
 # but can have values.
 
@@ -69,9 +78,11 @@ leafNode = element leafNode
     (command & properties)
 }
 
-# Normal and tag nodes may have children
+# Normal and tag nodes may have children: nodes, leaf nodes, or tag nodes.
+# There can only be one virtual tag node child, though.
 children = element children
 {
+    (virtualTagNode? & (node | tagNode | leafNode)*) |
     (node | tagNode | leafNode)+
 }
 

--- a/schema/op-mode-definition.rng
+++ b/schema/op-mode-definition.rng
@@ -102,6 +102,27 @@
     </element>
   </define>
   <!--
+    Virtual tag nodes provide a way to add a variable argument
+    to a command that also needs fixed arguments,
+    like "show ip route" that can take "show ip route bgp"
+    or a network and arguments after it, like "show ip route 10.0.0.0/8 longer-prefixes"
+  -->
+  <define name="virtualTagNode">
+    <element name="virtualTagNode">
+      <interleave>
+        <optional>
+          <ref name="properties"/>
+        </optional>
+        <optional>
+          <ref name="children"/>
+        </optional>
+        <optional>
+          <ref name="command"/>
+        </optional>
+      </interleave>
+    </element>
+  </define>
+  <!--
     Leaf nodes are terminal configuration nodes that can't have children,
     but can have values.
   -->
@@ -114,16 +135,33 @@
       </interleave>
     </element>
   </define>
-  <!-- Normal and tag nodes may have children -->
+  <!--
+    Normal and tag nodes may have children: nodes, leaf nodes, or tag nodes.
+    There can only be one virtual tag node child, though.
+  -->
   <define name="children">
     <element name="children">
-      <oneOrMore>
-        <choice>
-          <ref name="node"/>
-          <ref name="tagNode"/>
-          <ref name="leafNode"/>
-        </choice>
-      </oneOrMore>
+      <choice>
+        <interleave>
+          <optional>
+            <ref name="virtualTagNode"/>
+          </optional>
+          <zeroOrMore>
+            <choice>
+              <ref name="node"/>
+              <ref name="tagNode"/>
+              <ref name="leafNode"/>
+            </choice>
+          </zeroOrMore>
+        </interleave>
+        <oneOrMore>
+          <choice>
+            <ref name="node"/>
+            <ref name="tagNode"/>
+            <ref name="leafNode"/>
+          </choice>
+        </oneOrMore>
+      </choice>
     </element>
   </define>
   <!--

--- a/scripts/build-command-op-templates
+++ b/scripts/build-command-op-templates
@@ -3,7 +3,7 @@
 #    build-command-template: converts new style command definitions in XML
 #      to the old style (bunch of dirs and node.def's) command templates
 #
-#    Copyright (C) 2017-2024 VyOS maintainers <maintainers@vyos.net>
+#    Copyright (C) 2017-2025 VyOS maintainers <maintainers@vyos.net>
 #
 #    This library is free software; you can redistribute it and/or
 #    modify it under the terms of the GNU Lesser General Public
@@ -29,6 +29,8 @@ import functools
 
 from lxml import etree as ET
 from textwrap import fill
+
+debug = True
 
 # Defaults
 validator_dir = "/opt/vyatta/libexec/validators"
@@ -177,7 +179,13 @@ def process_node(n, tmpl_dir):
 
     node_type = n.tag
 
-    my_tmpl_dir.append(name)
+    if name:
+        my_tmpl_dir.append(name)
+    else:
+        # Virtual tag nodes have no names,
+        # that's a normal situation.
+        # In that case we create subdirs at the current level.
+        pass
 
     if debug:
         print(f"Name of the node: {name};\n Created directory: ", end="")
@@ -221,6 +229,27 @@ def process_node(n, tmpl_dir):
         os.makedirs(make_path(my_tmpl_dir), exist_ok=True)
         if debug:
             print("Created path for the tagNode: {}".format(make_path(my_tmpl_dir)), end="")
+
+        # Not sure if we want partially defined tag nodes, write the file unconditionally
+        nodedef_path = os.path.join(make_path(my_tmpl_dir), "node.def")
+        # Only create the "node.def" file if it exists but is empty, or if it
+        # does not exist at all.
+        if not os.path.exists(nodedef_path) or os.path.getsize(nodedef_path) == 0:
+            with open(nodedef_path, "w") as f:
+                f.write(make_node_def(props, command))
+
+        if children is not None:
+            inner_nodes = children.iterfind("*")
+            for inner_n in inner_nodes:
+                process_node(inner_n, my_tmpl_dir)
+    elif node_type == "virtualTagNode":
+        # The outer structure is already created
+
+        # Create the inner node.tag part
+        my_tmpl_dir.append("node.tag")
+        os.makedirs(make_path(my_tmpl_dir), exist_ok=True)
+        if debug:
+            print("Created path for the virtualTagNode: {}".format(make_path(my_tmpl_dir)), end="")
 
         # Not sure if we want partially defined tag nodes, write the file unconditionally
         nodedef_path = os.path.join(make_path(my_tmpl_dir), "node.def")


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

We have a whole bunch of commands where support for both variable and fixed arguments like in `show ip route <x.x.x.x/y ... | bgp | vrf ...>` is implemented via specially constructed XML definitions that are written to produce a structure for the old runner: either a duplicate `<node>` and `<tagNode>` at the same level or a child node like `<node name="node.tag">`.

To make every op mode command path unique and implement a new wrapper, we need to eliminate both hacks.

This PR provides a native way to add variably-named children to nodes that also have fixed argument: a new `<virtualTagNode>` element that can be included in any `<node>` alongside other elements.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): internal change.

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

* https://vyos.dev/T7541 ­— the parent task.

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
