### PR TITLE
T7489: Fix output state of ipsec passthrough child

### DIFF
--- a/src/op_mode/ipsec.py
+++ b/src/op_mode/ipsec.py
@@ -230,17 +230,25 @@ def _get_parent_sa_state(connection_name: str, data: list) -> str:
     return ike_state
 
 
-def _get_child_sa_state(connection_name: str, tunnel_name: str, data: list) -> str:
+def _get_child_sa_state(
+    connection_name: str, tunnel_name: str, data: list, mode: str
+) -> str:
     """Get child SA state by connection and tunnel name
 
     Args:
         connection_name (str): Connection name
         tunnel_name (str): Tunnel name
         data (list): List of current SAs from vici
+        mode (str): Mode of child from vici list_connections
 
     Returns:
-        str: `up` if child SA state is 'installed' otherwise `down`
+        str: `up` if child SA state is 'installed' or child is passthrough
+             otherwise `down`
     """
+    # passthrough child (trap mode) has 'PASS' mode and is always up,
+    # but has no sa, so is not present in list_sas (data)
+    if mode == 'PASS':
+        return 'up'
     child_sa = 'down'
     if not data:
         return child_sa
@@ -330,7 +338,8 @@ def _get_raw_data_connections(list_connections: list, list_sas: list) -> list:
             base_list['children'] = []
             children = conn_conf['children']
             for tunnel, tun_options in children.items():
-                state = _get_child_sa_state(connection, tunnel, list_sas)
+                mode = tun_options.get('mode')
+                state = _get_child_sa_state(connection, tunnel, list_sas, mode)
                 local_ts = tun_options.get('local-ts')
                 remote_ts = tun_options.get('remote-ts')
                 dpd_action = tun_options.get('dpd_action')


### PR DESCRIPTION
## Fix output state of ipsec passthrough child

Show state of passthrough tunnels as always up.

Passthrough children of connection have PASS mode but have no sa and are not shown in vici list_sas.

Fix by passing mode from vici list_connections to _get_child_sa_state and always return 'up' for child with PASS mode.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T7489

## Related PR(s)

## How to test / Smoketest result

Setup VPN IPSEC with one network being subnetwork of another e.g.

<img width="415" height="411" alt="topology-vpn-ipsec-passthrough" src="https://github.com/user-attachments/assets/78de6554-26eb-4ff1-b2df-2428572e29eb" />


```
For VyOS-central: 
    Public address of 203.0.113.2 on interface eth0
    Local private network of 10.1.1.0/24

For VyOS-remote:
    Public address of 203.0.113.27 on interface eth0
    Local private network of 10.1.1.100/30
    A VyOS router called vyos-remote
```

Commands to setup these machines:

VyOS-central:
```
    configure
    set system host-name vyos-central

    set interfaces ethernet eth0 address 203.0.113.2/24
    set interfaces ethernet eth0 description 'OUTSIDE'
    set interfaces ethernet eth1 address '10.1.1.1/24'
    set interfaces ethernet eth1 description 'LAN'

    set service dhcp-server shared-network-name LAN subnet 10.1.1.0/24 option default-router '10.1.1.1'
    set service dhcp-server shared-network-name LAN subnet 10.1.1.0/24 option name-server '10.1.1.1'
    set service dhcp-server shared-network-name LAN subnet 10.1.1.0/24 option domain-name 'central'
    set service dhcp-server shared-network-name LAN subnet 10.1.1.0/24 lease '86400'
    set service dhcp-server shared-network-name LAN subnet 10.1.1.0/24 range 0 start '10.1.1.9'
    set service dhcp-server shared-network-name LAN subnet 10.1.1.0/24 range 0 stop '10.1.1.254'
    set service dhcp-server shared-network-name LAN subnet 10.1.1.0/24 subnet-id '1'
    
    set service dns forwarding cache-size '0'
    set service dns forwarding listen-address '10.1.1.1'
    set service dns forwarding allow-from '10.1.1.0/24'

    set service ssh

    edit vpn ipsec
    set esp-group vyos-central-esp lifetime '1800'
    set esp-group vyos-central-esp mode 'tunnel'
    set esp-group vyos-central-esp pfs 'enable'
    set esp-group vyos-central-esp proposal 1 encryption 'aes256'
    set esp-group vyos-central-esp proposal 1 hash 'sha256'
    set ike-group vyos-central-ike key-exchange 'ikev1'
    set ike-group vyos-central-ike lifetime '3600'
    set ike-group vyos-central-ike proposal 1 encryption 'aes256'
    set ike-group vyos-central-ike proposal 1 hash 'sha256'
    set interface 'eth0'
    set authentication psk PSK-KEY id '203.0.113.27'
    set authentication psk PSK-KEY id '203.0.113.2'
    set authentication psk PSK-KEY secret 'not-so-secret'
    set site-to-site peer PEERREMOTE authentication mode 'pre-shared-secret'
    set site-to-site peer PEERREMOTE authentication local-id '203.0.113.2'
    set site-to-site peer PEERREMOTE authentication remote-id '203.0.113.27'
    set site-to-site peer PEERREMOTE ike-group 'vyos-central-ike'
    set site-to-site peer PEERREMOTE local-address '203.0.113.2'
    set site-to-site peer PEERREMOTE remote-address '203.0.113.27'
    set site-to-site peer PEERREMOTE tunnel 0 esp-group 'vyos-central-esp'
    set site-to-site peer PEERREMOTE tunnel 0 local prefix '10.1.1.0/24'
    set site-to-site peer PEERREMOTE tunnel 0 remote prefix '10.1.1.100/30'
    commit comment "ipsec configured"
    save

```

VyOS-remote
```
    configure
    set system host-name vyos-remote

    set interfaces ethernet eth0 address 203.0.113.27/24
    set interfaces ethernet eth0 description 'OUTSIDE'
    set interfaces ethernet eth1 address '10.1.1.101/30'
    set interfaces ethernet eth1 description 'LAN'

    set service dhcp-server shared-network-name LAN subnet 10.1.1.100/30 option default-router '10.1.1.101'
    set service dhcp-server shared-network-name LAN subnet 10.1.1.100/30 option name-server '10.1.1.101'
    set service dhcp-server shared-network-name LAN subnet 10.1.1.100/30 option domain-name 'remote'
    set service dhcp-server shared-network-name LAN subnet 10.1.1.100/30 lease '86400'
    set service dhcp-server shared-network-name LAN subnet 10.1.1.100/30 range 0 start '10.1.1.102'
    set service dhcp-server shared-network-name LAN subnet 10.1.1.100/30 range 0 stop '10.1.1.103'
    set service dhcp-server shared-network-name LAN subnet 10.1.1.100/30 subnet-id '2'
    
    set service dns forwarding cache-size '0'
    set service dns forwarding listen-address '10.1.1.101'
    set service dns forwarding allow-from '10.1.1.100/30'

    set service ssh

    edit vpn ipsec
    set esp-group vyos-remote-esp lifetime '1800'
    set esp-group vyos-remote-esp mode 'tunnel'
    set esp-group vyos-remote-esp pfs 'enable'
    set esp-group vyos-remote-esp proposal 1 encryption 'aes256'
    set esp-group vyos-remote-esp proposal 1 hash 'sha256'
    set ike-group vyos-remote-ike key-exchange 'ikev1'
    set ike-group vyos-remote-ike lifetime '3600'
    set ike-group vyos-remote-ike proposal 1 encryption 'aes256'
    set ike-group vyos-remote-ike proposal 1 hash 'sha256'
    set interface 'eth0'
    set authentication psk PSK-KEY id '203.0.113.27'
    set authentication psk PSK-KEY id '203.0.113.2'
    set authentication psk PSK-KEY secret 'not-so-secret'
    set site-to-site peer PEERCENTRAL authentication mode 'pre-shared-secret'
    set site-to-site peer PEERCENTRAL authentication local-id '203.0.113.27'
    set site-to-site peer PEERCENTRAL authentication remote-id '203.0.113.2'
    set site-to-site peer PEERCENTRAL ike-group 'vyos-remote-ike'
    set site-to-site peer PEERCENTRAL local-address '203.0.113.27'
    set site-to-site peer PEERCENTRAL remote-address '203.0.113.2'
    set site-to-site peer PEERCENTRAL tunnel 0 esp-group 'vyos-remote-esp'
    set site-to-site peer PEERCENTRAL tunnel 0 local prefix '10.1.1.100/30'
    set site-to-site peer PEERCENTRAL tunnel 0 remote prefix '10.1.1.0/24'

    commit comment "ipsec configure"
    save
```

Run on vyos-remote `show vpn ipsec connections`:

```
vyos@vyos-remote:~$ show vpn ipsec connections
Connection                        State    Type    Remote address    Local TS       Remote TS      Local id      Remote id    Proposal
--------------------------------  -------  ------  ----------------  -------------  -------------  ------------  -----------  ----------
PEERCENTRAL                       up       IKEv1   203.0.113.2       -              -              203.0.113.27  203.0.113.2  -
PEERCENTRAL-tunnel-0              up       IPsec   203.0.113.2       10.1.1.100/30  10.1.1.0/24    203.0.113.27  203.0.113.2  -
PEERCENTRAL-tunnel-0-passthrough  up       IPsec   203.0.113.2       10.1.1.100/30  10.1.1.100/30  203.0.113.27  203.0.113.2  -
```

Before the fix `PEERCENTRAL-tunnel-0-passthrough` was `down`. After fix it is `up` even if VPN is down as passthrough connection is available anyway.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
