### PR TITLE
T7757: VPP Verify buffers for rx/tx queues

### DIFF
--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -360,14 +360,19 @@
                 <properties>
                   <help>Number of buffers per numa node</help>
                   <valueHelp>
-                    <format>u32:0-4294967295</format>
+                    <format>u32:16384-4294967295</format>
                     <description>Number of buffers</description>
                   </valueHelp>
+                  <valueHelp>
+                     <format>auto</format>
+                     <description>Auto calculate number of buffers per numa node</description>
+                   </valueHelp>
                   <constraint>
-                    <validator name="numeric" argument="--range 0-4294967295"/>
+                    <validator name="numeric" argument="--range 16384-4294967295"/>
+                    <regex>(auto)</regex>
                   </constraint>
                 </properties>
-                <defaultValue>16384</defaultValue>
+                <defaultValue>auto</defaultValue>
               </leafNode>
               <leafNode name="data-size">
                 <properties>

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -367,6 +367,7 @@
                     <validator name="numeric" argument="--range 0-4294967295"/>
                   </constraint>
                 </properties>
+                <defaultValue>16384</defaultValue>
               </leafNode>
               <leafNode name="data-size">
                 <properties>
@@ -379,12 +380,14 @@
                     <validator name="numeric" argument="--range 0-4294967295"/>
                   </constraint>
                 </properties>
+                <defaultValue>2048</defaultValue>
               </leafNode>
               <leafNode name="page-size">
                 <properties>
                   <help>Set the page-size for buffer allocation</help>
                   #include <include/unformat_log2_page_size.xml.i>
                 </properties>
+                <defaultValue>default</defaultValue>
               </leafNode>
             </children>
           </node>
@@ -501,6 +504,7 @@
                         <validator name="numeric" argument="--range 256-8192"/>
                       </constraint>
                     </properties>
+                    <defaultValue>1024</defaultValue>
                   </leafNode>
                   <leafNode name="num-tx-desc">
                     <properties>
@@ -513,6 +517,7 @@
                         <validator name="numeric" argument="--range 256-8192"/>
                       </constraint>
                     </properties>
+                    <defaultValue>1024</defaultValue>
                   </leafNode>
                   <leafNode name="num-rx-queues">
                     <properties>

--- a/python/vyos/vpp/config_resource_checks/memory.py
+++ b/python/vyos/vpp/config_resource_checks/memory.py
@@ -28,6 +28,10 @@ from vyos.vpp.utils import (
 from vyos.vpp.config_resource_checks.resource_defaults import default_resource_map
 
 
+# VPP buffers default per NUMA node
+MIN_BUFFERS = 16_384
+
+
 def classify_page_size(page_size_bytes: int) -> str:
     """
     Returns one of: '4K', '2M', '1G' based on page size.
@@ -187,3 +191,33 @@ def total_memory_required(settings: dict) -> dict:
         memory[classify_page_size(page_size)] += memory_size
 
     return memory
+
+
+def buffers_required(settings: dict, workers) -> int:
+    """
+    Calculate total VPP buffer requirements based on interface settings and workers.
+    """
+    buffers_total = 0
+    for ifname, iface_config in settings.get('interface', {}).items():
+        if iface_config.get('driver') == 'xdp':
+            continue
+        dpdk_options = iface_config.get('dpdk_options', {})
+        rx_queues = int(dpdk_options.get('num_rx_queues', 1))
+        rx_desc = int(dpdk_options.get('num_rx_desc'))
+        tx_queues = int(dpdk_options.get('num_tx_queues', workers + 1))
+        tx_desc = int(dpdk_options.get('num_tx_desc'))
+
+        # buffers for RX/TX queues for interface
+        buffers_total += rx_queues * rx_desc + tx_queues * tx_desc
+
+    # per-thread buffer caches (approx. 256 buffers per worker)
+    buffers_total += workers * 256
+
+    # Safety margin for buffer calculations:
+    # traffic bursts, alignment/metadata overhead etc.
+    # The factor 2.5 is derived from VPP’s own calculations:
+    # https://github.com/FDio/vpp/blob/stable/2506/extras/vpp_config/vpplib/AutoConfig.py#L609
+    buffers_total = int(buffers_total * 2.5)
+
+    # Enforce minimum required by VPP (16K buffers)
+    return max(buffers_total, MIN_BUFFERS)

--- a/python/vyos/vpp/config_verify.py
+++ b/python/vyos/vpp/config_verify.py
@@ -442,3 +442,15 @@ def verify_routes_count(settings: dict, workers: int):
         'Extensive use of features like ACLs, NAT and others may reduce the numbers above. '
         'Please read the documentation for details: https://docs.vyos.io/'
     )
+
+
+def verify_vpp_buffers(settings: dict, workers: int):
+    buffers_configured = int(settings['buffers']['buffers_per_numa'])
+
+    buffers_required = mem_checks.buffers_required(settings, workers)
+
+    if buffers_required > buffers_configured:
+        raise ConfigError(
+            'Not enough buffers to initialize RX/TX queues for interfaces. '
+            f'Set "vpp settings buffers buffers-per-numa" to {buffers_required} or higher'
+        )

--- a/python/vyos/vpp/config_verify.py
+++ b/python/vyos/vpp/config_verify.py
@@ -317,7 +317,7 @@ def verify_vpp_cpu_main_core(cpu_settings: dict) -> None:
         )
 
 
-def verify_vpp_settings_cpu_workers(cpu_settings: dict) -> int:
+def verify_vpp_settings_cpu_workers(cpu_settings: dict):
     """
     Verify that the system has enough available CPU cores
     to run a given amount of worker processes (1 worker/core)
@@ -331,10 +331,8 @@ def verify_vpp_settings_cpu_workers(cpu_settings: dict) -> int:
             f'(reduce to {available_cores} or less)'
         )
 
-    return workers
 
-
-def verify_vpp_settings_cpu_corelist_workers(cpu_settings: dict) -> int:
+def verify_vpp_settings_cpu_corelist_workers(cpu_settings: dict):
     """
     Verify that the CPU cores provided to the config are free and can be used by VPP
     """
@@ -365,8 +363,6 @@ def verify_vpp_settings_cpu_corelist_workers(cpu_settings: dict) -> int:
 
     if len(all_core_nums) > cpu_checks.available_cores_count(cpu_settings):
         raise ConfigError(f'{error_msg}: Not enough free CPUs in the system.')
-
-    return len(all_core_nums)
 
 
 def verify_vpp_nat44_workers(workers: int, nat44_workers: list):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7757
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... skipped 'Skipping temporary bonding, sometimes get recursion T7117'
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... ok
test_14_mem_default_hugepage (__main__.TestVPP.test_14_mem_default_hugepage) ... ok
test_15_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_15_vpp_ipsec_xfrm_nl) ... ok
test_16_vpp_cgnat (__main__.TestVPP.test_16_vpp_cgnat) ... ok
test_17_vpp_nat (__main__.TestVPP.test_17_vpp_nat) ... ok
test_18_vpp_sflow (__main__.TestVPP.test_18_vpp_sflow) ... ok
test_19_resource_limits (__main__.TestVPP.test_19_resource_limits) ... ok

----------------------------------------------------------------------
Ran 21 tests in 513.783s

OK (skipped=2)
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
