### PR TITLE
ipsec: T7593: Add dynamic prefix for local and remote traffic selectors

### DIFF
--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -1228,6 +1228,13 @@
                       #include <include/generic-disable-node.xml.i>
                       #include <include/ipsec/esp-group.xml.i>
                       #include <include/ipsec/local-traffic-selector.xml.i>
+                      <node name="local">
+                        <children>
+                          <leafNode name="prefix">
+                            <defaultValue>dynamic</defaultValue>
+                          </leafNode>
+                        </children>
+                      </node>
                       #include <include/ip-protocol.xml.i>
                       <leafNode name="priority">
                         <properties>
@@ -1264,6 +1271,7 @@
                               </constraint>
                               <multi/>
                             </properties>
+                            <defaultValue>dynamic</defaultValue>
                           </leafNode>
                         </children>
                       </node>

--- a/src/conf_mode/vpn_ipsec.py
+++ b/src/conf_mode/vpn_ipsec.py
@@ -696,6 +696,8 @@ def generate(ipsec):
                 generate_pki_files_x509(ipsec['pki'], rw_conf['authentication']['x509'])
 
     if 'site_to_site' in ipsec and 'peer' in ipsec['site_to_site']:
+        DEFAULT_TS_PREFIX = 'dynamic'
+
         for peer, peer_conf in ipsec['site_to_site']['peer'].items():
             if f'peer_{peer}' in ipsec['dhcp_no_address']:
                 continue
@@ -724,7 +726,13 @@ def generate(ipsec):
                     passthrough = None
 
                     for local_prefix in local_prefixes:
+                        if local_prefix == DEFAULT_TS_PREFIX:
+                            continue
+
                         for remote_prefix in remote_prefixes:
+                            if remote_prefix == DEFAULT_TS_PREFIX:
+                                continue
+
                             local_net = ipaddress.ip_network(local_prefix)
                             remote_net = ipaddress.ip_network(remote_prefix)
                             if local_net.subnet_of(remote_net):


### PR DESCRIPTION
## Change summary
In case when there is no local/remote prefix configured in a tunnel settings, a protocol configured for such tunnel is ignored.

The correct way to generate the configuration is to set the prefix to `dynamic` if it was not set. The correct config for the described case is:

```
local_ts = dynamic[gre/]
remote_ts = dynamic[gre/]
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7593

## How to test / Smoketest result

**Manual test:**
```
configure
set vpn ipsec esp-group e1 proposal 10 encryption 'aes256'
set vpn ipsec esp-group e1 proposal 10 hash 'sha256'
set vpn ipsec ike-group i1 proposal 10 encryption 'aes256'
set vpn ipsec ike-group i1 proposal 10 hash 'sha256'
set vpn ipsec site-to-site peer p1 authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer p1 connection-type 'none'
set vpn ipsec site-to-site peer p1 default-esp-group 'e1'
set vpn ipsec site-to-site peer p1 ike-group 'i1'
set vpn ipsec site-to-site peer p1 local-address '192.168.122.5'
set vpn ipsec site-to-site peer p1 remote-address '192.168.122.6'
set vpn ipsec site-to-site peer p1 tunnel 1 protocol 'gre'
commit

vyos@de4ba67763de:~$ cat /etc/swanctl/swanctl.conf
...
       children {
            p1-tunnel-1 {
                esp_proposals = aes256-sha256-modp1024
                life_time = 3600s
                local_ts = dynamic[gre/]
                remote_ts = dynamic[gre/]
                ipcomp = no
                mode = tunnel
                start_action = none
                close_action = none
                replay_window = 32
            }
        }
...
```

**Smoke test:**
```
root@8ffa893d571b:/vyos/vyos-build# make test MATCH="vpn_ipsec"
...
DEBUG - /usr/bin/vyos-smoketest
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
DEBUG - test_dhcp_fail_handling (__main__.TestVPNIPsec.test_dhcp_fail_handling) ... ok
DEBUG - test_dmvpn (__main__.TestVPNIPsec.test_dmvpn) ... ok
DEBUG - test_flex_vpn_vips (__main__.TestVPNIPsec.test_flex_vpn_vips) ... ok
DEBUG - test_remote_access (__main__.TestVPNIPsec.test_remote_access) ... ok
DEBUG - test_remote_access_dhcp_fail_handling (__main__.TestVPNIPsec.test_remote_access_dhcp_fail_handling) ... ok
DEBUG - test_remote_access_eap_tls (__main__.TestVPNIPsec.test_remote_access_eap_tls) ... ok
DEBUG - test_remote_access_no_rekey (__main__.TestVPNIPsec.test_remote_access_no_rekey) ... ok
DEBUG - test_remote_access_pool_range (__main__.TestVPNIPsec.test_remote_access_pool_range) ... ok
DEBUG - test_remote_access_vti (__main__.TestVPNIPsec.test_remote_access_vti) ... ok
DEBUG - test_remote_access_x509 (__main__.TestVPNIPsec.test_remote_access_x509) ... ok
DEBUG - test_site_to_site (__main__.TestVPNIPsec.test_site_to_site) ... ok
DEBUG - test_site_to_site_vti (__main__.TestVPNIPsec.test_site_to_site_vti) ... ok
DEBUG - test_site_to_site_vti_ts_afi (__main__.TestVPNIPsec.test_site_to_site_vti_ts_afi) ... ok
DEBUG - test_site_to_site_with_default_ts (__main__.TestVPNIPsec.test_site_to_site_with_default_ts) ... ok
DEBUG - test_site_to_site_x509 (__main__.TestVPNIPsec.test_site_to_site_x509) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 15 tests in 98.695s
DEBUG -
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
