### PR TITLE
ipsec: T7562: Add support for `disable-uniqreqids` option in IPsec configs

### DIFF
--- a/data/templates/ipsec/swanctl.conf.j2
+++ b/data/templates/ipsec/swanctl.conf.j2
@@ -4,15 +4,17 @@
 {% import 'ipsec/swanctl/peer.j2' as peer_tmpl %}
 {% import 'ipsec/swanctl/remote_access.j2' as remote_access_tmpl %}
 
+{% set uniqreqids = 'never' if disable_uniqreqids is vyos_defined else None %}
+
 connections {
 {% if profile is vyos_defined %}
 {%     for name, profile_conf in profile.items() if profile_conf.disable is not vyos_defined and profile_conf.bind.tunnel is vyos_defined %}
-{{ profile_tmpl.conn(name, profile_conf, ike_group, esp_group) }}
+{{ profile_tmpl.conn(name, profile_conf, ike_group, esp_group, uniqreqids) }}
 {%     endfor %}
 {% endif %}
 {% if site_to_site.peer is vyos_defined %}
 {%     for peer, peer_conf in site_to_site.peer.items() if peer not in dhcp_no_address and peer_conf.disable is not vyos_defined %}
-{{ peer_tmpl.conn(peer, peer_conf, ike_group, esp_group) }}
+{{ peer_tmpl.conn(peer, peer_conf, ike_group, esp_group, uniqreqids) }}
 {%     endfor %}
 {% endif %}
 {% if remote_access.connection is vyos_defined %}
@@ -21,7 +23,7 @@ connections {
 {%     endfor %}
 {% endif %}
 {% if l2tp %}
-{{ l2tp_tmpl.conn(l2tp, l2tp_outside_address, l2tp_ike_default, l2tp_esp_default, ike_group, esp_group) }}
+{{ l2tp_tmpl.conn(l2tp, l2tp_outside_address, l2tp_ike_default, l2tp_esp_default, ike_group, esp_group, uniqreqids) }}
 {% endif %}
 }
 

--- a/data/templates/ipsec/swanctl/l2tp.j2
+++ b/data/templates/ipsec/swanctl/l2tp.j2
@@ -1,4 +1,4 @@
-{% macro conn(l2tp, l2tp_outside_address, l2tp_ike_default, l2tp_esp_default, ike_group, esp_group) %}
+{% macro conn(l2tp, l2tp_outside_address, l2tp_ike_default, l2tp_esp_default, ike_group, esp_group, uniqreqids) %}
 {% set l2tp_ike = ike_group[l2tp.ike_group] if l2tp.ike_group is vyos_defined else None %}
 {% set l2tp_esp = esp_group[l2tp.esp_group] if l2tp.esp_group is vyos_defined else None %}
     l2tp_remote_access {
@@ -8,6 +8,9 @@
         dpd_timeout = 45s
         rekey_time = {{ l2tp_ike.lifetime if l2tp_ike else l2tp.ike_lifetime }}s
         reauth_time = 0
+{% if uniqreqids is vyos_defined %}
+        unique = {{ uniqreqids }}
+{% endif %}
         local {
             auth = {{ 'psk' if l2tp.authentication.mode == 'pre-shared-secret' else 'pubkey' }}
 {% if l2tp.authentication.mode == 'x509' %}

--- a/data/templates/ipsec/swanctl/peer.j2
+++ b/data/templates/ipsec/swanctl/peer.j2
@@ -1,4 +1,4 @@
-{% macro conn(peer, peer_conf, ike_group, esp_group) %}
+{% macro conn(peer, peer_conf, ike_group, esp_group, uniqreqids) %}
 {% set name = peer.replace("@", "") | dot_colon_to_dash %}
 {# peer needs to reference the global IKE configuration for certain values #}
 {% set ike = ike_group[peer_conf.ike_group] %}
@@ -32,6 +32,9 @@
 {% endif %}
 {% if peer_conf.force_udp_encapsulation is vyos_defined %}
         encap = yes
+{% endif %}
+{% if uniqreqids is vyos_defined %}
+        unique = {{ uniqreqids }}
 {% endif %}
         local {
 {% if peer_conf.authentication.local_id is vyos_defined %}

--- a/data/templates/ipsec/swanctl/profile.j2
+++ b/data/templates/ipsec/swanctl/profile.j2
@@ -1,4 +1,4 @@
-{% macro conn(name, profile_conf, ike_group, esp_group) %}
+{% macro conn(name, profile_conf, ike_group, esp_group, uniqreqids) %}
 {# peer needs to reference the global IKE configuration for certain values #}
 {% set ike = ike_group[profile_conf.ike_group] %}
 {% set esp = esp_group[profile_conf.esp_group] %}
@@ -12,6 +12,9 @@
 {%         if ike.dead_peer_detection is vyos_defined %}
         dpd_timeout = {{ ike.dead_peer_detection.timeout }}
         dpd_delay = {{ ike.dead_peer_detection.interval }}
+{%         endif %}
+{%         if uniqreqids is vyos_defined %}
+        unique = {{ uniqreqids }}
 {%         endif %}
 {%         if profile_conf.authentication.mode is vyos_defined('pre-shared-secret') %}
         local {

--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -233,6 +233,9 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         self.cli_set(peer_base_path + ['tunnel', '2', 'remote', 'prefix', '10.2.0.0/16'])
         self.cli_set(peer_base_path + ['tunnel', '2', 'priority', priority])
 
+        # Passing the 'unique = never' for StrongSwan's `connections.<conn>.unique` parameter
+        self.cli_set(base_path + ['disable-uniqreqids'])
+
         self.cli_commit()
 
         # Verify strongSwan configuration
@@ -259,6 +262,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             f'priority = {priority}',
             f'mode = tunnel',
             f'replay_window = 32',
+            'unique = never',
         ]
         for line in swanctl_conf_lines:
             self.assertIn(line, swanctl_conf)
@@ -634,6 +638,9 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['profile', 'NHRPVPN', 'esp-group', esp_group])
         self.cli_set(base_path + ['profile', 'NHRPVPN', 'ike-group', ike_group])
 
+        # Passing the 'unique = never' for StrongSwan's `connections.<conn>.unique` parameter
+        self.cli_set(base_path + ['disable-uniqreqids'])
+
         self.cli_commit()
 
         swanctl_conf = read_file(swanctl_file)
@@ -646,7 +653,8 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             f'local_ts = dynamic[gre]',
             f'remote_ts = dynamic[gre]',
             f'mode = transport',
-            f'secret = {nhrp_secret}'
+            f'secret = {nhrp_secret}',
+            'unique = never',
         ]
         for line in swanctl_lines:
             self.assertIn(line, swanctl_conf)


### PR DESCRIPTION
## Change summary
This PR makes `set vpn ipsec disable-uniqreqids` work with the modern StrongSwan backend by setting `unique=never` in **swanctl.conf** for connections. This restores legacy behavior about multiple connections with the same identity.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T7562

## How to test / Smoketest result
```
root@c6392b5716ee:/vyos/vyos-build# make test MATCH="ipsec"

DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
DEBUG - test_dhcp_fail_handling (__main__.TestVPNIPsec.test_dhcp_fail_handling) ... ok
DEBUG - test_dmvpn (__main__.TestVPNIPsec.test_dmvpn) ... ok
DEBUG - test_flex_vpn_vips (__main__.TestVPNIPsec.test_flex_vpn_vips) ... ok
DEBUG - test_remote_access (__main__.TestVPNIPsec.test_remote_access) ... ok
DEBUG - test_remote_access_dhcp_fail_handling (__main__.TestVPNIPsec.test_remote_access_dhcp_fail_handling) ... ok
DEBUG - test_remote_access_eap_tls (__main__.TestVPNIPsec.test_remote_access_eap_tls) ... ok
DEBUG - test_remote_access_no_rekey (__main__.TestVPNIPsec.test_remote_access_no_rekey) ... ok
DEBUG - test_remote_access_pool_range (__main__.TestVPNIPsec.test_remote_access_pool_range) ... ok
DEBUG - test_remote_access_vti (__main__.TestVPNIPsec.test_remote_access_vti) ... ok
DEBUG - test_remote_access_x509 (__main__.TestVPNIPsec.test_remote_access_x509) ... ok
DEBUG - test_retransmission_default_settings (__main__.TestVPNIPsec.test_retransmission_default_settings) ... ok
DEBUG - test_retransmission_settings (__main__.TestVPNIPsec.test_retransmission_settings) ... ok
DEBUG - test_site_to_site (__main__.TestVPNIPsec.test_site_to_site) ... ok
DEBUG - test_site_to_site_ts_protocol_all (__main__.TestVPNIPsec.test_site_to_site_ts_protocol_all)
DEBUG - Test acceptance of 'all' protocol in site-to-site traffic selector. ... ok
DEBUG - test_site_to_site_vti (__main__.TestVPNIPsec.test_site_to_site_vti) ... ok
DEBUG - test_site_to_site_vti_ts_afi (__main__.TestVPNIPsec.test_site_to_site_vti_ts_afi) ... ok
DEBUG - test_site_to_site_with_default_ts (__main__.TestVPNIPsec.test_site_to_site_with_default_ts)
DEBUG - Test 'site to site' with default value of local and remote Traffic Selection ... ok
DEBUG - test_site_to_site_x509 (__main__.TestVPNIPsec.test_site_to_site_x509) ... ok
```

```
root@c6392b5716ee:/vyos/vyos-build# make test MATCH="l2tp"

DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_vpn_l2tp.py
DEBUG - test_accel_ipv4_pool (__main__.TestVPNL2TPServer.test_accel_ipv4_pool) ... ok
DEBUG - test_accel_ipv6_pool (__main__.TestVPNL2TPServer.test_accel_ipv6_pool) ... ok
DEBUG - test_accel_limits (__main__.TestVPNL2TPServer.test_accel_limits) ... ok
DEBUG - test_accel_local_authentication (__main__.TestVPNL2TPServer.test_accel_local_authentication) ... ok
DEBUG - test_accel_log_level (__main__.TestVPNL2TPServer.test_accel_log_level) ... ok
DEBUG - test_accel_name_servers (__main__.TestVPNL2TPServer.test_accel_name_servers) ... ok
DEBUG - test_accel_next_pool (__main__.TestVPNL2TPServer.test_accel_next_pool) ... ok
DEBUG - test_accel_ppp_options (__main__.TestVPNL2TPServer.test_accel_ppp_options) ... ok
DEBUG - test_accel_radius_authentication (__main__.TestVPNL2TPServer.test_accel_radius_authentication) ... ok
DEBUG - test_accel_shaper (__main__.TestVPNL2TPServer.test_accel_shaper) ... ok
DEBUG - test_accel_snmp (__main__.TestVPNL2TPServer.test_accel_snmp) ... ok
DEBUG - test_accel_wins_server (__main__.TestVPNL2TPServer.test_accel_wins_server) ... ok
DEBUG - test_l2tp_radius_server (__main__.TestVPNL2TPServer.test_l2tp_radius_server) ... ok
DEBUG - test_l2tp_server_authentication_protocols (__main__.TestVPNL2TPServer.test_l2tp_server_authentication_protocols) ... ok
DEBUG - test_vpn_l2tp_dependence_ipsec_swanctl (__main__.TestVPNL2TPServer.test_vpn_l2tp_dependence_ipsec_swanctl) ... ok
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
