### PR TITLE
T7668: Fix image update due to None kernel options

### DIFF
--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -494,10 +494,10 @@ def get_cli_kernel_options(config_file: str) -> list:
     config = ConfigTree(read_file(config_file))
     config_dict = loads(config.to_json())
     kernel_options = dict_search('system.option.kernel', config_dict)
-    k_cpu_opts = kernel_options.get('cpu', {})
-    k_memory_opts = kernel_options.get('memory', {})
     if kernel_options is None:
         kernel_options = {}
+    k_cpu_opts = kernel_options.get('cpu', {})
+    k_memory_opts = kernel_options.get('memory', {})
     cmdline_options = []
 
     # XXX: This code path and if statements must be kept in sync with the Kernel


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
If we do not have the `system options kernel` the update fails,
Change order for variables `k_cpu_opts` and `k_memory_opts`

If we do not have `kernel_options` set empty dictionary as a NoneType object has no attribute `get`

```
>>> kernel_options=None
>>> kernel_options.get('cpu', {})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'NoneType' object has no attribute 'get'
>>>
>>>
>>> kernel_options={}
>>> kernel_options.get('cpu', {})
{}
>>>
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7668

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
If we do no have the `system option kernel` try to update the image
Before the fix:
```
vyos@r14:~$ add system image vyos-2025.07.28-0022-rolling-generic-amd64.iso
Validating image compatibility
Validating image checksums
What would you like to name this image? (Default: 2025.07.28-0022-rolling) 
Would you like to set the new image as the default one for boot? [Y/n] 
An active configuration was found. Would you like to copy it to the new image? [Y/n] 
Copying configuration directory
Would you like to copy SSH host keys? [Y/n] 
Copying SSH host keys
Copying system image files
Cleaning up
Unmounting target filesystems
Removing temporary files
Cleaning up
Unmounting target filesystems
Removing temporary files
Error: 'NoneType' object has no attribute 'get'
vyos@r14:~$ 
```
After the fix:
```
vyos@r14:~$ show system image 
Name                     Default boot    Running
-----------------------  --------------  ---------
2025.07.29-0023-rolling  Yes             Yes
vyos@r14:~$ add system image vyos-2025.07.28-0022-rolling-generic-amd64.iso
Validating image compatibility
Validating image checksums
What would you like to name this image? (Default: 2025.07.28-0022-rolling) 
Would you like to set the new image as the default one for boot? [Y/n] 
An active configuration was found. Would you like to copy it to the new image? [Y/n] 
Copying configuration directory
Would you like to copy SSH host keys? [Y/n] 
Copying SSH host keys
Copying system image files
Cleaning up
Unmounting target filesystems
Removing temporary files
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ show system image 
Name                     Default boot    Running
-----------------------  --------------  ---------
2025.07.28-0022-rolling  Yes
2025.07.29-0023-rolling                  Yes
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
