### PR TITLE
bgp: T7708: correct logic for route-reflector-client peer_as check

### DIFF
--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -316,6 +316,7 @@ def verify(config_dict):
                     Warning(f'BGP neighbor "{peer}" requires address-family!')
 
                 # Peer-group member cannot override remote-as of peer-group
+                peer_group = None
                 if 'peer_group' in peer_config:
                     peer_group = peer_config['peer_group']
                     if 'remote_as' in peer_config and 'remote_as' in bgp['peer_group'][peer_group]:
@@ -330,6 +331,27 @@ def verify(config_dict):
                             peer_group = peer_config['interface']['v6only']['peer_group']
                             if 'remote_as' in peer_config['interface']['v6only'] and 'remote_as' in bgp['peer_group'][peer_group]:
                                 raise ConfigError(f'Peer-group member "{peer}" cannot override remote-as of peer-group "{peer_group}"!')
+                            
+                for afi in ['ipv4_unicast', 'ipv4_multicast', 'ipv4_labeled_unicast', 'ipv4_flowspec',
+                            'ipv6_unicast', 'ipv6_multicast', 'ipv6_labeled_unicast', 'ipv6_flowspec',
+                            'l2vpn_evpn']:
+                    if dict_search(
+                        f'address_family.{afi}.route_reflector_client',
+                        peer_config,
+                    ) == {} or (
+                        peer_group
+                        and dict_search(
+                            f'peer_group.{peer_group}.address_family.{afi}.route_reflector_client',
+                            bgp,
+                        )
+                        == {}
+                    ):
+                        peer_as = verify_remote_as(peer_config, bgp)
+                        if peer_as != 'internal' and peer_as != bgp['system_as']:
+                            raise ConfigError('route-reflector-client only supported for iBGP peers')
+                    else:
+                        # It doesn’t make sense to check the remote-as of a peer group.
+                        pass
 
                 # Only checks for ipv4 and ipv6 neighbors
                 # Check if neighbor address is assigned as system interface address
@@ -412,20 +434,7 @@ def verify(config_dict):
                         if tmp in afi_config['route_map']:
                             verify_route_map(afi_config['route_map'][tmp], bgp)
 
-                if 'route_reflector_client' in afi_config:
-                    peer_as = peer_config.get('remote_as')
-
-                    if peer_as is not None and (peer_as != 'internal' and peer_as != bgp['system_as']):
-                        raise ConfigError('route-reflector-client only supported for iBGP peers')
-                    else:
-                        # Check into the peer group for the remote as, if we are in a peer group, check in peer itself
-                        if 'peer_group' in peer_config:
-                            peer_group_as = dict_search(f'peer_group.{peer_group}.remote_as', bgp)
-                        elif neighbor == 'peer_group':
-                            peer_group_as = peer_config.get('remote_as')
-                        
-                        if peer_group_as is None or (peer_group_as != 'internal' and peer_group_as != bgp['system_as']):
-                            raise ConfigError('route-reflector-client only supported for iBGP peers')
+                # route-reflector-client verification has been moved to neighbor-only part
 
             # T5833 not all AFIs are supported for VRF
             if 'vrf' in bgp and 'address_family' in peer_config:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7708

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set protocols bgp system-as 65550
set protocols bgp neighbor 192.168.3.33 address-family ipv4-unicast route-reflector-client
set protocols bgp neighbor 192.168.3.33 address-family ipv4-unicast soft-reconfiguration inbound
set protocols bgp neighbor 192.168.3.33 address-family ipv4-unicast weight '32769'
set protocols bgp neighbor 192.168.3.33 description 'TEST'
set protocols bgp neighbor 192.168.3.33 remote-as '65550'
```
After this fix, vyos no longer raises this error:
```
UnboundLocalError: cannot access local variable 'peer_group_as' where it is not associated with a value
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
