### PR TITLE
ipsec: T7504: Added IKEv2 retransmission options

### DIFF
--- a/data/templates/ipsec/charon.j2
+++ b/data/templates/ipsec/charon.j2
@@ -202,15 +202,16 @@ charon {
     # Size of the AH/ESP replay window, in packets.
     # replay_window = 32
 
-    # Base to use for calculating exponential back off, see IKEv2 RETRANSMISSION
-    # in strongswan.conf(5).
-    # retransmit_base = 1.8
-
-    # Timeout in seconds before sending first retransmit.
-    # retransmit_timeout = 4.0
-
-    # Number of times to retransmit a packet before giving up.
-    # retransmit_tries = 5
+    # IKEv2 RETRANSMISSION
+{% if options.retransmission.attempts is vyos_defined %}
+    retransmit_tries = {{ options.retransmission.attempts }}
+{% endif %}
+{% if options.retransmission.base is vyos_defined %}
+    retransmit_base = {{ options.retransmission.base }}
+{% endif %}
+{% if options.retransmission.timeout is vyos_defined %}
+    retransmit_timeout = {{ options.retransmission.timeout }}
+{% endif %}
 
     # Interval in seconds to use when retrying to initiate an IKE_SA (e.g. if
     # DNS resolution failed), 0 to disable retries.

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -701,6 +701,52 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <node name="retransmission">
+                <properties>
+                  <help>IPsec retransmission settings</help>
+                </properties>
+                <children>
+                  <leafNode name="attempts">
+                    <properties>
+                      <help>Maximum number of retransmissions</help>
+                      <valueHelp>
+                        <format>u32:1-65535</format>
+                        <description>Maximum number of retransmissions</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-65535"/>
+                      </constraint>
+                    </properties>
+                    <defaultValue>5</defaultValue>
+                  </leafNode>
+                  <leafNode name="base">
+                    <properties>
+                      <help>Base of exponential backoff</help>
+                      <valueHelp>
+                        <format>&lt;1.0-5.0&gt;</format>
+                        <description>Base of exponential backoff</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-5 --float"/>
+                      </constraint>
+                    </properties>
+                    <defaultValue>1.8</defaultValue>
+                  </leafNode>
+                  <leafNode name="timeout">
+                    <properties>
+                      <help>Timeout in seconds before the first retransmission</help>
+                      <valueHelp>
+                        <format>u32:1-1000</format>
+                        <description>Timeout in seconds before the first retransmission</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 1-1000"/>
+                      </constraint>
+                    </properties>
+                    <defaultValue>4</defaultValue>
+                  </leafNode>
+                </children>
+              </node>
             </children>
           </node>
           <tagNode name="profile">


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Added IKEv2 retransmission options (base, tries, timeout).
These options allow changing the timeout to define when the IPsec IKEv2 peer is down.
https://docs.strongswan.org/docs/latest/config/retransmission.html

```
vyos@vyos# set vpn ipsec options retransmission
Possible completions:
   base                 Base of exponential backoff (default: 1.8)
   timeout              Timeout in seconds before sending first retransmit (default: 4)
   tries                Number of retransmissions to send before giving up (default: 5)
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7504

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Smoke tests:
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
test_dhcp_fail_handling (__main__.TestVPNIPsec.test_dhcp_fail_handling) ... ok
test_dmvpn (__main__.TestVPNIPsec.test_dmvpn) ... ok
test_flex_vpn_vips (__main__.TestVPNIPsec.test_flex_vpn_vips) ... ok
test_remote_access (__main__.TestVPNIPsec.test_remote_access) ... ok
test_remote_access_dhcp_fail_handling (__main__.TestVPNIPsec.test_remote_access_dhcp_fail_handling) ... ok
test_remote_access_eap_tls (__main__.TestVPNIPsec.test_remote_access_eap_tls) ... ok
test_remote_access_no_rekey (__main__.TestVPNIPsec.test_remote_access_no_rekey) ... ok
test_remote_access_pool_range (__main__.TestVPNIPsec.test_remote_access_pool_range) ... ok
test_remote_access_vti (__main__.TestVPNIPsec.test_remote_access_vti) ... ok
test_remote_access_x509 (__main__.TestVPNIPsec.test_remote_access_x509) ... ok
test_retransmission_settings (__main__.TestVPNIPsec.test_retransmission_settings) ... ok
test_site_to_site (__main__.TestVPNIPsec.test_site_to_site) ... ok
test_site_to_site_vti (__main__.TestVPNIPsec.test_site_to_site_vti) ... ok
test_site_to_site_vti_ts_afi (__main__.TestVPNIPsec.test_site_to_site_vti_ts_afi) ... ok
test_site_to_site_x509 (__main__.TestVPNIPsec.test_site_to_site_x509) ... ok

----------------------------------------------------------------------
Ran 15 tests in 321.991s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
