### PR TITLE
op-mode: T7741: Fixes for 'show interfaces kernel'

### DIFF
--- a/python/vyos/utils/dict.py
+++ b/python/vyos/utils/dict.py
@@ -211,6 +211,39 @@ def dict_set(key_path, value, dict_object):
             dynamic_dict = dynamic_dict[path_list[i]]
         dynamic_dict[path_list[len(path_list)-1]] = value
 
+def dict_set_nested(key_path, value, dict_object):
+    """
+    Set value to Python dictionary (dict_object) using a path to the key
+    delimited by dot ('.'). The key will be added if it does not exist.
+    Missing keys along the path will be created as nested dictionaries.
+
+    Parameters
+    ----------
+    key_path : str
+        Dot-delimited path to the key (e.g. "this.is.a.path").
+    value : any
+        The value to set at the final key in the path.
+    dict_object : dict
+        Dictionary to modify. Will be updated in place.
+
+    Examples
+    --------
+    d = {}
+    dict_set_nested("this.is.a.path", 42, d)
+    # {'this': {'is': {'a': {'path': 42}}}}
+
+    d = {"existing": {"branch": {}}}
+    dict_set_nested("existing.branch.leaf", "value", d)
+    # {'existing': {'branch': {'leaf': 'value'}}}
+    """
+    path_list = key_path.split(".")
+    dynamic_dict = dict_object
+    for i in range(0, len(path_list) - 1):
+        if path_list[i] not in dynamic_dict or not isinstance(dynamic_dict[path_list[i]], dict):
+            dynamic_dict[path_list[i]] = {}
+        dynamic_dict = dynamic_dict[path_list[i]]
+    dynamic_dict[path_list[-1]] = value
+
 def dict_delete(key_path, dict_object):
     """ Delete key in Python dictionary (dict_object) using path to key delimited by dot (.).
     """
@@ -370,4 +403,3 @@ class FixedDict(dict):
         if k not in self._allowed:
             raise ConfigError(f'Option "{k}" has no defined default')
         super().__setitem__(k, v)
-

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -81,7 +81,10 @@ def get_interface_vrf(interface):
     """ Returns VRF of given interface """
     from vyos.utils.dict import dict_search
     from vyos.utils.network import get_interface_config
-    tmp = get_interface_config(interface)
+    if isinstance(interface, str):
+        tmp = get_interface_config(interface)
+    elif isinstance(interface, dict):
+        tmp = interface
     if dict_search('linkinfo.info_slave_kind', tmp) == 'vrf':
         return tmp['master']
     return 'default'

--- a/src/op_mode/interfaces.py
+++ b/src/op_mode/interfaces.py
@@ -363,7 +363,7 @@ def _format_kernel_data(data, detail):
             podman_vrf[interface.get('ifname')]['vrf'] = interface.get('master', 'default')
 
         if interface.get('master', '').startswith('pod-'):
-            vrf = podman_vrf.get(interface.get('master', {})).get('vrf', 'default')
+            vrf = podman_vrf.get(interface.get('master', '')).get('vrf', 'default')
         elif interface.get('linkinfo', {}).get('info_slave_kind', '') == 'vrf':
             vrf = interface.get('master', 'default')
 

--- a/src/op_mode/interfaces.py
+++ b/src/op_mode/interfaces.py
@@ -87,6 +87,10 @@ def filtered_interfaces(ifnames: typing.Union[str, list],
 
         yield interface
 
+def is_interface_has_mac(interface_name):
+    interface_no_mac = ('tun', 'wg')
+    return not any(interface_name.startswith(prefix) for prefix in interface_no_mac)
+
 def detailed_output(dataset, headers):
     for data in dataset:
         adjusted_rule = data + [""] * (len(headers) - len(data)) # account for different header length, like default-action
@@ -247,10 +251,6 @@ def _get_summary_data(ifname: typing.Optional[str],
         iftype = ''
     ret = []
 
-    def is_interface_has_mac(interface_name):
-        interface_no_mac = ('tun', 'wg')
-        return not any(interface_name.startswith(prefix) for prefix in interface_no_mac)
-
     for interface in filtered_interfaces(ifname, iftype, vif, vrrp):
         res_intf = {}
 
@@ -376,7 +376,7 @@ def _format_kernel_data(data, detail):
         # Generate temporary dict to hold data
         tmpInfo['ifname'] = interface.get('ifname', '')
         tmpInfo['ip'] = ip_list
-        tmpInfo['mac'] = "n/a" if interface.get('ifname', '').startswith(("tun", "wg", "gre")) else interface.get('address', 'n/a')
+        tmpInfo['mac'] = interface.get('address', 'n/a') if is_interface_has_mac(interface.get('ifname', '')) else 'n/a'
         tmpInfo['mtu'] = interface.get('mtu', '')
         tmpInfo['vrf'] = vrf
         tmpInfo['status'] = sl_status

--- a/src/op_mode/interfaces.py
+++ b/src/op_mode/interfaces.py
@@ -29,8 +29,10 @@ import vyos.opmode
 from vyos.ifconfig import Section
 from vyos.ifconfig import Interface
 from vyos.ifconfig import VRRP
-from vyos.utils.process import cmd
+from vyos.utils.dict import dict_set_nested
+from vyos.utils.network import get_interface_vrf
 from vyos.utils.network import interface_exists
+from vyos.utils.process import cmd
 from vyos.utils.process import rc_cmd
 from vyos.utils.process import call
 from vyos.configquery import op_mode_config_dict
@@ -334,10 +336,17 @@ def _format_kernel_data(data, detail):
 
     # Sort interfaces by name
     for interface in sorted(data, key=lambda x: x.get('ifname', '')):
+        interface_name = interface.get('ifname', '')
+
+        # Skip VRF interfaces
         if interface.get('linkinfo', {}).get('info_kind') == 'vrf':
             continue
-        elif interface.get('ifname').startswith(('tunl', 'gre', 'erspan', 'pim6reg')):
+        # Skip spawned interfaces
+        elif interface_name.startswith(('tunl', 'gre', 'erspan', 'pim6reg')):
             continue
+
+        master = interface.get('master', 'default')
+        vrf = get_interface_vrf(interface)
 
         # Get the device model; ex. Intel Corporation Ethernet Controller I225-V
         dev_model = interface.get('parentdev', '')
@@ -349,7 +358,6 @@ def _format_kernel_data(data, detail):
         # Get the IP addresses on interface
         ip_list = []
         has_global = False
-        vrf = 'default'
 
         for ip in interface['addr_info']:
             if ip.get('scope') in ('global', 'host'):
@@ -358,25 +366,24 @@ def _format_kernel_data(data, detail):
                 prefixlen = ip.get('prefixlen', '')
                 ip_list.append(f"{local}/{prefixlen}")
 
-        if interface.get('ifname').startswith('pod-'):
-            podman_vrf[interface.get('ifname')] = {}
-            podman_vrf[interface.get('ifname')]['vrf'] = interface.get('master', 'default')
-
-        if interface.get('master', '').startswith('pod-'):
-            vrf = podman_vrf.get(interface.get('master', '')).get('vrf', 'default')
-        elif interface.get('linkinfo', {}).get('info_slave_kind', '') == 'vrf':
-            vrf = interface.get('master', 'default')
-
         # If no global IP address, add '-'; indicates no IP address on interface
         if not has_global:
             ip_list.append('-')
 
+        # Generate a mapping of podman interfaces to their VRF
+        if interface_name.startswith('pod-'):
+            dict_set_nested(f'{interface_name}.vrf', master, podman_vrf)
+
+        # If the veth interface's master is a podman interface, the VRF is the VRF of the podman interface
+        if master.startswith('pod-'):
+            vrf = podman_vrf.get(master).get('vrf', 'default')
+
         sl_status = ('A' if not 'UP' in interface['flags'] else 'u') + '/' + ('D' if interface['operstate'] == 'DOWN' else 'u')
 
         # Generate temporary dict to hold data
-        tmpInfo['ifname'] = interface.get('ifname', '')
+        tmpInfo['ifname'] = interface_name
         tmpInfo['ip'] = ip_list
-        tmpInfo['mac'] = interface.get('address', 'n/a') if is_interface_has_mac(interface.get('ifname', '')) else 'n/a'
+        tmpInfo['mac'] = interface.get('address', 'n/a') if is_interface_has_mac(interface_name) else 'n/a'
         tmpInfo['mtu'] = interface.get('mtu', '')
         tmpInfo['vrf'] = vrf
         tmpInfo['status'] = sl_status


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Fixes for the following:
 - Tunnel interfaces report an IP address in the field where a MAC is expected
 - Podman created veth interfaces list it's parent network as a VRF instead of the actual VRF.
 - Long descriptions should wrap
 - Non useful interfaces shouldn't be shown.

#### Output before:
```
Interface    IP Address          MAC                VRF         MTU  S/L    Description
-----------  ------------------  -----------------  --------  -----  -----  -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bond0        -                   0a:2e:e2:45:a5:9b  default    1500  u/D
br0          -                   22:e8:d6:72:c2:34  default    1500  u/u
br1          -                   8e:59:41:e4:08:d3  default    1500  u/u
dum123       -                   ce:1e:95:d9:bd:0f  default    1500  u/u
erspan0      -                   00:00:00:00:00:00  default    1450  A/D
eth0         172.16.0.12/28      0c:28:d8:f7:00:00  default    1500  u/u    This is a really long description This is a really long description This is a really long description This is a really long description This is a really long description
eth1         -                   0c:28:d8:f7:00:01  default    1500  u/u
eth2         10.0.202.10/24      0c:28:d8:f7:00:02  default    1500  u/u
gnv0         192.0.2.1/24        4a:d9:34:a2:76:cd  default    1500  u/u
gre0         -                   0.0.0.0            default    1476  A/D
gretap0      -                   00:00:00:00:00:00  default    1462  A/D
ifb0         -                   c6:98:63:b1:25:07  default    1500  u/u
l2tpeth0     -                   a6:15:1f:4e:c3:d0  br1        1500  u/u    L2 VPN Tunnel
lo           127.0.0.1/8         00:00:00:00:00:00  default   65536  u/u
             ::1/128
macsec1      192.0.2.1/24        0c:28:d8:f7:00:01  default    1460  u/u
             2001:db8::1/64
pim6reg      -                                      default    1452  u/u
pim6reg101   -                                      test       1452  u/u
pim6reg102   -                                      test2      1452  u/u
pim6reg103   -                                      testvrf    1452  u/u
pod-test     10.0.201.1/24       52:29:16:c9:81:be  testvrf    1500  u/u
tun0         192.168.100.200/24  192.0.2.10         default    1476  u/u
tunl0        -                   0.0.0.0            default    1480  A/D
veth0        -                   ea:d9:8e:19:ac:7b  default    1500  u/u
veth1        -                   d6:4c:fb:e1:b8:1b  pod-test   1500  u/u
veth2        -                   76:11:f3:6a:8d:99  pod-test   1500  u/u
vti0         192.168.2.249/30                       default    1500  A/D
vtun1        10.255.1.1/32                          default    1500  u/u
vxlan999999  -                   f6:14:bd:ca:a7:a8  br0        1500  u/u
wg01         10.1.0.1/30                            default    1420  u/u    VPN-to-wg02
```
#### Output After:
```
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address          MAC                VRF        MTU  S/L    Description
-----------  ------------------  -----------------  -------  -----  -----  --------------------------------------------------
bond0        -                   0a:2e:e2:45:a5:9b  default   1500  u/D
br0          -                   22:e8:d6:72:c2:34  default   1500  u/u
br1          -                   8e:59:41:e4:08:d3  default   1500  u/u
dum123       -                   ce:1e:95:d9:bd:0f  default   1500  u/u
eth0         172.16.0.12/28      0c:28:d8:f7:00:00  default   1500  u/u    This is a really long description This is a really
                                                                           long description This is a really long description
                                                                           This is a really long description This is a really
                                                                           long description
eth1         -                   0c:28:d8:f7:00:01  default   1500  u/u
eth2         10.0.202.10/24      0c:28:d8:f7:00:02  default   1500  u/u
gnv0         192.0.2.1/24        4a:d9:34:a2:76:cd  default   1500  u/u
ifb0         -                   c6:98:63:b1:25:07  default   1500  u/u
l2tpeth0     -                   a6:15:1f:4e:c3:d0  default   1500  u/u    L2 VPN Tunnel
lo           127.0.0.1/8         00:00:00:00:00:00  default  65536  u/u
             ::1/128
macsec1      192.0.2.1/24        0c:28:d8:f7:00:01  default   1460  u/u
             2001:db8::1/64
pod-test     10.0.201.1/24       52:29:16:c9:81:be  testvrf   1500  u/u
tun0         192.168.100.200/24  n/a                default   1476  u/u
tun100       10.0.0.1/30         n/a                default   1476  u/u
veth0        -                   ea:d9:8e:19:ac:7b  default   1500  u/u
veth1        -                   d6:4c:fb:e1:b8:1b  testvrf   1500  u/u
veth2        -                   76:11:f3:6a:8d:99  testvrf   1500  u/u
vti0         192.168.2.249/30    n/a                default   1500  A/D
vtun1        10.255.1.1/32       n/a                default   1500  u/u
vxlan999999  -                   f6:14:bd:ca:a7:a8  default   1500  u/u
wg01         10.1.0.1/30         n/a                default   1420  u/u    VPN-to-wg02
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7741
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
