### PR TITLE
serial: T7484: treat unavailable serial console devices as non-fatal

### DIFF
--- a/python/vyos/utils/serial.py
+++ b/python/vyos/utils/serial.py
@@ -116,3 +116,16 @@ def restart_login_consoles(prompt_user=False, quiet=True, devices: List[str]=[])
             cmd(f'systemctl stop {unit_name}')
 
     return True
+
+def is_tty(name: str) -> bool:
+    """ Check if a given device file (e.g. /dev/ttyS0) is a TTY (teletypewriter)
+    device in Linux
+    """
+    import os
+    path_tty = f'/dev/{name}'
+    if os.path.exists(path_tty):
+        with open(path_tty, 'rb') as f:
+            fd = f.fileno()
+            # True if filename is a TTY
+            return os.isatty(fd)
+    return False

--- a/src/conf_mode/system_console.py
+++ b/src/conf_mode/system_console.py
@@ -17,9 +17,11 @@
 import os
 from pathlib import Path
 
+from vyos.base import Warning
 from vyos.config import Config
 from vyos.utils.process import call
 from vyos.utils.serial import restart_login_consoles
+from vyos.utils.serial import is_tty
 from vyos.system import grub_util
 from vyos.template import render
 from vyos import ConfigError
@@ -66,6 +68,8 @@ def verify(console):
             # and it can not be used as a serial interface
             if not os.path.isdir(by_bus_dir) or not os.path.exists(by_bus_device):
                 raise ConfigError(f'Device {device} does not support beeing used as tty')
+        if not is_tty(device):
+            Warning(f'Device "{device}" used for console is not a TTY!')
 
     return None
 
@@ -98,6 +102,9 @@ def generate(console):
                 raise ConfigError(f'Device {device} does not support beeing used as tty')
 
     for device, device_config in console['device'].items():
+        # Do not render getty configuration if specified device is not a TTY.
+        if not is_tty(device):
+            continue
         config_file = base_dir + f'/serial-getty@{device}.service'
         Path(f'{base_dir}/getty.target.wants').mkdir(exist_ok=True)
         getty_wants_symlink = base_dir + f'/getty.target.wants/serial-getty@{device}.service'

--- a/src/conf_mode/system_console.py
+++ b/src/conf_mode/system_console.py
@@ -119,8 +119,6 @@ def generate(console):
 def apply(console):
     # Reset screen blanking
     call('/usr/bin/setterm -blank 0 -powersave off -powerdown 0 -term linux </dev/tty1 >/dev/tty1 2>&1')
-    # Reload systemd manager configuration
-    call('systemctl daemon-reload')
 
     # Service control moved to vyos.utils.serial to unify checks and prompts. 
     # If users are connected, we want to show an informational message on completing 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Instead of failing or starting agetty on an invalid device, we now check whether the specified serial console device is a valid TTY. If it's not, we display a warning to the user and skip starting the agetty process.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7484

## How to test / Smoketest result

```
vyos@vyos# set system console device ttyS0
[edit]
vyos@vyos# commit
[ system console ]

WARNING: "ttyS0" is not a TTY device and cannot be used as console!
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
