### PR TITLE
tpm: T7713: T7717: Multiple TPM fixes

### DIFF
--- a/src/helpers/vyos-config-encrypt.py
+++ b/src/helpers/vyos-config-encrypt.py
@@ -241,13 +241,25 @@ if __name__ == '__main__':
 
     if not is_opened():
         if tpm_exists:
+            existing_key = None
+
+            try:
+                existing_key = read_tpm_key()
+            except: pass
+
             if args.enable:
-                key = Fernet.generate_key()
+                if existing_key:
+                    print('WARNING: An encryption key already exists in the TPM.')
+                    print('If you choose not to use the existing key, any system image')
+                    print('using the old key will need the recovery key.')
+                if existing_key and ask_yes_no('Do you want to use the existing TPM key?'):
+                    key = existing_key
+                else:
+                    key = Fernet.generate_key()
             elif args.disable or args.load:
-                try:
-                    key = read_tpm_key()
+                if existing_key:
                     need_recovery = False
-                except:
+                else:
                     print('Failed to read key from TPM, recovery key required')
                     need_recovery = True
         else:

--- a/src/helpers/vyos-config-encrypt.py
+++ b/src/helpers/vyos-config-encrypt.py
@@ -135,7 +135,7 @@ def encrypt_config(key, recovery_key=None, is_tpm=True):
 
         # Move mount_path to encrypted volume
         shutil.copytree(mount_path, d, copy_function=shutil.move, dirs_exist_ok=True)
-
+        cmd(f'chgrp -R vyattacfg {d}')
         cmd(f'umount {d}')
 
     os.unlink(key_file)

--- a/src/helpers/vyos-config-encrypt.py
+++ b/src/helpers/vyos-config-encrypt.py
@@ -251,18 +251,19 @@ if __name__ == '__main__':
 
     question_key_str = 'recovery key' if tpm_exists else 'key'
 
-    if tpm_exists:
-        if args.enable:
-            key = Fernet.generate_key()
-        elif args.disable or args.load:
-            try:
-                key = read_tpm_key()
-                need_recovery = False
-            except:
-                print('Failed to read key from TPM, recovery key required')
-                need_recovery = True
-    else:
-        need_recovery = True
+    if not is_opened():
+        if tpm_exists:
+            if args.enable:
+                key = Fernet.generate_key()
+            elif args.disable or args.load:
+                try:
+                    key = read_tpm_key()
+                    need_recovery = False
+                except:
+                    print('Failed to read key from TPM, recovery key required')
+                    need_recovery = True
+        else:
+            need_recovery = True
 
     if args.enable and not tpm_exists:
         print('WARNING: VyOS will boot into a default config when encrypted without a TPM')

--- a/src/helpers/vyos-config-encrypt.py
+++ b/src/helpers/vyos-config-encrypt.py
@@ -197,7 +197,8 @@ def decrypt_config(key):
     os.unlink(image_path)
 
     try:
-        clear_tpm_key()
+        if ask_yes_no('Do you want to clear the TPM? This will cause issues if other system images use the key'):
+            clear_tpm_key()
     except:
         pass
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
* T7727: Adds prompt to overwrite existing config backup
* T7727: Move volume checks before prompting for key/recovery key
* T7720: Catch errors during config encryption and gracefully abort
* T7717: Recursively set `vyattacfg` group on mounted config directory
* T7713: Restore config bind mounts on config decrypt
* T7735: Don't prompt for key/recovery key if encrypted volume is mounted
* T7726: Copy encrypted config volume when using `add system image`
* T7726: Prompt user before clearing TPM on decrypt

Includes minor formatting changes, single-line imports.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
`make testtpm` passes and all error steps reported in Phorge now succeed.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
