### PR TITLE
vxlan: T7468: add VLAN-to-VNI mapping description

### DIFF
--- a/interface-definitions/interfaces_vxlan.xml.in
+++ b/interface-definitions/interfaces_vxlan.xml.in
@@ -128,6 +128,7 @@
               <constraintErrorMessage>Not a valid VLAN ID or range, VLAN ID must be between 0 and 4094</constraintErrorMessage>
             </properties>
             <children>
+              #include <include/generic-description.xml.i>
               <leafNode name="vni">
                 <properties>
                   <help>Virtual Network Identifier</help>

--- a/src/conf_mode/interfaces_vxlan.py
+++ b/src/conf_mode/interfaces_vxlan.py
@@ -66,7 +66,8 @@ def get_config(config=None):
         vxlan.update({'vlan_to_vni_removed': {}})
         for vlan in tmp:
             vni = leaf_node_changed(conf, base + [ifname, 'vlan-to-vni', vlan, 'vni'])
-            vxlan['vlan_to_vni_removed'].update({vlan : {'vni' : vni[0]}})
+            if vni:
+                vxlan['vlan_to_vni_removed'].update({vlan : {'vni' : vni[0]}})
 
     # We need to verify that no other VXLAN tunnel is configured when external
     # mode is in use - Linux Kernel limitation


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add descriptions per VLAN-to-VNI mapping on VxLAN interfaces

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7468
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Configure a description for the mappings:
```
set interfaces vxlan vxlan1 parameters external
set interfaces vxlan vxlan1 port '4789'
set interfaces vxlan vxlan1 source-address 10.5.5.5
set interfaces vxlan vxlan1 vlan-to-vni 10 vni '1001'
set interfaces vxlan vxlan1 vlan-to-vni 10 description "Cust-A"
set interfaces vxlan vxlan1 vlan-to-vni 20 vni '1002'
set interfaces vxlan vxlan1 vlan-to-vni 20 description "Cust-B"
```
Show the config to see the descriptions
```
vyos@PE2# show interfaces vxlan vxlan1 
 parameters {
     external
 }
 port 4789
 source-address 10.5.5.5
 vlan-to-vni 10 {
     description "Cust-A"
     vni 1001
 }
 vlan-to-vni 20 {
     description "Cust-B"
     vni 1002
 }
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
