### PR TITLE
op-mode: T7403: fix image deletion when a single image ID is provided

### DIFF
--- a/src/op_mode/container.py
+++ b/src/op_mode/container.py
@@ -76,6 +76,9 @@ def delete_image(name: str, force: typing.Optional[bool] = False):
         name = name.replace('\n', ' ')
         # convert to list
         name = name.split()
+    else:
+        # convert str -> list for further processing down the line
+        name = [name]
 
     for image in name:
         # convert the truncated image ID to a full image ID


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Commit a99ca6d11 ("op-mode: T7403: add option for forcefully removing a container image") did not account for the case where a single image ID is passed as a string. This led to incorrect behavior during iteration.

Without converting the string to a list, the code iterates over individual characters of the image ID rather than treating it as a single item. As a result, the system attempts to delete non-existent container images based on these characters.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7403

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4590

## How to test / Smoketest result

```
vyos@vyos:~$ show container image
REPOSITORY                        TAG         IMAGE ID      CREATED      SIZE
docker.io/lfkeitel/tacacs_plus    alpine      6950ba3bd449  3 years ago  51.5 MB
docker.io/dchidell/docker-tacacs  latest      84f7fe4db64b  4 years ago  51.5 MB
docker.io/dchidell/radius-web     latest      b613aa60659b  5 years ago  28.5 MB
```

```
vyos@vyos:~$ delete container image 6950ba3bd449
vyos@vyos:~$ show container image
REPOSITORY                        TAG         IMAGE ID      CREATED      SIZE
docker.io/dchidell/docker-tacacs  latest      84f7fe4db64b  4 years ago  51.5 MB
docker.io/dchidell/radius-web     latest      b613aa60659b  5 years ago  28.5 MB
```



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
