### PR TITLE
T7742: Add 'show interfaces kernel statistics' command

### DIFF
--- a/op-mode-definitions/show-interfaces.xml.in
+++ b/op-mode-definitions/show-interfaces.xml.in
@@ -42,7 +42,7 @@
                 <children>
                   <leafNode name="detail">
                     <properties>
-                      <help>Show system interface in JSON format</help>
+                      <help>Show system interface details</help>
                     </properties>
                     <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --intf-name=$4 --detail</command>
                   </leafNode>
@@ -52,11 +52,17 @@
                     </properties>
                     <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --intf-name=$4 --raw</command>
                   </leafNode>
+                  <leafNode name="statistics">
+                    <properties>
+                      <help>Show system interface statistics</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --intf-name=$4 --statistics</command>
+                  </leafNode>
                 </children>
               </virtualTagNode>
               <leafNode name="detail">
                 <properties>
-                  <help>Show system interface in JSON format</help>
+                  <help>Show system interface details</help>
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --detail</command>
               </leafNode>
@@ -65,6 +71,12 @@
                   <help>Show all interfaces in JSON format</help>
                 </properties>
                 <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --raw</command>
+              </leafNode>
+              <leafNode name="statistics">
+                <properties>
+                  <help>Show system interface statistics</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/interfaces.py show_kernel --statistics</command>
               </leafNode>
             </children>
           </node>


### PR DESCRIPTION
This change adds the following commands:

```
show interfaces kernel statistics
show interfaces kernel <interface-name> statistics
```
Output looks like this:
```
Interface      Rx Packets     Rx Bytes    Tx Packets     Tx Bytes    Rx Dropped    Tx Dropped    Rx Errors    Tx Errors
-----------  ------------  -----------  ------------  -----------  ------------  ------------  -----------  -----------
dum0                    0            0         76078     20464982             0             0            0            0
dum1                    0            0         13594      4757900             0             0            0            0
eth0             26100444  12515802215      23715927  12519390220        387292             0            0            0
eth1             10331043    692308845         76089     19401736        284914             0            0            0
eth2              1216638     82738654         76087     19401226             0             0            0            0
eth3                    0            0             0            0             0             0            0            0
eth4                    0            0             0            0             0             0            0            0
eth5                   43         3030         76161     19404632             0             0            0            0
eth6              3757448    229318250       6695209   9256563729             0             0            0            0
eth7                13449       966787         89352     21448906             0             0            0            0
lo                   1880      1155580          1880      1155580             0             0            0            0
tailscale0           2100       261304          6230      7024577             0             0            0            0
wlan0                   0            0             0            0             0             0            0            0
```

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7742
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Run `show interfaces kernel statistics`
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
