### PR TITLE
op-mode: T7516: expand 'reset bgp all' elements with in/out/soft options

### DIFF
--- a/op-mode-definitions/include/bgp/reset-bgp-afi-common.xml.i
+++ b/op-mode-definitions/include/bgp/reset-bgp-afi-common.xml.i
@@ -3,7 +3,7 @@
   <properties>
     <help>Reset all external peers</help>
   </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+  <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
   <children>
     #include <include/bgp/reset-bgp-neighbor-options.xml.i>
   </children>
@@ -12,7 +12,7 @@
   <properties>
     <help>Reset peers with the AS number</help>
   </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+  <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
   <children>
     #include <include/bgp/reset-bgp-neighbor-options.xml.i>
   </children>

--- a/op-mode-definitions/include/bgp/reset-bgp-neighbor-options.xml.i
+++ b/op-mode-definitions/include/bgp/reset-bgp-neighbor-options.xml.i
@@ -3,13 +3,13 @@
   <properties>
     <help>Send route-refresh unless using 'soft-reconfiguration inbound'</help>
   </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+  <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
   <children>
     <leafNode name="prefix-filter">
       <properties>
         <help>Push out prefix-list ORF and do inbound soft reconfig</help>
       </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+      <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
     </leafNode>
   </children>
 </node>
@@ -17,31 +17,31 @@
   <properties>
     <help>Reset message statistics</help>
   </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+  <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
 </leafNode>
 <leafNode name="out">
   <properties>
     <help>Resend all outbound updates</help>
   </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+  <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
 </leafNode>
 <node name="soft">
   <properties>
     <help>Soft reconfig inbound and outbound updates</help>
   </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+  <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
   <children>
     <node name="in">
       <properties>
         <help>Send route-refresh unless using 'soft-reconfiguration inbound'</help>
       </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+      <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
     </node>
     <node name="out">
       <properties>
         <help>Resend all outbound updates</help>
       </properties>
-      <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+      <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
     </node>
   </children>
 </node>

--- a/op-mode-definitions/include/bgp/reset-bgp-peer-group-vrf.xml.i
+++ b/op-mode-definitions/include/bgp/reset-bgp-peer-group-vrf.xml.i
@@ -6,7 +6,7 @@
       <path>vrf name ${COMP_WORDS[4]} protocols bgp peer-group</path>
     </completionHelp>
   </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+  <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
   <children>
     #include <include/bgp/reset-bgp-neighbor-options.xml.i>
   </children>

--- a/op-mode-definitions/include/bgp/reset-bgp-peer-group.xml.i
+++ b/op-mode-definitions/include/bgp/reset-bgp-peer-group.xml.i
@@ -6,7 +6,7 @@
       <path>protocols bgp peer-group</path>
     </completionHelp>
   </properties>
-  <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+  <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
   <children>
     #include <include/bgp/reset-bgp-neighbor-options.xml.i>
   </children>

--- a/op-mode-definitions/reset-bgp.xml.in
+++ b/op-mode-definitions/reset-bgp.xml.in
@@ -14,17 +14,20 @@
                 <script>${vyos_completion_dir}/list_bgp_neighbors.sh --both</script>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
             <children>
               #include <include/bgp/reset-bgp-neighbor-options.xml.i>
             </children>
           </virtualTagNode>
-          <leafNode name="all">
+          <node name="all">
             <properties>
               <help>Clear all peers</help>
             </properties>
-            <command>vtysh -c "clear bgp *"</command>
-          </leafNode>
+            <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
+            <children>
+              #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+            </children>
+          </node>
           #include <include/bgp/reset-bgp-afi-common.xml.i>
           #include <include/bgp/reset-bgp-peer-group.xml.i>
           <tagNode name="prefix">
@@ -34,19 +37,22 @@
                 <list>&lt;x.x.x.x/x&gt;</list>
               </completionHelp>
             </properties>
-            <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+            <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
           </tagNode>
           <node name="ipv4">
             <properties>
               <help>IPv4 Address Family</help>
             </properties>
             <children>
-              <leafNode name="all">
+              <node name="all">
                 <properties>
                   <help>Clear all peers</help>
                 </properties>
-                <command>vtysh -c "clear bgp ipv4 *"</command>
-              </leafNode>
+                <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
+                <children>
+                  #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                </children>
+              </node>
               #include <include/bgp/reset-bgp-afi-common.xml.i>
               #include <include/bgp/reset-bgp-peer-group.xml.i>
               <virtualTagNode>
@@ -56,7 +62,7 @@
                     <script>${vyos_completion_dir}/list_bgp_neighbors.sh --ipv4</script>
                   </completionHelp>
                 </properties>
-                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
                 <children>
                   #include <include/bgp/reset-bgp-neighbor-options.xml.i>
                 </children>
@@ -68,12 +74,15 @@
               <help>IPv6 Address Family</help>
             </properties>
             <children>
-              <leafNode name="all">
+              <node name="all">
                 <properties>
                   <help>Clear all peers</help>
                 </properties>
-                <command>vtysh -c "clear bgp ipv6 *"</command>
-              </leafNode>
+                <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
+                <children>
+                  #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                </children>
+              </node>
               #include <include/bgp/reset-bgp-afi-common.xml.i>
               #include <include/bgp/reset-bgp-peer-group.xml.i>
               <virtualTagNode>
@@ -83,7 +92,7 @@
                     <script>${vyos_completion_dir}/list_bgp_neighbors.sh --ipv6</script>
                   </completionHelp>
                 </properties>
-                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
                 <children>
                   #include <include/bgp/reset-bgp-neighbor-options.xml.i>
                 </children>
@@ -100,12 +109,15 @@
                   <help>Ethernet Virtual Private Network</help>
                 </properties>
                 <children>
-                  <leafNode name="all">
+                  <node name="all">
                     <properties>
                       <help>Clear all peers</help>
                     </properties>
-                    <command>vtysh -c "clear bgp l2vpn evpn *"</command>
-                  </leafNode>
+                    <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
+                    <children>
+                      #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                    </children>
+                  </node>
                   #include <include/bgp/reset-bgp-afi-common.xml.i>
                   #include <include/bgp/reset-bgp-peer-group.xml.i>
                   <virtualTagNode>
@@ -115,7 +127,7 @@
                         <script>${vyos_completion_dir}/list_bgp_neighbors.sh --both</script>
                       </completionHelp>
                     </properties>
-                    <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                    <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
                     <children>
                       #include <include/bgp/reset-bgp-neighbor-options.xml.i>
                     </children>
@@ -139,17 +151,20 @@
                     <script>${vyos_completion_dir}/list_bgp_neighbors.sh --both --vrf ${COMP_WORDS[3]}</script>
                   </completionHelp>
                 </properties>
-                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
                 <children>
                   #include <include/bgp/reset-bgp-neighbor-options.xml.i>
                 </children>
               </virtualTagNode>
-              <leafNode name="all">
+              <node name="all">
                 <properties>
                   <help>Clear all peers</help>
                 </properties>
-                <command>vtysh -c "clear bgp vrf $4 *"</command>
-              </leafNode>
+                <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
+                <children>
+                  #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                </children>
+              </node>
               #include <include/bgp/reset-bgp-afi-common.xml.i>
               #include <include/bgp/reset-bgp-peer-group-vrf.xml.i>
               <tagNode name="prefix">
@@ -159,19 +174,22 @@
                     <list>&lt;x.x.x.x/x&gt;</list>
                   </completionHelp>
                 </properties>
-                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
               </tagNode>
               <node name="ipv4">
                 <properties>
                   <help>IPv4 Address Family</help>
                 </properties>
                 <children>
-                  <leafNode name="all">
+                  <node name="all">
                     <properties>
                       <help>Clear all peers</help>
                     </properties>
-                    <command>vtysh -c "clear bgp vrf $4 ipv4 *"</command>
-                  </leafNode>
+                    <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
+                    <children>
+                      #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                    </children>
+                  </node>
                   #include <include/bgp/reset-bgp-afi-common.xml.i>
                   #include <include/bgp/reset-bgp-peer-group-vrf.xml.i>
                   <virtualTagNode>
@@ -181,7 +199,7 @@
                         <script>${vyos_completion_dir}/list_bgp_neighbors.sh --ipv4 --vrf ${COMP_WORDS[3]}</script>
                       </completionHelp>
                     </properties>
-                    <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                    <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
                     <children>
                       #include <include/bgp/reset-bgp-neighbor-options.xml.i>
                     </children>
@@ -193,12 +211,15 @@
                   <help>IPv6 Address Family</help>
                 </properties>
                 <children>
-                  <leafNode name="all">
+                  <node name="all">
                     <properties>
                       <help>Clear all peers</help>
                     </properties>
-                    <command>vtysh -c "clear bgp vrf $4 ipv6 *"</command>
-                  </leafNode>
+                    <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
+                    <children>
+                      #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                    </children>
+                  </node>
                   #include <include/bgp/reset-bgp-afi-common.xml.i>
                   #include <include/bgp/reset-bgp-peer-group-vrf.xml.i>
                   <virtualTagNode>
@@ -208,7 +229,7 @@
                         <script>${vyos_completion_dir}/list_bgp_neighbors.sh --ipv6 --vrf ${COMP_WORDS[3]}</script>
                       </completionHelp>
                     </properties>
-                    <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                    <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
                     <children>
                       #include <include/bgp/reset-bgp-neighbor-options.xml.i>
                     </children>
@@ -225,12 +246,15 @@
                       <help>Ethernet Virtual Private Network</help>
                     </properties>
                     <children>
-                      <leafNode name="all">
+                      <node name="all">
                         <properties>
                           <help>Clear all peers</help>
                         </properties>
-                        <command>vtysh -c "clear bgp vrf $4 l2vpn evpn *"</command>
-                      </leafNode>
+                        <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
+                        <children>
+                          #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                        </children>
+                      </node>
                       #include <include/bgp/reset-bgp-afi-common.xml.i>
                       #include <include/bgp/reset-bgp-peer-group-vrf.xml.i>
                       <virtualTagNode>
@@ -240,7 +264,7 @@
                             <script>${vyos_completion_dir}/list_bgp_neighbors.sh --both --vrf ${COMP_WORDS[3]}</script>
                           </completionHelp>
                         </properties>
-                        <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                        <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
                         <children>
                           #include <include/bgp/reset-bgp-neighbor-options.xml.i>
                         </children>

--- a/op-mode-definitions/reset-ip-bgp.xml.in
+++ b/op-mode-definitions/reset-ip-bgp.xml.in
@@ -16,17 +16,20 @@
                     <script>${vyos_completion_dir}/list_bgp_neighbors.sh --ipv4</script>
                   </completionHelp>
                 </properties>
-                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+                <command>${vyos_op_scripts_dir}/reset_bgp.py --command="$*"</command>
                 <children>
                   #include <include/bgp/reset-bgp-neighbor-options.xml.i>
                 </children>
               </virtualTagNode>
-              <leafNode name="all">
+              <node name="all">
                 <properties>
                   <help>Clear all BGP peering sessions</help>
                 </properties>
-                <command>vtysh -c "clear bgp ipv4 *"</command>
-              </leafNode>
+                <command>${vyos_op_scripts_dir}/reset_bgp.py --command="$*"</command>
+                <children>
+                  #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                </children>
+              </node>
               <tagNode name="dampening">
                 <properties>
                   <help>Clear BGP route flap dampening information for given host ornetwork address</help>
@@ -36,9 +39,9 @@
                 </properties>
                 <standalone>
                   <help>Clear BGP route flap dampening information</help>
-                  <command>vtysh -c "clear ip bgp dampening"</command>
+                  <command>${vyos_op_scripts_dir}/reset_bgp.py --command="$*"</command>
                 </standalone>
-                <command>vtysh -c "clear ip bgp dampening $5"</command>
+                <command>${vyos_op_scripts_dir}/reset_bgp.py --command="$*"</command>
                 <children>
                   <virtualTagNode>
                     <properties>
@@ -47,7 +50,7 @@
                         <list>&lt;x.x.x.x&gt;</list>
                       </completionHelp>
                     </properties>
-                    <command>vtysh -c "clear ip bgp dampening $5 $6"</command>
+                    <command>${vyos_op_scripts_dir}/reset_bgp.py --command="$*"</command>
                   </virtualTagNode>
                 </children>
               </tagNode>
@@ -61,12 +64,15 @@
                   </completionHelp>
                 </properties>
                 <children>
-                  <leafNode name="all">
+                  <node name="all">
                     <properties>
                       <help>Clear all BGP peering sessions for vrf</help>
                     </properties>
-                    <command>vtysh -c "clear bgp vrf $5 *"</command>
-                  </leafNode>
+                    <command>${vyos_op_scripts_dir}/reset_bgp.py --command="$*"</command>
+                    <children>
+                      #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                    </children>
+                  </node>
                   <virtualTagNode>
                     <properties>
                       <help>Clear BGP neighbor IP address</help>
@@ -74,7 +80,10 @@
                         <list>&lt;x.x.x.x&gt;</list>
                       </completionHelp>
                     </properties>
-                    <command>vtysh -c "clear bgp vrf $5 $6"</command>
+                    <command>${vyos_op_scripts_dir}/reset_bgp.py --command="$*"</command>
+                    <children>
+                      #include <include/bgp/reset-bgp-neighbor-options.xml.i>
+                    </children>
                   </virtualTagNode>
                 </children>
               </tagNode>

--- a/src/op_mode/bgp.py
+++ b/src/op_mode/bgp.py
@@ -80,6 +80,29 @@ show bgp
 ArgFamily = typing.Literal['inet', 'inet6', 'l2vpn']
 ArgFamilyModifier = typing.Literal['unicast', 'labeled_unicast', 'multicast', 'vpn', 'flowspec']
 
+def reset(command: str):
+    from vyos.utils.process import cmd
+
+    tokens = command.split()
+
+    # reset -> clear (only if it's the first token)
+    if tokens and tokens[0] == "reset":
+        tokens[0] = "clear"
+
+    # peer-group and vrf may have 'all' in their names; don't replace 'all' with '*'
+    skip_indexes = []
+    for index, word in enumerate(tokens[:-1]):
+        if word in ("peer-group", "vrf"):
+            skip_indexes.append(index + 1)
+
+    # replace standalone "all" with "*" unless it's in the skip list
+    for index, word in enumerate(tokens):
+        if word == "all" and index not in skip_indexes:
+            tokens[index] = "*"
+
+    command = " ".join(tokens)
+    cmd(f'vtysh -c "{command}"')
+
 def show_summary(raw: bool):
     from vyos.utils.process import cmd
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Updated resetting (clearing) of `all` BGP peers within a given section to allow for `in`, `out`, `soft`, `soft in`, and `soft out`

Calls to the `vtysh_wrapper.sh` script were replaced with calls to a new `reset` function in the `bgp.py` `opmode` script.

Replaced direct calls to `vtysh -c` with the same `reset` function in the `bgp.py` script.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7516
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
#### Test new command syntax (small sampling):
```
vyos@vyos:~$ reset bgp all
Possible completions:
  <Enter>               Execute the current command
  in                    Send route-refresh unless using 'soft-reconfiguration inbound'
  message-stats         Reset message statistics
  out                   Resend all outbound updates
  soft                  Soft reconfig inbound and outbound updates


vyos@vyos:~$ reset bgp ipv4 all
Possible completions:
  <Enter>               Execute the current command
  in                    Send route-refresh unless using 'soft-reconfiguration inbound'
  message-stats         Reset message statistics
  out                   Resend all outbound updates
  soft                  Soft reconfig inbound and outbound updates


vyos@vyos:~$ reset bgp vrf test all
Possible completions:
  <Enter>               Execute the current command
  in                    Send route-refresh unless using 'soft-reconfiguration inbound'
  message-stats         Reset message statistics
  out                   Resend all outbound updates
  soft                  Soft reconfig inbound and outbound updates
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
