### PR TITLE
op-mode: T7764:  Add 'vlan-to-vni statistics' op-mode command

### DIFF
--- a/op-mode-definitions/show-interfaces-vxlan.xml.in
+++ b/op-mode-definitions/show-interfaces-vxlan.xml.in
@@ -54,7 +54,7 @@
                           </leafNode>
                           <leafNode name="statistics">
                             <properties>
-                              <help>Show statistics for the  t0 VNI mapping</help>
+                              <help>Show VLAN to VNI statistics for the specified VLAN</help>
                             </properties>
                             <command>${vyos_op_scripts_dir}/interfaces.py show_vlan_to_vni --intf-name="$4" --vid="$7" --statistics</command>
                           </leafNode>

--- a/op-mode-definitions/show-interfaces-vxlan.xml.in
+++ b/op-mode-definitions/show-interfaces-vxlan.xml.in
@@ -52,6 +52,12 @@
                             </properties>
                             <command>${vyos_op_scripts_dir}/interfaces.py show_vlan_to_vni --intf-name="$4" --vid="$7" --detail</command>
                           </leafNode>
+                          <leafNode name="statistics">
+                            <properties>
+                              <help>Show statistics for the  t0 VNI mapping</help>
+                            </properties>
+                            <command>${vyos_op_scripts_dir}/interfaces.py show_vlan_to_vni --intf-name="$4" --vid="$7" --statistics</command>
+                          </leafNode>
                         </children>
                       </tagNode>
                       <leafNode name="detail">
@@ -59,6 +65,12 @@
                           <help>Show detailed VLAN to VNI mapping for the specified VXLAN interface</help>
                         </properties>
                         <command>${vyos_op_scripts_dir}/interfaces.py show_vlan_to_vni --intf-name="$4" --detail</command>
+                      </leafNode>
+                      <leafNode name="statistics">
+                        <properties>
+                          <help>Show VLAN to VNI statistics for the specified VXLAN interface</help>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/interfaces.py show_vlan_to_vni --intf-name="$4" --statistics</command>
                       </leafNode>
                     </children>
                   </node>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
VLAN-to-VNI interface statistics are not returned with any existing op-mode command. This would provide that useful information. The following commands would be added:
```
show interfaces vxlan <interface name> statistics
show interfaces vxlan <interface name>vlan <vlan-id> statistics
```
The output would like like this:
```
show interfaces vxlan vxlan0 statistics
Interface      VLAN    VNI    Rx Packets    Rx Bytes    Tx Packets    Tx Bytes
-----------  ------  -----  ------------  ----------  ------------  ----------
vxlan0           10   1001             0           0             0           0
vxlan0           20   1002             0           0             0           0
```
```
show interfaces vxlan vxlan0 vlan 10 statistics
Interface      VLAN    VNI    Rx Packets    Rx Bytes    Tx Packets    Tx Bytes
-----------  ------  -----  ------------  ----------  ------------  ----------
vxlan0           10   1001             0           0             0           0
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7764
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
#### Configure a vxlan interface with `vlan-to-vni` mappings and attach to bridge:
```
set interfaces vxlan vxlan1 parameters external
set interfaces vxlan vxlan1 port '4789'
set interfaces vxlan vxlan1 source-address '10.5.5.5'
set interfaces vxlan vxlan1 vlan-to-vni 10 description 'Cust-A'
set interfaces vxlan vxlan1 vlan-to-vni 10 vni '1001'
set interfaces vxlan vxlan1 vlan-to-vni 20 description 'Cust-B'
set interfaces vxlan vxlan1 vlan-to-vni 20 vni '1002'

set interfaces bridge br0 member interface vxlan1
```
Run commands:
```
vyos@PE2:~$ show interfaces vxlan vxlan1 vlan-to-vni statistics
Interface      VLAN    VNI    Rx Packets    Rx Bytes    Tx Packets    Tx Bytes
-----------  ------  -----  ------------  ----------  ------------  ----------
vxlan1           10   1001             0           0             0           0
vxlan1           20   1002             0           0             0           0

vyos@PE2:~$ show interfaces vxlan vxlan1 vlan-to-vni vlan 10 statistics
Interface      VLAN    VNI    Rx Packets    Rx Bytes    Tx Packets    Tx Bytes
-----------  ------  -----  ------------  ----------  ------------  ----------
vxlan1           10   1001             0           0             0           0
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
