### PR TITLE
dhcp-server: T3936: Added support for DHCP Option 82

### DIFF
--- a/data/templates/dhcp-server/kea-dhcp4.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp4.conf.j2
@@ -23,6 +23,9 @@
             "persist": true,
             "name": "{{ lease_file }}"
         },
+{% if client_class is vyos_defined %}
+        "client-classes": {{ client_class | kea_client_class_json }},
+{% endif %}
         "option-def": [
             {
                 "name": "wpad-url",

--- a/interface-definitions/service_dhcp-server.xml.in
+++ b/interface-definitions/service_dhcp-server.xml.in
@@ -9,6 +9,35 @@
           <priority>911</priority>
         </properties>
         <children>
+          <tagNode name="client-class">
+            <properties>
+              <help>Client class name</help>
+              <constraint>
+                #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+              </constraint>
+              <constraintErrorMessage>Shared network name may only contain letters, numbers and, dots, underscores, and hyphens</constraintErrorMessage>
+            </properties>
+            <children>
+              #include <include/generic-disable-node.xml.i>
+              <node name="option82">
+                <properties>
+                  <help>Match DHCP option 82 (relay agent information)</help>
+                </properties>
+                <children>
+                <leafNode name="circuit-id">
+                    <properties>
+                      <help>Filters on the contents of the circuit-id sub option. Assumes ASCII text unless input starts with 0x in which case it is interpreted as raw hex</help>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="remote-id">
+                    <properties>
+                      <help>Filters on the contents of the remote-id sub option. Assumes ASCII text unless input starts with 0x in which case it is interpreted as raw hex</help>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+            </children>
+          </tagNode>
           #include <include/generic-disable-node.xml.i>
           <node name="dynamic-dns-update">
             <properties>
@@ -239,6 +268,14 @@
                   #include <include/dhcp/ping-check.xml.i>
                   #include <include/generic-description.xml.i>
                   #include <include/generic-disable-node.xml.i>
+                  <leafNode name="client-class">
+                    <properties>
+                      <help>DHCP client class</help>
+                        <completionHelp>
+                          <path>service dhcp-server client-class</path>
+                        </completionHelp>
+                    </properties>
+                  </leafNode>
                   <node name="dynamic-dns-update">
                     <properties>
                       <help>Dynamically update Domain Name System (RFC4702)</help>
@@ -290,6 +327,14 @@
                     </properties>
                     <children>
                       #include <include/dhcp/option-v4.xml.i>
+                      <leafNode name="client-class">
+                        <properties>
+                          <help>DHCP client class</help>
+                          <completionHelp>
+                            <path>service dhcp-server client-class</path>
+                          </completionHelp>
+                        </properties>
+                      </leafNode>
                       <leafNode name="start">
                         <properties>
                           <help>First IP address for DHCP lease range</help>

--- a/interface-definitions/service_dhcp-server.xml.in
+++ b/interface-definitions/service_dhcp-server.xml.in
@@ -9,6 +9,35 @@
           <priority>911</priority>
         </properties>
         <children>
+          <tagNode name="client-class">
+            <properties>
+              <help>Name of client class</help>
+              <constraint>
+                #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+              </constraint>
+              <constraintErrorMessage>Invalid shared network name. May only contain letters, numbers and .-_</constraintErrorMessage>
+            </properties>
+            <children>
+              #include <include/generic-disable-node.xml.i>
+              <node name="option82">
+                <properties>
+                  <help>Match this class based on the contents of Option 82 of the DHCP request</help>
+                </properties>
+                <children>
+                <leafNode name="circuit-id">
+                    <properties>
+                      <help>Filters on the contents of the circuit-id sub option. Assumes ASCII text unless input starts with 0x in which case it is interpreted as raw hex</help>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="remote-id">
+                    <properties>
+                      <help>Filters on the contents of the remote-id sub option. Assumes ASCII text unless input starts with 0x in which case it is interpreted as raw hex</help>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+            </children>
+          </tagNode>
           #include <include/generic-disable-node.xml.i>
           <node name="dynamic-dns-update">
             <properties>
@@ -239,6 +268,14 @@
                   #include <include/dhcp/ping-check.xml.i>
                   #include <include/generic-description.xml.i>
                   #include <include/generic-disable-node.xml.i>
+                  <leafNode name="client-class">
+                    <properties>
+                      <help>Client class which should match against this range</help>
+                        <completionHelp>
+                          <path>service dhcp-server client-class</path>
+                        </completionHelp>
+                    </properties>
+                  </leafNode>
                   <node name="dynamic-dns-update">
                     <properties>
                       <help>Dynamically update Domain Name System (RFC4702)</help>
@@ -290,6 +327,14 @@
                     </properties>
                     <children>
                       #include <include/dhcp/option-v4.xml.i>
+                      <leafNode name="client-class">
+                        <properties>
+                          <help>Client class which should match against this range</help>
+                          <completionHelp>
+                            <path>service dhcp-server client-class</path>
+                          </completionHelp>
+                        </properties>
+                      </leafNode>
                       <leafNode name="start">
                         <properties>
                           <help>First IP address for DHCP lease range</help>

--- a/interface-definitions/service_dhcp-server.xml.in
+++ b/interface-definitions/service_dhcp-server.xml.in
@@ -26,12 +26,20 @@
                 <children>
                 <leafNode name="circuit-id">
                     <properties>
-                      <help>Filters on the contents of the circuit-id sub option. Assumes ASCII text unless input starts with 0x in which case it is interpreted as raw hex</help>
+                      <help>Filters on the contents of the circuit-id sub option.</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Assumes ASCII text unless input starts with 0x in which case it is interpreted as raw hex</description>
+                      </valueHelp>
                     </properties>
                   </leafNode>
                   <leafNode name="remote-id">
                     <properties>
-                      <help>Filters on the contents of the remote-id sub option. Assumes ASCII text unless input starts with 0x in which case it is interpreted as raw hex</help>
+                      <help>Filters on the contents of the remote-id sub option.</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Assumes ASCII text unless input starts with 0x in which case it is interpreted as raw hex</description>
+                      </valueHelp>
                     </properties>
                   </leafNode>
                 </children>

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -19,7 +19,6 @@ import socket
 
 from datetime import datetime
 from datetime import timezone
-from operator import truediv
 
 from vyos import ConfigError
 from vyos.template import is_ipv6
@@ -361,7 +360,6 @@ def kea6_parse_subnet(subnet, config):
 
     return out
 
-
 def kea_parse_tsig_algo(algo_spec):
     translate = {
         'md5': 'HMAC-MD5',
@@ -375,10 +373,8 @@ def kea_parse_tsig_algo(algo_spec):
         raise ConfigError(f'Unsupported TSIG algorithm: {algo_spec}')
     return translate[algo_spec]
 
-
 def kea_parse_enable_disable(value):
     return True if value == 'enable' else False
-
 
 def kea_parse_ddns_settings(config):
     data = {}
@@ -412,7 +408,6 @@ def kea_parse_ddns_settings(config):
         data['hostname-char-replacement'] = config['hostname_char_replacement']
 
     return data
-
 
 def _ctrl_socket_command(inet, command, args=None):
     path = kea_ctrl_socket.format(inet=inet)
@@ -451,13 +446,13 @@ def kea_get_leases(inet):
 
 
 def kea_add_lease(
-        inet,
-        ip_address,
-        host_name=None,
-        mac_address=None,
-        iaid=None,
-        duid=None,
-        subnet_id=None,
+    inet,
+    ip_address,
+    host_name=None,
+    mac_address=None,
+    iaid=None,
+    duid=None,
+    subnet_id=None,
 ):
     args = {'ip-address': ip_address}
 
@@ -653,10 +648,10 @@ def kea_get_server_leases(config, inet, pools=[], state=[], origin=None) -> list
 
         # Do not add old leases
         if (
-                data_lease['remaining'] != ''
-                and data_lease['pool'] in pools
-                and data_lease['state'] != 'free'
-                and (not state or state == 'all' or data_lease['state'] in state)
+            data_lease['remaining'] != ''
+            and data_lease['pool'] in pools
+            and data_lease['state'] != 'free'
+            and (not state or state == 'all' or data_lease['state'] in state)
         ):
             data.append(data_lease)
 
@@ -672,7 +667,6 @@ def kea_get_server_leases(config, inet, pools=[], state=[], origin=None) -> list
                     data.pop(idx)
 
     return data
-
 
 def kea_build_client_class_test(config):
     conditions = []

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -361,7 +361,6 @@ def kea6_parse_subnet(subnet, config):
 
     return out
 
-
 def kea_parse_tsig_algo(algo_spec):
     translate = {
         'md5': 'HMAC-MD5',
@@ -451,13 +450,13 @@ def kea_get_leases(inet):
 
 
 def kea_add_lease(
-        inet,
-        ip_address,
-        host_name=None,
-        mac_address=None,
-        iaid=None,
-        duid=None,
-        subnet_id=None,
+    inet,
+    ip_address,
+    host_name=None,
+    mac_address=None,
+    iaid=None,
+    duid=None,
+    subnet_id=None,
 ):
     args = {'ip-address': ip_address}
 
@@ -653,10 +652,10 @@ def kea_get_server_leases(config, inet, pools=[], state=[], origin=None) -> list
 
         # Do not add old leases
         if (
-                data_lease['remaining'] != ''
-                and data_lease['pool'] in pools
-                and data_lease['state'] != 'free'
-                and (not state or state == 'all' or data_lease['state'] in state)
+            data_lease['remaining'] != ''
+            and data_lease['pool'] in pools
+            and data_lease['state'] != 'free'
+            and (not state or state == 'all' or data_lease['state'] in state)
         ):
             data.append(data_lease)
 

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -19,6 +19,7 @@ import socket
 
 from datetime import datetime
 from datetime import timezone
+from operator import truediv
 
 from vyos import ConfigError
 from vyos.template import is_ipv6
@@ -169,6 +170,9 @@ def kea_parse_subnet(subnet, config):
     if 'ping_check' in config:
         out['user-context']['enable-ping-check'] = True
 
+    if 'client_class' in config:
+        out['client-class'] = config['client_class']
+
     if 'range' in config:
         pools = []
         for num, range_config in config['range'].items():
@@ -183,6 +187,9 @@ def kea_parse_subnet(subnet, config):
 
                 if 'bootfile_server' in range_config['option']:
                     pool['next-server'] = range_config['option']['bootfile_server']
+
+            if 'client_class' in range_config:
+                pool['client-class'] = range_config['client_class']
 
             pools.append(pool)
         out['pools'] = pools
@@ -354,6 +361,7 @@ def kea6_parse_subnet(subnet, config):
 
     return out
 
+
 def kea_parse_tsig_algo(algo_spec):
     translate = {
         'md5': 'HMAC-MD5',
@@ -367,8 +375,10 @@ def kea_parse_tsig_algo(algo_spec):
         raise ConfigError(f'Unsupported TSIG algorithm: {algo_spec}')
     return translate[algo_spec]
 
+
 def kea_parse_enable_disable(value):
     return True if value == 'enable' else False
+
 
 def kea_parse_ddns_settings(config):
     data = {}
@@ -402,6 +412,7 @@ def kea_parse_ddns_settings(config):
         data['hostname-char-replacement'] = config['hostname_char_replacement']
 
     return data
+
 
 def _ctrl_socket_command(inet, command, args=None):
     path = kea_ctrl_socket.format(inet=inet)
@@ -440,13 +451,13 @@ def kea_get_leases(inet):
 
 
 def kea_add_lease(
-    inet,
-    ip_address,
-    host_name=None,
-    mac_address=None,
-    iaid=None,
-    duid=None,
-    subnet_id=None,
+        inet,
+        ip_address,
+        host_name=None,
+        mac_address=None,
+        iaid=None,
+        duid=None,
+        subnet_id=None,
 ):
     args = {'ip-address': ip_address}
 
@@ -642,10 +653,10 @@ def kea_get_server_leases(config, inet, pools=[], state=[], origin=None) -> list
 
         # Do not add old leases
         if (
-            data_lease['remaining'] != ''
-            and data_lease['pool'] in pools
-            and data_lease['state'] != 'free'
-            and (not state or state == 'all' or data_lease['state'] in state)
+                data_lease['remaining'] != ''
+                and data_lease['pool'] in pools
+                and data_lease['state'] != 'free'
+                and (not state or state == 'all' or data_lease['state'] in state)
         ):
             data.append(data_lease)
 
@@ -661,3 +672,26 @@ def kea_get_server_leases(config, inet, pools=[], state=[], origin=None) -> list
                     data.pop(idx)
 
     return data
+
+
+def kea_build_client_class_test(config):
+    conditions = []
+
+    if "option82" in config:
+        if "circuit_id" in config["option82"]:
+            conditions.append("relay4[1].hex == 0x" + config["option82"]["circuit_id"].encode().hex().lower())
+        if "remote_id" in config["option82"]:
+            conditions.append("relay4[2].hex == 0x" + config["option82"]["remote_id"].encode().hex().lower())
+
+    is_first = True
+
+    test = ""
+    for condition in conditions:
+        if not is_first:
+            test += " and "
+
+        is_first = False
+
+        test += condition
+
+    return test

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -910,6 +910,25 @@ def kea_high_availability_json(config):
 
     return dumps(data)
 
+@register_filter('kea_client_class_json')
+def kea_client_class_json(client_classes):
+    from vyos.kea import kea_build_client_class_test
+    from json import dumps
+    out = []
+
+    for name, config in client_classes.items():
+        if 'disable' in config:
+            continue
+
+        client_class = {
+            'name': name,
+            'test': kea_build_client_class_test(config)
+        }
+
+        out.append(client_class)
+
+    return dumps(out, indent=4)
+
 @register_filter('kea_dynamic_dns_update_main_json')
 def kea_dynamic_dns_update_main_json(config):
     from vyos.kea import kea_parse_ddns_settings

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -113,27 +113,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         range_1_start = inc_ip(subnet, 40)
         range_1_stop = inc_ip(subnet, 50)
 
-        self.cli_set(base_path + ['listen-interface', interface])
-
-        self.cli_set(base_path + ['shared-network-name', shared_net_name, 'ping-check'])
-
-        pool = base_path + ['shared-network-name', shared_net_name, 'subnet', subnet]
-        self.cli_set(pool + ['subnet-id', '1'])
-        self.cli_set(pool + ['ignore-client-id'])
-        self.cli_set(pool + ['ping-check'])
-        # we use the first subnet IP address as default gateway
-        self.cli_set(pool + ['option', 'default-router', router])
-        self.cli_set(pool + ['option', 'name-server', dns_1])
-        self.cli_set(pool + ['option', 'name-server', dns_2])
-        self.cli_set(pool + ['option', 'domain-name', domain_name])
-
-        # check validate() - No DHCP address range or active static-mapping set
-        with self.assertRaises(ConfigSessionError):
-            self.cli_commit()
-        self.cli_set(pool + ['range', '0', 'start', range_0_start])
-        self.cli_set(pool + ['range', '0', 'stop', range_0_stop])
-        self.cli_set(pool + ['range', '1', 'start', range_1_start])
-        self.cli_set(pool + ['range', '1', 'stop', range_1_stop])
+        self.setup_single_pool_range(range_0_start, range_0_stop, range_1_start, range_1_stop, shared_net_name)
 
         # commit changes
         self.cli_commit()
@@ -205,6 +185,84 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
             obj,
             ['Dhcp4', 'shared-networks', 0, 'subnet4', 0, 'pools'],
             {'pool': f'{range_1_start} - {range_1_stop}'},
+        )
+
+        # Check for running process
+        self.verify_service_running()
+
+    def setup_single_pool_range(self, range_0_start, range_0_stop, range_1_start, range_1_stop, shared_net_name):
+        self.cli_set(base_path + ['listen-interface', interface])
+        self.cli_set(base_path + ['shared-network-name', shared_net_name, 'ping-check'])
+
+        pool = base_path + ['shared-network-name', shared_net_name, 'subnet', subnet]
+
+        self.cli_set(pool + ['subnet-id', '1'])
+        self.cli_set(pool + ['ignore-client-id'])
+        self.cli_set(pool + ['ping-check'])
+        # we use the first subnet IP address as default gateway
+        self.cli_set(pool + ['option', 'default-router', router])
+        self.cli_set(pool + ['option', 'name-server', dns_1])
+        self.cli_set(pool + ['option', 'name-server', dns_2])
+        self.cli_set(pool + ['option', 'domain-name', domain_name])
+
+        # check validate() - No DHCP address range or active static-mapping set
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_set(pool + ['range', '0', 'start', range_0_start])
+        self.cli_set(pool + ['range', '0', 'stop', range_0_stop])
+        self.cli_set(pool + ['range', '1', 'start', range_1_start])
+        self.cli_set(pool + ['range', '1', 'stop', range_1_stop])
+
+    def test_dhcp_client_class(self):
+        shared_net_name = 'SMOKE-1'
+
+        range_0_start = inc_ip(subnet, 10)
+        range_0_stop = inc_ip(subnet, 20)
+        range_1_start = inc_ip(subnet, 40)
+        range_1_stop = inc_ip(subnet, 50)
+
+        self.setup_single_pool_range(range_0_start, range_0_stop, range_1_start, range_1_stop, shared_net_name)
+
+        self.cli_set(base_path + ['shared-network-name', shared_net_name, 'subnet', subnet, 'client-class', 'test'])
+
+        # check validate() - Client class referenced that doesn't exist yet
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_delete(base_path + ['shared-network-name', shared_net_name, 'subnet', subnet, 'client-class', 'test'])
+
+        self.cli_set(base_path + ['shared-network-name', shared_net_name, 'subnet', subnet, 'range', '0', 'client-class', 'test'])
+
+        # check validate() - Client class referenced that doesn't exist yet
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_set(base_path + ['shared-network-name', shared_net_name, 'subnet', subnet, 'client-class', 'test'])
+
+        client_class = base_path + ['client-class', 'test']
+        self.cli_set(client_class + ['option82', 'circuit-id', 'foo'])
+        self.cli_set(client_class + ['option82', 'remote-id', 'bar'])
+
+        self.cli_commit()
+
+        config = read_file(KEA4_CONF)
+        obj = loads(config)
+
+        self.verify_config_value(
+            obj, ['Dhcp4', 'client-classes', 0], 'name', 'test'
+        )
+
+        self.verify_config_value(
+            obj, ['Dhcp4', 'client-classes', 0], 'test', 'relay4[1].hex == 0x666f6f and relay4[2].hex == 0x626172'
+        )
+
+        self.verify_config_value(
+            obj, ['Dhcp4', 'shared-networks', 0, 'subnet4', 0], 'client-class', 'test'
+        )
+
+        self.verify_config_value(
+            obj, ['Dhcp4', 'shared-networks', 0, 'subnet4', 0, 'pools', 0], 'client-class', 'test'
         )
 
         # Check for running process

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -231,6 +231,15 @@ def verify(dhcp):
                             f'DHCP static-route "{route}" requires router to be defined!'
                         )
 
+            # If a client class has been specified then it must exist
+            if 'client_class' in subnet_config:
+                client_class = subnet_config['client_class']
+                if 'client_class' not in dhcp:
+                    raise ConfigError(f'Client class "{client_class}" set in subnet "{subnet}" but does not exist')
+
+                if client_class not in dhcp['client_class'].keys():
+                    raise ConfigError(f'Client class "{client_class}" set in subnet "{subnet}" but does not exist')
+
             # Check if DHCP address range is inside configured subnet declaration
             if 'range' in subnet_config:
                 networks = []
@@ -239,6 +248,15 @@ def verify(dhcp):
                         raise ConfigError(
                             f'DHCP range "{range}" start and stop address must be defined!'
                         )
+
+                    # If a client class has been specified then it must exist
+                    if 'client_class' in range_config:
+                        client_class = range_config['client_class']
+                        if 'client_class' not in dhcp:
+                            raise ConfigError(f'Client class "{client_class}" set in range "{range}" but does not exist')
+
+                        if client_class not in dhcp['client_class'].keys():
+                            raise ConfigError(f'Client class "{client_class}" set in range "{range}" but does not exist')
 
                     # Start/Stop address must be inside network
                     for key in ['start', 'stop']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
This commit adds support in both the CLI and the underlying code for DHCP Option 82 to be used to filter/route DHCP address assignments.

The primary use case for this is to support enterprise switches which can "tag" DHCP requests with physical real world information such as which switch first saw the request and which port it originated from (known in this context as remote-id and circuit-id). Once client-classes have been defined they can be assigned to subnets or ranges so that only certain addresses get assigned to specific requests.

There is also a corresponding documentation update which pairs with this code change.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T3936

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-documentation/pull/1666

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
I have tested these changes by adding new smoketests into the pre existing smoketest file. These new tests specifically check the new functionality including verifying that the generated config files are as expected and that the CLI refuses to take an incorrect commit.

I have also done integration testing in our lab which is set up with a switch which injects DHCP Option 82 information into live DHCP requests and these are processed as expected by VyOS.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
