### PR TITLE
T7682: incorrect sla-len in DHCPv6 client prefix delegation (DHCPv6-PD)

### DIFF
--- a/data/templates/dhcp-client/ipv6.j2
+++ b/data/templates/dhcp-client/ipv6.j2
@@ -39,12 +39,10 @@ id-assoc na 0 {
 id-assoc pd {{ pd }} {
 {#   length got a default value #}
     prefix ::/{{ pd_config.length }} infinity;
-{%         set sla_len = 64 - pd_config.length | int %}
 {%         set count = namespace(value=0) %}
 {%         if pd_config.interface is vyos_defined %}
 {%             for interface, interface_config in pd_config.interface.items() if pd_config.interface is vyos_defined %}
     prefix-interface {{ interface }} {
-        sla-len {{ sla_len }};
 {%                 if interface_config.sla_id is vyos_defined %}
         sla-id {{ interface_config.sla_id }};
 {%                 else %}

--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -1228,7 +1228,6 @@ class BasicInterfaceTest:
                     self.assertIn(f'prefix-interface {delegatee}' + r' {', dhcpc6_config)
                     self.assertIn(f'ifid {address};', dhcpc6_config)
                     self.assertIn(f'sla-id {sla_id};', dhcpc6_config)
-                    self.assertIn(f'sla-len {sla_len};', dhcpc6_config)
 
                     # increment sla-id
                     sla_id = str(int(sla_id) + 1)
@@ -1294,7 +1293,6 @@ class BasicInterfaceTest:
                     self.assertIn(f'prefix-interface {delegatee}' + r' {', dhcpc6_config)
                     self.assertIn(f'ifid {address};', dhcpc6_config)
                     self.assertIn(f'sla-id {sla_id};', dhcpc6_config)
-                    self.assertIn(f'sla-len {sla_len};', dhcpc6_config)
 
                     # increment sla-id
                     sla_id = str(int(sla_id) + 1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The current template has an overly optimistic logic for sla-len calculation, relying on an assumption that a server always provides a prefix with the exact length requested by the client. This is incorrect. According to RFC8415 and RFC7084, the prefix length in a request is only a hint for the server, which may decide to provide a different prefix size.

The big issue here is that wide-dhcpv6-client uses the sla-len value from the configuration regardless of the received prefix size. This seems to be the known issue.

The good news is that we have already inherited a patch from Debian to mitigate the issue [1]. It accomplishes exactly what we are doing in the configuration template, but with the advantage of using the actual prefix length from the received prefix, rather than the one configured in the configuration file.

If we simply remove sla-len from the template, everything appears to function normally.

Before - server sending /56

```
set interfaces ethernet eth1 address 'dhcpv6'
set interfaces ethernet eth1 dhcpv6-options pd 1 interface eth2 address '1'
set interfaces ethernet eth1 dhcpv6-options pd 1 interface eth2 sla-id '0'
set interfaces ethernet eth1 dhcpv6-options pd 1 length '60'
```

Resulted in:

```
vyos@vyos# run show interfaces
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address           MAC                VRF        MTU  S/L    Description
-----------  -------------------  -----------------  -------  -----  -----  -------------
eth1         fc00:0:0:1::200/128  0c:67:94:67:00:01  default   1500  u/u
eth2         fc00:0:2:ff00::1/60  0c:67:94:67:00:02  default   1500  u/u
```

Whereas IPv6 PD should always use a /64 prefix on the interface we assign a dynamic DHCPv6 prefix to.

After the fix:

```
vyos@vyos:~$ show interfaces
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address           MAC                VRF        MTU  S/L    Description
-----------  -------------------  -----------------  -------  -----  -----  -------------
eth1         fc00:0:0:1::200/128  0c:67:94:67:00:01  default   1500  u/u
eth2         fc00:0:2:ff00::1/64  0c:67:94:67:00:02  default   1500  u/u
```

1: https://salsa.debian.org/debian/wide-dhcpv6/-/blob/debian/20080615-23/debian/patches/0021-Make-sla-len-config-optional.patch

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7682

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result


If a DHCPv6 server (e.g. VyOS itself) even provides multiple PD prefixes, the right one is choosen. Assume the following server configuration:

```
set service dhcpv6-server shared-network-name dhcpv6-1 subnet fc00:0:0:1::/64 address-range start fc00:0:0:1::100 stop 'fc00:0:0:1::200'
set service dhcpv6-server shared-network-name dhcpv6-1 subnet fc00:0:0:1::/64 lease-time default '120'
set service dhcpv6-server shared-network-name dhcpv6-1 subnet fc00:0:0:1::/64 prefix-delegation start fc00:0:2:: prefix-length '56' 
set service dhcpv6-server shared-network-name dhcpv6-1 subnet fc00:0:0:1::/64 prefix-delegation start fc00:0:2:: stop 'fc00:0:2:ff00::'
set service dhcpv6-server shared-network-name dhcpv6-1 subnet fc00:0:0:1::/64 prefix-delegation start fc00:0:3:: prefix-length '60'
set service dhcpv6-server shared-network-name dhcpv6-1 subnet fc00:0:0:1::/64 prefix-delegation start fc00:0:3:: stop 'fc00:0:3:ff00::'
```

If a /56 is requested (`dhcpv6-options pd 1 length 56`) - we will get a per interface /64 from the original /56 prefix-delegation from the DHCPv6 server - from the above `fc00:0:2::` pool.

If the user suddently requests a /60 (`dhcpv6-options pd 1 length 60`) the delegated prefix will be from the above `fc00:0:3::` pool.

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_ethernet.py
test_add_multiple_ip_addresses (__main__.EthernetInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.EthernetInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.EthernetInterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.EthernetInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.EthernetInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.EthernetInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.EthernetInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.EthernetInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.EthernetInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol (__main__.EthernetInterfaceTest.test_eapol) ... ok
test_ethtool_evpn_uplink_tracking (__main__.EthernetInterfaceTest.test_ethtool_evpn_uplink_tracking) ... ok
test_ethtool_flow_control (__main__.EthernetInterfaceTest.test_ethtool_flow_control) ... ok
test_ethtool_ring_buffer (__main__.EthernetInterfaceTest.test_ethtool_ring_buffer) ... ok
test_interface_description (__main__.EthernetInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.EthernetInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.EthernetInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.EthernetInterfaceTest.test_interface_ipv6_options) ... ok
test_interface_mtu (__main__.EthernetInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.EthernetInterfaceTest.test_ipv6_link_local_address) ... ok
test_move_interface_between_vrf_instances (__main__.EthernetInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.EthernetInterfaceTest.test_mtu_1200_no_ipv6_interface) ... ok
test_non_existing_interface (__main__.EthernetInterfaceTest.test_non_existing_interface) ... ok
test_offloading_rfs (__main__.EthernetInterfaceTest.test_offloading_rfs) ... ok
test_offloading_rps (__main__.EthernetInterfaceTest.test_offloading_rps) ... ok
test_span_mirror (__main__.EthernetInterfaceTest.test_span_mirror) ... ok
test_speed_duplex_verify (__main__.EthernetInterfaceTest.test_speed_duplex_verify) ... ok
test_switchdev (__main__.EthernetInterfaceTest.test_switchdev) ... ok
test_vif_8021q_interfaces (__main__.EthernetInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.EthernetInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.EthernetInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.EthernetInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.EthernetInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.EthernetInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 34 tests in 462.121s

OK
``` 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
