### PR TITLE
Monitoring: T7794: Fixed blackbox_exporter, frr_exporter, node_exporter IPv6 listen-address invalid format

### DIFF
--- a/data/templates/prometheus/blackbox_exporter.service.j2
+++ b/data/templates/prometheus/blackbox_exporter.service.j2
@@ -11,7 +11,7 @@ User=node_exporter
 ExecStart={{ vrf_command }}/usr/sbin/blackbox_exporter \
 {% if listen_address is vyos_defined %}
 {%     for address in listen_address %}
-        --web.listen-address={{ address }}:{{ port }} \
+        --web.listen-address={{ address | bracketize_ipv6 }}:{{ port }} \
 {%     endfor %}
 {% else %}
         --web.listen-address=:{{ port }} \

--- a/data/templates/prometheus/frr_exporter.service.j2
+++ b/data/templates/prometheus/frr_exporter.service.j2
@@ -11,7 +11,7 @@ User=frr
 ExecStart={{ vrf_command }}/usr/sbin/frr_exporter \
 {% if listen_address is vyos_defined %}
 {%     for address in listen_address %}
-        --web.listen-address={{ address }}:{{ port }}
+        --web.listen-address={{ address | bracketize_ipv6 }}:{{ port }}
 {%     endfor %}
 {% else %}
         --web.listen-address=:{{ port }}

--- a/data/templates/prometheus/node_exporter.service.j2
+++ b/data/templates/prometheus/node_exporter.service.j2
@@ -16,7 +16,7 @@ ExecStart={{ vrf_command }}/usr/sbin/node_exporter \
 {% endif %}
 {% if listen_address is vyos_defined %}
 {%     for address in listen_address %}
-        --web.listen-address={{ address }}:{{ port }}
+        --web.listen-address={{ address | bracketize_ipv6 }}:{{ port }}
 {%     endfor %}
 {% else %}
         --web.listen-address=:{{ port }}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Implemented the `| bracketize_ipv6` filter for the `{{ address }}` variable in the *.service.j2 templates for Prometheus exporters. This change ensures that IPv6 listen addresses are automatically enclosed in brackets. (Transforming `{{ address }}` into `{{ address | bracketize_ipv6 }}`).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7794

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# /usr/libexec/vyos/tests/smoke/cli/test_service_monitoring_prometheus.py 
test_01_node_exporter (__main__.TestMonitoringPrometheus.test_01_node_exporter) ... ok
test_02_frr_exporter (__main__.TestMonitoringPrometheus.test_02_frr_exporter) ... ok
test_03_blackbox_exporter (__main__.TestMonitoringPrometheus.test_03_blackbox_exporter) ... ok
test_04_blackbox_exporter_with_config (__main__.TestMonitoringPrometheus.test_04_blackbox_exporter_with_config) ... ok

----------------------------------------------------------------------
Ran 4 tests in 9.718s

OK
[edit]
vyos@vyos# show service monitoring prometheus 
 blackbox-exporter {
     listen-address ::1
 }
 frr-exporter {
     listen-address ::1
 }
 node-exporter {
     listen-address ::1
 }
[edit]
vyos@vyos# systemctl status blackbox_exporter
● blackbox_exporter.service - Blackbox Exporter
     Loaded: loaded (/etc/systemd/system/blackbox_exporter.service; disabled; preset: enabled)
     Active: active (running) since Sun 2025-09-07 20:14:22 UTC; 15s ago
       Docs: https://github.com/prometheus/blackbox_exporter
   Main PID: 5319 (blackbox_export)
      Tasks: 7 (limit: 9489)
     Memory: 6.9M
        CPU: 4ms
     CGroup: /system.slice/blackbox_exporter.service
             └─5319 /usr/sbin/blackbox_exporter "--web.listen-address=[::1]:9115" --config.file=/run/blackbox_exporter/config.yml

Sep 07 20:14:22 vyos systemd[1]: Started Blackbox Exporter.
Sep 07 20:14:22 vyos blackbox_exporter[5319]: time=2025-09-07T20:14:22.243Z level=INFO source=main.go:86 msg="Starting blackbox_exporter" version="(version=, branch=, revision=444e3d089ae1aeeed385712ef84a5fa4f0c083ec-modified)"
Sep 07 20:14:22 vyos blackbox_exporter[5319]: time=2025-09-07T20:14:22.243Z level=INFO source=main.go:87 msg="(go=go1.23.2, platform=linux/amd64, user=, date=, tags=unknown)"
Sep 07 20:14:22 vyos blackbox_exporter[5319]: time=2025-09-07T20:14:22.243Z level=INFO source=main.go:99 msg="Loaded config file"
Sep 07 20:14:22 vyos blackbox_exporter[5319]: time=2025-09-07T20:14:22.243Z level=INFO source=tls_config.go:347 msg="Listening on" address=[::1]:9115
Sep 07 20:14:22 vyos blackbox_exporter[5319]: time=2025-09-07T20:14:22.243Z level=INFO source=tls_config.go:350 msg="TLS is disabled." http2=false address=[::1]:9115
[edit]
vyos@vyos# systemctl status frr_exporter
● frr_exporter.service - FRR Exporter
     Loaded: loaded (/etc/systemd/system/frr_exporter.service; disabled; preset: enabled)
     Active: active (running) since Sun 2025-09-07 20:14:22 UTC; 25s ago
       Docs: https://github.com/tynany/frr_exporter
   Main PID: 5312 (frr_exporter)
      Tasks: 6 (limit: 9489)
     Memory: 4.8M
        CPU: 3ms
     CGroup: /system.slice/frr_exporter.service
             └─5312 /usr/sbin/frr_exporter "--web.listen-address=[::1]:9342"

Sep 07 20:14:22 vyos systemd[1]: Started FRR Exporter.
Sep 07 20:14:22 vyos frr_exporter[5312]: time=2025-09-07T20:14:22.235Z level=INFO source=frr_exporter.go:39 msg="Starting frr_exporter" version="(version=, branch=, revision=e2e1f38462fe3da26ca5b314712b7813e2b9f3e9-modified)"
Sep 07 20:14:22 vyos frr_exporter[5312]: time=2025-09-07T20:14:22.235Z level=INFO source=frr_exporter.go:40 msg="Build context" build_context="(go=go1.23.2, platform=linux/amd64, user=, date=, tags=unknown)"
Sep 07 20:14:22 vyos frr_exporter[5312]: time=2025-09-07T20:14:22.235Z level=INFO source=tls_config.go:347 msg="Listening on" address=[::1]:9342
Sep 07 20:14:22 vyos frr_exporter[5312]: time=2025-09-07T20:14:22.235Z level=INFO source=tls_config.go:350 msg="TLS is disabled." http2=false address=[::1]:9342
[edit]
vyos@vyos# systemctl status node_exporter
● node_exporter.service - Node Exporter
     Loaded: loaded (/etc/systemd/system/node_exporter.service; disabled; preset: enabled)
     Active: active (running) since Sun 2025-09-07 20:14:22 UTC; 29s ago
       Docs: https://github.com/prometheus/node_exporter
   Main PID: 5307 (node_exporter)
      Tasks: 4 (limit: 9489)
     Memory: 4.7M
        CPU: 5ms
     CGroup: /system.slice/node_exporter.service
             └─5307 /usr/sbin/node_exporter "--web.listen-address=[::1]:9100"

Sep 07 20:14:22 vyos node_exporter[5307]: time=2025-09-07T20:14:22.230Z level=INFO source=node_exporter.go:141 msg=time
Sep 07 20:14:22 vyos node_exporter[5307]: time=2025-09-07T20:14:22.230Z level=INFO source=node_exporter.go:141 msg=timex
Sep 07 20:14:22 vyos node_exporter[5307]: time=2025-09-07T20:14:22.230Z level=INFO source=node_exporter.go:141 msg=udp_queues
Sep 07 20:14:22 vyos node_exporter[5307]: time=2025-09-07T20:14:22.230Z level=INFO source=node_exporter.go:141 msg=uname
Sep 07 20:14:22 vyos node_exporter[5307]: time=2025-09-07T20:14:22.230Z level=INFO source=node_exporter.go:141 msg=vmstat
Sep 07 20:14:22 vyos node_exporter[5307]: time=2025-09-07T20:14:22.230Z level=INFO source=node_exporter.go:141 msg=watchdog
Sep 07 20:14:22 vyos node_exporter[5307]: time=2025-09-07T20:14:22.230Z level=INFO source=node_exporter.go:141 msg=xfs
Sep 07 20:14:22 vyos node_exporter[5307]: time=2025-09-07T20:14:22.230Z level=INFO source=node_exporter.go:141 msg=zfs
Sep 07 20:14:22 vyos node_exporter[5307]: time=2025-09-07T20:14:22.230Z level=INFO source=tls_config.go:347 msg="Listening on" address=[::1]:9100
Sep 07 20:14:22 vyos node_exporter[5307]: time=2025-09-07T20:14:22.230Z level=INFO source=tls_config.go:350 msg="TLS is disabled." http2=false address=[::1]:9100

```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
