### PR TITLE
op-mode: T7745: add a CLI for operator user command permissions

### DIFF
--- a/data/config.boot.default
+++ b/data/config.boot.default
@@ -33,6 +33,11 @@ system {
     }
     host-name "vyos"
     login {
+        operator-group default {
+            command-policy {
+                allow "*"
+            }
+        }
         user vyos {
             authentication {
                 encrypted-password "$6$QxPS.uk6mfo$9QBSo8u1FkH16gMyAVhus6fU3LOzvLR9Z9.82m3tiHFAxTtIkhaZSWssSgzt4v4dGAL8rhVQxTg0oAG9/q11h/"

--- a/interface-definitions/system_login.xml.in
+++ b/interface-definitions/system_login.xml.in
@@ -8,6 +8,38 @@
           <priority>400</priority>
         </properties>
         <children>
+          <tagNode name="operator-group">
+            <properties>
+              <help>Operator group</help>
+              <constraint>
+                #include <include/constraint/login-username.xml.i>
+              </constraint>
+              <constraintErrorMessage>Operator group name contains illegal characters or\nexceeds 100 character limitation.</constraintErrorMessage>
+            </properties>
+            <children>
+              <node name="command-policy">
+                <properties>
+                  <help>Command policy</help>
+                </properties>
+                <children>
+                  <leafNode name="allow">
+                    <properties>
+                      <multi/>
+                      <help>Command subtree allowed to execute</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Exact command (e.g., 'show interfaces')</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Command wildcard (e.g., '* vpn')</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+            </children>
+          </tagNode>
           <tagNode name="user">
             <properties>
               <help>Local user account information</help>
@@ -17,6 +49,26 @@
               <constraintErrorMessage>Username contains illegal characters or\nexceeds 100 character limitation.</constraintErrorMessage>
             </properties>
             <children>
+              <node name="operator">
+                <properties>
+                  <help>Restrict the user to operational mode</help>
+                </properties>
+                <children>
+                  <leafNode name="group">
+                    <properties>
+                      <multi/>
+                      <help>Operator group</help>
+                      <completionHelp>
+                        <path>system login operator-group</path>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Operator group name</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
               <node name="authentication">
                 <properties>
                   <help>Authentication settings</help>

--- a/src/opt/vyatta/etc/shell/level/users/allowed-op
+++ b/src/opt/vyatta/etc/shell/level/users/allowed-op
@@ -11,7 +11,10 @@ exit
 force
 monitor
 ping
+poweroff
+reboot
 reset
+restart
 release
 renew
 set

--- a/src/opt/vyatta/etc/shell/level/users/allowed-op.in
+++ b/src/opt/vyatta/etc/shell/level/users/allowed-op.in
@@ -7,7 +7,10 @@ exit
 force
 monitor
 ping
+poweroff
+reboot
 reset
+restart
 release
 renew
 set

--- a/src/opt/vyatta/share/vyatta-op/functions/interpreter/vyatta-op-run
+++ b/src/opt/vyatta/share/vyatta-op/functions/interpreter/vyatta-op-run
@@ -217,6 +217,20 @@ _vyatta_op_run ()
     local run_cmd=$(_vyatta_op_get_node_def_field $tpath/node.def run)
     run_cmd=$(_vyatta_op_conv_run_cmd "$run_cmd") # convert the positional parameters
     local ret=0
+
+    if groups "$(whoami)" | grep -q -E ' vyattacfg(\s|$)'; then
+      # If the user is an admin,
+      # use sudo directly for now
+      op_runner="sudo"
+    else
+      # If the user is an operator,
+      # use the new operational command runner
+      # (operator users have no sudo permissions)
+      # and give it the original VyOS command
+      op_runner="vyos-op-run"
+      run_cmd="$@"
+    fi
+
     # Exception for the `show file` command
     local file_cmd='\$\{vyos_op_scripts_dir\}\/file\.py'
     local cmd_regex="^(LESSOPEN=|less|pager|tail|(sudo )?$file_cmd).*"
@@ -234,9 +248,9 @@ _vyatta_op_run ()
         # to be able to do their job.
         eval "$run_cmd"
       elif [[ -t 1 && "${args[1]}" == "show" && ! $run_cmd =~ $cmd_regex ]] ; then
-        eval "(sudo $run_cmd) | ${VYATTA_PAGER:-cat}"
+        eval "($op_runner $run_cmd) | ${VYATTA_PAGER:-cat}"
       else
-        eval "sudo $run_cmd"
+        eval "$op_runner $run_cmd"
       fi
     else
       echo -ne "\n  Incomplete command: ${args[@]}\n\n" >&2


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Introduces a CLI for creating _local_ operator-level users.

This PR adds the following commands:

* `set system login operator-group <name> command-policy allow <cmd>` — allows creating permission groups that limit operator users to specific sets of commands.
* `set system login user <name> operator group <name>` — allows assigning operator-level users to groups.

Every operator-level user must be assigned to at least one group. The default config is updated to include a default operator group that allows all commands.

Operator user permissions are saved to a data file at commit time:

```
vyos@vyos# cat /etc/vyos/operators.json | jq
{
  "users": {
    "bofh": [
      "default"
    ],
    "pfy": [
      "Test"
    ]
  },
  "groups": {
    "default": {
      "command_policy": {
        "allow": [
          [
            "*"
          ]
        ]
      }
    },
    "Test": {
      "command_policy": {
        "allow": [
          [
            "show"
          ],
          [
            "reset",
            "*",
            "ipsec"
          ]
        ]
      }
    }
  }
}

```

The new operational command runner  (`/usr/bin/vyos-op-run`) then uses that file to check command permissions.

This PR _does not_ allow retrieving user level information from remote authentication sources like RADIUS ­— we'll need to work out the details there.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-utils/pull/41

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
