### PR TITLE
T7623: Add test route static dhcp in VRF

### DIFF
--- a/smoketest/scripts/cli/test_protocols_static.py
+++ b/smoketest/scripts/cli/test_protocols_static.py
@@ -619,5 +619,37 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
         while process_named_running('dhclient', cmdline=interface, timeout=10):
             sleep(0.250)
 
+    def test_06_dhcp_default_route_for_vrf(self):
+        # When running via vyos-build under the QEMU environment a local DHCP
+        # server is available. This test verifies that the default route is set.
+        # When not running under the VyOS QEMU environment, this test is skipped.
+        if not os.path.exists('/tmp/vyos.smoketests.hint'):
+            self.skipTest('Not running under VyOS CI/CD QEMU environment!')
+
+        interface = 'eth0'
+        vrf = 'red'
+        vrf_path = ['vrf', 'name', vrf]
+        interface_path = ['interfaces', 'ethernet', interface]
+        self.cli_set(vrf_path + ['table', '1000'])
+        default_distance = default_value(interface_path + ['dhcp-options', 'default-route-distance'])
+        self.cli_set(interface_path + ['address', 'dhcp'])
+        self.cli_set(interface_path + ['vrf', vrf])
+        self.cli_commit()
+
+        # Wait for dhclient to receive IP address and default gateway
+        sleep(5)
+
+        router = get_dhcp_router(interface)
+        frrconfig = self.getFRRconfig(f'vrf {vrf}', endsection='^exit-vrf')
+        self.assertIn(rf'ip route 0.0.0.0/0 {router} {interface} tag 210 {default_distance}', frrconfig)
+
+        self.cli_delete(interface_path + ['address'])
+        self.cli_delete(interface_path + ['vrf'])
+        self.cli_commit()
+
+        # Wait for dhclient to stop
+        while process_named_running('dhclient', cmdline=interface, timeout=10):
+            sleep(0.250)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
I use VyOS as a router between multiple WANs with different routes, where each interface is on a different VRF.

This test I added while investigating why dhcp-interface doesn't run during boot (but runs if commited when VyOS is running). Hopefully it will improve stability

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Add smoketest

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7623
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
