### PR TITLE
T7175: Added VPP option

### DIFF
--- a/data/templates/sflow/hsflowd.conf.j2
+++ b/data/templates/sflow/hsflowd.conf.j2
@@ -32,4 +32,7 @@ sflow {
   dropmon { limit={{ drop_monitor_limit }} start=on sw=on hw=off }
 {% endif %}
   dbus { }
+{% if vpp is vyos_defined %}
+  vpp { }
+{% endif %}
 }

--- a/interface-definitions/system_sflow.xml.in
+++ b/interface-definitions/system_sflow.xml.in
@@ -112,6 +112,12 @@
               <valueless/>
             </properties>
           </leafNode>
+          <leafNode name="vpp">
+            <properties>
+              <help>Enable VPP sampling</help>
+              <valueless/>
+            </properties>
+          </leafNode>
           #include <include/interface/vrf.xml.i>
         </children>
       </node>

--- a/interface-definitions/system_sflow.xml.in
+++ b/interface-definitions/system_sflow.xml.in
@@ -106,15 +106,15 @@
               </leafNode>
             </children>
           </tagNode>
-          <leafNode name="enable-egress">
-            <properties>
-              <help>Enable egress sampling</help>
-              <valueless/>
-            </properties>
-          </leafNode>
           <leafNode name="vpp">
             <properties>
               <help>Enable VPP sampling</help>
+              <valueless/>
+            </properties>
+          </leafNode>
+          <leafNode name="enable-egress">
+            <properties>
+              <help>Enable egress sampling</help>
               <valueless/>
             </properties>
           </leafNode>

--- a/src/conf_mode/system_sflow.py
+++ b/src/conf_mode/system_sflow.py
@@ -60,7 +60,8 @@ def verify(sflow):
             )
 
     # Check if at least one interface is configured
-    if 'interface' not in sflow:
+    # Skip this check if VPP is enabled
+    if 'interface' not in sflow and 'vpp' not in sflow:
         raise ConfigError(
             'sFlow requires at least one interface to be configured!')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Updated hsflowd CLI to have VPP option and updated error check to handle interface checks when using VPP.
```
vyos@vyos# set system sflow 
Possible completions:
   agent-address        sFlow agent IPv4 or IPv6 address
   agent-interface      IP address associated with this interface
   drop-monitor-limit   Export headers of dropped by kernel packets
   enable-egress        Enable egress sampling
   vpp                  Enable VPP sampling
+  interface            Interface
   polling              Schedule counter-polling in seconds (default: 30)
   sampling-rate        sFlow sampling-rate (default: 1000)
+> server               sFlow destination server
   vrf                  VRF instance name
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7175
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-build/pull/962
https://github.com/vyos/vyos-vpp/pull/32
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
