### PR TITLE
ipsec: T7581: Fix unsupported 'all' protocol in site-to-site tunnels after upgrade to 1.4.x

### DIFF
--- a/data/templates/ipsec/swanctl/peer.j2
+++ b/data/templates/ipsec/swanctl/peer.j2
@@ -111,6 +111,12 @@
 {%         set tunnel_esp_name = tunnel_conf.esp_group if tunnel_conf.esp_group is vyos_defined else peer_conf.default_esp_group %}
 {%         set tunnel_esp = esp_group[tunnel_esp_name] %}
 {%         set proto = tunnel_conf.protocol if tunnel_conf.protocol is vyos_defined else '' %}
+{#         VyOS 1.3.x (with strongSwan 5.7.x) previously allowed using `all` in traffic selectors, converting it to `%any`. #}
+{#         In strongSwan 5.9.x (VyOS >= 1.4.x), the syntax `x.x.x.0/24[all/]` is no longer accepted. #}
+{#         We must now explicitly specify a protocol (e.g., `tcp`, `udp`). #}
+{#         To achieve "all" protocol behavior, simply use the subnet notation without brackets, #}
+{#         such as `x.x.x.0/24` or `x.x.x.0/24[/443]`. #}
+{%         set proto = '' if proto == 'all' else proto %}
 {%         set local_port = tunnel_conf.local.port if tunnel_conf.local.port is vyos_defined else '' %}
 {%         set local_suffix = '[{0}/{1}]'.format(proto, local_port) if proto or local_port else '' %}
 {%         set remote_port = tunnel_conf.remote.port if tunnel_conf.remote.port is vyos_defined else '' %}


### PR DESCRIPTION
## Change summary

Upgrading from VyOS 1.3.8 (strongSwan **5.7.2**) to 1.4.x (strongSwan **5.9.11**) caused the IPsec service to fail if the configuration contained:

```
  set vpn ipsec site-to-site peer <peer> tunnel <id> protocol 'all'
```

In 1.3.8, `all` was supported in the CLI for protocol and converted internally to `%any` in **ipsec.conf** traffic selectors, allowing the tunnel to match all protocols. However, in 1.4.x and strongSwan 5.9.11+, the `[all/]` syntax is no longer supported, and use of 'protocol all' produces an invalid traffic selector (e.g., `x.x.x.0/24[all/]`), causing the strongSwan service to fail on reload.

As per the [strongSwan documentation ](https://docs.strongswan.org/docs/5.9/swanctl/swanctlConf.html): 
> A protocol/port selector is surrounded by opening and closing square brackets. Between these brackets, a numeric or getservent(3) protocol name may be specified. After the optional protocol restriction, an optional port restriction may be specified, separated by a slash. The port restriction may be numeric, a getservent(3) service name, or the special value opaque for [RFC 4301](https://datatracker.ietf.org/doc/html/rfc4301) OPAQUE selectors. 

The documentation makes no mention of the keyword `all` being valid; only actual protocol names or numbers and optional port/service info are supported.

This PR ensures that 'protocol all' is converted to just the subnet notation (e.g., `x.x.x.0/24`) in the generated traffic selector, restoring previous behavior and allowing seamless service startup after upgrade.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7581

## How to test / Smoketest result

**Manual test:**
```
configure
set vpn ipsec esp-group esp01 lifetime '1800'
set vpn ipsec esp-group esp01 mode 'tunnel'
set vpn ipsec esp-group esp01 pfs 'dh-group19'
set vpn ipsec esp-group esp01 proposal 10 encryption 'aes128'
set vpn ipsec esp-group esp01 proposal 10 hash 'sha512'
set vpn ipsec ike-group IKEv2_01 key-exchange 'ikev2'
set vpn ipsec ike-group IKEv2_01 lifetime '10800'
set vpn ipsec ike-group IKEv2_01 proposal 10 dh-group '19'
set vpn ipsec ike-group IKEv2_01 proposal 10 encryption 'aes256'
set vpn ipsec ike-group IKEv2_01 proposal 10 hash 'sha512'

set vpn ipsec site-to-site peer vpn_03 authentication local-id '10.110.2.62'
set vpn ipsec site-to-site peer vpn_03 authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer vpn_03 authentication remote-id '10.110.1.59'
set vpn ipsec site-to-site peer vpn_03 ike-group 'IKEv2_01'
set vpn ipsec site-to-site peer vpn_03 local-address '10.110.2.62'
set vpn ipsec site-to-site peer vpn_03 remote-address '10.110.1.59'
set vpn ipsec site-to-site peer vpn_03 tunnel 0 esp-group 'esp01'
set vpn ipsec site-to-site peer vpn_03 tunnel 0 local prefix '10.110.10.0/24'
set vpn ipsec site-to-site peer vpn_03 tunnel 0 protocol 'all'
set vpn ipsec site-to-site peer vpn_03 tunnel 0 remote prefix '10.120.10.0/24'
commit
cat /etc/swanctl/swanctl.conf | grep local_ts
systemctl status strongswan
```

**Smoketest**:

```
root@770f4e5200fc:/vyos/vyos-build# make test MATCH="ipsec"
...
DEBUG - test_site_to_site (__main__.TestVPNIPsec.test_site_to_site) ... ok
DEBUG - test_site_to_site_ts_protocol_all (__main__.TestVPNIPsec.test_site_to_site_ts_protocol_all) ... ok
...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
