### PR TITLE
container: T7186: Add macvlan network type for containers

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -566,6 +566,24 @@
         <children>
           #include <include/generic-description.xml.i>
           #include <include/interface/mtu-68-16000.xml.i>
+          <leafNode name="gateway">
+            <properties>
+              <help>Gateway address to use for this network</help>
+              <valueHelp>
+                <format>ipv4</format>
+                <description>IPv4 gateway address</description>
+              </valueHelp>
+              <valueHelp>
+                <format>ipv6</format>
+                <description>IPv6 gateway address</description>
+              </valueHelp>
+              <constraint>
+                <validator name="ip-address"/>
+                <validator name="ipv6-address"/>
+              </constraint>
+              <multi/>
+            </properties>
+          </leafNode>
           <leafNode name="prefix">
             <properties>
               <help>Prefix which allocated to that network</help>
@@ -590,6 +608,62 @@
               <valueless/>
             </properties>
           </leafNode>
+          <node name="type">
+            <properties>
+              <help>Network type (default: bridge)</help>
+            </properties>
+            <children>
+              <leafNode name="bridge">
+                <properties>
+                  <help>Bridge network</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <node name="macvlan">
+                <properties>
+                  <help>MACVLAN network</help>
+                </properties>
+                <children>
+                  <leafNode name="mode">
+                    <properties>
+                      <help>MACVLAN mode</help>
+                      <completionHelp>
+                        <list>bridge private vepa</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>bridge</format>
+                        <description>Containers act as separate hosts on the parent network</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>private</format>
+                        <description>Containers are isolated from the host and each other</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>vepa</format>
+                        <description>Containers send all traffic through the parent switch for forwarding</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>bridge|private|vepa</regex>
+                      </constraint>
+                      <constraintErrorMessage>Invalid mode</constraintErrorMessage>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="parent">
+                    <properties>
+                      <help>Parent network interface</help>
+                      <completionHelp>
+                        <script>${vyos_completion_dir}/list_interfaces --type ethernet --type bonding --type bridge</script>
+                      </completionHelp>
+                      <constraint>
+                        <regex>((bond|br|eth)[0-9]+(\.[0-9]+)?)</regex>
+                      </constraint>
+                      <constraintErrorMessage>Invalid parent interface</constraintErrorMessage>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
+            </children>
+          </node>
           #include <include/interface/vrf.xml.i>
         </children>
       </tagNode>

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -68,7 +68,7 @@ def get_host_identity() -> str:
     host = cmd("hostname").strip().lower()
     return f"{uuid}:{host}"
 
-def gen_mac(name: str, addr: str) -> str:
+def gen_mac(name: str, addr: str, ident: str) -> str:
     """
     Generate a deterministic locally-administered MAC address.
 
@@ -88,7 +88,6 @@ def gen_mac(name: str, addr: str) -> str:
     Returns:
         str: Deterministic MAC address in standard "xx:xx:xx:xx:xx:xx" format.
     """
-    ident = get_host_identity()
     h = hashlib.sha256(f"{ident}:{name}:{addr}".encode()).hexdigest()
     # 0x02 = locally-administered, unicast
     b = [0x02] + [int(h[i:i+2], 16) for i in range(0, 10, 2)]  # 5 bytes = 40 bits


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
This change adds the ability to configure macvlan as a network type for podman.

#### Syntax additions:
```
set container network <network name> gateway (ipv4-address|ipv6-address)
set container network <network name> type macvlan mode (bridge|private|vepa)
set container network <network name> type macvlan parent <host interface name>
```
#### Example network JSON:
```
{
  "name": "macvlan1",
  "id": "f284f716fb76eabbb8409c7c76fb7ad95df9472e5010c010a810cf0df08f0913",
  "driver": "macvlan",
  "network_interface": "eth0",
  "subnets": [
    {
      "subnet": "10.0.0.0/24",
      "gateway": "10.0.0.1"
    }
  ],
  "ipv6_enabled": false,
  "internal": false,
  "dns_enabled": true,
  "ipam_options": {
    "driver": "host-local"
  },
  "options": {
    "mode": "bridge",
    "mtu": "1500"
  }
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7186
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
#### Configure physical interface to use as container network's parent (note that it doesn't need an IP):
```
set interfaces ethernet eth0 vif 100
```
#### Configure the macvlan network:
```
set container network macvlan1 prefix '10.0.101.0/24'
set container network macvlan1 type macvlan mode 'bridge'
set container network macvlan1 type macvlan parent 'eth0.101'
```
##### Optionally add a gateway. This is important since a physical network might have a gateway that isn't the first IP in the subnet:
```
set container network macvlan1 gateway '10.0.101.10'
```
#### Attach a container to the network. This will be the same syntax as it's always been:
```
set container name alpine1 image 'alpine'
set container name alpine1 network macvlan1 address 10.0.101.137
```
You should see the MAC address for the container in the FDB of VyOS:
```
vyos@PE2# run connect container alpine1
/ # ifconfig eth0 | grep HWaddr
eth0      Link encap:Ethernet  HWaddr 02:19:74:91:63:E4
/ # exit
```
```
vyos@PE2# sudo bridge fdb show dev eth0.101 | match 02:19:74:91:63:e4
02:19:74:91:63:e4 self permanent
```
#### The IP should be reachable on your physical network:
```
C:\WINDOWS\system32>fping 10.0.101.137 -n 1
Pinging 10.0.101.137 with 32 bytes of data every 1000 ms:

Reply[1] from 10.0.101.137: bytes=32 time=3.7 ms TTL=63

Ping statistics for 10.0.101.137:
        Packets: Sent = 1, Received = 1, Lost = 0 (0% loss)
```
### Smoketest results:
```
test_api_socket (__main__.TestContainer.test_api_socket) ... ok
test_basic (__main__.TestContainer.test_basic) ... ok
test_cpu_limit (__main__.TestContainer.test_cpu_limit) ... ok
test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... ok
test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... ok
test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... ok
test_name_server (__main__.TestContainer.test_name_server) ... ok
test_network_mtu (__main__.TestContainer.test_network_mtu) ... ok
test_network_types (__main__.TestContainer.test_network_types) ... ok
test_no_name_server (__main__.TestContainer.test_no_name_server) ... ok
test_uid_gid (__main__.TestContainer.test_uid_gid) ... ok
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
