### PR TITLE
conntrack: T7700: Prevent empty policy generation

### DIFF
--- a/data/templates/conntrack/nftables-ct.j2
+++ b/data/templates/conntrack/nftables-ct.j2
@@ -30,7 +30,9 @@ table ip vyos_conntrack {
         l3proto ip;
 {%         for protocol, protocol_config in rule_config.protocol.items() %}
         protocol {{ protocol }};
+{%             if protocol_config | count > 0 %}
         policy = { {{ protocol_config | conntrack_ct_policy() }} }
+{%             endif %}
 {%         endfor %}
     }
 {%     endfor %}
@@ -126,7 +128,9 @@ table ip6 vyos_conntrack {
         l3proto ip;
 {%         for protocol, protocol_config in rule_config.protocol.items() %}
         protocol {{ protocol }};
+{%             if protocol_config | count > 0 %}
         policy = { {{ protocol_config | conntrack_ct_policy() }} }
+{%             endif %}
 {%         endfor %}
     }
 {%     endfor %}


### PR DESCRIPTION
Only print policy in nftables-ct.conf if protocol config is defined

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Prevent empty `policy = {  }` from being generated in nftables-ct.conf when protocol configuration nodes are removed from the config tree for CT timeouts.

The empty policy block was causing the commit to fail:
```
vyos@vyos# commit
[ system conntrack ]
Failed to apply configuration: /run/nftables-ct.conf:20:21-21: Error:
syntax error, unexpected '}', expecting string     policy = { }
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7700

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Create a CT timeout rule, add some config and then remove the config (but do not delete the timeout rule itself)

Example from Phabricator task:
```
set system conntrack timeout custom ipv4 rule 1 destination port '53'
set system conntrack timeout custom ipv4 rule 1 protocol udp replied '700'
commit
delete system conntrack timeout custom ipv4 rule 1 destination port '53'
delete system conntrack timeout custom ipv4 rule 1 protocol udp replied '700'
commit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
