### PR TITLE
op-mode: T7677: fix BrokenPipeError when user quits output of show firewall summary or group

### DIFF
--- a/src/op_mode/firewall.py
+++ b/src/op_mode/firewall.py
@@ -17,13 +17,24 @@
 import argparse
 import ipaddress
 import json
+import os
 import re
+import sys
 import tabulate
 import textwrap
 
 from vyos.config import Config
 from vyos.utils.process import cmd
 from vyos.utils.dict import dict_search_args
+
+def catch_broken_pipe(func):
+    def wrapped(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except (BrokenPipeError, KeyboardInterrupt):
+            # Flush standard streams; redirect remaining output to devnull
+            os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno()) # pylint: disable = no-member
+    return wrapped
 
 def get_config_node(conf, node=None, family=None, hook=None, priority=None):
     if node == 'nat':
@@ -339,6 +350,7 @@ def show_firewall_rule(family, hook, priority, rule_id):
     if firewall:
         output_firewall_name(family, hook, priority, firewall, rule_id)
 
+@catch_broken_pipe
 def show_firewall_group(name=None):
     conf = Config()
     firewall = get_config_node(conf, node='firewall')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Adds exception handling wrapper function to catch BrokenPipeError when user quits output of show firewall function using 'q'

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7677

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Tested by making edits to /usr/libexec/vyos/op_mode/firewall.py on a 1.4.x system to handle BrokenPipeError exception when user quits ('q') output of either show firewall summary or show firewall group commands.

```
vyos@firewall:$ show version 
Version:          VyOS 1.4.2
Release train:    sagitta
Release flavor:   generic

Built by:         VyOS Networks Iberia S.L.U.
Built on:         Tue 01 Apr 2025 17:21 UTC
Build UUID:       01cfd92d-64ae-406c-83f7-bc75e509b75a
Build commit ID:  9cc58255f19640-dirty

Architecture:     x86_64
Boot via:         installed image
System type:      bare metal

Hardware vendor:  (redacted)
Hardware model:   (redacted)
Hardware S/N:     (redacted)
Hardware UUID:    (redacted)

Copyright:        VyOS maintainers and contributors
```
```
vyos@firewall:~$ show firewall summary
Ruleset Summary

IPv6 Ruleset:

Ruleset Hook    Ruleset Priority    Description
--------------  ------------------  --------------------
name            LAN-LOCAL-6         LAN to firewall IPv6
name            LAN-WAN-6           LAN to WAN IPv6
name            LOCAL-LAN-6         Firewall to LAN IPv6
name            LOCAL-WAN-6         Firewall to WAN IPv6
name            WAN-LAN-6           WAN to LAN IPv6
name            WAN-LOCAL-6         WAN to Firewall IPv6

IPv4 Ruleset:

Ruleset Hook    Ruleset Priority    Description
--------------  ------------------  --------------------
name            LAN-LOCAL           LAN to firewall IPv4
name            LAN-WAN             LAN to WAN IPv4
name            LOCAL-LAN           Firewall to LAN IPv4
name            LOCAL-WAN           Firewall to WAN IPv4
name            WAN-LAN             WAN to LAN IPv4
name            WAN-LOCAL           WAN to Firewall IPv4

Firewall Groups

Name                Type                References                Members
------------------  ------------------  ------------------------  -------------------
PrivateNetworks-v6  ipv6_network_group  ipv6-name-WAN-LAN-6-5     ::/96
                                        ipv6-name-WAN-LOCAL-6-5   ::/128
                                                                  ::1/128
                                                                  ::ffff:0:0/96
                                                                  100::/64
                                                                  2001:10::/28
                                                                  2001:db8::/32
                                                                  fc00::/7
                                                                  fe80::/10
                                                                  fec0::/10
:
```
A "q" is entered at the : above and we are returned to the system prompt below:
```
vyos@firewall:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
