### PR TITLE
Revert "Makefile: T7793: "make clean" should also clean libvyosconfig"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,6 @@ clean:
 	rm -rf $(BUILD_DIR)
 	rm -rf $(TMPL_DIR)
 	rm -rf $(OP_TMPL_DIR)
-	$(MAKE) -C libvyosconfig clean
 	$(MAKE) -C $(SHIM_DIR) clean
 
 .PHONY: test


### PR DESCRIPTION
Reverts vyos/vyos-1x#4712

This change introduced an unintended side effect: subsequent package builds
fail. Debian’s build system performs an implicit dh_clean, which removes the
libvyosconfig/_build directory.

However, the current Makefile logic only builds libvyosconfig once (see Makefile:L18)
and does not trigger a rebuild if the library is already marked as installed.

As a result, after the first successful build, later builds fail with:

cp libvyosconfig/_build/libvyosconfig.so debian/tmp/libvyosconfig/usr/lib/libvyosconfig.so.0
cp: cannot stat 'libvyosconfig/_build/libvyosconfig.so': No such file or directory
