### PR TITLE
firewall: T7739: Default ruleset for firewall zones

### DIFF
--- a/data/templates/firewall/nftables-zone.j2
+++ b/data/templates/firewall/nftables-zone.j2
@@ -56,6 +56,10 @@
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
+{%         if zone_conf.default_firewall is vyos_defined and zone_conf.default_firewall[fw_name] is vyos_defined %}
+        counter jump NAME{{ suffix }}_{{ zone_conf.default_firewall[fw_name] }}
+        counter return
+{%         endif %}
         {{ zone_conf | nft_default_rule('zone_' + zone_name, family) }}
     }
     chain VZONE_{{ zone_name }}_OUT {
@@ -69,6 +73,20 @@
 {%                 if 'vrf' in zone[from_zone].member %}
         oifname { {{ zone[from_zone].member.vrf | quoted_join(",") }} } counter jump NAME{{ suffix }}_{{ from_conf.firewall[fw_name] }}
         oifname { {{ zone[from_zone].member.vrf | quoted_join(",") }} } counter return
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%         if zone_conf.default_local is vyos_defined %}
+{%             for from_zone, from_conf in zone_conf.default_local.items() if from_conf[fw_name] is vyos_defined %}
+{%                 if 'interface' in zone[from_zone].member %}
+        oifname { {{ zone[from_zone].member.interface | quoted_join(",") }} } counter jump NAME{{ suffix }}_{{ from_conf[fw_name] }}
+        oifname { {{ zone[from_zone].member.interface | quoted_join(",") }} } counter return
+{%                 endif %}
+{%                 if 'vrf' in zone[from_zone].member %}
+{%                     for vrf_name in zone[from_zone].member.vrf %}
+        oifname { "{{ zone[from_zone]['vrf_interfaces'][vrf_name] }}" } counter jump NAME{{ suffix }}_{{ from_conf[fw_name] }}
+        oifname { "{{ zone[from_zone]['vrf_interfaces'][vrf_name] }}" } counter return
+{%                     endfor %}
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
@@ -103,6 +121,10 @@
 {%                     endif %}
 {%                 endif %}
 {%             endfor %}
+{%         endif %}
+{%         if zone_conf.default_firewall is vyos_defined and zone_conf.default_firewall[fw_name] is vyos_defined %}
+        counter jump NAME{{ suffix }}_{{ zone_conf.default_firewall[fw_name] }}
+        counter return
 {%         endif %}
         {{ zone_conf | nft_default_rule('zone_' + zone_name, family) }}
     }

--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -428,6 +428,29 @@
             </properties>
             <defaultValue>drop</defaultValue>
           </leafNode>
+          <node name="default-firewall">
+            <properties>
+              <help>Default firewall rules for traffic coming into this zone</help>
+            </properties>
+            <children>
+              <leafNode name="ipv6-name">
+                <properties>
+                  <help>IPv6 firewall ruleset</help>
+                  <completionHelp>
+                    <path>firewall ipv6 name</path>
+                  </completionHelp>
+                </properties>
+              </leafNode>
+              <leafNode name="name">
+                <properties>
+                  <help>IPv4 firewall ruleset</help>
+                  <completionHelp>
+                    <path>firewall ipv4 name</path>
+                  </completionHelp>
+                </properties>
+              </leafNode>
+            </children>
+          </node>
           <tagNode name="from">
             <properties>
               <help>Zone from which to filter traffic</help>

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -992,6 +992,50 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.verify_nftables(nftables_search, 'ip vyos_filter')
         self.verify_nftables(nftables_search_v6, 'ip6 vyos_filter')
 
+    def test_zone_with_default_firewall(self):
+        self.cli_set(['firewall', 'ipv4', 'name', 'smoketest', 'default-action', 'drop'])
+        self.cli_set(['firewall', 'ipv4', 'name', 'smoketest-default', 'default-action', 'drop'])
+        self.cli_set(['firewall', 'zone', 'smoketest-eth0', 'member', 'interface', 'eth0'])
+        self.cli_set(['firewall', 'zone', 'smoketest-eth0', 'from', 'smoketest-eth1', 'firewall', 'name', 'smoketest'])
+        self.cli_set(['firewall', 'zone', 'smoketest-eth0', 'from', 'smoketest-local', 'firewall', 'name', 'smoketest'])
+        self.cli_set(['firewall', 'zone', 'smoketest-eth0', 'default-firewall', 'name', 'smoketest-default'])
+        self.cli_set(['firewall', 'zone', 'smoketest-eth1', 'member', 'interface', 'eth1'])
+        self.cli_set(['firewall', 'zone', 'smoketest-eth1', 'default-firewall', 'name', 'smoketest-default'])
+        self.cli_set(['firewall', 'zone', 'smoketest-eth2', 'member', 'interface', 'eth2'])
+        self.cli_set(['firewall', 'zone', 'smoketest-local', 'local-zone'])
+        self.cli_set(['firewall', 'zone', 'smoketest-local', 'from', 'smoketest-eth0', 'firewall', 'name', 'smoketest'])
+        self.cli_set(['firewall', 'zone', 'smoketest-local', 'default-firewall', 'name', 'smoketest-default'])
+        self.cli_commit()
+
+        smoketest_eth0_search = [
+            ['iifname "eth1"', 'jump NAME_smoketest'],
+            ['jump NAME_smoketest-default']
+        ]
+        self.verify_nftables_chain_exists('ip vyos_filter', 'VZONE_smoketest-eth0')
+        self.verify_nftables_chain(smoketest_eth0_search, 'ip vyos_filter', 'VZONE_smoketest-eth0')
+
+        smoketest_eth1_search = [
+            ['jump NAME_smoketest-default']
+        ]
+        self.verify_nftables_chain_exists('ip vyos_filter', 'VZONE_smoketest-eth1')
+        self.verify_nftables_chain(smoketest_eth1_search, 'ip vyos_filter', 'VZONE_smoketest-eth1')
+
+        self.verify_nftables_chain_exists('ip vyos_filter', 'VZONE_smoketest-eth2')
+
+        smoketest_local_in_search = [
+            ['iifname "eth0"', 'jump NAME_smoketest'],
+            ['jump NAME_smoketest-default'],
+        ]
+        self.verify_nftables_chain_exists('ip vyos_filter', 'VZONE_smoketest-local_IN')
+        self.verify_nftables_chain(smoketest_local_in_search, 'ip vyos_filter', 'VZONE_smoketest-local_IN')
+
+        smoketest_local_out_search = [
+            ['oifname "eth0"', 'jump NAME_smoketest'],
+            ['oifname "eth1"', 'jump NAME_smoketest-default']
+        ]
+        self.verify_nftables_chain_exists('ip vyos_filter', 'VZONE_smoketest-local_OUT')
+        self.verify_nftables_chain(smoketest_local_out_search, 'ip vyos_filter', 'VZONE_smoketest-local_OUT')
+
     def test_zone_with_vrf(self):
         self.cli_set(['firewall', 'ipv4', 'name', 'ZONE1-to-LOCAL', 'default-action', 'accept'])
         self.cli_set(['firewall', 'ipv4', 'name', 'ZONE2_to_ZONE1', 'default-action', 'continue'])

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -153,12 +153,15 @@ def get_config(config=None):
                 continue
 
             local_zone_conf['from_local'] = {}
+            local_zone_conf['default_local'] = {}
 
             for zone, zone_conf in firewall['zone'].items():
-                if zone == local_zone or 'from' not in zone_conf:
+                if zone == local_zone:
                     continue
-                if local_zone in zone_conf['from']:
+                if 'from' in zone_conf and local_zone in zone_conf['from']:
                     local_zone_conf['from_local'][zone] = zone_conf['from'][local_zone]
+                elif 'default_firewall' in zone_conf:
+                    local_zone_conf['default_local'][zone] = zone_conf['default_firewall']
 
     set_dependents('conntrack', conf)
 
@@ -625,6 +628,18 @@ def verify(firewall):
                     v6_name = dict_search_args(from_conf, 'firewall', 'ipv6_name')
                     if v6_name and not dict_search_args(firewall, 'ipv6', 'name', v6_name):
                         raise ConfigError(f'Firewall ipv6-name "{v6_name}" does not exist')
+
+            if 'default_firewall' in zone_conf:
+                v4_name = dict_search_args(zone_conf, 'default_firewall', 'name')
+                if v4_name and not dict_search_args(firewall, 'ipv4', 'name', v4_name):
+                    raise ConfigError(f'Firewall name "{v4_name}" does not exist')
+
+                v6_name = dict_search_args(zone_conf, 'default_firewall', 'ipv6_name')
+                if v6_name and not dict_search_args(firewall, 'ipv6', 'name', v6_name):
+                    raise ConfigError(f'Firewall ipv6-name "{v6_name}" does not exist')
+
+                if not v4_name and not v6_name:
+                    raise ConfigError('No firewall names specified for default-firewall')
 
     return None
 


### PR DESCRIPTION
In large networks with many zones where simple allow/deny rules are not sufficient, zones become tedious to manage. Many use cases can be simplified by providing an ability to define a default ruleset for traffic from other zones. This change proposes adding the follwing syntax:
   set firewall zone <name> default_firewall name <name>
   set firewall zone <name> default_firewall ipv6_name <name>

The proposed behavior is the following:
-   local in:
    - The default firewall ruleset for the local zone will be appended after all from configurations.
-   local out:
    - If a non-local zone does not have a from local ruleset but does have a default_firewall ruleset, the default_firewall ruleset will be appended using oifname
-   forward:
    - The default firewall ruleset for the zone will be appended after all from configurations

To keep the behavior consistent with from ruleset configurations, a return is appended after the default_firewall ruleset.

The proposed behavior differs slightly from the default_policy configuration for the local out chains. The default_policy applied in the out templates comes from the local zone, not the actual outbound zone. The proposed change does not amend this, but does make default_firewall logically consistent with the intent of the out rules.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7739

## Related PR(s)
https://github.com/vyos/vyos-documentation/pull/1714

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Added additional firewall smoketest case to validate. All smoke tests are passing.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
