### PR TITLE
isis: T7639: set SRv6 locator in ISIS

### DIFF
--- a/data/templates/frr/isisd.frr.j2
+++ b/data/templates/frr/isisd.frr.j2
@@ -130,6 +130,11 @@ advertise-passive-only
 {%     if segment_routing.maximum_label_depth is vyos_defined %}
  segment-routing node-msd {{ segment_routing.maximum_label_depth }}
 {%     endif %}
+{%     if segment_routing.srv6.locator is vyos_defined %}
+ segment-routing srv6
+  locator {{ segment_routing.srv6.locator }}
+ exit
+{%     endif %}
 {%     if segment_routing.global_block is vyos_defined %}
 {%         if segment_routing.local_block is vyos_defined %}
  segment-routing global-block {{ segment_routing.global_block.low_label_value }} {{ segment_routing.global_block.high_label_value }} local-block {{ segment_routing.local_block.low_label_value }} {{ segment_routing.local_block.high_label_value }}

--- a/interface-definitions/include/isis/protocol-common-config.xml.i
+++ b/interface-definitions/include/isis/protocol-common-config.xml.i
@@ -275,7 +275,7 @@
   <children>
     <node name="global-block">
       <properties>
-        <help>Segment Routing Global Block label range</help>
+        <help>Segment-Routing Global Block label range</help>
       </properties>
       <children>
         #include <include/segment-routing-label-value.xml.i>
@@ -283,7 +283,7 @@
     </node>
     <node name="local-block">
       <properties>
-        <help>Segment Routing Local Block label range</help>
+        <help>Segment-Routing Local Block label range</help>
       </properties>
       <children>
         #include <include/segment-routing-label-value.xml.i>

--- a/interface-definitions/include/isis/protocol-common-config.xml.i
+++ b/interface-definitions/include/isis/protocol-common-config.xml.i
@@ -289,6 +289,25 @@
         #include <include/segment-routing-label-value.xml.i>
       </children>
     </node>
+    <node name="srv6">
+      <properties>
+        <help>Segment-Routing SRv6 configuration</help>
+      </properties>
+      <children>
+        <leafNode name="locator">
+          <properties>
+            <help>Specify SRv6 locator</help>
+            <valueHelp>
+              <format>txt</format>
+              <description>SRv6 locator name</description>
+            </valueHelp>
+            <constraint>
+              #include <include/constraint/alpha-numeric-hyphen-underscore.xml.i>
+            </constraint>
+          </properties>
+        </leafNode>
+      </children>
+    </node>
     <leafNode name="maximum-label-depth">
       <properties>
         <help>Maximum MPLS labels allowed for this router</help>

--- a/interface-definitions/include/ospf/protocol-common-config.xml.i
+++ b/interface-definitions/include/ospf/protocol-common-config.xml.i
@@ -680,7 +680,7 @@
   <children>
     <node name="global-block">
       <properties>
-        <help>Segment Routing Global Block label range</help>
+        <help>Segment-Routing Global Block label range</help>
       </properties>
       <children>
         #include <include/segment-routing-label-value.xml.i>
@@ -688,7 +688,7 @@
     </node>
     <node name="local-block">
       <properties>
-        <help>Segment Routing Local Block label range</help>
+        <help>Segment-Routing Local Block label range</help>
       </properties>
       <children>
         #include <include/segment-routing-label-value.xml.i>

--- a/interface-definitions/protocols_segment-routing.xml.in
+++ b/interface-definitions/protocols_segment-routing.xml.in
@@ -4,13 +4,13 @@
     <children>
        <node name="segment-routing" owner="${vyos_conf_scripts_dir}/protocols_segment-routing.py">
         <properties>
-          <help>Segment Routing</help>
+          <help>Segment-Routing (SR) parameters</help>
           <priority>900</priority>
         </properties>
         <children>
           <tagNode name="interface">
             <properties>
-              <help>Interface specific Segment Routing options</help>
+              <help>Interface specific Segment-Routing options</help>
               <completionHelp>
                 <script>${vyos_completion_dir}/list_interfaces</script>
               </completionHelp>
@@ -63,7 +63,7 @@
             <children>
               <tagNode name="locator">
                 <properties>
-                  <help>Segment Routing SRv6 locator</help>
+                  <help>Segment-Routing SRv6 locators configuration</help>
                   <constraint>
                     #include <include/constraint/alpha-numeric-hyphen-underscore.xml.i>
                   </constraint>

--- a/interface-definitions/service_config-sync.xml.in
+++ b/interface-definitions/service_config-sync.xml.in
@@ -337,7 +337,7 @@
                   </leafNode>
                   <leafNode name="segment-routing">
                     <properties>
-                      <help>Segment Routing</help>
+                      <help>Segment-Routing (SR) parameters</help>
                       <valueless/>
                     </properties>
                   </leafNode>

--- a/smoketest/scripts/cli/test_protocols_isis.py
+++ b/smoketest/scripts/cli/test_protocols_isis.py
@@ -418,5 +418,25 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f' net {net}', tmp)
             self.assertIn(f' topology {topology}', tmp)
 
+    def test_isis_11_srv6(self):
+        locator = "TEST"
+        interface = 'lo'
+
+        self.cli_set(base_path + ['net', net])
+        self.cli_set(base_path + ['interface', interface])
+        self.cli_set(base_path + ['segment-routing', 'srv6', 'locator', locator])
+
+        # Commit main ISIS changes
+        self.cli_commit()
+
+        # Verify main ISIS changes
+        tmp = self.getFRRconfig(f'router isis {domain}', endsection='^exit')
+        self.assertIn(f' net {net}', tmp)
+        self.assertIn(f' segment-routing srv6', tmp)
+        self.assertIn(f'  locator {locator}', tmp)
+
+        # Commit for isis
+        self.cli_commit()
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Extend the ability SRv6 which enables extensions in IS-IS to support Segment Routing over IPv6
data plane (SRv6) as per RFC 9352.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7639

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/998
* https://github.com/vyos/vyos-build/pull/1000


## How to test / Smoketest result
<!---

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

vyos basic configuration : 

```
set protocols isis interface eth1
set protocols isis interface lo
set protocols isis level 'level-2'
set protocols isis net '49.0000.0000.0000.0001.00'
set protocols isis segment-routing srv6 locator 'L3VPN'
```
frr : 
```
router isis VyOS
 net 49.0000.0000.0000.0001.00
 segment-routing srv6
  locator L3VPN
 exit
exit
!
```
smoke test: 

```
 vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_isis.py
test_isis_01_redistribute (__main__.TestProtocolsISIS.test_isis_01_redistribute) ... ok
test_isis_02_vrfs (__main__.TestProtocolsISIS.test_isis_02_vrfs) ... ok
test_isis_04_default_information (__main__.TestProtocolsISIS.test_isis_04_default_information) ... ok
test_isis_05_password (__main__.TestProtocolsISIS.test_isis_05_password) ... ok
test_isis_06_spf_delay_bfd (__main__.TestProtocolsISIS.test_isis_06_spf_delay_bfd) ... ok
test_isis_07_segment_routing_configuration (__main__.TestProtocolsISIS.test_isis_07_segment_routing_configuration) ... ok
test_isis_08_ldp_sync (__main__.TestProtocolsISIS.test_isis_08_ldp_sync) ... ok
test_isis_09_lfa (__main__.TestProtocolsISIS.test_isis_09_lfa) ... ok
test_isis_10_topology (__main__.TestProtocolsISIS.test_isis_10_topology) ... ok
test_isis_11_srv6 (__main__.TestProtocolsISIS.test_isis_11_srv6) ... ok
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
