### PR TITLE
vbash: T7575: Fix bash-completion for bash 5.2

### DIFF
--- a/src/etc/bash_completion.d/vyatta-op
+++ b/src/etc/bash_completion.d/vyatta-op
@@ -3,20 +3,20 @@
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 as
 # published by the Free Software Foundation.
-# 
+#
 # This program is distributed in the hope that it will be useful, but
 # WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # General Public License for more details.
-# 
+#
 # This code was originally developed by Vyatta, Inc.
 # Portions created by Vyatta are Copyright (C) 2006, 2007 Vyatta, Inc.
 # All Rights Reserved.
-# 
+#
 # Author: Tom Grennan
 # Date: 2007
 # Description: setup bash completion for Vyatta operational commands
-# 
+#
 # **** End License ****
 
 test -z "$_vyatta_less_options" && \
@@ -45,10 +45,10 @@ _vyatta_op_do_key_bindings ()
   shopt -u nullglob
   case "$-" in
     *i*)
-      bind '"?": possible-completions' 
-      bind 'set show-all-if-ambiguous on' 
+      bind '"?": possible-completions'
+      bind 'set show-all-if-ambiguous on'
       bind_cmds=$(grep '^bind .* # vyatta key binding$' $HOME/.bashrc)
-      eval $bind_cmds 
+      eval $bind_cmds
     ;;
   esac
   eval $nullglob_save
@@ -64,7 +64,9 @@ test ! -d "$vyatta_op_templates" && \
 
 case "$-" in
   *i*)
-    declare -r _vyatta_op_last_comp_init='>>>>>>LASTCOMP<<<<<<'
+    if ! declare -p _vyatta_op_last_comp_init &>/dev/null; then
+      declare -r _vyatta_op_last_comp_init='>>>>>>LASTCOMP<<<<<<'
+    fi
   ;;
 esac
 declare _vyatta_op_last_comp=${_vyatta_op_last_comp_init}
@@ -261,18 +263,18 @@ _vyatta_op_set_completions ()
           completions+=( ${allowed[i]} )
         elif [[ $_vyatta_op_node_path == $vyatta_op_templates ]];then
           continue
-        else 
+        else
           completions+=( ${allowed[i]} )
         fi
       fi
     done
-    
+
     # Prefix filter the non empty completions
     if [ -n "$cur" ]; then
       _vyatta_op_completions=()
-      get_prefix_filtered_list "$cur" completions _vyatta_op_completions 
+      get_prefix_filtered_list "$cur" completions _vyatta_op_completions
       _vyatta_op_completions=($( printf "%s\n" ${_vyatta_op_completions[@]} | sort -u ))
-    else 
+    else
       _vyatta_op_completions=($( printf "%s\n" ${completions[@]} | sort -u ))
     fi
     #shopt -s nullglob
@@ -294,7 +296,7 @@ _vyatta_op_invalid_completion ()
 {
       local tpath=$vyatta_op_templates
       local -a args
-      local i=1 
+      local i=1
       for arg in "${COMP_WORDS[@]}"; do
         arg=( $(_vyatta_op_conv_node_path $tpath $arg) )  # expand the arguments
         # output proper error message based on the above expansion
@@ -308,16 +310,16 @@ _vyatta_op_invalid_completion ()
         elif [[ "${arg[1]}" == "invalid" ]]; then
           echo -ne "\n\n  Invalid command: ${args[@]} [$arg]"
           break
-        fi  
+        fi
 
         if [ -f "$tpath/$arg/node.def" ] ; then
             tpath+=/$arg
         elif [ -f $tpath/node.tag/node.def ] ; then
             tpath+=/node.tag
         else
-            echo -ne "\n\n  Invalid command: ${args[@]} [$arg]" >&2 
+            echo -ne "\n\n  Invalid command: ${args[@]} [$arg]" >&2
             break
-        fi  
+        fi
         args[$i]=$arg
         let "i+=1"
         if [ $[${#COMP_WORDS[@]}+1] -eq $i ];then
@@ -366,7 +368,7 @@ _vyatta_op_expand ()
     fi
 
     # this needs to be done on every completion even if it is the 'same' comp.
-    # The cursor can be at different places in the string. 
+    # The cursor can be at different places in the string.
     # this will lead to unexpected cases if setting the node path isn't attempted
     # each time.
     if ! _vyatta_op_set_node_path ; then
@@ -376,11 +378,11 @@ _vyatta_op_expand ()
       eval "$restore_shopts"
       return 1
     fi
-    
+
     if [ "${COMP_WORDS[*]:0:$[$COMP_CWORD+1]}" != "$_vyatta_op_last_comp" ] ; then
         _vyatta_set_comptype
         case $_vyatta_comptype in
-          'imagefiles') 
+          'imagefiles')
               _has_comptype=1
               _vyatta_image_file_complete
           ;;
@@ -429,22 +431,22 @@ _vyatta_op_expand ()
       echo -e "Current comp: '${COMP_WORDS[*]:0:$[$COMP_CWORD+1]}'\n"
     fi
 
-    # This is non obvious... 
+    # This is non obvious...
     # To have completion continue to work when working with words that aren't the last word,
     # we have to set nospace at the beginning of this script and then append the spaces here.
-    if [ ${#COMPREPLY[@]} -eq 1 ] && 
+    if [ ${#COMPREPLY[@]} -eq 1 ] &&
        [[ $_has_comptype -ne 1 ]]; then
        COMPREPLY=( "${COMPREPLY[0]} " )
     fi
     # if there are no completions then handle invalid commands
     if [ ${#_vyatta_op_noncompletions[@]} -eq 0 ] &&
        [ ${#_vyatta_op_completions[@]} -eq 0 ]; then
-          _vyatta_op_invalid_completion 
+          _vyatta_op_invalid_completion
           COMPREPLY=( "" " " )
           _vyatta_op_last_comp=${_vyatta_op_last_comp_init}
     elif [ ${#COMPREPLY[@]} -eq 0 ] &&
          [ -n "$current_prefix" ]; then
-          _vyatta_op_invalid_completion 
+          _vyatta_op_invalid_completion
           COMPREPLY=( "" " " )
           _vyatta_op_last_comp=${_vyatta_op_last_comp_init}
     # Stop completions from getting stuck
@@ -457,7 +459,7 @@ _vyatta_op_expand ()
          [[ "${COMPREPLY[0]}" =~ "$current_prefix" ]]; then
           _vyatta_op_last_comp=${_vyatta_op_last_comp_init}
     # if there are no completions then always show the non-comps
-    elif [ "${COMP_WORDS[*]:0:$[$COMP_CWORD+1]}" == "$_vyatta_op_last_comp" ] || 
+    elif [ "${COMP_WORDS[*]:0:$[$COMP_CWORD+1]}" == "$_vyatta_op_last_comp" ] ||
          [ ${#_vyatta_op_completions[@]} -eq 0 ] ||
          [ -z "$cur" ]; then
           _vyatta_op_help "$current_prefix" \
@@ -598,7 +600,7 @@ _vyatta_pipe_completion ()
 }
 
 # comptype
-_vyatta_set_comptype () 
+_vyatta_set_comptype ()
 {
   local comptype
   unset _vyatta_comptype


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
* Fix bash-completion for bash 5.2

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyatta-bash/pull/15
* https://github.com/vyos/vyatta-cfg/pull/105

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
