### PR TITLE
T7786: VPP clarify error message for corelist-workers

### DIFF
--- a/python/vyos/vpp/config_verify.py
+++ b/python/vyos/vpp/config_verify.py
@@ -327,8 +327,9 @@ def verify_vpp_settings_cpu_workers(cpu_settings: dict) -> int:
 
     if workers > available_cores:
         raise ConfigError(
-            f'Not enough free CPU cores for {workers} VPP workers '
-            f'(reduce to {available_cores} or less)'
+            f'Not enough free physical CPU cores for {workers} VPP workers. '
+            f'Only {available_cores} cores are available (2 cores are reserved for system use). '
+            f'Please reduce the number of workers to {available_cores} or fewer.'
         )
 
     return workers
@@ -363,8 +364,13 @@ def verify_vpp_settings_cpu_corelist_workers(cpu_settings: dict) -> int:
             f'{error_msg}: CPU# {",".join(invalid_cores)} are not available.'
         )
 
-    if len(all_core_nums) > cpu_checks.available_cores_count(cpu_settings):
-        raise ConfigError(f'{error_msg}: Not enough free CPUs in the system.')
+    available_cores_count = cpu_checks.available_cores_count(cpu_settings)
+    if len(all_core_nums) > available_cores_count:
+        raise ConfigError(
+            f'{error_msg}: Not enough free physical CPUs in the system. '
+            f'Only {available_cores_count} cores are available '
+            f'(2 cores are reserved for system use).'
+        )
 
     return len(all_core_nums)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): clarify error message

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7786
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set vpp settings interface eth1 driver dpdk
set vpp settings cpu corelist-workers 1-2
set vpp settings cpu corelist-workers 3-4

vyos@vyos# commit
[ vpp ]
Cannot set VPP "cpu corelist-workers": Not enough free physical CPUs in
the system. Only 3 cores are available (2 cores are reserved for system
use).
[[vpp]] failed
Commit failed
[edit]
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
