### PR TITLE
Python: T7740: Update dict_search to return optional default value

### DIFF
--- a/python/vyos/utils/dict.py
+++ b/python/vyos/utils/dict.py
@@ -147,7 +147,16 @@ def get_sub_dict(source, lpath, get_first_key=False):
 
 def dict_search(path, dict_object, default=None):
     """ Traverse Python dictionary (dict_object) delimited by dot (.).
-    Return value of key if found, None otherwise.
+
+    Args:
+        path (str): Dot-delimited key path, e.g. "foo.bar.baz".
+        dict_object (dict): The dictionary to search.
+        default (Any, optional): Value to return if the path is not found
+            or if dict_object is not a dict. Defaults to None.
+
+    Returns:
+        Any: The value found at the given path, or None if not found. Optionally,
+            a default value can be provided to be returned.
 
     This is faster implementation then jmespath.search('foo.bar', dict_object)"""
     if not isinstance(dict_object, dict) or not path:

--- a/python/vyos/utils/dict.py
+++ b/python/vyos/utils/dict.py
@@ -145,24 +145,24 @@ def get_sub_dict(source, lpath, get_first_key=False):
 
     return ret
 
-def dict_search(path, dict_object):
+def dict_search(path, dict_object, default=None):
     """ Traverse Python dictionary (dict_object) delimited by dot (.).
     Return value of key if found, None otherwise.
 
     This is faster implementation then jmespath.search('foo.bar', dict_object)"""
     if not isinstance(dict_object, dict) or not path:
-        return None
+        return default
 
     parts = path.split('.')
     inside = parts[:-1]
     if not inside:
         if path not in dict_object:
-            return None
+            return default
         return dict_object[path]
     c = dict_object
     for p in parts[:-1]:
         c = c.get(p, {})
-    return c.get(parts[-1], None)
+    return c.get(parts[-1], default)
 
 def dict_search_args(dict_object, *path):
     # Traverse dictionary using variable arguments

--- a/src/tests/test_dict_search.py
+++ b/src/tests/test_dict_search.py
@@ -44,6 +44,14 @@ class TestDictSearch(TestCase):
         self.assertEqual(dict_search('non_existing', data), None)
         self.assertEqual(dict_search('non.existing.fancy.key', data), None)
 
+    def test_non_existing_keys_with_default_positional(self):
+        # TestDictSearch: Return a default value when querying for non-existent key (positional arg)
+        self.assertEqual(dict_search('non.existing.fancy.key', data, 'test'), 'test')
+
+    def test_non_existing_keys_with_default_named(self):
+        # TestDictSearch: Return a default value when querying for non-existent key (named arg)
+        self.assertEqual(dict_search('non.existing.fancy.key', data, default='test'), 'test')
+		
     def test_string(self):
         # TestDictSearch: Return value when querying string
         self.assertEqual(dict_search('string', data), data['string'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
I've often found myself needing to return a default value when using dict_search, requiring me to use `.get()` instead, which makes for inconsistent code for ultimately the same function.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7740
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
#### Python Test script:
``` python
from vyos.utils.dict import dict_search

test_data = {
    "interfaces": {
        "ethernet": {
            "eth0": {
                "address": "192.0.2.1/24",
                "description": "WAN uplink"
            },
            "eth1": {
                "address": "10.0.0.1/24",
                "description": "LAN"
            }
        }
    },
    "system": {
        "hostname": "vyos-router"
    }
}

print(dict_search("interfaces.ethernet.eth0.address", test_data))       # 192.0.2.1/24
print(dict_search("interfaces.ethernet.eth1.description", test_data))   # LAN
print(dict_search("interfaces.ethernet.eth3", test_data))               # None
print(dict_search("system.hostname", test_data))                        # vyos-router
print(dict_search("system.login", test_data, "not found"))      # not found
```
#### Results:
```
root@vyos:/home/vyos# python3 test.py
192.0.2.1/24
LAN
None
vyos-router
not found
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
