### PR TITLE
op-mode: T7403: add an option to forcefully remove a container image

### DIFF
--- a/op-mode-definitions/container.xml.in
+++ b/op-mode-definitions/container.xml.in
@@ -46,6 +46,14 @@
               </completionHelp>
             </properties>
             <command>${vyos_op_scripts_dir}/container.py delete_image --name "${4}"</command>
+            <children>
+              <leafNode name="force">
+                <properties>
+                  <help>Force removal of container image</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/container.py delete_image --name "${4}" --force</command>
+              </leafNode>
+            </children>
           </tagNode>
         </children>
       </node>

--- a/op-mode-definitions/container.xml.in
+++ b/op-mode-definitions/container.xml.in
@@ -42,7 +42,7 @@
               <help>Delete container image</help>
               <completionHelp>
                 <list>all</list>
-                <script>podman image ls -q</script>
+                <script>sudo bash -c 'podman image ls -q'</script>
               </completionHelp>
             </properties>
             <command>${vyos_op_scripts_dir}/container.py delete_image --name "${4}"</command>

--- a/src/op_mode/container.py
+++ b/src/op_mode/container.py
@@ -56,6 +56,7 @@ def add_image(name: str):
                     if rc != 0: raise vyos.opmode.InternalError(out)
 
     rc, output = rc_cmd(f'podman image pull {name}')
+    print(output)
     if rc != 0:
         raise vyos.opmode.InternalError(output)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

```
If you have multiple images (tags) loaded for a container which point to the exact same hash - you can only forcefully delete them.

vyos@vyos:~$ delete container image 70dc5806
Error: unable to delete image "70dc5806" by ID with more than one tag
  ([registry.io/foo/bar:v1.0 registry.io/foo/bar:v1.0.1]):
  please force removal
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7403

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-documentation/pull/1654

## How to test / Smoketest result
```
vyos@vyos:~$ add container image docker.io/jacobalberty/unifi:v8.6
vyos@vyos:~$ add container image docker.io/jacobalberty/unifi:v8.6.9
```

```
vyos@vyos:~$ delete container image 70dc580695b9
Error: unable to delete image "70dc580695b9bd2908c49f67e3100ccefd160a07164bdf475e76177e85383444" by ID with more than one tag ([docker.io/jacobalberty/unifi:v8.6.9 docker.io/jacobalberty/unifi:v8.6]): please force removal
```

```
vyos@vyos:~$ delete container image 70dc580695b9 force
vyos@vyos:~$ show container image
REPOSITORY  TAG         IMAGE ID    CREATED     SIZE
```

If an image which is still in use is about to be deleted - error out

```
vyos@vyos:~$ delete container image all force
Cannot delete image "d205499ae8bb" because it is currently being used by container "3b290f90e83d"!
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
