### PR TITLE
ipsec: T7545: Fix show vpn debug peer

### DIFF
--- a/src/op_mode/vpn_ipsec.py
+++ b/src/op_mode/vpn_ipsec.py
@@ -23,13 +23,13 @@ SWANCTL_CONF = '/etc/swanctl/swanctl.conf'
 
 
 def get_peer_connections(peer, tunnel, return_all = False):
-    search = rf'^[\s]*(peer_{peer}_(tunnel_[\d]+|vti)).*'
+    search = rf'^[\s]*({peer}-(tunnel-[\d]+|vti))[\s]*{{'
     matches = []
     with open(SWANCTL_CONF, 'r') as f:
         for line in f.readlines():
             result = re.match(search, line)
             if result:
-                suffix = f'tunnel_{tunnel}' if tunnel.isnumeric() else tunnel
+                suffix = f'tunnel-{tunnel}' if tunnel.isnumeric() else tunnel
                 if return_all or (result[2] == suffix):
                     matches.append(result[1])
     return matches
@@ -66,7 +66,8 @@ def debug_peer(peer, tunnel):
         return
 
     for conn in conns:
-        call(f'/usr/sbin/ipsec statusall | grep {conn}')
+        command = f'/usr/sbin/ipsec statusall | grep {conn}'
+        call(command)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Fix show vpn debug peer

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

https://vyos.dev/T7545

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

As I understand any setup with ipsec peers will allow testing.

I've used `/usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py`:

I had to fix interface number and remove `.interface` in several places so that it passed.

Added `from vyos.utils.process import cmd`

Added

````
        print("BEGIN show vpn ipsec connections")
        out = cmd(['/opt/vyatta/bin/vyatta-op-cmd-wrapper', 'show', 'vpn', 'ipsec', 'connections'])
        print(out)
        print("END")
        print("BEGIN show vpn debug peer main-branch")
        out = cmd(['/opt/vyatta/bin/vyatta-op-cmd-wrapper', 'show', 'vpn', 'debug', 'peer', 'main-branch'])
        print(out)
        print("END")
````

in `test_site_to_site` after `self.cli_commit()`

Before fix `python3 test_vpn_ipsec.py TestVPNIPsec.test_site_to_site` output was  `Peer not found, aborting` as in https://vyos.dev/T7545.

After fix:

````
### /usr/sbin/ipsec statusall | grep main-branch-tunnel-1 ###

### /usr/sbin/ipsec statusall | grep main-branch-tunnel-2 ###
````

## Open questions

1. I'm not sure the fix is robust. I've tested it under latest VyOS image, but maybe on other configurations `/etc/swanctl/swanctl.conf` contains other data (e.g. previous RE is appropriate for some configurations).
2. Maybe it would be better to use something like `_get_all_sitetosite_peers_name_list` from `src/op_mode/ipsec.py` instead of parsing Jinja-generated file `/etc/swanctl/swanctl.conf`?..
3. Maybe we should change output for vpn debug peer?.. Currently it just uses `/usr/sbin/ipsec statusall | grep {conn}` which outputs nothing in my case, and in origin logs in https://vyos.dev/T7545 the command also had no output.
4. Should I add test for `show vpn debug peer`?..

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
