### PR TITLE
T7649: Fix use hyphens instead of underscores for kernel options

### DIFF
--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -514,44 +514,44 @@ def get_cli_kernel_options(config_file: str) -> list:
     if 'quiet' in kernel_options:
         cmdline_options.append('quiet')
 
-    if 'disable_hpet' in kernel_options:
+    if 'disable-hpet' in kernel_options:
         cmdline_options.append('hpet=disable')
 
-    if 'disable_mce' in kernel_options:
+    if 'disable-mce' in kernel_options:
         cmdline_options.append('mce=off')
 
-    if 'disable_softlockup' in kernel_options:
+    if 'disable-softlockup' in kernel_options:
         cmdline_options.append('nosoftlockup')
 
     # CPU options
-    isol_cpus = k_cpu_opts.get('isolate_cpus')
+    isol_cpus = k_cpu_opts.get('isolate-cpus')
     if isol_cpus:
         cmdline_options.append(f'isolcpus={isol_cpus}')
 
-    nohz_full = k_cpu_opts.get('nohz_full')
+    nohz_full = k_cpu_opts.get('nohz-full')
     if nohz_full:
         cmdline_options.append(f'nohz_full={nohz_full}')
 
-    rcu_nocbs = k_cpu_opts.get('rcu_no_cbs')
+    rcu_nocbs = k_cpu_opts.get('rcu-no-cbs')
     if rcu_nocbs:
         cmdline_options.append(f'rcu_nocbs={rcu_nocbs}')
 
-    if 'disable_nmi_watchdog' in k_cpu_opts:
+    if 'disable-nmi-watchdog' in k_cpu_opts:
         cmdline_options.append('nmi_watchdog=0')
 
     # Memory options
-    if 'disable_numa_balancing' in k_memory_opts:
+    if 'disable-numa-balancing' in k_memory_opts:
         cmdline_options.append('numa_balancing=disable')
 
-    default_hp_size = k_memory_opts.get('default_hugepage_size')
+    default_hp_size = k_memory_opts.get('default-hugepage-size')
     if default_hp_size:
         cmdline_options.append(f'default_hugepagesz={default_hp_size}')
 
-    hp_sizes = k_memory_opts.get('hugepage_size')
+    hp_sizes = k_memory_opts.get('hugepage-size')
     if hp_sizes:
         for size, settings in hp_sizes.items():
             cmdline_options.append(f'hugepagesz={size}')
-            count = settings.get('hugepage_count')
+            count = settings.get('hugepage-count')
             if count:
                 cmdline_options.append(f'hugepages={count}')
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
The ConfigTree for operation mode uses hyphens instead of underscores.
Fix kernel options during image upgrade.
Backport is not required, I'll force-push to backport manually.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7649

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Initial configuration:
```
set system option kernel cpu disable-nmi-watchdog
set system option kernel cpu isolate-cpus '1,2,4-5'
set system option kernel cpu nohz-full '1,2,4-5'
set system option kernel cpu rcu-no-cbs '1,2,4-5'
set system option kernel disable-hpet
set system option kernel disable-mce
set system option kernel disable-mitigations
set system option kernel disable-softlockup
set system option kernel memory default-hugepage-size '2M'
set system option kernel memory disable-numa-balancing
set system option kernel memory hugepage-size 1G hugepage-count '2'
set system option kernel memory hugepage-size 2M hugepage-count '1650'

```

DEBUG update system image:
```
vyos@r14:~$ add system image vyos-2025.07.25-0021-rolling-generic-amd64.iso
Validating image compatibility
Validating image checksums
What would you like to name this image? (Default: 2025.07.25-0021-rolling) 
Would you like to set the new image as the default one for boot? [Y/n] 
An active configuration was found. Would you like to copy it to the new image? [Y/n] 
Copying configuration directory
Would you like to copy SSH host keys? [Y/n] 
Copying SSH host keys
Copying system image files
Cleaning up
Unmounting target filesystems
Removing temporary files

{'cpu': {'disable-nmi-watchdog': {}, 'isolate-cpus': '1,2,4-5', 'nohz-full': '1,2,4-5', 'rcu-no-cbs': '1,2,4-5'}, 'disable-hpet': {}, 'disable-mce': {}, 'disable-mitigations': {}, 'disable-softlockup': {}, 'memory': {'default-hugepage-size': '2M', 'disable-numa-balancing': {}, 'hugepage-size': {'1G': {'hugepage-count': '2'}, '2M': {'hugepage-count': '1650'}}}}

['mitigations=off', 'hpet=disable', 'mce=off', 'nosoftlockup', 'isolcpus=1,2,4-5', 'nohz_full=1,2,4-5', 'rcu_nocbs=1,2,4-5', 'nmi_watchdog=0', 'numa_balancing=disable', 'default_hugepagesz=2M', 'hugepagesz=1G', 'hugepages=2', 'hugepagesz=2M', 'hugepages=1650']
vyos@r14:~$ 

```
Reboot the system and check the `cmdline`:
```
vyos@r14:~$ cat /proc/cmdline 
BOOT_IMAGE=/boot/2025.07.25-0021-rolling/vmlinuz boot=live rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/2025.07.25-0021-rolling mitigations=off hpet=disable mce=off nosoftlockup isolcpus=1,2,4-5 nohz_full=1,2,4-5 rcu_nocbs=1,2,4-5 nmi_watchdog=0 numa_balancing=disable default_hugepagesz=2M hugepagesz=1G hugepages=2 hugepagesz=2M hugepages=1650 console=tty0
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
