### PR TITLE
T5811: Move DHCP gateway address lookup to FRR

### DIFF
--- a/data/templates/frr/staticd.frr.j2
+++ b/data/templates/frr/staticd.frr.j2
@@ -51,10 +51,7 @@
 {% endif %}
 {% if prefix_config.dhcp_interface is vyos_defined %}
 {%     for dhcp_interface in prefix_config.dhcp_interface %}
-{%         set next_hop = dhcp_interface | get_dhcp_router %}
-{%         if next_hop is vyos_defined %}
-{{ ip_ipv6 }} route {{ prefix }} {{ next_hop }} {{ dhcp_interface }} {{ 'table ' ~ table if table is vyos_defined }}
-{%         endif %}
+{{ ip_ipv6 }} route {{ prefix }} dhcp-gateway {{ dhcp_interface }} {{ 'table ' ~ table if table is vyos_defined }}
 {%     endfor %}
 {% endif %}
 {% if prefix_config.blackhole is vyos_defined %}
@@ -84,10 +81,7 @@ vrf {{ vrf }}
 {# IPv4 default routes from DHCP interfaces #}
 {% if dhcp is vyos_defined %}
 {%     for interface, interface_config in dhcp.items() if interface_config.dhcp_options.no_default_route is not vyos_defined %}
-{%         set next_hop = interface | get_dhcp_router %}
-{%         if next_hop is vyos_defined %}
-{{ ip_prefix }} route 0.0.0.0/0 {{ next_hop }} {{ interface }} tag 210 {{ interface_config.dhcp_options.default_route_distance if interface_config.dhcp_options.default_route_distance is vyos_defined }}
-{%         endif %}
+{{ ip_prefix }} route 0.0.0.0/0 dhcp-gateway {{ interface }} tag 210 {{ interface_config.dhcp_options.default_route_distance if interface_config.dhcp_options.default_route_distance is vyos_defined }}
 {%     endfor %}
 {% endif %}
 {# IPv4 default routes from PPPoE interfaces #}

--- a/src/etc/dhcp/dhclient-exit-hooks.d/04-frr-dhcp-gateway-hook
+++ b/src/etc/dhcp/dhclient-exit-hooks.d/04-frr-dhcp-gateway-hook
@@ -1,0 +1,13 @@
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0-or-later
+#
+# DHCP gateway related functions
+# Copyright (C) 2025 VyOS Inc.
+# Kyrylo Yatsenko
+
+# Try to inform FRR of any events that can change ip or DHCP state
+case "${reason}" in
+    BOUND|RENEW|REBIND|REBOOT|EXPIRE|FAIL|STOP|RELEASE)
+        vtysh -c 'static-route-dhcp-gateway update'
+        ;;
+esac


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary

Fixes various problems with routes via dhcp gateway by moving responsibility to FRR.

First PR to vyos-build must be merged: https://github.com/vyos/vyos-build/pull/1004

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T3680
* https://vyos.dev/T5811

## Related PR(s)

https://github.com/vyos/vyos-build/pull/1004

## How to test / Smoketest result

Create topology of  VyOS DHCP client and VyOS DHCP server.
Add static route for client:

```
set protocols static route 10.1.2.0/24 dhcp-interface 'eth0'
```

Stop link between client-server, reboot client. Wait a little. Start link between client-server.
Before fix no route is added. After fix route is added.

## Checklist:

- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
