### PR TITLE
T7588: Call libvyosconfig functions from main thread under http-api

### DIFF
--- a/python/vyos/config_mgmt.py
+++ b/python/vyos/config_mgmt.py
@@ -25,10 +25,12 @@ from filecmp import cmp
 from datetime import datetime
 from textwrap import dedent
 from pathlib import Path
-from tabulate import tabulate
 from shutil import copy, chown
+from subprocess import Popen
+from subprocess import DEVNULL
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
+from tabulate import tabulate
 
 from vyos.config import Config
 from vyos.configtree import ConfigTree
@@ -231,7 +233,14 @@ Proceed ?"""
         else:
             cmd = f'sudo -b /usr/libexec/vyos/commit-confirm-notify.py {minutes}'
 
-        os.system(cmd)
+        Popen(
+            cmd.split(),
+            stdout=DEVNULL,
+            stderr=DEVNULL,
+            stdin=DEVNULL,
+            close_fds=True,
+            preexec_fn=os.setsid,
+        )
 
         if self.reboot_unconfirmed:
             msg = f'Initialized commit-confirm; {minutes} minutes to confirm before reboot'

--- a/python/vyos/configsession.py
+++ b/python/vyos/configsession.py
@@ -333,7 +333,7 @@ class ConfigSession(object):
         if self._vyconf_session is None:
             config_data = self.__run_command(SHOW_CONFIG + path)
         else:
-            config_data, _ = self._vyconf_session.show_config()
+            config_data, _ = self._vyconf_session.show_config(path)
 
         if format == 'raw':
             return config_data

--- a/python/vyos/utils/backend.py
+++ b/python/vyos/utils/backend.py
@@ -22,6 +22,7 @@ from pathlib import Path
 
 from vyos.utils.io import ask_yes_no
 from vyos.utils.process import call
+from vyos.utils.process import is_systemd_service_active
 
 VYCONF_SENTINEL = '/run/vyconf_backend'
 
@@ -69,6 +70,8 @@ def vyconf_backend() -> bool:
 
 def set_vyconf_backend(value: bool, no_prompt: bool = False):
     vyconfd_service = 'vyconfd.service'
+    commitd_service = 'vyos-commitd.service'
+    http_api_service = 'vyos-http-api.service'
     match value:
         case True:
             if vyconf_backend():
@@ -78,6 +81,9 @@ def set_vyconf_backend(value: bool, no_prompt: bool = False):
             Path(VYCONF_SENTINEL).touch()
             chattri(VYCONF_SENTINEL, True)
             call(f'systemctl restart {vyconfd_service}')
+            call(f'systemctl restart {commitd_service}')
+            if is_systemd_service_active(http_api_service):
+                call(f'systemctl restart {http_api_service}')
         case False:
             if not vyconf_backend():
                 return


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The libvyosconfig functions `read/write_internal` are a necessary tool to avoid reparsing of a config file when communicating with the backend --- this was unavoidable with the legacy backend, where for example every instantiation of Config must parse the output of `cli-shell-api showConfig`. Under vyconf,, there is a simple way to avoid this, using the ast json representation provided by the preprocessor ppx_deriving_yojson; example time difference for a large config (smoketest/configs.no-load/firewall-big):

```
# parse config
In [5]: %time ct = ConfigTree(config_str)
CPU times: user 5.52 s, sys: 15.6 ms, total: 5.54 s
Wall time: 5.54 s

# write abstract json representation
In [6]: %time ct.write_cache('./config.cache')
CPU times: user 91.6 ms, sys: 11.1 ms, total: 103 ms
Wall time: 112 ms

# read abstract json representation
In [7]: %time nt = ConfigTree(internal='./config.cache')
CPU times: user 113 ms, sys: 8.09 ms, total: 121 ms
Wall time: 120 ms
```

The `read_internal` function is what is used for instantiating `ConfigTree(internal)`.

The one problem with this approach is that `read_internal`, unlike analogous libvyosconfig functions, does not correctly register its thread when the thread is created in Python --- conjecturally, this is a missing detail in the ocaml-ctypes library for functions defined via ppx tools. Again, no other functions, such as the analogous `from_string` or `diff_tree`, have this problem.

The only place this occurs is the http-api, due to configure operations being defined as 'sync' instead of 'async' (the former are run in a threadpool; the latter in an event loop on the main thread). They are defined as sync since config operations can block (cf. https://vyos.dev/T5305).

As a fix for upstream ocaml-ctypes is investigated, we avoid the problem with http-api so as not to delay vyconf development:  the blocking portion of a config operation is run in a threadpool, allowing the handler itself to be defined async. This is  a minor adjustment, as we already rely on FastAPI `BackgroundTasks` for configuration of paths that modify `['service', 'https']` itself.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos_bld@1af90e4051e2:/vyos$ make test MATCH="service_https"
...
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_service_https.py
DEBUG - test_api_add_delete (__main__.TestHTTPSService.test_api_add_delete) ... ok
DEBUG - test_api_auth (__main__.TestHTTPSService.test_api_auth) ... ok
DEBUG - test_api_config_file (__main__.TestHTTPSService.test_api_config_file) ... ok
DEBUG - test_api_config_file_load_http (__main__.TestHTTPSService.test_api_config_file_load_http) ... ok
DEBUG - test_api_configure (__main__.TestHTTPSService.test_api_configure) ... ok
DEBUG - test_api_generate (__main__.TestHTTPSService.test_api_generate) ... ok
DEBUG - test_api_image (__main__.TestHTTPSService.test_api_image) ... ok
DEBUG - test_api_incomplete_key (__main__.TestHTTPSService.test_api_incomplete_key) ... ok
DEBUG - test_api_missing_keys (__main__.TestHTTPSService.test_api_missing_keys) ... ok
DEBUG - test_api_reset (__main__.TestHTTPSService.test_api_reset) ... ok
DEBUG - test_api_show (__main__.TestHTTPSService.test_api_show) ... ok
DEBUG - test_certificate (__main__.TestHTTPSService.test_certificate) ... ok
DEBUG - test_listen_address (__main__.TestHTTPSService.test_listen_address) ... ok

vyos_bld@1af90e4051e2:/vyos$ make test MATCH="service_https" -- --vyconf
...
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_service_https.py
DEBUG - test_api_add_delete (__main__.TestHTTPSService.test_api_add_delete) ... ok
DEBUG - test_api_auth (__main__.TestHTTPSService.test_api_auth) ... ok
DEBUG - test_api_config_file (__main__.TestHTTPSService.test_api_config_file) ... ok
DEBUG - test_api_config_file_load_http (__main__.TestHTTPSService.test_api_config_file_load_http) ... FAIL
DEBUG - test_api_configure (__main__.TestHTTPSService.test_api_configure) ... ok
DEBUG - test_api_generate (__main__.TestHTTPSService.test_api_generate) ... ok
DEBUG - test_api_image (__main__.TestHTTPSService.test_api_image) ... ok
DEBUG - test_api_incomplete_key (__main__.TestHTTPSService.test_api_incomplete_key) ... ok
DEBUG - test_api_missing_keys (__main__.TestHTTPSService.test_api_missing_keys) ... ok
DEBUG - test_api_reset (__main__.TestHTTPSService.test_api_reset) ... ok
DEBUG - test_api_show (__main__.TestHTTPSService.test_api_show) ... ok
DEBUG - test_certificate (__main__.TestHTTPSService.test_certificate) ... ok
DEBUG - test_listen_address (__main__.TestHTTPSService.test_listen_address) ... ok

```
The one failing service_https smoketest under vyconf will be addressed in the PR for https://vyos.dev/T7499: load itself works as expected; it remains to debug the smoketest error.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
