### PR TITLE
T7707: VPP add dependency vpp-crypto-engines required for IPsec

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -338,6 +338,7 @@ Depends:
   libvppinfra,
   python3-vpp-api,
   vpp,
+  vpp-crypto-engines,
   vpp-dev,
   vpp-plugin-core,
   vpp-plugin-dpdk,


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add the dependency `vpp-crypto-engines` (vpp-2506) required for IPsec over VPP. Without this, VPP cannot handle IPsec SAs

```
vpp[1901]: linux-cp/ipsec: ipsec sa add cce6bfeb failure(err: -9) 10.0.0.1 -> 10.0.0.2
vpp[1901]: ipsec_sa_add_and_lock:548: No crypto engine support for sha-256-128
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7707

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
VyOS config:
```
set interfaces ethernet eth0 address '10.0.0.2/30'
set interfaces ethernet eth0 description 'WAN'
set system host-name 'vpp-right'
set system option kernel memory default-hugepage-size '2M'
set system option kernel memory hugepage-size 2M hugepage-count '1800'
set vpn ipsec authentication psk PSK id '10.0.0.1'
set vpn ipsec authentication psk PSK id '10.0.0.2'
set vpn ipsec authentication psk PSK secret '1234567890'
set vpn ipsec esp-group ESP-group lifetime '3600'
set vpn ipsec esp-group ESP-group mode 'tunnel'
set vpn ipsec esp-group ESP-group pfs 'enable'
set vpn ipsec esp-group ESP-group proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-group proposal 1 hash 'sha256'
set vpn ipsec ike-group IKE-group key-exchange 'ikev2'
set vpn ipsec ike-group IKE-group lifetime '28800'
set vpn ipsec ike-group IKE-group proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE-group proposal 1 hash 'sha1'
set vpn ipsec interface 'eth0'
set vpn ipsec site-to-site peer LEFT authentication local-id '10.0.0.2'
set vpn ipsec site-to-site peer LEFT authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer LEFT authentication remote-id '10.0.0.1'
set vpn ipsec site-to-site peer LEFT connection-type 'respond'
set vpn ipsec site-to-site peer LEFT ike-group 'IKE-group'
set vpn ipsec site-to-site peer LEFT local-address '10.0.0.2'
set vpn ipsec site-to-site peer LEFT remote-address '10.0.0.1'
set vpn ipsec site-to-site peer LEFT tunnel 0 esp-group 'ESP-group'
set vpn ipsec site-to-site peer LEFT tunnel 0 local prefix '100.64.2.0/24'
set vpn ipsec site-to-site peer LEFT tunnel 0 remote prefix '100.64.1.0/24'
set vpp settings interface eth0 driver 'dpdk'
set vpp settings interface eth1 driver 'dpdk'
set vpp settings ipsec
set vpp settings unix poll-sleep-usec '120'
```
Without the fix, the log
```
Aug 11 12:10:07 vpp-right charon[5429]: 06[NET] <LEFT|2> sending packet: from 10.0.0.2[4500] to 10.0.0.1[4500] (220 bytes)
Aug 11 12:10:07 vpp-right vpp[1901]: ipsec_sa_add_and_lock:548: No crypto engine support for sha-256-128
Aug 11 12:10:07 vpp-right vpp[1901]: linux-cp/ipsec: ipsec sa add cda99a7b failure(err: -9) 10.0.0.1 -> 10.0.0.2
Aug 11 12:10:07 vpp-right vpp[1901]: ipsec_sa_add_and_lock:548: No crypto engine support for sha-256-128
Aug 11 12:10:07 vpp-right vpp[1901]: linux-cp/ipsec: ipsec sa add cd16e0ec failure(err: -9) 10.0.0.2 -> 10.0.0.1

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
