### PR TITLE
firewall: T7475: Add an option to disable conntrack for individual firewall chaisn

### DIFF
--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -155,9 +155,7 @@ table ip vyos_filter {
 {%     if ipv4.output.filter.disable_conntrack is vyos_defined %}
     chain VYOS_DISABLE_CONNTRACK_OUT {
         type filter hook output priority -320; policy accept;
-{%         if ipv4.output.filter.disable_conntrack is vyos_defined %}
-               notrack counter comment "DISABLE-CT-OUT"
-{%         endif %}
+        notrack counter comment "DISABLE-CT-OUT"
     }
 {%     endif %}
 
@@ -344,9 +342,7 @@ table ip6 vyos_filter {
 {%     if ipv6.output.filter.disable_conntrack is vyos_defined %}
     chain VYOS_DISABLE_CONNTRACK_OUT_V6 {
         type filter hook output priority -320; policy accept;
-{%         if ipv6.output.filter.disable_conntrack is vyos_defined %}
-              notrack counter comment "DISABLE-CT-OUT-V6"
-{%         endif %}
+        notrack counter comment "DISABLE-CT-OUT-V6"
     }
 {%     endif %}
 

--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -140,6 +140,27 @@ table ip vyos_filter {
 {%         endfor %}
 {%     endif %}
 
+{%     if ipv4.forward.filter.disable_conntrack is vyos_defined or ipv4.input.filter.disable_conntrack is vyos_defined %}
+    chain VYOS_DISABLE_CONNTRACK_INP_FWD {
+        type filter hook prerouting priority -320; policy accept;
+{%         if ipv4.forward.filter.disable_conntrack is vyos_defined %}
+               fib daddr . iif type unicast notrack counter comment "DISABLE-CT-FWD"
+{%         endif %}
+{%         if ipv4.input.filter.disable_conntrack is vyos_defined %}
+               fib daddr . iif type local notrack counter comment "DISABLE-CT-INP"
+{%         endif %}
+    }
+{%     endif %}
+
+{%     if ipv4.output.filter.disable_conntrack is vyos_defined %}
+    chain VYOS_DISABLE_CONNTRACK_OUT {
+        type filter hook output priority -320; policy accept;
+{%         if ipv4.output.filter.disable_conntrack is vyos_defined %}
+               notrack counter comment "DISABLE-CT-OUT"
+{%         endif %}
+    }
+{%     endif %}
+
 {%     for set_name in ns.sets %}
     set RECENT_{{ set_name }} {
         type ipv4_addr
@@ -306,6 +327,27 @@ table ip6 vyos_filter {
         {{ conf | nft_default_rule('NAM-' + name_text, 'ipv6') }}
     }
 {%         endfor %}
+{%     endif %}
+
+{%     if ipv6.forward.filter.disable_conntrack is vyos_defined or ipv6.input.filter.disable_conntrack is vyos_defined %}
+    chain VYOS_DISABLE_CONNTRACK_INP_FWD_V6 {
+        type filter hook prerouting priority -320; policy accept;
+{%         if ipv6.forward.filter.disable_conntrack is vyos_defined %}
+               fib daddr . iif type unicast notrack counter comment "DISABLE-CT-FWD-V6"
+{%         endif %}
+{%         if ipv6.input.filter.disable_conntrack is vyos_defined %}
+               fib daddr . iif type local notrack counter comment "DISABLE-CT-INP-V6"
+{%         endif %}
+    }
+{%     endif %}
+
+{%     if ipv6.output.filter.disable_conntrack is vyos_defined %}
+    chain VYOS_DISABLE_CONNTRACK_OUT_V6 {
+        type filter hook output priority -320; policy accept;
+{%         if ipv6.output.filter.disable_conntrack is vyos_defined %}
+              notrack counter comment "DISABLE-CT-OUT-V6"
+{%         endif %}
+    }
 {%     endif %}
 
 {%     for set_name in ns.sets %}

--- a/interface-definitions/include/firewall/disable-conntrack.xml.i
+++ b/interface-definitions/include/firewall/disable-conntrack.xml.i
@@ -1,0 +1,8 @@
+<!-- include start from firewall/disable-conntrack.xml.i -->
+<leafNode name="disable-conntrack">
+  <properties>
+    <help>Disable conntrack within this chain</help>
+    <valueless/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/firewall/ipv4-hook-forward.xml.i
+++ b/interface-definitions/include/firewall/ipv4-hook-forward.xml.i
@@ -9,6 +9,7 @@
         <help>IPv4 firewall forward filter</help>
       </properties>
       <children>
+        #include <include/firewall/disable-conntrack.xml.i>
         #include <include/firewall/default-action-base-chains.xml.i>
         #include <include/firewall/default-log.xml.i>
         #include <include/generic-description.xml.i>

--- a/interface-definitions/include/firewall/ipv4-hook-input.xml.i
+++ b/interface-definitions/include/firewall/ipv4-hook-input.xml.i
@@ -9,6 +9,7 @@
         <help>IPv4 firewall input filter</help>
       </properties>
       <children>
+        #include <include/firewall/disable-conntrack.xml.i>
         #include <include/firewall/default-action-base-chains.xml.i>
         #include <include/firewall/default-log.xml.i>
         #include <include/generic-description.xml.i>

--- a/interface-definitions/include/firewall/ipv4-hook-output.xml.i
+++ b/interface-definitions/include/firewall/ipv4-hook-output.xml.i
@@ -9,6 +9,7 @@
         <help>IPv4 firewall output filter</help>
       </properties>
       <children>
+        #include <include/firewall/disable-conntrack.xml.i>
         #include <include/firewall/default-action-base-chains.xml.i>
         #include <include/firewall/default-log.xml.i>
         #include <include/generic-description.xml.i>

--- a/interface-definitions/include/firewall/ipv6-hook-forward.xml.i
+++ b/interface-definitions/include/firewall/ipv6-hook-forward.xml.i
@@ -9,6 +9,7 @@
         <help>IPv6 firewall forward filter</help>
       </properties>
       <children>
+        #include <include/firewall/disable-conntrack.xml.i>
         #include <include/firewall/default-action-base-chains.xml.i>
         #include <include/firewall/default-log.xml.i>
         #include <include/generic-description.xml.i>

--- a/interface-definitions/include/firewall/ipv6-hook-input.xml.i
+++ b/interface-definitions/include/firewall/ipv6-hook-input.xml.i
@@ -9,6 +9,7 @@
         <help>IPv6 firewall input filter</help>
       </properties>
       <children>
+        #include <include/firewall/disable-conntrack.xml.i>
         #include <include/firewall/default-action-base-chains.xml.i>
         #include <include/firewall/default-log.xml.i>
         #include <include/generic-description.xml.i>

--- a/interface-definitions/include/firewall/ipv6-hook-output.xml.i
+++ b/interface-definitions/include/firewall/ipv6-hook-output.xml.i
@@ -9,6 +9,7 @@
         <help>IPv6 firewall output filter</help>
       </properties>
       <children>
+        #include <include/firewall/disable-conntrack.xml.i>
         #include <include/firewall/default-action-base-chains.xml.i>
         #include <include/firewall/default-log.xml.i>
         #include <include/generic-description.xml.i>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
This change will allow conntrack to be disabled per nftables chain. This is important for users that want the most throughput possible (like service providers), while still being able to secure VyOS itself using the input and output chains.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7475
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
### Disable conntrack in a chain:
```
set firewall ipv4 forward filter disable-conntrack
```
### Generate traffic that would hit the chain you disabled
```
PC1#ping 10.0.2.10
Type escape sequence to abort.
Sending 5, 100-byte ICMP Echos to 10.0.2.10, timeout is 2 seconds:
!!!!!
Success rate is 100 percent (5/5), round-trip min/avg/max = 1/2/5 ms

PC1#traceroute 10.0.2.10 numeric 
Type escape sequence to abort.
Tracing the route to 10.0.2.10
VRF info: (vrf in name/id, vrf out name/id)
  1 10.0.1.1 2 msec 2 msec 1 msec
  2 10.0.2.10 3 msec 2 msec 2 msec
```
### Check the conntrack table. You will not see any entries for traffic in the chain you disabled conntrack for.
```
vyos@vyos:~$ show conntrack table ipv4
Entries not found
```
#### Smoketest results:
```
test_bridge_firewall (__main__.TestFirewall.test_bridge_firewall) ... ok
test_cyclic_jump_validation (__main__.TestFirewall.test_cyclic_jump_validation) ... ok
test_disable_conntrack_per_chain (__main__.TestFirewall.test_disable_conntrack_per_chain) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
test_geoip (__main__.TestFirewall.test_geoip) ... ok
test_gre_match (__main__.TestFirewall.test_gre_match) ... ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipsec_metadata_match (__main__.TestFirewall.test_ipsec_metadata_match) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_dynamic_groups (__main__.TestFirewall.test_ipv4_dynamic_groups) ... ok
test_ipv4_global_state (__main__.TestFirewall.test_ipv4_global_state) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_remote_group (__main__.TestFirewall.test_ipv4_remote_group) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_dynamic_groups (__main__.TestFirewall.test_ipv6_dynamic_groups) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_ipv6_remote_group (__main__.TestFirewall.test_ipv6_remote_group) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
test_remote_group (__main__.TestFirewall.test_remote_group) ... ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_timeout_sysctl (__main__.TestFirewall.test_timeout_sysctl) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... ok
test_zone_with_vrf (__main__.TestFirewall.test_zone_with_vrf) ... ok

----------------------------------------------------------------------
Ran 29 tests in 536.548s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
