### PR TITLE
T7699: Fix update of command/help fields in the op_mode_cache generator when paths are shared across files

### DIFF
--- a/python/vyos/xml_ref/generate_op_cache.py
+++ b/python/vyos/xml_ref/generate_op_cache.py
@@ -93,7 +93,7 @@ def translate_command(s: str, pos: list[str]) -> str:
     # it means the command is incorrect,
     # e.g., it references "$6" when it only has five words.
     if re.search(r'_place_holder_', s):
-        print(f"Command translation failed: {s}")
+        print(f'Command translation failed: {s}')
         sys.exit(1)
 
     return s
@@ -155,7 +155,9 @@ def insert_node(
     else:
         name = n.get('name')
         if not name:
-            raise ValueError("Node name is required for all node types except <virtualTagNode>")
+            raise ValueError(
+                'Node name is required for all node types except <virtualTagNode>'
+            )
 
     if path is None:
         path = []

--- a/python/vyos/xml_ref/generate_op_cache.py
+++ b/python/vyos/xml_ref/generate_op_cache.py
@@ -223,22 +223,41 @@ def insert_node(
     new_node_data.standalone_help_text = standalone_help_text
     new_node_data.standalone_command = standalone_command
     new_node_data.path = path
+    new_node_data.files = [file]
 
     value = {('__node_data', None): new_node_data}
     key = (name, node_type)
 
     cur_value = d.setdefault(key, value)
-    # track the correct pointer reference:
-    cur_node_data = cur_value[('__node_data', None)]
-    cur_node_data.files.append(file)
-
-    if parent and key not in parent.children:
-        parent.children.append(key)
 
     if CHECK_XML_CONSISTENCY:
         out = node_data_difference(get_node_data(cur_value), get_node_data(value))
         if out:
             err_buf.write(out)
+
+    # track the correct pointer reference:
+    cur_node_data = cur_value[('__node_data', None)]
+
+    if file not in cur_node_data.files:
+        cur_node_data.files.append(file)
+
+    if not cur_node_data.comp_help and comp_help:
+        cur_node_data.comp_help = comp_help
+
+    if not cur_node_data.help_text and help_text:
+        cur_node_data.help_text = help_text
+
+    if not cur_node_data.command and command_text:
+        cur_node_data.command = command_text
+
+    if not cur_node_data.standalone_help_text and standalone_help_text:
+        cur_node_data.standalone_help_text = standalone_help_text
+
+    if not cur_node_data.standalone_command and standalone_command:
+        cur_node_data.standalone_command = standalone_command
+
+    if parent and key not in parent.children:
+        parent.children.append(key)
 
     if children is not None:
         inner_nodes = children.iterfind('*')

--- a/python/vyos/xml_ref/op_definition.py
+++ b/python/vyos/xml_ref/op_definition.py
@@ -126,13 +126,13 @@ def get_node_data_at_path(d: dict, tpath):
 def node_data_difference(a: NodeData, b: NodeData):
     out = ''
     for fld in fields(NodeData):
-        if fld.name in ('children', 'file'):
+        if fld.name in ('children', 'files'):
             continue
         a_fld = getattr(a, fld.name)
         b_fld = getattr(b, fld.name)
         if a_fld != b_fld:
-            out += f'prev: {a.file} {a.path} {fld.name}: {a_fld}\n'
-            out += f'new:  {b.file} {b.path} {fld.name}: {b_fld}\n'
+            out += f'prev: {a.files[-1:]} {a.path} {fld.name}: {a_fld}\n'
+            out += f'new:  {b.files[-1:]} {b.path} {fld.name}: {b_fld}\n'
             out += '\n'
 
     return out


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

An addendum to
https://github.com/vyos/vyos-1x/pull/4636
this will be needed for correct behavior of the op-mode-runner on paths shared across files, for example:

Before:

```
vyos@vyos:~$ /usr/bin/vyos-op-run show interfaces 
Incomplete command: show interfaces

```

After the bug fix herein:

```
vyos@vyos:~$ /usr/bin/vyos-op-run show interfaces
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address          MAC                VRF        MTU  S/L    Description
-----------  ------------------  -----------------  -------  -----  -----  -------------
eth0         192.168.122.218/24  52:54:00:df:6e:8c  default   1500  u/u
eth1         -                   52:54:00:22:5a:62  default   1500  u/u
eth2         -                   52:54:00:c7:9e:eb  default   1500  u/u
eth3         -                   52:54:00:15:2b:df  default   1500  u/u
lo           127.0.0.1/8         00:00:00:00:00:00  default  65536  u/u
             ::1/128
```


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
