### PR TITLE
T7625: config: pass recursive=True for with_recursive_defaults

### DIFF
--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -345,9 +345,11 @@ class Config(object):
                                          abs_path=rpath,
                                          no_tag_node_value_mangle=no_tag_node_value_mangle)
 
-        if with_defaults or with_recursive_defaults:
-            defaults = self.get_config_defaults(**kwargs,
-                                                recursive=with_recursive_defaults)
+        if with_defaults:
+            defaults = self.get_config_defaults(**kwargs)
+            conf_dict = config_dict_merge(defaults, conf_dict)
+        elif with_recursive_defaults:
+            defaults = self.get_config_defaults(**kwargs, recursive=True)
             conf_dict = config_dict_merge(defaults, conf_dict)
         else:
             conf_dict = ConfigDict(conf_dict)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
WAN load balancer configurations always add a default 5 packet/sec limit on nftables configurations, despite [code being present](https://github.com/vyos/vyos-1x/blob/current/src/conf_mode/load-balancing_wan.py#L41-L44) to remove such configuration. The issue appears to trace back to the `get_config_dict()` function in `config.py`. When `with_recursive_results` is passed to the function, `recursive=True` isn't passed to `get_config_defaults()`, meaning defaults aren't recursively checked and the default limit configuration never gets removed.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7625

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
