### PR TITLE
T7687: Add op-mode for VLAN-to-VNI mapping

### DIFF
--- a/op-mode-definitions/show-interfaces-vxlan.xml.in
+++ b/op-mode-definitions/show-interfaces-vxlan.xml.in
@@ -31,6 +31,37 @@
                     </properties>
                     <command>${vyos_op_scripts_dir}/interfaces.py show_summary --intf-name="$4" --intf-type=vxlan</command>
                   </leafNode>
+                  <node name="vlan-to-vni">
+                    <properties>
+                      <help>Show VLAN to VNI mapping for the specified VXLAN interface</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_vlan_to_vni --intf-name="$4"</command>
+                    <children>
+                      <tagNode name="vlan">
+                        <properties>
+                          <help>Show VLAN to VNI mapping for the specified VLAN</help>
+                          <completionHelp>
+                            <path>interfaces vxlan ${COMP_WORDS[3]} vlan-to-vni</path>
+                          </completionHelp>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/interfaces.py show_vlan_to_vni --intf-name="$4" --vid="$7"</command>
+                        <children>
+                          <leafNode name="detail">
+                            <properties>
+                              <help>Show detailed VLAN to VNI mapping for the specified VLAN</help>
+                            </properties>
+                            <command>${vyos_op_scripts_dir}/interfaces.py show_vlan_to_vni --intf-name="$4" --vid="$7" --detail</command>
+                          </leafNode>
+                        </children>
+                      </tagNode>
+                      <leafNode name="detail">
+                        <properties>
+                          <help>Show detailed VLAN to VNI mapping for the specified VXLAN interface</help>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/interfaces.py show_vlan_to_vni --intf-name="$4" --detail</command>
+                      </leafNode>
+                    </children>
+                  </node>
                   #include <include/show-interface-type-event-log.xml.i>
                 </children>
               </virtualTagNode>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
This adds the following commands:
```
show interfaces vxlan <interface> vlan-to-vni
show interfaces vxlan <interface> vlan-to-vni detail
show interfaces vxlan <interface> vlan-to-vni vlan <vlan-id>
show interfaces vxlan <interface> vlan-to-vni vlan <vlan-id> detail
```
```
vyos@PE2:~$ show interfaces vxlan vxlan1 vlan-to-vni
Interface      VLAN    VNI  Description
-----------  ------  -----  -------------
vxlan1           10   1010  Customer-A
vxlan1           20   1020  Customer-B
```
```
vyos@PE2:~$ show interfaces vxlan vxlan1 vlan-to-vni vlan 10 detail
-----------------------------------
Interface: vxlan1

 VLAN        | 10
 VNI         | 1010
 Description | Customer-A
 Rx Bytes    | 0
 Tx Bytes    | 0
 Rx Packets  | 0
 Tx Packets  | 0

```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7687
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Configure a vxlan interface with vlan-to-vni mappings:
```
set interfaces bridge br0 member interface vxlan1
set interfaces vxlan vxlan1 parameters external
set interfaces vxlan vxlan1 port '4789'
set interfaces vxlan vxlan1 source-address '10.5.5.5'
set interfaces vxlan vxlan1 vlan-to-vni 10 description 'Customer-A'
set interfaces vxlan vxlan1 vlan-to-vni 10 vni '1010'
set interfaces vxlan vxlan1 vlan-to-vni 20 description 'Customer-B'
set interfaces vxlan vxlan1 vlan-to-vni 20 vni '1020'
```
Run the new op-mode command:
```
vyos@PE2:~$ show interfaces vxlan vxlan1 vlan-to-vni
Interface      VLAN    VNI  Description
-----------  ------  -----  -------------
vxlan1           10   1010  Customer-A
vxlan1           20   1020  Customer-B
```
```
vyos@PE2:~$ show interfaces vxlan vxlan1 vlan-to-vni detail
-----------------------------------
Interface: vxlan1

 VLAN        | 10
 VNI         | 1010
 Description | Customer-A
 Rx Bytes    | 0
 Tx Bytes    | 0
 Rx Packets  | 0
 Tx Packets  | 0

 VLAN        | 20
 VNI         | 1020
 Description | Customer-B
 Rx Bytes    | 0
 Tx Bytes    | 0
 Rx Packets  | 0
 Tx Packets  | 0
```
>Note: The ability to configure a per vlan-to-vni description is dependent on https://github.com/vyos/vyos-1x/pull/4645, but this PR itself is not dependent on that PR. It can be merged independently.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
