### PR TITLE
Debian: T7762: adjust vyos-1x package version to not mention 1.5 in any way

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-vyos-1x (1.5dev0) unstable; urgency=medium
+vyos-1x (999.0) unstable; urgency=medium
 
   * Dummy changelog entry for vyos-1x repository
     This is a internal VyOS package and the VyOS package process does not use

--- a/debian/rules
+++ b/debian/rules
@@ -19,6 +19,11 @@ SERVICES_DIR := usr/libexec/vyos/services
 
 DEB_TARGET_ARCH := $(shell dpkg-architecture -qDEB_TARGET_ARCH)
 
+# Base version prefix from debian/changelog
+BASE_VERSION := 999.0
+COMMIT_ID := $(shell echo -n g && git rev-parse --short HEAD)
+DIRTY_FLAG := $(shell ! git diff --quiet || ! git diff --cached --quiet && echo -dirty || echo)
+
 %:
 	dh $@ --with python3, --with quilt
 
@@ -27,7 +32,7 @@ DEB_TARGET_ARCH := $(shell dpkg-architecture -qDEB_TARGET_ARCH)
 override_dh_strip_nondeterminism:
 
 override_dh_gencontrol:
-	dh_gencontrol -- -v$(shell (git describe --tags --long --match 'vyos/*' --match '1.4.*' --dirty 2>/dev/null || echo 0.0-no.git.tag) | sed -E 's%vyos/%%' | sed -E 's%-dirty%+dirty%')
+	dh_gencontrol -- -v$(BASE_VERSION)-$(COMMIT_ID)$(DIRTY_FLAG)
 
 override_dh_auto_build:
 	make all


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

We've always used 999 as a kind of special super development version. Right now when a vyos-1x package is build from the current branch it's named like:

`vyos-1x_1.5dev0-3578-g2f1d1d343_all.deb`

marking the 3578th commit after tag 1.5dev0 was created ad some random point in time. The current Git repo commit id is 2f1d1d343.

To clearly unbind this from the 1.4, 1.5 and rolling development branch the naming scheme of the package should be changed to:

`vyos-1x_999.0-g20a4de757_amd64.deb`

marking it a development package build from Git (g) from commit `20a4de757`


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7762

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

```
-rw-r--r--  1 vyos  vyos     11922 Aug 28 17:06 vyos-1x_999.0_amd64.buildinfo
-rw-r--r--  1 vyos  vyos      2820 Aug 28 17:06 vyos-1x_999.0_amd64.changes
-rw-r--r--  1 vyos  vyos   2129880 Aug 28 17:06 vyos-1x_999.0-g5c03a86c0_amd64.deb
-rw-r--r--  1 vyos  vyos      5020 Aug 28 17:06 vyos-1x-aws_999.0-g5c03a86c0_all.deb
-rw-r--r--  1 vyos  vyos      2680 Aug 28 17:06 vyos-1x-dbgsym_999.0-g5c03a86c0_amd64.deb
-rw-r--r--  1 vyos  vyos    236228 Aug 28 17:06 vyos-1x-smoketest_999.0-g5c03a86c0_all.deb
-rw-r--r--  1 vyos  vyos      3216 Aug 28 17:06 vyos-1x-vmware_999.0-g5c03a86c0_all.deb
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
