### PR TITLE
T7671: move AWS GLB CLI configuration to a separate package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ debian/.debhelper/
 debian/vyos-1x
 debian/vyos-1x-vmware
 debian/vyos-1x-smoketest
+debian/vyos-1x-aws
 debian/*.postinst.debhelper
 debian/*.prerm.debhelper
 debian/*.postrm.debhelper

--- a/debian/control
+++ b/debian/control
@@ -199,8 +199,6 @@ Depends:
   console-data,
   dropbear,
 # End "service console-server"
-# For "service aws glb"
-  aws-gwlbtun,
 # For "service dns dynamic"
   ddclient (>= 3.11.1),
 # End "service dns dynamic"
@@ -393,13 +391,15 @@ Depends:
 Description: VyOS configuration scripts and data
  VyOS configuration scripts, interface definitions, and everything
 
-Package: vyos-1x-vmware
+Package: vyos-1x-aws
 Architecture: all
 Depends:
  vyos-1x,
- open-vm-tools
-Description: VyOS configuration scripts and data for VMware
- Adds configuration files required for VyOS running on VMware hosts.
+# For "service aws glb"
+ aws-gwlbtun,
+Description: VyOS configuration scripts and data for AWS Gateway Load Balancer
+ Adds configuration files required for AWS Gateway Load Balancer service
+ running on top of VyOS.
 
 Package: vyos-1x-smoketest
 Architecture: all
@@ -408,3 +408,11 @@ Depends:
  snmp,
  vyos-1x
 Description: VyOS build sanity checking toolkit
+
+Package: vyos-1x-vmware
+Architecture: all
+Depends:
+ vyos-1x,
+ open-vm-tools
+Description: VyOS configuration scripts and data for VMware
+ Adds configuration files required for VyOS running on VMware hosts.

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 DIR := debian/tmp
+DIR_AWS := $(DIR)/vyos-1x-aws
 VYOS_SBIN_DIR := usr/sbin
 VYOS_BIN_DIR := usr/bin
 VYOS_LIBEXEC_DIR := usr/libexec/vyos
@@ -35,6 +36,9 @@ override_dh_auto_install:
 	dh_auto_install
 
 	cd python; python3 setup.py install --install-layout=deb --root ../$(DIR); cd ..
+
+	# Remove all __pycache__ directories before installing
+	find . -type d -name '__pycache__' -exec rm -rf {} +
 
 	# Install scripts
 	mkdir -p $(DIR)/$(VYOS_SBIN_DIR)
@@ -142,6 +146,21 @@ override_dh_auto_install:
 	# Install udev script
 	mkdir -p $(DIR)/usr/lib/udev
 	cp src/helpers/vyos_net_name $(DIR)/usr/lib/udev
+
+	# vyos-1x-aws package
+	# Move some files to dedicated DEB packages
+	#
+	mkdir -p $(DIR_AWS)/lib/systemd/system
+	mv $(DIR)/lib/systemd/system/aws-gwlbtun.service $(DIR_AWS)/lib/systemd/system
+
+	mkdir -p $(DIR_AWS)/opt/vyatta/share/vyatta-cfg/templates/service
+	mv $(DIR)/opt/vyatta/share/vyatta-cfg/templates/service/aws $(DIR_AWS)/opt/vyatta/share/vyatta-cfg/templates/service
+
+	mkdir -p $(DIR_AWS)/usr/libexec/vyos/conf_mode
+	mv $(DIR)/usr/libexec/vyos/conf_mode/service_aws_glb.py $(DIR_AWS)/usr/libexec/vyos/conf_mode
+
+	mkdir -p $(DIR_AWS)/usr/share/vyos/templates
+	mv $(DIR)/usr/share/vyos/templates/aws/ $(DIR_AWS)/usr/share/vyos/templates
 
 override_dh_installsystemd:
 	dh_installsystemd -pvyos-1x --name vyos-router vyos-router.service

--- a/debian/vyos-1x-aws.install
+++ b/debian/vyos-1x-aws.install
@@ -1,0 +1,3 @@
+vyos-1x-aws/lib/* /lib
+vyos-1x-aws/opt/* /opt
+vyos-1x-aws/usr/* /usr


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Since AWS Gateway Load Balancer is specific to the AWS platform, its CLI and binary dependencies don’t need to be included in generic images.

This commit removes the AWS GLB CLI definitions from all images and introduces a new vyos-1x-aws package to provide the necessary CLI configuration and binary dependencies.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7671

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

Check that there are no aws related files left in the package:

`dpkg-deb -c ../vyos-1x_1.5dev0-3339-ga551fa455+dirty_amd64.deb | grep aws`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
