### PR TITLE
Debian: T7762: extend package version with a number always counting up

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -22,6 +22,7 @@ DEB_TARGET_ARCH := $(shell dpkg-architecture -qDEB_TARGET_ARCH)
 # Base version prefix from debian/changelog
 BASE_VERSION := 999.0
 COMMIT_ID := $(shell echo -n g && git rev-parse --short HEAD)
+COMMIT_COUNT := $(shell git rev-list HEAD --count)
 DIRTY_FLAG := $(shell ! git diff --quiet || ! git diff --cached --quiet && echo -dirty || echo)
 
 %:
@@ -32,7 +33,7 @@ DIRTY_FLAG := $(shell ! git diff --quiet || ! git diff --cached --quiet && echo 
 override_dh_strip_nondeterminism:
 
 override_dh_gencontrol:
-	dh_gencontrol -- -v$(BASE_VERSION)-$(COMMIT_ID)$(DIRTY_FLAG)
+	dh_gencontrol -- -v$(BASE_VERSION)-$(COMMIT_COUNT)-$(COMMIT_ID)$(DIRTY_FLAG)
 
 override_dh_auto_build:
 	make all


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

This extends commit 53d8ed6cc01e ("Debian: T7762: adjust vyos-1x package version to not mention 1.5 in any way") with a counter that counts the number of commits since the beginning to become HEAD. It kind of mimics `git describe --tags` where commits after the last Git tag are counted.

Why do we need it? It's better for sorting multiple revisions of the vyos-1x package, as we are unable to sort using a commit ID which was the commit before one or another.

Packages are now named e.g.:
```
vyos-1x_999.0-12876-gb1b4545cb_amd64.deb
vyos-1x-aws_999.0-12876-gb1b4545cb_all.deb
vyos-1x-dbgsym_999.0-12876-gb1b4545cb_amd64.deb
vyos-1x-smoketest_999.0-12876-gb1b4545cb_all.deb
vyos-1x-vmware_999.0-12876-gb1b4545cb_all.deb
```
Meaning it is the 12876th commit since repo start and the commit ID used for the build is b1b4545cb.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7762

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4685

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
