### PR TITLE
dhcp-server: T3936: Added support for DHCP Option 82

### DIFF
--- a/data/templates/dhcp-server/kea-dhcp4.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp4.conf.j2
@@ -28,6 +28,9 @@
             "persist": true,
             "name": "{{ lease_file }}"
         },
+{% if client_class is vyos_defined %}
+        "client-classes": {{ client_class | kea_client_class_json }},
+{% endif %}
         "option-def": [
             {
                 "name": "wpad-url",

--- a/interface-definitions/include/dhcp/dhcp-server-common-config.xml.i
+++ b/interface-definitions/include/dhcp/dhcp-server-common-config.xml.i
@@ -1,4 +1,49 @@
 <!-- include start from dhcp/dhcp-server-common-config.xml.i -->
+<tagNode name="client-class">
+  <properties>
+    <help>Client class name</help>
+    <constraint>
+      #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+    </constraint>
+    <constraintErrorMessage>Client class name may only contain letters, numbers, dots, underscores, and hyphens</constraintErrorMessage>
+  </properties>
+  <children>
+    #include <include/generic-disable-node.xml.i>
+    <node name="relay-agent-information">
+      <properties>
+        <help>Match DHCP Option 82 (relay agent information)</help>
+      </properties>
+      <children>
+        <leafNode name="circuit-id">
+          <properties>
+            <help>Filters on the contents of the circuit-id sub option</help>
+            <valueHelp>
+              <format>hex</format>
+              <description>Values that start with 0x are interpreted as raw hex. This must only be hexadecimal characters e.g. 0x1234567890ABCDEF</description>
+            </valueHelp>
+            <valueHelp>
+              <format>txt</format>
+              <description>Any other text string is interpreted as ASCII text</description>
+            </valueHelp>
+          </properties>
+        </leafNode>
+        <leafNode name="remote-id">
+          <properties>
+            <help>Filters on the contents of the remote-id sub option.</help>
+            <valueHelp>
+              <format>hex</format>
+              <description>Values that start with 0x are interpreted as raw hex. This must only be hexadecimal characters e.g. 0x1234567890ABCDEF</description>
+            </valueHelp>
+            <valueHelp>
+              <format>txt</format>
+              <description>Any other text string is interpreted as ASCII text</description>
+            </valueHelp>
+          </properties>
+        </leafNode>
+      </children>
+    </node>
+  </children>
+</tagNode>
 #include <include/generic-disable-node.xml.i>
 <node name="dynamic-dns-update">
   <properties>
@@ -229,6 +274,14 @@
         #include <include/dhcp/ping-check.xml.i>
         #include <include/generic-description.xml.i>
         #include <include/generic-disable-node.xml.i>
+        <leafNode name="client-class">
+          <properties>
+            <help>DHCP client class</help>
+              <completionHelp>
+                <path>service dhcp-server client-class</path>
+              </completionHelp>
+          </properties>
+        </leafNode>
         <node name="dynamic-dns-update">
           <properties>
             <help>Dynamically update Domain Name System (RFC4702)</help>
@@ -280,6 +333,14 @@
           </properties>
           <children>
             #include <include/dhcp/option-v4.xml.i>
+            <leafNode name="client-class">
+              <properties>
+                <help>DHCP client class</help>
+                <completionHelp>
+                  <path>service dhcp-server client-class</path>
+                </completionHelp>
+              </properties>
+            </leafNode>
             <leafNode name="start">
               <properties>
                 <help>First IP address for DHCP lease range</help>

--- a/interface-definitions/include/dhcp/dhcp-server-common-config.xml.i
+++ b/interface-definitions/include/dhcp/dhcp-server-common-config.xml.i
@@ -29,7 +29,7 @@
         </leafNode>
         <leafNode name="remote-id">
           <properties>
-            <help>Filters on the contents of the remote-id sub option.</help>
+            <help>Filters on the contents of the remote-id sub option</help>
             <valueHelp>
               <format>hex</format>
               <description>Values that start with 0x are interpreted as raw hex. This must only be hexadecimal characters e.g. 0x1234567890ABCDEF</description>

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -914,6 +914,25 @@ def kea_high_availability_json(config):
 
     return dumps(data)
 
+@register_filter('kea_client_class_json')
+def kea_client_class_json(client_classes):
+    from vyos.kea import kea_build_client_class_test
+    from json import dumps
+    out = []
+
+    for name, config in client_classes.items():
+        if 'disable' in config:
+            continue
+
+        client_class = {
+            'name': name,
+            'test': kea_build_client_class_test(config)
+        }
+
+        out.append(client_class)
+
+    return dumps(out, indent=4)
+
 @register_filter('kea_dynamic_dns_update_main_json')
 def kea_dynamic_dns_update_main_json(config):
     from vyos.kea import kea_parse_ddns_settings

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -291,10 +291,7 @@ def verify(dhcp):
             # If a client class has been specified then it must exist
             if 'client_class' in subnet_config:
                 client_class = subnet_config['client_class']
-                if 'client_class' not in dhcp:
-                    raise ConfigError(f'Client class "{client_class}" set in subnet "{subnet}" but does not exist')
-
-                if client_class not in dhcp['client_class'].keys():
+                if client_class not in dhcp.get('client_class', {}):
                     raise ConfigError(f'Client class "{client_class}" set in subnet "{subnet}" but does not exist')
 
             # Check if DHCP address range is inside configured subnet declaration

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import re
 
 from sys import exit
 from sys import argv
@@ -287,6 +288,15 @@ def verify(dhcp):
                             f'DHCP static-route "{route}" requires router to be defined!'
                         )
 
+            # If a client class has been specified then it must exist
+            if 'client_class' in subnet_config:
+                client_class = subnet_config['client_class']
+                if 'client_class' not in dhcp:
+                    raise ConfigError(f'Client class "{client_class}" set in subnet "{subnet}" but does not exist')
+
+                if client_class not in dhcp['client_class'].keys():
+                    raise ConfigError(f'Client class "{client_class}" set in subnet "{subnet}" but does not exist')
+
             # Check if DHCP address range is inside configured subnet declaration
             if 'range' in subnet_config:
                 networks = []
@@ -295,6 +305,15 @@ def verify(dhcp):
                         raise ConfigError(
                             f'DHCP range "{range}" start and stop address must be defined!'
                         )
+
+                    # If a client class has been specified then it must exist
+                    if 'client_class' in range_config:
+                        client_class = range_config['client_class']
+                        if 'client_class' not in dhcp:
+                            raise ConfigError(f'Client class "{client_class}" set in range "{range}" but does not exist')
+
+                        if client_class not in dhcp['client_class'].keys():
+                            raise ConfigError(f'Client class "{client_class}" set in range "{range}" but does not exist')
 
                     # Start/Stop address must be inside network
                     for key in ['start', 'stop']:
@@ -503,6 +522,26 @@ def verify(dhcp):
 
         if 'reverse_domain' in ddns:
             verify_ddns_domain_servers('Reverse', ddns['reverse_domain'])
+
+    if 'client_class' in dhcp:
+        # Check client class values are valid
+        for class_name, class_config in dhcp['client_class'].items():
+            if 'relay_agent_information' in class_config:
+                relay_agent_information_config = class_config['relay_agent_information']
+                # Compile a regex that will scan for valid inputs. Input can be
+                # either hex in the form 0x0123456789ABCDEF or a string that
+                # does *not* start with 0x. i.e. 0xHELLOWORLD is bad
+                pattern = re.compile(r'^(?:0x[0-9A-Fa-f]+|(?!0x).+)$')
+
+                if 'circuit_id' in relay_agent_information_config:
+                    circuit_id = relay_agent_information_config['circuit_id']
+                    if not pattern.match(circuit_id):
+                        raise ConfigError(f'Invalid circuit-id "{circuit_id}" must be either text literal or hex string starting with 0x')
+
+                if 'remote_id' in relay_agent_information_config:
+                    remote_id = relay_agent_information_config['remote_id']
+                    if not pattern.match(remote_id):
+                        raise ConfigError(f'Invalid remote-id "{remote_id}" must be either text literal or hex string starting with 0x')
 
     return None
 

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -309,10 +309,7 @@ def verify(dhcp):
                     # If a client class has been specified then it must exist
                     if 'client_class' in range_config:
                         client_class = range_config['client_class']
-                        if 'client_class' not in dhcp:
-                            raise ConfigError(f'Client class "{client_class}" set in range "{range}" but does not exist')
-
-                        if client_class not in dhcp['client_class'].keys():
+                       if client_class not in dhcp.get('client_class', {}):
                             raise ConfigError(f'Client class "{client_class}" set in range "{range}" but does not exist')
 
                     # Start/Stop address must be inside network


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
NB: This is a replacement pull request for one which I had to close as I was unable to rebase the commits into a single commit, as is required by the coding standard of VyOS. I have linked the previous PR in the Related PR's section so the history can be seen.

This commit adds support in both the CLI and the underlying code for DHCP Option 82 to be used to filter/route DHCP address assignments.

The primary use case for this is to support enterprise switches which can "tag" DHCP requests with physical real world informaiton such as which switch first saw the request and which port it originated from (known in this context as remote-id and circuit-id). Once client-classes have been defined they can be assigned to subnets or ranges so that only certain addresses get assigned to specific requests.

There is also a corresponding documentation update which pairs with this code change.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T3936

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-documentation/pull/1666
https://github.com/vyos/vyos-1x/pull/4654 <-- Old Pull request this replaces

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
I have tested these changes by adding new smoketests into the pre existing smoketest file. These new tests specifically check the new functionality including verifying that the generated config files are as expected and that the CLI refuses to take an incorrect commit.

I have also done integration testing in our lab which is set up with a switch which injects DHCP Option 82 information into live DHCP requests and these are processed as expected by VyOS.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
