### PR TITLE
T7625: load-balancing: prune limit key based on conf.exists()

### DIFF
--- a/src/conf_mode/load-balancing_wan.py
+++ b/src/conf_mode/load-balancing_wan.py
@@ -33,14 +33,13 @@ def get_config(config=None):
 
     base = ['load-balancing', 'wan']
 
-    lb = conf.get_config_dict(base, key_mangling=('-', '_'),
-                              no_tag_node_value_mangle=True,
-                              get_first_key=True,
-                              with_recursive_defaults=True)
+    lb = conf.get_config_dict(
+        base, key_mangling=('-', '_'), no_tag_node_value_mangle=True, get_first_key=True
+    )
 
     # prune limit key if not set by user
     for rule in lb.get('rule', []):
-        if lb.from_defaults(['rule', rule, 'limit']):
+        if not conf.exists(base + ['rule', rule, 'limit']):
             del lb['rule'][rule]['limit']
 
     set_dependents('conntrack', conf)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
1. `conf.exists()` checks the candidate (session) configuration exactly as the user entered it, without the XML defaults merged in.                                                        
2. If the user never typed the `limit` command for a rule, the path is absent and we drop the node for that rule entirely.                                                                                                   
3. If the user did type `limit` for a rule, the path exists - regardless of whether all its leaves still equal their default values - so we keep the rule's instance of `limit` and all leaves.

This ensures that the default limits remain configured for a rule if the user configures the `limit` node under the rule, but if the `limit` node is not configured by the user under a rule, all `limit` configuration under that rule is dropped.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7625

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
