### PR TITLE
T7670: VPP: Rely on all types of memory to verify memory resources

### DIFF
--- a/python/vyos/vpp/config_resource_checks/memory.py
+++ b/python/vyos/vpp/config_resource_checks/memory.py
@@ -16,7 +16,9 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+import os
 import re
+import psutil
 
 from vyos.utils.process import cmd
 from vyos.vpp.utils import (
@@ -26,29 +28,55 @@ from vyos.vpp.utils import (
 from vyos.vpp.config_resource_checks.resource_defaults import default_resource_map
 
 
+def classify_page_size(page_size_bytes: int) -> str:
+    """
+    Returns one of: '4K', '2M', '1G' based on page size.
+    """
+    if page_size_bytes == 1 << 30:
+        return '1G'
+    if page_size_bytes == 2 << 20:
+        return '2M'
+    return '4K'
+
+
 def get_hugepages_info() -> dict:
     """
-    Returns the information about HugePages for default hugepage size
-    retrieved from /proc/meminfo
+    Returns the information about HugePages
+    retrieved from /sys/kernel/mm/hugepages
     """
+    base_path = '/sys/kernel/mm/hugepages'
     info = {}
-    with open('/proc/meminfo', 'r') as meminfo:
-        for line in meminfo:
-            if line.startswith('Huge'):
-                key, value, *_ = line.strip().split()
-                info[key.rstrip(':')] = int(value)
+
+    for entry in os.listdir(base_path):
+        page_size_kb = entry[10:]
+        page_size = human_page_memory_to_bytes(page_size_kb)
+        key = classify_page_size(page_size)
+        info[key] = {}
+
+        with open(os.path.join(base_path, entry, 'nr_hugepages')) as f:
+            count = int(f.read().strip())
+            info[key]['pages'] = count
+            info[key]['memory'] = page_size * count
+
     return info
 
 
-def get_total_hugepages_memory() -> int:
-    """
-    Returns the total amount of hugepage memory (in bytes)
-    """
-    info = get_hugepages_info()
-    hugepages_total = info.get('HugePages_Total')
-    hugepage_size = info.get('Hugepagesize') * 1024
+def get_available_memory() -> dict:
+    memory = {size: info.get('memory') for size, info in get_hugepages_info().items()}
+    memory['4K'] = psutil.virtual_memory().available
 
-    return hugepage_size * hugepages_total
+    return memory
+
+
+def get_vpp_used_memory() -> int:
+    """
+    Returns memory currently used by VPP in bytes (RSS value)
+    """
+    try:
+        out = cmd('ps -o rss= -p $(pidof vpp)')
+    except OSError:
+        out = 0
+    return int(out) << 10
 
 
 def get_numa_count():
@@ -59,6 +87,11 @@ def get_numa_count():
     # e.g. "available: 2 nodes (0-1)"
     m = re.search(r'available:\s*(\d+)\s+nodes', out)
     return int(m.group(1)) if m else 0
+
+
+def buffer_page_size(settings: dict) -> int:
+    page_size = settings.get('buffers', {}).get('page_size', 'default')
+    return human_page_memory_to_bytes(page_size)
 
 
 def buffer_size(settings: dict) -> int:
@@ -110,7 +143,7 @@ def statseg_size(settings: dict) -> int:
 
 
 def statseg_page_size(settings: dict) -> int:
-    page_size = settings.get('statseg', {}).get('page_size', 'default')
+    page_size = settings.get('statseg', {}).get('page_size')
     return human_page_memory_to_bytes(page_size)
 
 
@@ -118,28 +151,39 @@ def total_statseg_size(_statseg_size: int, _statseg_page: int) -> int:
     return (_statseg_size + _statseg_page - 1) & ~(_statseg_page - 1)
 
 
-def total_memory_required(settings: dict) -> int:
-    mem_required = 0
+def total_memory_required(settings: dict) -> dict:
+    memory = {'2M': 0, '1G': 0, '4K': 0}
 
     mem_stats = {
-        'memory_buffers': buffer_size(settings),
-        'netlink_buffer_size': int(
-            settings.get('lcp', {}).get(
-                'rx_buffer_size', default_resource_map.get('netlink_rx_buffer_size')
-            )
+        'memory_buffers': (buffer_size(settings), buffer_page_size(settings)),
+        'netlink_buffer_size': (
+            int(
+                settings.get('lcp', {})
+                .get('netlink', {})
+                .get(
+                    'rx_buffer_size', default_resource_map.get('netlink_rx_buffer_size')
+                )
+            ),
+            0,
         ),
-        'heap_size': total_heap_size(
-            heap_size=memory_main_heap(settings),
-            heap_page_size=main_heap_page_size(settings),
+        'heap_size': (
+            total_heap_size(
+                heap_size=memory_main_heap(settings),
+                heap_page_size=main_heap_page_size(settings),
+            ),
+            main_heap_page_size(settings),
         ),
-        'statseg_size': total_statseg_size(
-            _statseg_size=statseg_size(settings),
-            _statseg_page=statseg_page_size(settings),
+        'statseg_size': (
+            total_statseg_size(
+                _statseg_size=statseg_size(settings),
+                _statseg_page=statseg_page_size(settings),
+            ),
+            statseg_page_size(settings),
         ),
-        'ipv6_heap_size': ipv6_heap_size(settings),
+        'ipv6_heap_size': (ipv6_heap_size(settings), 0),
     }
 
-    for stat in mem_stats:
-        mem_required += mem_stats[stat]
+    for memory_size, page_size in mem_stats.values():
+        memory[classify_page_size(page_size)] += memory_size
 
-    return mem_required
+    return memory

--- a/python/vyos/vpp/utils.py
+++ b/python/vyos/vpp/utils.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from struct import pack
 
 
-mem_shift = {'K': 10, 'k': 10, 'M': 20, 'm': 20, 'G': 30, 'g': 30}
+mem_shift = {'K': 10, 'KB': 10, 'M': 20, 'MB': 20, 'G': 30, 'GB': 30}
 
 
 def iftunnel_transform(iface: str) -> str:
@@ -302,15 +302,19 @@ def get_hugepage_sizes() -> list[int]:
 
 def human_memory_to_bytes(value: str) -> int:
     """
-    Convert a human-readable vpp memory format (K, M, G) to a byte value.
+    Convert a human-readable vpp memory format (K, M, G, xB) to a byte value.
 
     :param value: The string memory size in vpp human-readable format.
     :return: A int representing the value.
     """
+    value = value.strip().upper()
     try:
         return int(value)
     except ValueError:
-        return int(value[:-1]) << mem_shift[value[-1]]
+        for unit in sorted(mem_shift.keys(), key=len, reverse=True):
+            if value.endswith(unit):
+                num = value[: -len(unit)]
+                return int(num) << mem_shift[unit]
 
 
 def bytes_to_human_memory(value: int, unit: str) -> str | None:
@@ -321,6 +325,7 @@ def bytes_to_human_memory(value: int, unit: str) -> str | None:
     :param unit: The unit to convert to ('K', 'M', 'G').
     :return: A string representing the value in the specified unit, or None if zero.
     """
+    unit = unit.upper()
     val = value >> mem_shift[unit]
     return f'{val}{unit}' if val else None
 

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -53,6 +53,7 @@ from vyos.vpp.config_verify import (
     verify_vpp_statseg_size,
     verify_vpp_interfaces_dpdk_num_queues,
     verify_routes_count,
+    verify_vpp_main_heap_size,
 )
 from vyos.vpp.config_filter import iface_filter_eth
 from vyos.vpp.utils import EthtoolGDrvinfo
@@ -191,7 +192,12 @@ def get_config(config=None):
 
     # add running config
     if effective_config:
-        config['effective'] = effective_config
+        default_values_effective = conf.get_config_defaults(
+            **effective_config.kwargs, recursive=True
+        )
+        config['effective'] = config_dict_merge(
+            default_values_effective, effective_config
+        )
 
     if 'settings' in config:
         if 'interface' in config['settings']:
@@ -358,11 +364,11 @@ def verify(config):
             workers=workers, nat44_workers=config['settings']['nat44']['workers']
         )
 
+    verify_vpp_main_heap_size(config['settings'])
+    verify_vpp_statseg_size(config['settings'])
+
     # Check if available memory is enough for current VPP config
     verify_vpp_memory(config)
-
-    if 'statseg' in config['settings']:
-        verify_vpp_statseg_size(config['settings'])
 
     # ensure DPDK/XDP settings are properly configured
     for iface, iface_config in config['settings']['interface'].items():


### PR DESCRIPTION
VPP can use 2M hugepages and 1G hugepages at the same time

Now if we configure `main-heap-page-size 1G` and `statseg page-size 2M` it will be verified properly

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7670
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ show configuration comm | grep kernel
set system option kernel memory hugepage-size 1G hugepage-count '3'
set system option kernel memory hugepage-size 2M hugepage-count '2048'

set vpp set interface eth1 driver dpdk
set vpp settings memory main-heap-page-size 1G
set vpp settings memory main-heap-size 5G

vyos@vyos# commit
[ vpp ]
Not enough free memory to start VPP! 1G HugePages memory: available 3.0
GB, required 5.0 GB. To add HugePages memory please use command "set
system option kernel memory hugepage-size ..." and reboot!

[[vpp]] failed
Commit failed
[edit]
vyos@vyos# set vpp settings memory main-heap-size 2G
[edit]
vyos@vyos# commit
[ vpp ]

WARNING: NOTE: Current dataplane capacity (estimated): 2.1 M IPv4
routes. Exceeding these values will lead to a dataplane out-of-memory
condition and a crash. Extensive use of features like ACLs, NAT and
others may reduce the numbers above. Please read the documentation for
details: https://docs.vyos.io/


[edit]
vyos@vyos#  sudo vppctl show memory main-heap
Thread 0 vpp_main
  base 0x7facc0000000, size 2g, locked, unmap-on-destroy, name 'main heap'
    page stats: page-size 1G, total 2, mapped 2, not-mapped 0
      numa 0: 2 pages, 2g bytes
    total: 2.00G, used: 52.48M, free: 1.95G, trimmable: 1.95G
```

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... skipped 'Skipping temporary bonding, sometimes get recursion'
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... ok
test_14_mem_default_hugepage (__main__.TestVPP.test_14_mem_default_hugepage) ... ok
test_15_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_15_vpp_ipsec_xfrm_nl) ... ok
test_16_vpp_cgnat (__main__.TestVPP.test_16_vpp_cgnat) ... ok
test_17_vpp_nat (__main__.TestVPP.test_17_vpp_nat) ... ok
test_18_vpp_sflow (__main__.TestVPP.test_18_vpp_sflow) ... ok

----------------------------------------------------------------------
Ran 20 tests in 747.515s

OK (skipped=2)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
