### PR TITLE
T7366: Firewall rules allow empty nodes

### DIFF
--- a/interface-definitions/include/version/firewall-version.xml.i
+++ b/interface-definitions/include/version/firewall-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/firewall-version.xml.i -->
-<syntaxVersion component='firewall' version='19'></syntaxVersion>
+<syntaxVersion component='firewall' version='20'></syntaxVersion>
 <!-- include end -->

--- a/smoketest/config-tests/firewall-empty-nodes
+++ b/smoketest/config-tests/firewall-empty-nodes
@@ -1,0 +1,31 @@
+set firewall bridge forward filter rule 1 action 'accept'
+set firewall ipv4 forward filter rule 1 action 'accept'
+set firewall ipv4 forward filter rule 2 action 'accept'
+set firewall ipv4 forward filter rule 3 action 'accept'
+set firewall ipv4 forward filter rule 5 action 'accept'
+set firewall ipv4 forward filter rule 6 action 'accept'
+set firewall ipv4 forward filter rule 7 action 'accept'
+set firewall ipv4 forward filter rule 8 action 'accept'
+set firewall ipv4 forward filter rule 9 action 'accept'
+set firewall ipv4 forward filter rule 10 action 'accept'
+set firewall ipv4 forward filter rule 10 log
+set firewall ipv4 forward filter rule 11 action 'accept'
+set firewall ipv4 forward filter rule 13 action 'accept'
+set firewall ipv4 forward filter rule 14 action 'accept'
+set firewall ipv4 forward filter rule 15 action 'accept'
+set firewall ipv4 forward filter rule 16 action 'accept'
+set firewall ipv4 forward filter rule 17 action 'accept'
+set firewall ipv4 forward filter rule 18 action 'accept'
+set firewall ipv4 forward filter rule 19 action 'accept'
+set firewall ipv4 forward filter rule 20 action 'accept'
+set firewall ipv4 forward filter rule 21 action 'accept'
+set firewall ipv6 forward filter rule 1 action 'accept'
+set firewall ipv6 forward filter rule 2 action 'accept'
+set interfaces ethernet eth0
+set interfaces ethernet eth1
+set interfaces ethernet eth2
+set interfaces loopback lo
+set system console device ttyS0 speed '115200'
+set system host-name 'vyos'
+set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'
+set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/firewall-empty-nodes
+++ b/smoketest/configs/firewall-empty-nodes
@@ -1,0 +1,149 @@
+firewall {
+    bridge {
+        forward {
+            filter {
+                rule 1 {
+                    action "accept"
+                    vlan
+                }
+            }
+        }
+    }
+    ipv4 {
+        forward {
+            filter {
+                rule 1 {
+                    action "accept"
+                    add-address-to-group
+                }
+                rule 2 {
+                    action "accept"
+                    connection-status
+                }
+                rule 3 {
+                    action "accept"
+                    destination
+                }
+                rule 5 {
+                    action "accept"
+                    fragment
+                }
+                rule 6 {
+                    action "accept"
+                    icmp
+                }
+                rule 7 {
+                    action "accept"
+                    inbound-interface
+                }
+                rule 8 {
+                    action "accept"
+                    ipsec
+                }
+                rule 9 {
+                    action "accept"
+                    limit
+                }
+                rule 10 {
+                    action "accept"
+                    log
+                    log-options
+                }
+                rule 11 {
+                    action "accept"
+                    outbound-interface
+                }
+                rule 13 {
+                    action "accept"
+                    source
+                }
+                rule 14 {
+                    action "accept"
+                    tcp
+                }
+                rule 15 {
+                    action "accept"
+                    time
+                }
+                rule 16 {
+                    action "accept"
+                    ttl
+                }
+                rule 17 {
+                    action "accept"
+                    destination {
+                        group
+                    }
+                }
+                rule 18 {
+                    action "accept"
+                    destination {
+                        geoip
+                    }
+                }
+                rule 19 {
+                    action "accept"
+                    source {
+                        group
+                    }
+                }
+                rule 20 {
+                    action "accept"
+                    source {
+                        geoip
+                    }
+                }
+                rule 21 {
+                    action "accept"
+                    tcp {
+                        flags
+                    }
+                }
+            }
+        }
+    }
+    ipv6 {
+        forward {
+            filter {
+                rule 1 {
+                    action "accept"
+                    hop-limit
+                }
+                rule 2 {
+                    action "accept"
+                    icmpv6
+                }
+            }
+        }
+    }
+}
+interfaces {
+    ethernet eth0 {
+    }
+    ethernet eth1 {
+    }
+    ethernet eth2 {
+    }
+    loopback lo {
+    }
+}
+system {
+    console {
+        device ttyS0 {
+            speed "115200"
+        }
+    }
+    host-name "vyos"
+    login {
+        user vyos {
+            authentication {
+                encrypted-password "$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0"
+                plaintext-password ""
+            }
+        }
+    }
+}
+
+// Warning: Do not remove the following line.
+// vyos-config-version: "bgp@6:broadcast-relay@1:cluster@2:config-management@1:conntrack@6:conntrack-sync@2:container@2:dhcp-relay@2:dhcp-server@8:dhcpv6-server@1:dns-dynamic@4:dns-forwarding@4:firewall@15:flow-accounting@1:https@6:ids@1:interfaces@32:ipoe-server@3:ipsec@13:isis@3:l2tp@9:lldp@2:mdns@1:monitoring@1:nat@8:nat66@3:ntp@3:openconnect@3:ospf@2:pim@1:policy@8:pppoe-server@10:pptp@5:qos@2:quagga@11:reverse-proxy@1:rip@1:rpki@2:salt@1:snmp@3:ssh@2:sstp@6:system@27:vrf@3:vrrp@4:vyos-accel-ppp@2:wanloadbalance@3:webproxy@2"
+// Release version: 1.4.3

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -196,6 +196,42 @@ def verify_jump_target(firewall, hook, jump_target, family, recursive=False):
 
         targets_seen.append(target)
 
+def is_node_empty(rule_conf):
+    is_empty_list = []
+    is_empty_list.append([
+                        ['add_address_to_group'],
+                        ['connection_status'],
+                        ['destination'],
+                        ['destination', 'group'],
+                        ['destination', 'geoip'],
+                        ['fragment'],
+                        ['gre'],
+                        ['gre', 'flags'],
+                        ['hop_limit'],
+                        ['icmp'],
+                        ['icmpv6'],
+                        ['inbound_interface'],
+                        ['ipsec'],
+                        ['limit'],
+                        ['log_options'],
+                        ['outbound_interface'],
+                        ['set'],
+                        ['source'],
+                        ['source', 'group'],
+                        ['source', 'geoip'],
+                        ['tcp'],
+                        ['tcp', 'flags'],
+                        ['time'],
+                        ['ttl'],
+                        ['vlan']
+                        ])
+
+    for node in is_empty_list[0]:
+        if dict_search_args(rule_conf, *node) == {}:
+            return True, node
+
+    return False, None
+
 def verify_rule(firewall, family, hook, priority, rule_id, rule_conf):
     if 'action' not in rule_conf:
         raise ConfigError('Rule action must be defined')
@@ -243,6 +279,11 @@ def verify_rule(firewall, family, hook, priority, rule_id, rule_conf):
     if 'fragment' in rule_conf:
         if {'match_frag', 'match_non_frag'} <= set(rule_conf['fragment']):
             raise ConfigError('Cannot specify both "match-frag" and "match-non-frag"')
+
+    node_empty, node_name = is_node_empty(rule_conf)
+    if node_empty:
+        tmp = ' '.join(node_name).replace('_', '-')
+        raise ConfigError(f'Configuration node {tmp} may not be empty')
 
     if 'limit' in rule_conf:
         if 'rate' in rule_conf['limit']:

--- a/src/migration-scripts/firewall/19-to-20
+++ b/src/migration-scripts/firewall/19-to-20
@@ -1,0 +1,100 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# T7366: Firewall rules allow empty nodes
+# When configuring the firewall, many nodes are accepted with empty values,
+# which are not parsed into rules.
+
+# Very few of these have subsequent error handling. Some should be obvious
+# to the user that a value is required, like 'inbound-interface' (though
+# an error should still be thrown if they're configured without children).
+
+# But some could be misunderstood and lead to an outage or wide open firewall.
+# For instance, let's say someone wanted to block all icmp. They may incorrectly
+# configure:
+
+# set firewall ipv4 input filter rule 10 action drop
+# set firewall ipv4 input filter rule 10 icmp
+
+# And this would create this rule in nftables, dropping all traffic in subsequent rules:
+
+# counter packets 0 bytes 0 drop comment "ipv4-INP-filter-10"
+
+# They could also unintentionally allow all traffic by attempting to only allow icmp in a rule.
+
+import json
+
+from vyos.configtree import ConfigTree
+from vyos.utils.dict import dict_search_args
+
+firewall_base = ['firewall']
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(firewall_base):
+        # Nothing to do
+        return
+
+    firewall_dict = json.loads(config.to_json()).get('firewall')
+
+    is_empty_list = []
+    is_empty_list.append([
+                        ['add-address-to-group'],
+                        ['connection-status'],
+                        ['destination', 'group'],
+                        ['destination', 'geoip'],
+                        ['destination'],
+                        ['fragment'],
+                        ['gre', 'flags'],
+                        ['gre'],
+                        ['hop-limit'],
+                        ['icmp'],
+                        ['icmpv6'],
+                        ['inbound-interface'],
+                        ['ipsec'],
+                        ['limit'],
+                        ['log-options'],
+                        ['outbound-interface'],
+                        ['set'],
+                        ['source', 'group'],
+                        ['source', 'geoip'],
+                        ['source'],
+                        ['tcp', 'flags'],
+                        ['tcp'],
+                        ['time'],
+                        ['ttl'],
+                        ['vlan']
+                        ])
+
+    for family in ['ipv4', 'ipv6', 'bridge']:
+        if family in firewall_dict:
+            for chain in ['name','forward','input','output', 'prerouting']:
+                if chain in firewall_dict[family]:
+                    for priority, priority_conf in firewall_dict[family][chain].items():
+                        if 'rule' in priority_conf:
+                            for rule_id, rule_conf in priority_conf['rule'].items():
+                                node_deleted_list = []
+                                for node in is_empty_list[0]:
+                                    if dict_search_args(rule_conf, *node) == {}:
+                                        if len(node) == 1:
+                                            if node not in node_deleted_list:
+                                                config.delete(firewall_base + [family, chain, priority, 'rule', rule_id, node[0]])
+                                        else:
+                                            del firewall_dict[family][chain][priority]['rule'][rule_id][node[0]][node[1]]
+
+                                            if dict_search_args(rule_conf, node[0]) == {}:
+                                                config.delete(firewall_base + [family, chain, priority, 'rule', rule_id, node[0]])
+                                                node_deleted_list.append([node[0]])
+                                            else:
+                                                config.delete(firewall_base + [family, chain, priority, 'rule', rule_id, node[0], node[1]])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
When configuring the firewall, many nodes are accepted with empty values, which are not parsed into rules. Here is an example of commands that are allowed:
```
set firewall ipv4 forward filter rule 10 add-address-to-group
set firewall ipv4 forward filter rule 10 connection-status
set firewall ipv4 forward filter rule 10 destination
set firewall ipv4 forward filter rule 10 fragment
set firewall ipv4 forward filter rule 10 gre
set firewall ipv4 forward filter rule 10 icmp
set firewall ipv4 forward filter rule 10 ipsec
set firewall ipv4 forward filter rule 10 limit
set firewall ipv4 forward filter rule 10 log-options
set firewall ipv4 forward filter rule 10 outbound-interface
set firewall ipv4 forward filter rule 10 recent
set firewall ipv4 forward filter rule 10 set
set firewall ipv4 forward filter rule 10 source
set firewall ipv4 forward filter rule 10 tcp
set firewall ipv4 forward filter rule 10 time
set firewall ipv4 forward filter rule 10 ttl
```
Very few of these have subsequent error handling. Some should be obvious to the user that a value is required, like these (though an error should still be thrown if they're configured without children).:
```
set firewall ipv4 forward filter rule 10 destination
set firewall ipv4 forward filter rule 10 inbound-interface
set firewall ipv4 forward filter rule 10 outbound-interface
set firewall ipv4 forward filter rule 10 set
set firewall ipv4 forward filter rule 10 source
```
But some could be misunderstood and lead to an outage or wide open firewall. For instance, let's say someone wanted to block all icmp. They may incorrectly configure:
```
set firewall ipv4 input filter rule 10 action drop
set firewall ipv4 input filter rule 10 icmp
```
And this would create this rule in nftables, dropping all traffic in subsequent rules:
```
counter packets 0 bytes 0 drop comment "ipv4-INP-filter-10"
```
They could also unintentionally allow all traffic by attempting to only allow icmp in a rule.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7366
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Attempt to configure an empty node:
```
set firewall ipv4 input filter rule 10 action 'accept'
set firewall ipv4 input filter rule 10 tcp
```
You should receive a ConfigError:
```
vyos@vyos# commit
[ firewall ]
Configuration node "tcp" may not be empty
[[firewall]] failed
Commit failed
```
### Smoketest results:
```
test_bridge_firewall (__main__.TestFirewall.test_bridge_firewall) ... ok
test_cyclic_jump_validation (__main__.TestFirewall.test_cyclic_jump_validation) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
test_geoip (__main__.TestFirewall.test_geoip) ... ok
test_gre_match (__main__.TestFirewall.test_gre_match) ... ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipsec_metadata_match (__main__.TestFirewall.test_ipsec_metadata_match) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_dynamic_groups (__main__.TestFirewall.test_ipv4_dynamic_groups) ... ok
test_ipv4_global_state (__main__.TestFirewall.test_ipv4_global_state) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_remote_group (__main__.TestFirewall.test_ipv4_remote_group) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_dynamic_groups (__main__.TestFirewall.test_ipv6_dynamic_groups) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_ipv6_remote_group (__main__.TestFirewall.test_ipv6_remote_group) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
test_remote_group (__main__.TestFirewall.test_remote_group) ... ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_timeout_sysctl (__main__.TestFirewall.test_timeout_sysctl) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... ok
test_zone_with_vrf (__main__.TestFirewall.test_zone_with_vrf) ... ok

----------------------------------------------------------------------
Ran 28 tests in 580.603s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
