### PR TITLE
T7744: Migrate from accel-ppp to accel-ppp-ng

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -145,7 +145,7 @@ Depends:
   iputils-ping,
   isc-dhcp-client,
 # For "vpn pptp", "vpn l2tp", "vpn sstp", "service ipoe-server"
-  accel-ppp,
+  accel-ppp-ng,
 # End "vpn pptp", "vpn l2tp", "vpn sstp", "service ipoe-server"
   avahi-daemon,
   conntrack,


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Migrate from `accel-ppp` to `accel-ppp-ng`

It has all old/current features plus several features that work without patches (full compatibility).
Also, it includes developing compatibility for the PPPoE server and VPP
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Migration to `accel-ppp-ng`

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7744

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Manual testing
RADIUS user configuration:
```
# PPPoE static
client-1	Cleartext-Password := "client-1"
    Service-Type = Framed-User,
    Accel-VRF-Name = "red",
    Framed-IP-Address = 10.0.0.11,
    Framed-Route = "100.64.0.11/32 10.0.0.11 1",
    Framed-Protocol = PPP

client-2	Cleartext-Password := "client-2"
    Service-Type = Framed-User,
    Framed-IP-Address = 10.0.0.12,
    Framed-Route = "100.64.0.12/32 10.0.0.12 1",
    Framed-Protocol = PPP
```


PPPoE server configuration:
```
vyos@r14:~$ show ver all | match accel
ii  accel-ppp-ng                     1.13.0                           amd64        PPtP/L2TP/PPPoE/SSTP server for Linux
vyos@r14:~$ 

set service pppoe-server access-concentrator 'ACN'
set service pppoe-server authentication mode 'radius'
set service pppoe-server authentication radius server 192.168.122.14 key 'vyos-secret'
set service pppoe-server client-ip-pool FIRST range '100.64.0.0/18'
set service pppoe-server client-ipv6-pool IPv6-POOL delegate 2001:db8:8003::/48 delegation-prefix '56'
set service pppoe-server client-ipv6-pool IPv6-POOL prefix 2001:db8:8002::/48 mask '64'
set service pppoe-server default-ipv6-pool 'IPv6-POOL'
set service pppoe-server default-pool 'FIRST'
set service pppoe-server gateway-address '100.64.0.1'
set service pppoe-server interface eth1 combined
set service pppoe-server interface eth1.23
set service pppoe-server log level '5'
set service pppoe-server name-server '1.1.1.1'
set service pppoe-server name-server '1.0.0.1'
set service pppoe-server ppp-options disable-ccp
set service pppoe-server ppp-options ipv6 'allow'

```
Check sessions on the `server` site:
```
vyos@r14:~$ show pppoe-server sessions 
 ifname | username |    ip     |            ip6           |         ip6-dp         |    calling-sid    | rate-limit | state  |  uptime  | rx-bytes | tx-bytes 
--------+----------+-----------+--------------------------+------------------------+-------------------+------------+--------+----------+----------+----------
 ppp0   | client-1 | 10.0.0.11 | 2001:db8:8002:0:200::/64 | 2001:db8:8003::/56     | 52:54:00:09:0b:01 |            | active | 00:01:36 | 1.8 KiB  | 1.6 KiB  
 ppp1   | client-2 | 10.0.0.12 | 2001:db8:8002:1:200::/64 | 2001:db8:8003:100::/56 | 52:54:00:09:0b:01 |            | active | 00:00:07 | 742 B    | 916 B
vyos@r14:~$ 

```
Routes with VRF:
```
vyos@r14:~$ show ip route vrf red | match ppp
K * 10.0.0.11/32 [0/0] is directly connected, ppp0, weight 1, 00:31:41
C>* 10.0.0.11/32 is directly connected, ppp0, weight 1, 00:31:41
L>* 100.64.0.1/32 is directly connected, ppp0, weight 1, 00:31:41
K>* 100.64.0.11/32 [0/1] via 10.0.0.11, ppp0, weight 1, 00:31:41
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ show ipv6 route vrf red | match ppp
C>* 2001:db8:8002::/64 is directly connected, ppp0, weight 1, 00:31:46
L>* 2001:db8:8002:0:100::/128 is directly connected, ppp0, weight 1, 00:31:46
K>* 2001:db8:8003::/56 [0/1024] via fe80::f449:15ff:fe64:22e6, ppp0, weight 1, 00:31:44
C>* fe80::/64 is directly connected, ppp0, weight 1, 00:31:46
vyos@r14:~$ 

```
Routes without VRF:
```
vyos@r14:~$ show ip route | match ppp
K * 10.0.0.12/32 [0/0] is directly connected, ppp1, weight 1, 00:31:08
C>* 10.0.0.12/32 is directly connected, ppp1, weight 1, 00:31:08
L>* 100.64.0.1/32 is directly connected, ppp1, weight 1, 00:31:08
K>* 100.64.0.12/32 [0/1] via 10.0.0.12, ppp1, weight 1, 00:31:08
vyos@r14:~$ 
vyos@r14:~$ show ipv6 route | match ppp
C>* 2001:db8:8002:1::/64 is directly connected, ppp1, weight 1, 00:31:12
L>* 2001:db8:8002:1:100::/128 is directly connected, ppp1, weight 1, 00:31:12
K>* 2001:db8:8003:100::/56 [0/1024] via fe80::f4ce:e3ff:fe2b:fff5, ppp1, weight 1, 00:31:10
C * fe80::/64 is directly connected, ppp1, weight 1, 00:31:12
vyos@r14:~$ 

```

Check sessions on the `client` site IPv4/IPv6 + prefix-delegation to dummy interfaces:
```
vyos@r15:~$ show int
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address                                MAC                VRF        MTU  S/L    Description
-----------  ----------------------------------------  -----------------  -------  -----  -----  -------------
dum1         2001:db8:8003:0:41c:89ff:fe32:a6ab/56     06:1c:89:32:a6:ab  default   1500  u/u
dum2         2001:db8:8003:100:68da:23ff:fe8c:c02b/56  6a:da:23:8c:c0:2b  default   1500  u/u
eth0         192.168.122.15/24                         52:54:00:55:80:8c  default   1500  u/u
eth1         -                                         52:54:00:09:0b:01  default   1500  u/u
eth2         -                                         52:54:00:96:17:74  default   1500  u/u
eth3         -                                         52:54:00:60:2a:d6  default   1500  u/u
eth4         -                                         52:54:00:73:28:72  default   1500  u/u
lo           127.0.0.1/8                               00:00:00:00:00:00  default  65536  u/u
             ::1/128
pppoe1       10.0.0.11/32                              n/a                default   1492  u/u
             2001:db8:8002:0:200::/64
pppoe2       10.0.0.12/32                              n/a                default   1492  u/u
             2001:db8:8002:1:200::/64
vyos@r15:~$ 

```

Config load tests:
```
sudo make testc | tee smoketest_make_testc.log
...
DEBUG - test_basic_api_service (__main__.TestConfigBasicApiService.test_basic_api_service) ...  time: 26.385
DEBUG - ok
DEBUG - test_basic_haproxy (__main__.TestConfigBasicHaproxy.test_basic_haproxy) ...  time: 27.426
DEBUG - ok
DEBUG - test_basic_syslog (__main__.TestConfigBasicSyslog.test_basic_syslog) ...  time: 9.364
DEBUG - ok
DEBUG - test_basic_vyos (__main__.TestConfigBasicVyos.test_basic_vyos) ...  time: 31.606
DEBUG - ok
DEBUG - test_basic_vyos_no_ntp (__main__.TestConfigBasicVyosNoNtp.test_basic_vyos_no_ntp) ...  time: 27.007
DEBUG - ok
DEBUG - test_bgp_azure_ipsec_gateway (__main__.TestConfigBgpAzureIpsecGateway.test_bgp_azure_ipsec_gateway) ...  time: 39.086
DEBUG - ok
DEBUG - test_bgp_bfd_communities (__main__.TestConfigBgpBfdCommunities.test_bgp_bfd_communities) ...  time: 28.792
DEBUG - ok
DEBUG - test_bgp_big_as_cloud (__main__.TestConfigBgpBigAsCloud.test_bgp_big_as_cloud) ...  time: 71.860
DEBUG - ok
DEBUG - test_bgp_dmvpn_hub (__main__.TestConfigBgpDmvpnHub.test_bgp_dmvpn_hub) ...  time: 27.446
DEBUG - ok
DEBUG - test_bgp_dmvpn_spoke (__main__.TestConfigBgpDmvpnSpoke.test_bgp_dmvpn_spoke) ...  time: 28.632
DEBUG - ok
DEBUG - test_bgp_evpn_l2vpn_leaf (__main__.TestConfigBgpEvpnL2vpnLeaf.test_bgp_evpn_l2vpn_leaf) ...  time: 26.345
DEBUG - ok
DEBUG - test_bgp_evpn_l2vpn_spine (__main__.TestConfigBgpEvpnL2vpnSpine.test_bgp_evpn_l2vpn_spine) ...  time: 25.246
DEBUG - ok
DEBUG - test_bgp_evpn_l3vpn_pe_router (__main__.TestConfigBgpEvpnL3vpnPeRouter.test_bgp_evpn_l3vpn_pe_router) ...  time: 32.062
DEBUG - ok
DEBUG - test_bgp_medium_confederation (__main__.TestConfigBgpMediumConfederation.test_bgp_medium_confederation) ...  time: 12.742
DEBUG - ok
DEBUG - test_bgp_rpki (__main__.TestConfigBgpRpki.test_bgp_rpki) ...  time: 24.531
DEBUG - ok
DEBUG - test_bgp_small_internet_exchange (__main__.TestConfigBgpSmallInternetExchange.test_bgp_small_internet_exchange) ...  time: 29.039
DEBUG - ok
DEBUG - test_bgp_small_ipv4_unicast (__main__.TestConfigBgpSmallIpv4Unicast.test_bgp_small_ipv4_unicast) ...  time: 24.772
DEBUG - ok
DEBUG - test_cluster_basic (__main__.TestConfigClusterBasic.test_cluster_basic) ...  time: 10.993
DEBUG - ok
DEBUG - test_conntrack_basic (__main__.TestConfigConntrackBasic.test_conntrack_basic) ...  time: 25.432
DEBUG - ok
DEBUG - test_container_simple (__main__.TestConfigContainerSimple.test_container_simple) ...  time: 9.674
DEBUG - ok
DEBUG - test_dialup_router_complex (__main__.TestConfigDialupRouterComplex.test_dialup_router_complex) ...  time: 50.687
DEBUG - ok
DEBUG - test_dialup_router_medium_vpn (__main__.TestConfigDialupRouterMediumVpn.test_dialup_router_medium_vpn) ...  time: 42.194
DEBUG - ok
DEBUG - test_dialup_router_wireguard_ipv6 (__main__.TestConfigDialupRouterWireguardIpv6.test_dialup_router_wireguard_ipv6) ...  time: 50.513
DEBUG - ok
DEBUG - test_egp_igp_route_maps (__main__.TestConfigEgpIgpRouteMaps.test_egp_igp_route_maps) ...  time: 12.081
DEBUG - ok
DEBUG - test_firewall_bridged_global_options (__main__.TestConfigFirewallBridgedGlobalOptions.test_firewall_bridged_global_options) ...  time: 9.280
DEBUG - ok
DEBUG - test_igmp_pim_small (__main__.TestConfigIgmpPimSmall.test_igmp_pim_small) ...  time: 25.156
DEBUG - ok
DEBUG - test_ipoe_server (__main__.TestConfigIpoeServer.test_ipoe_server) ...  time: 27.286
DEBUG - ok
DEBUG - test_ipv6_disable (__main__.TestConfigIpv6Disable.test_ipv6_disable) ...  time: 26.076
DEBUG - ok
DEBUG - test_isis_small (__main__.TestConfigIsisSmall.test_isis_small) ...  time: 24.989
DEBUG - ok
DEBUG - test_nat_basic (__main__.TestConfigNatBasic.test_nat_basic) ...  time: 29.067
DEBUG - ok
DEBUG - test_ospf_simple (__main__.TestConfigOspfSimple.test_ospf_simple) ...  time: 10.039
DEBUG - ok
DEBUG - test_ospf_small (__main__.TestConfigOspfSmall.test_ospf_small) ...  time: 28.418
DEBUG - ok
DEBUG - test_pppoe_server (__main__.TestConfigPppoeServer.test_pppoe_server) ...  time: 27.040
DEBUG - ok
DEBUG - test_qos_basic (__main__.TestConfigQosBasic.test_qos_basic) ...  time: 25.271
DEBUG - ok
DEBUG - test_rip_router (__main__.TestConfigRipRouter.test_rip_router) ...  time: 26.718
DEBUG - ok
DEBUG - test_rpki_only (__main__.TestConfigRpkiOnly.test_rpki_only) ...  time: 25.815
DEBUG - ok
DEBUG - test_static_route_basic (__main__.TestConfigStaticRouteBasic.test_static_route_basic) ...  time: 11.018
DEBUG - ok
DEBUG - test_tunnel_broker (__main__.TestConfigTunnelBroker.test_tunnel_broker) ...  time: 27.617
DEBUG - ok
DEBUG - test_vpn_openconnect_sstp (__main__.TestConfigVpnOpenconnectSstp.test_vpn_openconnect_sstp) ...  time: 29.771
DEBUG - ok
DEBUG - test_vrf_basic (__main__.TestConfigVrfBasic.test_vrf_basic) ...  time: 27.762
DEBUG - ok
DEBUG - test_vrf_bgp_pppoe_underlay (__main__.TestConfigVrfBgpPppoeUnderlay.test_vrf_bgp_pppoe_underlay) ...  time: 39.268
DEBUG - ok
DEBUG - test_vrf_ospf (__main__.TestConfigVrfOspf.test_vrf_ospf) ...  time: 25.835
DEBUG - ok
DEBUG - test_wireless_basic (__main__.TestConfigWirelessBasic.test_wireless_basic) ...  time: 10.394
DEBUG - ok
DEBUG - 
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 43 tests in 1151.233s
DEBUG - 
DEBUG - OK
DEBUG - vyos@vyos:~$ echo EXITCODE:$?
DEBUG - echo EXITCODE:$?
DEBUG - EXITCODE:0

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
