### PR TITLE
op-mode: T6857: Fix default action for prerouting hook

### DIFF
--- a/src/op_mode/firewall.py
+++ b/src/op_mode/firewall.py
@@ -214,7 +214,7 @@ def output_firewall_name(family, hook, priority, firewall_conf, single_rule_id=N
                 row.append(rule_details['conditions'])
             rows.append(row)
 
-    if hook in ['input', 'forward', 'output']:
+    if hook in ['input', 'forward', 'output', 'prerouting']:
         def_action = firewall_conf['default_action'] if 'default_action' in firewall_conf else 'accept'
     else:
         def_action = firewall_conf['default_action'] if 'default_action' in firewall_conf else 'drop'
@@ -352,7 +352,7 @@ def output_firewall_name_statistics(family, hook, prior, prior_conf, single_rule
             rows.append(row)
 
 
-    if hook in ['input', 'forward', 'output']:
+    if hook in ['input', 'forward', 'output', 'prerouting']:
         row = ['default', '']
         rule_details = details['default-action']
         row.append(rule_details.get('packets', 0))


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
The firewall op-mode output for the `prerouting` chain has some cosmetic bugs related to the `default-action`. If there is no default-action set for `prerouting raw`, then the `show firewall ipv4 prerouting raw` shows the wrong verdict for the output:
#### Nftables output (verdict is actually accept as expected):
```
table ip vyos_filter {
        chain VYOS_PREROUTING_raw {
                type filter hook prerouting priority raw; policy accept;
                counter packets 191 bytes 13038 accept comment "ipv4-PRE-raw-10"
                counter packets 0 bytes 0 accept comment "PRE-raw default-action accept"
        }
}
```
#### show firewall ipv4 prerouting raw:
```
Ruleset Information

---------------------------------
ipv4 Firewall "prerouting raw"

Rule     Action    Protocol      Packets    Bytes  Conditions
-------  --------  ----------  ---------  -------  ------------
10       accept    all               192    12262  accept
default  drop      all                 0        0
```
#### show firewall statistics (no default-action listed):
```
Rulesets Statistics

---------------------------------
ipv4 Firewall "prerouting raw"

  Rule    Packets    Bytes  Action    Source    Destination    Inbound-Interface    Outbound-interface
------  ---------  -------  --------  --------  -------------  -------------------  --------------------
    10        286    17769  accept    any       any            any                  any
```
### After changes:
#### show firewall ipv4 prerouting raw:
```
Ruleset Information

---------------------------------
ipv4 Firewall "prerouting raw"

Rule     Action    Protocol      Packets    Bytes  Conditions
-------  --------  ----------  ---------  -------  ------------
10       accept    all                83     5259  accept
default  accept    all                 0        0
```
#### show firewall statistics:
```
Rulesets Statistics

---------------------------------
ipv4 Firewall "prerouting raw"

Rule       Packets    Bytes  Action    Source    Destination    Inbound-Interface    Outbound-interface
-------  ---------  -------  --------  --------  -------------  -------------------  --------------------
10             144     9254  accept    any       any            any                  any
default          0        0  accept    any       any            any                  any
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
