### PR TITLE
T7759: Revert "T7709: add atomic write for config file save"

### DIFF
--- a/python/vyos/component_version.py
+++ b/python/vyos/component_version.py
@@ -209,16 +209,6 @@ def version_info_prune_component(x: VersionInfo, y: VersionInfo) -> VersionInfo:
     x.component = {k: v for k, v in x.component.items() if k in y.component}
 
 
-def add_system_version_string(config_str: str = None) -> str:
-    """Wrap config string with system version and return string."""
-    version_info = version_info_from_system()
-    if config_str is not None:
-        version_info.update_config_body(config_str)
-    version_info.update_footer()
-
-    return version_info.write_string()
-
-
 def add_system_version(config_str: str = None, out_file: str = None):
     """Wrap config string with system version and write to out_file.
 

--- a/src/helpers/vyos-save-config.py
+++ b/src/helpers/vyos-save-config.py
@@ -23,18 +23,15 @@ from argparse import ArgumentParser
 
 from vyos.config import Config
 from vyos.remote import urlc
-from vyos.component_version import add_system_version_string
+from vyos.component_version import add_system_version
 from vyos.defaults import directories
-from vyos.utils.file import write_file_atomic
 
 DEFAULT_CONFIG_PATH = os.path.join(directories['config'], 'config.boot')
 remote_save = None
 
 parser = ArgumentParser(description='Save configuration')
 parser.add_argument('file', type=str, nargs='?', help='Save configuration to file')
-parser.add_argument(
-    '--write-json-file', type=str, help='Save JSON of configuration to file'
-)
+parser.add_argument('--write-json-file', type=str, help='Save JSON of configuration to file')
 args = parser.parse_args()
 file = args.file
 json_file = args.write_json_file
@@ -59,14 +56,7 @@ write_file = save_file if remote_save is None else NamedTemporaryFile(delete=Fal
 # config_tree is None before boot configuration is complete;
 # automated saves should check boot_configuration_complete
 config_str = None if ct is None else ct.to_string()
-versioned_config_str = add_system_version_string(config_str)
-
-try:
-    with write_file_atomic(write_file) as f:
-        f.write(versioned_config_str)
-except OSError as e:
-    print(f'failed to write config file: {e}')
-    sys.exit(1)
+add_system_version(config_str, write_file)
 
 if json_file is not None and ct is not None:
     try:


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The utility `write_file_atomic` does not correctly update the file in the bind mount directory `/config`.
Revert for investigation and a proper implementation.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
