### PR TITLE
conntrack: T7482: Fix custom timeouts

### DIFF
--- a/data/templates/conntrack/nftables-ct.j2
+++ b/data/templates/conntrack/nftables-ct.j2
@@ -16,17 +16,15 @@ table ip vyos_conntrack {
 {% endif %}
          return
     }
-    chain VYOS_CT_TIMEOUT {
 {% if timeout.custom.ipv4.rule is vyos_defined %}
+    chain VYOS_CT_TIMEOUT {
 {%     for rule, rule_config in timeout.custom.ipv4.rule.items() %}
         # rule-{{ rule }} {{ '- ' ~ rule_config.description if rule_config.description is vyos_defined }}
         {{ rule_config | conntrack_rule(rule, 'timeout', ipv6=False) }}
 {%     endfor %}
-{% endif %}
         return
     }
 
-{% if timeout.custom.ipv4.rule is vyos_defined %}
 {%     for rule, rule_config in timeout.custom.ipv4.rule.items() %}
     ct timeout ct-timeout-{{ rule }} {
         l3proto ip;
@@ -36,12 +34,21 @@ table ip vyos_conntrack {
 {%         endfor %}
     }
 {%     endfor %}
+
+    chain PREROUTING_CT_TIMEOUT {
+        type filter hook prerouting priority -199; policy accept;
+        counter jump VYOS_CT_TIMEOUT
+    }
+
+    chain OUTPUT_CT_TIMEOUT {
+        type filter hook output priority -199; policy accept;
+        counter jump VYOS_CT_TIMEOUT
+    }
 {% endif %}
 
     chain PREROUTING {
         type filter hook prerouting priority -300; policy accept;
         counter jump VYOS_CT_IGNORE
-        counter jump VYOS_CT_TIMEOUT
         counter jump FW_CONNTRACK
         counter jump NAT_CONNTRACK
         counter jump WLB_CONNTRACK
@@ -58,7 +65,6 @@ table ip vyos_conntrack {
     chain OUTPUT {
         type filter hook output priority -300; policy accept;
         counter jump VYOS_CT_IGNORE
-        counter jump VYOS_CT_TIMEOUT
         counter jump FW_CONNTRACK
         counter jump NAT_CONNTRACK
 {% if wlb_local_action %}
@@ -106,17 +112,15 @@ table ip6 vyos_conntrack {
 {% endif %}
         return
     }
-    chain VYOS_CT_TIMEOUT {
 {% if timeout.custom.ipv6.rule is vyos_defined %}
+    chain VYOS_CT_TIMEOUT {
 {%     for rule, rule_config in timeout.custom.ipv6.rule.items() %}
         # rule-{{ rule }} {{ '- ' ~ rule_config.description if rule_config.description is vyos_defined }}
         {{ rule_config | conntrack_rule(rule, 'timeout', ipv6=True) }}
 {%     endfor %}
-{% endif %}
         return
     }
 
-{% if timeout.custom.ipv6.rule is vyos_defined %}
 {%     for rule, rule_config in timeout.custom.ipv6.rule.items() %}
     ct timeout ct-timeout-{{ rule }} {
         l3proto ip;
@@ -126,12 +130,21 @@ table ip6 vyos_conntrack {
 {%         endfor %}
     }
 {%     endfor %}
+
+    chain PREROUTING_CT_TIMEOUT {
+        type filter hook prerouting priority -199; policy accept;
+        counter jump VYOS_CT_TIMEOUT
+    }
+
+    chain OUTPUT_CT_TIMEOUT {
+        type filter hook output priority -199; policy accept;
+        counter jump VYOS_CT_TIMEOUT
+    }
 {% endif %}
 
     chain PREROUTING {
         type filter hook prerouting priority -300; policy accept;
         counter jump VYOS_CT_IGNORE
-        counter jump VYOS_CT_TIMEOUT
         counter jump FW_CONNTRACK
         counter jump NAT_CONNTRACK
         notrack
@@ -147,7 +160,6 @@ table ip6 vyos_conntrack {
     chain OUTPUT {
         type filter hook output priority -300; policy accept;
         counter jump VYOS_CT_IGNORE
-        counter jump VYOS_CT_TIMEOUT
         counter jump FW_CONNTRACK
         counter jump NAT_CONNTRACK
         notrack


### PR DESCRIPTION
Fix custom conntrack timeout rules and add smoketests

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Custom timeout rules were previously not working at all.

The problem is that the firewall rules were originally configured to jump directly to the VYOS_CT_TIMEOUT chain from the PREROUTING and OUTPUT base chains. But those two base chains have a priority of raw (-300), and conntrack hooks at priority -200, therefore any rules that modify conntrack entries must have a priority above -200.

So I removed the VYOS_CT_TIMEOUT jumps from PREROUTING and OUTPUT, and created my own prerouting and output base chains with priority -199 to perform the jump to VYOS_CT_TIMEOUT. The two timeout jumping base chains are only created if custom timeout rules have been configured by an administrator.

To tidy up the nftables config, it also removes the empty VYOS_CT_TIMEOUT chain if there are no custom timeout rules created, since nothing else uses it.

I also added much more extensive smoke testing for this to ensure it doesn't accidentally break in the future. Custom timeout rules are very important to have for VoIP, and I'm sure there are plenty of other use cases for it as well.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7482

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Experiment with creating custom conntrack timeout rules and verifying the records are being updated in conntrack.

Here is an IPv4 example using DNS traffic from a server with IP address 172.16.99.2:

```
configure

# UDP rule using DNS as an example
set system conntrack timeout custom ipv4 rule 1 destination port '53'
set system conntrack timeout custom ipv4 rule 1 protocol udp replied '700'
set system conntrack timeout custom ipv4 rule 1 protocol udp unreplied '700'
set system conntrack timeout custom ipv4 rule 1 source address '172.16.99.2'

commit ; save
```

Using this DNS example rule, you'll need to generate some DNS queries from your 172.16.99.2 server. You can just use `dig google.com` or ping a domain name.

After querying DNS records, run `conntrack -E` or `show conntrack table ipv4 | grep "172.16.99.2"`, and you should see your new timeouts of 700 seconds instead of the default of 30 for unreplied and 180 for stream.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
