### PR TITLE
T7716: VPP: Change defaults and add a warning about maximum routes count for current configuration

### DIFF
--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -778,6 +778,7 @@
                 <help>Main heap page size</help>
                 #include <include/unformat_log2_page_size.xml.i>
               </properties>
+              <defaultValue>2M</defaultValue>
             </leafNode>
             <leafNode name="default-hugepage-size">
               <properties>
@@ -905,12 +906,14 @@
                 <help>Size of stats segment</help>
                 #include <include/unformat_memory_size.xml.i>
               </properties>
+              <defaultValue>128M</defaultValue>
             </leafNode>
             <leafNode name="page-size">
               <properties>
                 <help>Stats page size</help>
                 #include <include/unformat_log2_page_size.xml.i>
               </properties>
+              <defaultValue>2M</defaultValue>
             </leafNode>
           </children>
         </node>

--- a/python/vyos/vpp/config_resource_checks/resource_defaults.py
+++ b/python/vyos/vpp/config_resource_checks/resource_defaults.py
@@ -31,7 +31,7 @@ default_resource_map = {
     # Default size of buffers transferred via netlink
     'netlink_rx_buffer_size': 212992,
     # Default amount of memory allocated for VPP stats segment usage
-    'statseg_heap_size': '96M',
+    'statseg_heap_size': '128M',
     # Minimal amount of memory required to start VPP
     'min_memory': '8G',
     # Minimal number of physical CPU cores required to start VPP

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -54,6 +54,7 @@ from vyos.vpp.config_verify import (
     verify_vpp_statseg_size,
     verify_vpp_interfaces_dpdk_num_queues,
     verify_vpp_host_resources,
+    verify_routes_count,
 )
 from vyos.vpp.config_filter import iface_filter_eth
 from vyos.vpp.utils import EthtoolGDrvinfo
@@ -464,6 +465,8 @@ def verify(config):
             raise ConfigError(
                 f'Interface {iface_config["iface_name"]} is an xconnect member and cannot be removed'
             )
+
+    verify_routes_count(config['settings'], workers)
 
 
 def generate(config):


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7716
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set vpp settings interface eth1 driver 'dpdk'
set vpp settings unix poll-sleep-usec '221'

vyos@vyos# commit
[ vpp ]

WARNING: [VPP] The statistics segment (statseg) size is set to 128M
with 0 worker(s). Based on this, the maximum recommended number of
routes is approximately 2.1 million(s). Exceeding this may cause VPP
to run out of statistics segment memory, resulting in route counter
allocation failures.


[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
