### PR TITLE
isis: T7722: Added interface fast-reroute configuration commands

### DIFF
--- a/data/templates/frr/isisd.frr.j2
+++ b/data/templates/frr/isisd.frr.j2
@@ -16,6 +16,33 @@ interface {{ iface }}
 {%         if iface_config.circuit_type is vyos_defined %}
  isis circuit-type {{ iface_config.circuit_type }}
 {%         endif %}
+{%         if iface_config.fast_reroute.lfa is vyos_defined %}
+{%             for level, level_config in iface_config.fast_reroute.lfa.items() %}
+{%                 if level_config.enable is vyos_defined %}
+isis fast-reroute lfa {{ level | replace('_', '-') }}
+{%                 endif %}
+{%                 if level_config.exclude.interface is vyos_defined %}
+{%                     for excl_if in level_config.exclude.interface %}
+isis fast-reroute lfa {{ level | replace('_', '-') }} exclude interface {{ excl_if }}
+{%                     endfor %}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%         if iface_config.fast_reroute.remote_lfa is vyos_defined %}
+{%             for level, level_config in iface_config.fast_reroute.remote_lfa.items() %}
+{%                 if level_config.maximum_metric is vyos_defined %}
+isis fast-reroute remote-lfa maximum-metric {{ level_config.maximum_metric }} {{ level | replace('_', '-') }}
+{%                 endif %}
+{%                 if level_config.tunnel.mpls_ldp is vyos_defined %}
+isis fast-reroute remote-lfa tunnel mpls-ldp {{ level | replace('_', '-') }}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%         if iface_config.fast_reroute.ti_lfa is vyos_defined %}
+{%             for level, level_config in iface_config.fast_reroute.ti_lfa.items() %}
+isis fast-reroute ti-lfa {{ level | replace('_', '-') }} {{ 'node-protection' if level_config.node_protection is vyos_defined }} {{ 'link-fallback' if level_config.node_protection.link_fallback is vyos_defined }}
+{%             endfor %}
+{%         endif %}
 {%         if iface_config.hello_interval is vyos_defined %}
  isis hello-interval {{ iface_config.hello_interval }}
 {%         endif %}

--- a/interface-definitions/include/isis/exclude-interface.xml.i
+++ b/interface-definitions/include/isis/exclude-interface.xml.i
@@ -1,0 +1,10 @@
+<!-- include start from isis/exclude-interface.xml.i -->
+<node name="exclude">
+  <properties>
+    <help>Exclude interfaces from fast reroute</help>
+  </properties>
+  <children>
+      #include <include/generic-interface-multi.xml.i>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/isis/frr-maxmetric.xml.i
+++ b/interface-definitions/include/isis/frr-maxmetric.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from isis/frr-maxmetric.xml.i -->
+<leafNode name="maximum-metric">
+  <properties>
+    <help>Limit remote LFA node selection within the metric</help>
+    <valueHelp>
+      <format>u32:1-16777215</format>
+      <description>Metric value</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-16777215"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/isis/node-protection.xml.i
+++ b/interface-definitions/include/isis/node-protection.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from isis/node-protection.xml.i -->
+<node name="node-protection">
+  <properties>
+    <help>Protect against node failures</help>
+  </properties>
+  <children>
+    <leafNode name="link-fallback">
+      <properties>
+        <help>Enable link-protection fallback</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/isis/protocol-common-config.xml.i
+++ b/interface-definitions/include/isis/protocol-common-config.xml.i
@@ -667,6 +667,96 @@
         </constraint>
       </properties>
     </leafNode>
+    <node name="fast-reroute">
+      <properties>
+        <help>IS-IS fast reroute</help>
+      </properties>
+      <children>
+        <node name="lfa">
+          <properties>
+            <help>Enable LFA computation</help>
+          </properties>
+          <children>
+            <node name="level-1">
+              <properties>
+                <help> Enable LFA computation for Level 1 only</help>
+              </properties>
+              <children>
+                <leafNode name="enable">
+                  <properties>
+                    <help>Enable LFA</help>
+                    <valueless/>
+                  </properties>
+                </leafNode>
+                #include <include/isis/exclude-interface.xml.i>
+              </children>
+            </node>
+            <node name="level-2">
+              <properties>
+                <help>Enable LFA computation for Level 2 only</help>
+              </properties>
+              <children>
+                <leafNode name="enable">
+                  <properties>
+                    <help>Enable LFA</help>
+                    <valueless/>
+                  </properties>
+                </leafNode>
+                #include <include/isis/exclude-interface.xml.i>
+              </children>
+            </node>
+          </children>
+        </node>
+        <node name="remote-lfa">
+          <properties>
+            <help>Enable remote LFA computation</help>
+          </properties>
+          <children>
+            <node name="level-1">
+              <properties>
+                <help> Enable remote LFA computation for Level 1 only</help>
+              </properties>
+              <children>
+                #include <include/isis/frr-maxmetric.xml.i>
+                #include <include/isis/remote_lfa_tunnel.xml.i>
+              </children>
+            </node>
+            <node name="level-2">
+              <properties>
+                <help>Enable remote LFA computation for Level 2 only</help>
+              </properties>
+              <children>
+                #include <include/isis/frr-maxmetric.xml.i>
+                #include <include/isis/remote_lfa_tunnel.xml.i>
+              </children>
+            </node>
+          </children>
+        </node>
+        <node name="ti-lfa">
+          <properties>
+            <help> Enable TI-LFA computation</help>
+          </properties>
+          <children>
+            <node name="level-1">
+              <properties>
+                <help>Enable TI-LFA computation for Level 1 only</help>
+              </properties>
+              <children>
+                #include <include/isis/node-protection.xml.i>
+              </children>
+            </node>
+            <node name="level-2">
+              <properties>
+                <help>Enable TI-LFA computation for Level 2 only</help>
+              </properties>
+              <children>
+                #include <include/isis/node-protection.xml.i>
+              </children>
+            </node>
+          </children>
+        </node>
+      </children>
+    </node>
     <leafNode name="hello-padding">
       <properties>
         <help>Add padding to IS-IS hello packets</help>

--- a/interface-definitions/include/isis/remote_lfa_tunnel.xml.i
+++ b/interface-definitions/include/isis/remote_lfa_tunnel.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from isis/remote_lfa_tunnel.xml.i -->
+<node name="tunnel">
+  <properties>
+    <help>Enable remote LFA computation using tunnels</help>
+  </properties>
+  <children>
+    <leafNode name="mpls-ldp">
+      <properties>
+        <help>Use MPLS LDP tunnel to reach the remote LFA node</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Added interface fast-reroute configuration commands

Added commands:
```
set protocols isis interface <INTERFACE NAME> fast-reroute lfa <level-1 | level-2> enable
set protocols isis interface <INTERFACE NAME> fast-reroute lfa  <level-1 | level-2>  exclude interface <INTERFACE NAME> 
set protocols isis interface <INTERFACE NAME> fast-reroute remote-lfa <level-1 | level-2> maximum-metric <METRIC>
set protocols isis interface <INTERFACE NAME> fast-reroute remote-lfa  [level-1 | level-2] tunnel mpls-ldp
set protocols isis interface <INTERFACE NAME> fast-reroute ti-lfa  <level-1 | level-2> [node-protection [link-fallback]]
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7722

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Smoketests:
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_isis.py
test_isis_01_redistribute (__main__.TestProtocolsISIS.test_isis_01_redistribute) ... ok
test_isis_02_vrfs (__main__.TestProtocolsISIS.test_isis_02_vrfs) ... ok
test_isis_04_default_information (__main__.TestProtocolsISIS.test_isis_04_default_information) ... ok
test_isis_05_password (__main__.TestProtocolsISIS.test_isis_05_password) ... ok
test_isis_06_spf_delay_bfd (__main__.TestProtocolsISIS.test_isis_06_spf_delay_bfd) ... ok
test_isis_07_segment_routing_configuration (__main__.TestProtocolsISIS.test_isis_07_segment_routing_configuration) ... ok
test_isis_08_ldp_sync (__main__.TestProtocolsISIS.test_isis_08_ldp_sync) ... ok
test_isis_09_lfa (__main__.TestProtocolsISIS.test_isis_09_lfa) ... ok
test_isis_10_topology (__main__.TestProtocolsISIS.test_isis_10_topology) ... ok
test_isis_11_srv6 (__main__.TestProtocolsISIS.test_isis_11_srv6) ... ok
test_isis_12_frr_interface_lfa_remotelfa (__main__.TestProtocolsISIS.test_isis_12_frr_interface_lfa_remotelfa) ... ok
test_isis_13_frr_interface_tilfa (__main__.TestProtocolsISIS.test_isis_13_frr_interface_tilfa) ... ok

----------------------------------------------------------------------
Ran 12 tests in 374.663s

OK

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
