### PR TITLE
bond: T7571: fix inconsistent MAC address behaviour

### DIFF
--- a/python/vyos/ifconfig/bond.py
+++ b/python/vyos/ifconfig/bond.py
@@ -485,11 +485,25 @@ class BondIf(Interface):
 
             # Add (enslave) interfaces to bond
             value = dict_search('member.interface', config)
+            is_first = True
             for interface in (value or []):
-                # if we've come here we already verified the interface
-                # does not have an addresses configured so just flush
-                # any remaining ones
-                Interface(interface).flush_addrs()
+                # Physical bond member interface instance
+                tmp_if = Interface(interface)
+                # At this point, we've confirmed that the interface has no
+                # configured addresses, so we can safely flush any remaining ones.
+                tmp_if.flush_addrs()
+
+                # T7571: This behavior changed from Linux Kernel 5.4 (used in VyOS 1.3)
+                # to Kernel 6.6 (starting with VyOS 1.4). Previously, the MAC address of
+                # the first member interface in a bond was adopted as the bond's default MAC.
+                # In newer versions, a synthetic MAC address is assigned instead.
+                #
+                # Re-assign first underlay MAC address to the bond
+                if is_first:
+                    self.set_mac(tmp_if.get_mac())
+                    is_first = False
+
+                # Assign underlaying interface to logical bond
                 self.add_port(interface)
 
         # Add system mac address for 802.3ad - default address is all zero


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

After upgrading from VyOS 1.3 to 1.4, there is an inconsistent behavior with MAC address assignment on bonded interfaces. In VyOS 1.3, bond interfaces used a hardware MAC address from one of the member interfaces. In 1.4, a synthetic MAC is used by default - generated by the Linux Kernel.

Oddly, setting mode 802.3ad (which is also the default) temporarily causes the hardware MAC to be used again - until a reboot, after which the synthetic MAC returns.

Deleting the mode config again causes the hardware MAC to be used. This inconsistent behavior has caused issues with MAC-based filtering in networks.

The fix is to retrive the hardware MAC address from the first bond member interface and use set it explicitly for the bond interface.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7571

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

```
cpo@LR1.wue3:~$ TEST_ETH="eth1 eth2" /usr/libexec/vyos/tests/smoke/cli/test_interfaces_bonding.py
test_add_multiple_ip_addresses (__main__.BondingInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.BondingInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.BondingInterfaceTest.test_add_to_invalid_vrf) ... ok
test_bonding_evpn_multihoming (__main__.BondingInterfaceTest.test_bonding_evpn_multihoming) ... ok
test_bonding_hash_policy (__main__.BondingInterfaceTest.test_bonding_hash_policy) ... ok
test_bonding_keep_mac (__main__.BondingInterfaceTest.test_bonding_keep_mac) ... ok
test_bonding_lacp_rate (__main__.BondingInterfaceTest.test_bonding_lacp_rate) ... ok
test_bonding_mii_monitoring_interval (__main__.BondingInterfaceTest.test_bonding_mii_monitoring_interval) ... ok
test_bonding_min_links (__main__.BondingInterfaceTest.test_bonding_min_links) ... ok
test_bonding_multi_use_member (__main__.BondingInterfaceTest.test_bonding_multi_use_member) ... ok
test_bonding_remove_member (__main__.BondingInterfaceTest.test_bonding_remove_member) ... ok
test_bonding_source_bridge_interface (__main__.BondingInterfaceTest.test_bonding_source_bridge_interface) ... ok
test_bonding_source_interface (__main__.BondingInterfaceTest.test_bonding_source_interface) ... ok
test_bonding_system_mac (__main__.BondingInterfaceTest.test_bonding_system_mac) ... ok
test_bonding_uniq_member_description (__main__.BondingInterfaceTest.test_bonding_uniq_member_description) ... ok
test_dhcp_client_options (__main__.BondingInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.BondingInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.BondingInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.BondingInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.BondingInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.BondingInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.BondingInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol (__main__.BondingInterfaceTest.test_eapol) ... ok
test_interface_description (__main__.BondingInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.BondingInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.BondingInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.BondingInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.BondingInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.BondingInterfaceTest.test_ipv6_link_local_address) ... ok
test_move_interface_between_vrf_instances (__main__.BondingInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.BondingInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_span_mirror (__main__.BondingInterfaceTest.test_span_mirror) ... ok
test_vif_8021q_interfaces (__main__.BondingInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.BondingInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.BondingInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.BondingInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.BondingInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.BondingInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 38 tests in 332.409s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
