### PR TITLE
T7743: PPPoE-server add option for VPP control plane

### DIFF
--- a/data/templates/accel-ppp/pppoe.config.j2
+++ b/data/templates/accel-ppp/pppoe.config.j2
@@ -55,14 +55,15 @@ verbose=1
 ac-name={{ access_concentrator }}
 {% if interface is vyos_defined %}
 {%     for iface, iface_config in interface.items() %}
+{%         set vpp_cp_opt = ',vpp-cp=true' if iface_config.vpp_cp is vyos_defined else '' %}
 {%         if iface_config.vlan is not vyos_defined %}
-interface={{ iface }}
+interface={{ iface }}{{ vpp_cp_opt }}
 {%         else %}
 {%             for vlan in iface_config.vlan %}
 interface=re:^{{ iface }}\.{{ vlan | range_to_regex }}$
 {%             endfor %}
 {%             if iface_config.combined is vyos_defined %}
-interface={{ iface }}
+interface={{ iface }}{{ vpp_cp_opt }}
 {%             endif %}
 {%             if iface_config.vlan_mon is vyos_defined %}
 vlan-mon={{ iface }},{{ iface_config.vlan | join(',') }}

--- a/interface-definitions/service_pppoe-server.xml.in
+++ b/interface-definitions/service_pppoe-server.xml.in
@@ -71,6 +71,12 @@
               </leafNode>
               #include <include/accel-ppp/vlan.xml.i>
               #include <include/accel-ppp/vlan-mon.xml.i>
+              <leafNode name="vpp-cp">
+                <properties>
+                  <help>Enable PPPoE control-plane integration with VPP</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
             </children>
           </tagNode>
           <leafNode name="service-name">

--- a/smoketest/scripts/cli/test_service_pppoe-server.py
+++ b/smoketest/scripts/cli/test_service_pppoe-server.py
@@ -211,6 +211,20 @@ class TestServicePPPoEServer(BasicAccelPPPTest.TestCase):
         self.assertIn('accept-any-service=1', config)
         self.assertIn('accept-blank-service=1', config)
 
+    def test_accel_vpp_cp(self):
+        interface_vpp = f'{interface},vpp-cp=true'
+
+        self.basic_config()
+        self.set(['interface', interface, 'vpp-cp'])
+        self.cli_commit()
+
+        # Validate configuration values
+        conf = ConfigParser(allow_no_value=True, delimiters='=')
+        conf.read(self._config_file)
+
+        # Validate configuration
+        self.assertEqual(conf['pppoe']['interface'], interface_vpp)
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Enable PPPoE control-plane integration with VPP, add configurable option:
 - set service pppoe-server interface eth1 vpp-cp

```
interface=eth1,vpp-cp=true
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7743

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Config:
```
set service pppoe-server access-concentrator 'ACN'
set service pppoe-server authentication any-login
set service pppoe-server authentication mode 'radius'
set service pppoe-server authentication radius server 192.168.122.14 key 'vyos-secret'
set service pppoe-server client-ip-pool FIRST range '100.64.0.0/18'
set service pppoe-server client-ipv6-pool IPv6-POOL delegate 2001:db8:8003::/48 delegation-prefix '56'
set service pppoe-server client-ipv6-pool IPv6-POOL prefix 2001:db8:8002::/48 mask '64'
set service pppoe-server default-ipv6-pool 'IPv6-POOL'
set service pppoe-server default-pool 'FIRST'
set service pppoe-server gateway-address '100.64.0.1'
set service pppoe-server interface eth1 combined
set service pppoe-server interface eth1 vpp-cp
set service pppoe-server log level '0'
set service pppoe-server name-server '1.1.1.1'
set service pppoe-server name-server '1.0.0.1'
set service pppoe-server ppp-options disable-ccp
set service pppoe-server ppp-options ipv6 'allow'
set service pppoe-server session-control 'disable'

```
Expected `vpp-cp` option for pppoe conf
```
[pppoe]
verbose=1
ac-name=ACN
interface=eth1,vpp-cp=true

```

Smoketest
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py -k test_accel_vpp_cp
test_accel_vpp_cp (__main__.TestServicePPPoEServer.test_accel_vpp_cp) ... ok

----------------------------------------------------------------------
Ran 1 test in 6.277s

OK
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
