### PR TITLE
op-mode: T7751: fix re-generating SSH server key causes PermissionError

### DIFF
--- a/src/op_mode/generate_ssh_server_key.py
+++ b/src/op_mode/generate_ssh_server_key.py
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from sys import exit
+
+from vyos.defaults import directories
 from vyos.utils.io import ask_yes_no
 from vyos.utils.process import cmd
 from vyos.utils.commit import commit_in_progress
@@ -26,6 +28,8 @@ if commit_in_progress():
     print('Cannot restart SSH while a commit is in progress')
     exit(1)
 
+conf_mode_dir = directories['conf_mode']
+
 cmd('rm -v /etc/ssh/ssh_host_*')
 cmd('dpkg-reconfigure openssh-server')
-cmd('systemctl restart ssh.service')
+cmd(f'{conf_mode_dir}/service_ssh.py')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Fixes an issue when re-generating SSH server key

```
vyos@vyos:~$ generate ssh server-key
Do you really want to remove the existing SSH host keys? [y/N] y Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/generate_ssh_server_key.py", line 31, in <module>
    cmd('systemctl restart ssh.service')
  File "/usr/lib/python3/dist-packages/vyos/utils/process.py", line 155, in cmd
    raise OSError(code, feedback)
PermissionError: [Errno 1] failed to run command: systemctl restart ssh.service returned:
exit code: 1
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7751

## How to test / Smoketest result

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_ssh.py
test_ssh_default (__main__.TestServiceSSH.test_ssh_default) ... ok
test_ssh_dynamic_protection (__main__.TestServiceSSH.test_ssh_dynamic_protection) ... ok
test_ssh_login (__main__.TestServiceSSH.test_ssh_login) ... ok
test_ssh_multiple_listen_addresses (__main__.TestServiceSSH.test_ssh_multiple_listen_addresses) ... ok
test_ssh_ndcpp (__main__.TestServiceSSH.test_ssh_ndcpp) ... ok
test_ssh_pubkey_accepted_algorithm (__main__.TestServiceSSH.test_ssh_pubkey_accepted_algorithm) ... ok
test_ssh_single_listen_address (__main__.TestServiceSSH.test_ssh_single_listen_address) ... ok
test_ssh_trusted_user_ca (__main__.TestServiceSSH.test_ssh_trusted_user_ca) ... ok
test_ssh_vrf_multi (__main__.TestServiceSSH.test_ssh_vrf_multi) ... ok
test_ssh_vrf_single (__main__.TestServiceSSH.test_ssh_vrf_single) ... ok

----------------------------------------------------------------------
Ran 10 tests in 48.286s

OK
```

```
vyos@vyos:~$ generate ssh server-key
Do you really want to remove the existing SSH host keys? [y/N] y
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
