### PR TITLE
T7528: Fix service monitoring prometheus stops services

### DIFF
--- a/src/conf_mode/service_monitoring_prometheus.py
+++ b/src/conf_mode/service_monitoring_prometheus.py
@@ -23,6 +23,7 @@ from vyos.configdict import is_node_changed
 from vyos.configverify import verify_vrf
 from vyos.template import render
 from vyos.utils.process import call
+from vyos.utils.process import is_systemd_service_active
 from vyos import ConfigError
 from vyos import airbag
 
@@ -173,11 +174,14 @@ def apply(monitoring):
     # Reload systemd manager configuration
     call('systemctl daemon-reload')
     if not monitoring or 'node_exporter' not in monitoring:
-        call(f'systemctl stop {node_exporter_systemd_service}')
+        if is_systemd_service_active(node_exporter_systemd_service):
+            call(f'systemctl stop {node_exporter_systemd_service}')
     if not monitoring or 'frr_exporter' not in monitoring:
-        call(f'systemctl stop {frr_exporter_systemd_service}')
+        if is_systemd_service_active(frr_exporter_systemd_service):
+            call(f'systemctl stop {frr_exporter_systemd_service}')
     if not monitoring or 'blackbox_exporter' not in monitoring:
-        call(f'systemctl stop {blackbox_exporter_systemd_service}')
+        if is_systemd_service_active(blackbox_exporter_systemd_service):
+            call(f'systemctl stop {blackbox_exporter_systemd_service}')
 
     if not monitoring:
         return


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Fix for service monitoring prometheus stops unconfigured services. 
Check if the service is in active state before stopping it.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7528

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Config:
```
set interfaces dummy dum0 address '192.0.2.1/32'
set service monitoring prometheus node-exporter collectors textfile
set service monitoring prometheus node-exporter listen-address '192.0.2.1'
commit
```
Before the fix, the unconfigured services are stopped `frr_exporter/blackbox_exporter`:
```
Jun 06 11:49:05 r14 vyos-configd[788]: Received message: {"type": "node", "last": true, "data": "/usr/libexec/vyos/conf_mode/service_monitoring_prometheus.py"}
Jun 06 11:49:05 r14 systemd[1]: Reloading.
Jun 06 11:49:05 r14 systemctl[5629]: Failed to stop frr_exporter.service: Unit frr_exporter.service not loaded.
Jun 06 11:49:05 r14 systemctl[5630]: Failed to stop blackbox_exporter.service: Unit blackbox_exporter.service not loaded.
Jun 06 11:49:05 r14 systemd[1]: Started Node Exporter.
```
After the fix:
```
Jul 07 20:27:47 r14 vyos-configd[7698]: Received message: {"type": "init"}
Jul 07 20:27:47 r14 vyos-configd[7698]: config session pid is 8958
Jul 07 20:27:47 r14 vyos-configd[7698]: config session sudo_user is vyos
Jul 07 20:27:47 r14 vyos-configd[7698]: commit_scripts: ['service_monitoring_prometheus']
Jul 07 20:27:47 r14 vyos-configd[7698]: Received message: {"type": "node", "last": true, "data": "/usr/libexec/vyos/conf_mode/service_monitoring_prometheus.py"}
Jul 07 20:27:47 r14 systemd[1]: Reloading.
Jul 07 20:27:48 r14 systemd[1]: Started Node Exporter.
Jul 07 20:27:48 r14 vyos-configd[7698]: Sending reply: SUCCESS with output

```

Smoketests
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_monitoring_prometheus.py 
test_01_node_exporter (__main__.TestMonitoringPrometheus.test_01_node_exporter) ... ok
test_02_frr_exporter (__main__.TestMonitoringPrometheus.test_02_frr_exporter) ... ok
test_03_blackbox_exporter (__main__.TestMonitoringPrometheus.test_03_blackbox_exporter) ... ok
test_04_blackbox_exporter_with_config (__main__.TestMonitoringPrometheus.test_04_blackbox_exporter_with_config) ... ok

----------------------------------------------------------------------
Ran 4 tests in 19.496s

OK
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
