### PR TITLE
T7485: ia-na ipv6 for PPPoE link

### DIFF
--- a/data/templates/dhcp-client/ipv6.j2
+++ b/data/templates/dhcp-client/ipv6.j2
@@ -6,8 +6,12 @@ interface {{ ifname }} {
     send client-id {{ dhcpv6_options.duid }};
 {% endif %}
 {% if address is vyos_defined and 'dhcpv6' in address %}
+{%     if dhcpv6_options.no_request_dns is not vyos_defined %}
     request domain-name-servers;
+{%     endif %}
+{%     if dhcpv6_options.no_request_domain_name is not vyos_defined %}
     request domain-name;
+{%     endif %}
 {%     if dhcpv6_options.parameters_only is vyos_defined %}
     information-only;
 {%     endif %}

--- a/interface-definitions/include/interface/dhcpv6-options.xml.i
+++ b/interface-definitions/include/interface/dhcpv6-options.xml.i
@@ -11,6 +11,18 @@
         <valueless/>
       </properties>
     </leafNode>
+    <leafNode name="no-request-domain-name">
+      <properties>
+        <help>Do not request domain name</help>
+        <valueless/>
+      </properties>
+    </leafNode>
+    <leafNode name="no-request-dns">
+      <properties>
+        <help>Do not request DNS servers</help>
+        <valueless/>
+      </properties>
+    </leafNode>
     <tagNode name="pd">
       <properties>
         <help>DHCPv6 prefix delegation interface statement</help>

--- a/interface-definitions/interfaces_pppoe.xml.in
+++ b/interface-definitions/interfaces_pppoe.xml.in
@@ -16,6 +16,21 @@
           </valueHelp>
         </properties>
         <children>
+          <leafNode name="address">
+            <properties>
+              <help>IP address</help>
+              <completionHelp>
+                <list>dhcpv6</list>
+              </completionHelp>
+              <valueHelp>
+                <format>dhcpv6</format>
+                <description>Dynamic Host Configuration Protocol for IPv6</description>
+              </valueHelp>
+              <constraint>
+                <regex>(dhcpv6)</regex>
+              </constraint>
+            </properties>
+          </leafNode>
           #include <include/pppoe-access-concentrator.xml.i>
           #include <include/interface/authentication.xml.i>
           #include <include/interface/dial-on-demand.xml.i>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
If a pppoe interface define `ipv6 address autoconf`, this interface doesn't register the provided IA-NA address from RA's/DHPCv6 announces (dhcp6c).

By modifying the dhcp6c configuration template and handling pppoe interfaces edge cases, the right ia-na entry can be written and handled by dhcp6c to the pppoe interface.

See : https://vyos.dev/T7485#234216

### NOTE 
It doesn't handle requesting a specific IA-NA address (`send ia_na` is always defaulting to `0`).
_Is a new parameter in `interfaces pppoe [pppoeN] ipv6` xml definition should be handled has well?_

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7485

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
