### PR TITLE
pki: T7573: fix TypeError when HAProxy is not in use

### DIFF
--- a/src/conf_mode/pki.py
+++ b/src/conf_mode/pki.py
@@ -144,7 +144,7 @@ def certbot_request(name: str, config: dict, dry_run: bool=True):
 
     # When ACME is used behind a reverse proxy, we always bind to localhost
     # whatever the CLI listen-address is configured for.
-    if ('haproxy' in dict_search('used_by', config) and
+    if ('used_by' in config and 'haproxy' in config['used_by'] and
         is_systemd_service_running(systemd_services['haproxy']) and
         not check_port_availability(listen_address, 80)):
         tmp += f' --http-01-address 127.0.0.1 --http-01-port {internal_ports["certbot_haproxy"]}'
@@ -551,7 +551,7 @@ def generate(pki):
             if not ca_cert_present:
                 tmp = dict_search_args(pki, 'ca', f'{autochain_prefix}{cert}', 'certificate')
                 if not bool(tmp) or tmp != cert_chain_base64:
-                    Message(f'Add/replace automatically imported CA certificate for "{cert}"...')
+                    Message(f'Add/replace automatically imported CA certificate for "{cert}" ...')
                     add_cli_node(['pki', 'ca', f'{autochain_prefix}{cert}', 'certificate'], value=cert_chain_base64)
 
     return None


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Commit 59d86826a2f ("haproxy: T7122: add ACME/certbot bootstrap support") introduced a regression where a None value was inadvertently iterated over. This patch prevents the invalid access by verifying that all required keys are present in the dictionary before proceeding.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7573

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4480

## How to test / Smoketest result
```
set pki certificate repka acme domain foo.bar.com
set pki certificate repka acme email 'someone@gmail.com'
set pki certificate repka acme url https://acme-staging-v02.api.letsencrypt.org/directory
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
