### PR TITLE
container: T6673: Fix restart of containers with podman

### DIFF
--- a/python/vyos/defaults.py
+++ b/python/vyos/defaults.py
@@ -38,6 +38,7 @@ directories = {
   'vyos_configdir' : '/opt/vyatta/config',
   'completion_dir' : f'{base_dir}/completion',
   'ca_certificates' : '/usr/local/share/ca-certificates/vyos',
+  'podman_storage' : '/usr/lib/live/mount/persistence/container/storage',
   'ppp_nexthop_dir' : '/run/ppp_nexthop',
   'proto_path' : '/usr/share/vyos/vyconf',
   'vyconf_session_dir' : f'{base_dir}/vyconf/session'

--- a/src/op_mode/container.py
+++ b/src/op_mode/container.py
@@ -55,7 +55,7 @@ def clean_layer(name: str) -> int:
 
     purge_layer_by_id(layer_id)
 
-    # Reinitate the container's overlay layer
+    # Reinitiate the container's overlay layer
     cmd(f"rm -f /run/{unit}.cid /run/{unit}.pid")
     cmd(f"systemctl reset-failed {unit}")
     result = run(f"systemctl start {unit}")

--- a/src/op_mode/container.py
+++ b/src/op_mode/container.py
@@ -16,12 +16,49 @@
 
 import typing
 import json
+import shutil
 import sys
 import subprocess
 
+from pathlib import Path
 from vyos.utils.process import cmd
 from vyos.utils.process import rc_cmd
+from vyos.utils.process import run
 import vyos.opmode
+
+def clean_layer(name: str) -> int:
+    def layer_id_from_containers(name: str) -> str | None:
+        if containers.is_file():
+            try:
+                index = json.loads(containers.read_text())
+            except Exception:
+                return None
+            for item in index:
+                if name in item.get("names", []):
+                    return item.get("layer")
+        return None
+
+    def purge_layer_by_id(layer_id: str):
+        layer_dir = overlay_root / layer_id
+
+        # Remove the overlay ID directory
+        shutil.rmtree(layer_dir, ignore_errors=True)
+
+    overlay_root = Path("/usr/lib/live/mount/persistence/container/storage/overlay")
+    containers = Path("/usr/lib/live/mount/persistence/container/storage/overlay-containers/containers.json")
+    unit = f"vyos-container-{name}.service"
+    layer_id = layer_id_from_containers(name)
+    if not layer_id:
+        # No mapping found; nothing to do
+        return 2
+
+    purge_layer_by_id(layer_id)
+
+    # Reinitate the container's overlay layer
+    cmd(f"rm -f /run/{unit}.cid /run/{unit}.pid")
+    cmd(f"systemctl reset-failed {unit}")
+    result = run(f"systemctl start {unit}")
+    return result
 
 def _get_json_data(command: str) -> list:
     """
@@ -131,8 +168,10 @@ def restart(name: str):
 
     rc, output = rc_cmd(f'systemctl restart vyos-container-{name}.service')
     if rc != 0:
-        print(output)
-        return None
+        rc2 = clean_layer(name)
+        if rc2 != 0:
+            print(output)
+            return None
     print(f'Container "{name}" restarted!')
     return output
 

--- a/src/op_mode/container.py
+++ b/src/op_mode/container.py
@@ -21,6 +21,7 @@ import sys
 import subprocess
 
 from pathlib import Path
+from vyos.defaults import directories
 from vyos.utils.process import cmd
 from vyos.utils.process import rc_cmd
 from vyos.utils.process import run
@@ -43,9 +44,9 @@ def clean_layer(name: str) -> int:
 
         # Remove the overlay ID directory
         shutil.rmtree(layer_dir, ignore_errors=True)
-
-    overlay_root = Path("/usr/lib/live/mount/persistence/container/storage/overlay")
-    containers = Path("/usr/lib/live/mount/persistence/container/storage/overlay-containers/containers.json")
+    storage_dir = Path(directories['podman_storage'])
+    overlay_root = storage_dir / "overlay"
+    containers = storage_dir / "overlay-containers/containers.json"
     unit = f"vyos-container-{name}.service"
     layer_id = layer_id_from_containers(name)
     if not layer_id:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
When a user incorrectly tries to restart a podman container with `podman container restart <container>`, the podman and quadlet config will go out of sync, and you will not be able to recover the container.
```
vyos@PE2:~$ sudo podman container restart alpine1
WARN[0010] StopSignal SIGTERM failed to stop container alpine1 in 10 seconds, resorting to SIGKILL
ERRO[0010] Cleaning up container 0721bc4a562ffe28276b203adc17fa79e7269a574a100c72c71137a285fe8157: unmounting container 0721bc4a562ffe28276b203adc17fa79e7269a574a100c72c71137a285fe8157 storage: cleaning up container 0721bc4a562ffe28276b203adc17fa79e7269a574a100c72c71137a285fe8157 storage: unmounting container 0721bc4a562ffe28276b203adc17fa79e7269a574a100c72c71137a285fe8157 root filesystem: removing mount point "/usr/lib/live/mount/persistence/container/storage/overlay/42a8fff3d1a21fa4bd5c592dc017c39463dc4a24a9c75e94793ae88cef682ed8/merged": directory not empty
Error: crun: executable file `/bin/sh` not found in $PATH: No such file or directory: OCI runtime attempted to invoke a command that was not found
```
Attempting to restart the container afterwards the correct way will result in a failure.
```
vyos@PE2:~$ restart container alpine1
Job for vyos-container-alpine1.service failed because the control process exited with error code.
See "systemctl status vyos-container-alpine1.service" and "journalctl -xeu vyos-container-alpine1.service" for details.
```
Deleting the config and trying to reapply it doesn't work:
```
vyos@PE2# delete container name alpine1
vyos@PE2# commit

vyos@PE2# set container name alpine1 image 'alpine'
vyos@PE2# set container name alpine1 allow-host-network
vyos@PE2# commit

[ container ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 156, in run_script
    script.apply(c)
  File "/usr/libexec/vyos/conf_mode/container.py", line 618, in apply
    cmd(f'systemctl restart vyos-container-{name}.service')
  File "/usr/lib/python3/dist-packages/vyos/utils/process.py", line 189, in cmd
    raise OSError(code, feedback)
PermissionError: [Errno 1] failed to run command: None systemctl restart vyos-container-alpine1.service
returned:
exit code: 1

[[container]] failed
Commit failed
```
Even restarting won't correct the issue. When looking at the logs, we can see that the issue is that the previous overlay layer directory still has data in it. And the quadlet wants to recreate the container, which fails due to the `directory not empty` error:
```
Sep 02 11:59:49 PE2 systemd[1]: Starting VyOS Container alpine1...
Sep 02 11:59:49 PE2 podman[6739]: time="2025-09-02T11:59:49Z" level=warning msg="The input device is not a TTY. The --tty and --interactive flags might not work properly"
Sep 02 11:59:49 PE2 podman[6739]: time="2025-09-02T11:59:49Z" level=warning msg="Unmounting container \"alpine1\" while attempting to delete storage: removing mount point \"/usr/lib/live/mount/persistence/container/storage/overlay/42a8fff3d1a21fa4bd5c592dc017c39463dc4a24a9c75e94793ae88cef682ed8/merged\": directory not empty"
Sep 02 11:59:49 PE2 podman[6739]: Error: removing storage for container "alpine1": removing mount point "/usr/lib/live/mount/persistence/container/storage/overlay/42a8fff3d1a21fa4bd5c592dc017c39463dc4a24a9c75e94793ae88cef682ed8/merged": directory not empty
Sep 02 11:59:49 PE2 systemd[1]: vyos-container-alpine1.service: Control process exited, code=exited, status=125/n/a
Sep 02 11:59:49 PE2 systemd[1]: vyos-container-alpine1.service: Failed with result 'exit-code'.
Sep 02 11:59:49 PE2 systemd[1]: Failed to start VyOS Container alpine1.
```
This added function will clean the stale overlay layer so the container can be reinitialized correctly.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6673
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
#### Create a container:
```
set container name alpine1 image 'alpine'
set container name alpine1 allow-host-network
```
#### Restart the container with podman commands:
```
vyos@PE2:~$ sudo podman container restart alpine1
WARN[0010] StopSignal SIGTERM failed to stop container alpine1 in 10 seconds, resorting to SIGKILL
ERRO[0010] Cleaning up container 0721bc4a562ffe28276b203adc17fa79e7269a574a100c72c71137a285fe8157: unmounting container 0721bc4a562ffe28276b203adc17fa79e7269a574a100c72c71137a285fe8157 storage: cleaning up container 0721bc4a562ffe28276b203adc17fa79e7269a574a100c72c71137a285fe8157 storage: unmounting container 0721bc4a562ffe28276b203adc17fa79e7269a574a100c72c71137a285fe8157 root filesystem: removing mount point "/usr/lib/live/mount/persistence/container/storage/overlay/42a8fff3d1a21fa4bd5c592dc017c39463dc4a24a9c75e94793ae88cef682ed8/merged": directory not empty
Error: crun: executable file `/bin/sh` not found in $PATH: No such file or directory: OCI runtime attempted to invoke a command that was not found
```
### Attempt to restart the container using VyOS op-mode command:
#### Before:
```
vyos@PE2:~$ restart container alpine1
Job for vyos-container-alpine1.service failed because the control process exited with error code.
See "systemctl status vyos-container-alpine1.service" and "journalctl -xeu vyos-container-alpine1.service" for details.
```
#### After:
```
vyos@PE2:~$ restart container alpine1
Container "alpine1" restarted!
```
#### Verify container is present:
```
vyos@PE2:~$ show container
CONTAINER ID  IMAGE                                 COMMAND               CREATED        STATUS        PORTS       NAMES
6ccb774230dd  docker.io/library/alpine:latest       /bin/sh               3 seconds ago  Up 3 seconds              alpine1
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
