### PR TITLE
T7806: VPP do not allow skip-cores to be configured without main-core

### DIFF
--- a/python/vyos/vpp/config_verify.py
+++ b/python/vyos/vpp/config_verify.py
@@ -328,14 +328,15 @@ def verify_vpp_settings_cpu_skip_cores(skip_cores: int):
         )
 
 
-def verify_vpp_settings_cpu_and_corelist_workers(settings: dict):
+def verify_vpp_settings_cpu(settings: dict):
     """
+    Verify 'cpu main-core' is set if worker-related settings are used.
     `set vpp settings cpu workers` and `set vpp settings cpu corelist-workers`
     are mutually exclusive!
     """
-    if (
-        'corelist_workers' in settings or 'workers' in settings
-    ) and 'main_core' not in settings:
+    worker_related = ('corelist_workers', 'workers', 'skip_cores')
+
+    if any(key in settings for key in worker_related) and 'main_core' not in settings:
         raise ConfigError('"cpu main-core" is required but not set!')
 
     if 'corelist_workers' in settings and 'workers' in settings:

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -47,7 +47,7 @@ from vyos.vpp.config_verify import (
     verify_dev_driver,
     verify_vpp_minimum_cpus,
     verify_vpp_minimum_memory,
-    verify_vpp_settings_cpu_and_corelist_workers,
+    verify_vpp_settings_cpu,
     verify_vpp_settings_cpu_corelist_workers,
     verify_vpp_cpu_main_core,
     verify_vpp_settings_cpu_skip_cores,
@@ -405,13 +405,13 @@ def verify(config):
         verify_vpp_minimum_cpus()
 
     if 'cpu' in config['settings']:
+        # Check whether the workers and corelist-workers are configured properly
+        verify_vpp_settings_cpu(cpu_settings)
+
         # Check if there are enough CPU cores to skip according to config
         if 'skip_cores' in cpu_settings:
             skip_cores = int(cpu_settings['skip_cores'])
             verify_vpp_settings_cpu_skip_cores(skip_cores)
-
-        # Check whether the workers and corelist-workers are configured properly
-        verify_vpp_settings_cpu_and_corelist_workers(cpu_settings)
 
         # Check if there are enough CPU cores to add workers
         if 'workers' in cpu_settings:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7806
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set vpp settings interface eth1 driver dpdk
set vpp settings cpu skip-cores 1

vyos@vyos# commit
[ vpp ]
"cpu main-core" is required but not set!

[[vpp]] failed
Commit failed
vyos@vyos# set vpp settings cpu main-core 2
[edit]
vyos@vyos# commit
[edit]
vyos@vyos#

vyos@vyos# /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... skipped 'Skipping temporary bonding, sometimes get recursion T7117'
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... ok
test_14_mem_default_hugepage (__main__.TestVPP.test_14_mem_default_hugepage) ... ok
test_15_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_15_vpp_ipsec_xfrm_nl) ... ok
test_16_vpp_cgnat (__main__.TestVPP.test_16_vpp_cgnat) ... ok
test_17_vpp_nat (__main__.TestVPP.test_17_vpp_nat) ... ok
test_18_vpp_sflow (__main__.TestVPP.test_18_vpp_sflow) ... ok
test_19_resource_limits (__main__.TestVPP.test_19_resource_limits) ... ok

----------------------------------------------------------------------
Ran 21 tests in 640.113s

OK (skipped=2)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
