### PR TITLE
T7635: OpenConnect Certificate Authentication

### DIFF
--- a/data/templates/ocserv/ocserv_config.j2
+++ b/data/templates/ocserv/ocserv_config.j2
@@ -30,6 +30,15 @@ auth = "plain[otp=/run/ocserv/users.oath]"
 {%     else %}
 auth = "plain[/run/ocserv/ocpasswd]"
 {%     endif %}
+{% elif "certificate" in authentication.mode %}
+auth = "certificate"
+{%     if authentication.mode.certificate.user_identifier_field == "cn" %}
+cert-user-oid = 2.5.4.3
+{%     elif authentication.mode.certificate.user_identifier_field == "uid" %}
+cert-user-oid = 0.9.2342.19200300.100.1.1
+{%     else %}
+cert-user-oid = {{ authentication.mode.certificate.user_identifier_field }}
+{%     endif %}
 {% else %}
 auth = "plain[/run/ocserv/ocpasswd]"
 {% endif %}

--- a/interface-definitions/vpn_openconnect.xml.in
+++ b/interface-definitions/vpn_openconnect.xml.in
@@ -71,7 +71,7 @@
                   </leafNode>
                   <node name="certificate">
                     <properties>
-                      <help>Use certificate based authentication</help>
+                      <help>Use certificate-based authentication</help>
                     </properties>
                     <children>
                       <leafNode name="user-identifier-field">

--- a/interface-definitions/vpn_openconnect.xml.in
+++ b/interface-definitions/vpn_openconnect.xml.in
@@ -76,7 +76,7 @@
                     <children>
                       <leafNode name="user-identifier-field">
                         <properties>
-                          <help>Defines what field in the certificate identifies the username</help>
+                          <help>Certificate field to identify users by</help>
                           <valueHelp>
                             <format>cn</format>
                             <description>OID 2.5.4.3 - Common Name</description>

--- a/interface-definitions/vpn_openconnect.xml.in
+++ b/interface-definitions/vpn_openconnect.xml.in
@@ -69,6 +69,37 @@
                       <valueless/>
                     </properties>
                   </leafNode>
+                  <node name="certificate">
+                    <properties>
+                      <help>Use certificate based authentication</help>
+                    </properties>
+                    <children>
+                      <leafNode name="user-identifier-field">
+                        <properties>
+                          <help>Defines what field in the certificate identifies the username</help>
+                          <valueHelp>
+                            <format>cn</format>
+                            <description>OID 2.5.4.3 - Common Name</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>uid</format>
+                            <description>OID 0.9.2342.19200300.100.1.1 - UID</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>x.x.xx.xxx</format>
+                            <description>Custom OID in dotted decimal format</description>
+                          </valueHelp>
+                          <constraint>
+                            <regex>(^\d{1,5}(?:\.\d{1,5})*$|cn|uid)</regex>
+                          </constraint>
+                          <constraintErrorMessage>Invalid OID selection. Must be cn, uid, or a valid OID format.</constraintErrorMessage>
+                          <completionHelp>
+                            <list>cn uid x.x.xx.xxx</list>
+                          </completionHelp>
+                         </properties>
+                       </leafNode>
+                     </children>
+                   </node>
                 </children>
               </node>
               <node name="identity-based-config">

--- a/src/conf_mode/vpn_openconnect.py
+++ b/src/conf_mode/vpn_openconnect.py
@@ -115,7 +115,7 @@ def verify(ocserv):
                  and 'certificate' in ocserv['authentication']['mode'])
             ):
                 raise ConfigError(
-                    'OpenConnect authentication modes are mutually-exclusive. Only one of local, radius, or certificate.'
+                    'OpenConnect authentication modes are mutually-exclusive. Use only one of local, radius, or certificate.'
                 )
             if 'radius' in ocserv['authentication']['mode']:
                 if 'server' not in ocserv['authentication']['radius']:

--- a/src/conf_mode/vpn_openconnect.py
+++ b/src/conf_mode/vpn_openconnect.py
@@ -105,11 +105,17 @@ def verify(ocserv):
     if 'authentication' in ocserv:
         if 'mode' in ocserv['authentication']:
             if (
-                'local' in ocserv['authentication']['mode']
-                and 'radius' in ocserv['authentication']['mode']
+                ('local' in ocserv['authentication']['mode']
+                 and 'radius' in ocserv['authentication']['mode'])
+                or
+                ('local' in ocserv['authentication']['mode']
+                 and 'certificate' in ocserv['authentication']['mode'])
+                or
+                ('radius' in ocserv['authentication']['mode']
+                 and 'certificate' in ocserv['authentication']['mode'])
             ):
                 raise ConfigError(
-                    'OpenConnect authentication modes are mutually-exclusive, remove either local or radius from your configuration'
+                    'OpenConnect authentication modes are mutually-exclusive. Only one of local, radius, or certificate.'
                 )
             if 'radius' in ocserv['authentication']['mode']:
                 if 'server' not in ocserv['authentication']['radius']:
@@ -202,6 +208,9 @@ def verify(ocserv):
     if 'certificate' not in ocserv['ssl']:
         raise ConfigError('SSL certificate missing on OpenConnect config!')
     verify_pki_certificate(ocserv, ocserv['ssl']['certificate'])
+
+    if 'ca_certificate' not in ocserv['ssl'] and 'certificiate' in ocserv['authentication']['mode']:
+        raise ConfigError('CA certificate must be provided in certificate authentication mode!')
 
     if 'ca_certificate' in ocserv['ssl']:
         for ca_cert in ocserv['ssl']['ca_certificate']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
Adds feature to enable certificate based authentication for OpenConnect

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7635

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-documentation/pull/1662

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
configure
run generate pki ca install catest
commit
run generate pki certificate sign catest install certtest
commit
set vpn openconnect authentication mode certificate user-identifier-field cn
set vpn openconnect network-settings client-ip-settings subnet 192.168.1.0/24
set vpn openconnect ssl ca-certificate catest
set vpn openconnect ssl certificate certtest
commit
exit
```

Check ocserv.conf for auth = "certificate" and cert-user-oid = 2.5.4.3

```
sudo cat /var/run/ocserv/ocserv.conf
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
