### PR TITLE
T7685: load-balancing: fix rules with multiple ports

### DIFF
--- a/python/vyos/wanloadbalance.py
+++ b/python/vyos/wanloadbalance.py
@@ -65,7 +65,7 @@ def nft_rule(rule_conf, rule_id, local=False, exclude=False, limit=False, weight
             if port[:1] == '!':
                 operator = '!='
                 port = port[1:]
-            output.append(f'th {prefix}port {operator} {port}')
+            output.append(f'th {prefix}port {operator} {{ {port} }}')
 
     if 'source_based_routing' not in rule_conf and not restore_mark:
         output.append('ct state new')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
If we use several ports for WLB rules, there have to be curly braces used for the  `nftables` config.

Incorrect format: `dport  500,4500`
Correct format: `dport { 500, 4500 }`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7685

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_load-balancing_wan.py
DEBUG - test_check_chains (__main__.TestLoadBalancingWan.test_check_chains) ... ok
DEBUG - test_criteria_failover_hook (__main__.TestLoadBalancingWan.test_criteria_failover_hook) ... ok
DEBUG - test_table_routes (__main__.TestLoadBalancingWan.test_table_routes) ... ok
DEBUG - 
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 3 tests in 44.586s
DEBUG - 
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
