### PR TITLE
T7796: PPPoE-server add mapping in vpp if vpp-cp is enabled

### DIFF
--- a/data/config-mode-dependencies/vyos-vpp.json
+++ b/data/config-mode-dependencies/vyos-vpp.json
@@ -14,7 +14,8 @@
         "vpp_nat": ["vpp_nat"],
         "vpp_nat_cgnat": ["vpp_nat_cgnat"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"],
-        "vpp_sflow": ["vpp_sflow"]
+        "vpp_sflow": ["vpp_sflow"],
+        "pppoe_server": ["service_pppoe-server"]
     },
     "vpp_interfaces_bonding": {
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],

--- a/python/vyos/vpp/control_vpp.py
+++ b/python/vyos/vpp/control_vpp.py
@@ -486,3 +486,20 @@ class VPPControl:
             Callable[AnyParam, AnyType]: API functions
         """
         return self.__vpp_api_client.api
+
+    @_Decorators.api_call
+    def map_pppoe_interface(self, ifname: str, is_add: bool) -> None:
+        """Create or delete PPPoE mapping between data-plain and control-plane interfaces
+
+        Args:
+            ifname (str): name of an interface in kernel
+            is_add (bool): create or delete mapping
+        """
+        vpp_pair = self.lcp_pair_find(kernel_name=ifname)
+        if vpp_pair:
+            vpp_pair_name = vpp_pair['vpp_name_kernel']
+            self.__vpp_api_client.api.pppoe_add_del_cp(
+                dp_sw_if_index=self.get_sw_if_index(ifname),
+                cp_sw_if_index=self.get_sw_if_index(vpp_pair_name),
+                is_add=is_add,
+            )

--- a/smoketest/scripts/cli/test_service_pppoe-server.py
+++ b/smoketest/scripts/cli/test_service_pppoe-server.py
@@ -212,18 +212,17 @@ class TestServicePPPoEServer(BasicAccelPPPTest.TestCase):
         self.assertIn('accept-blank-service=1', config)
 
     def test_accel_vpp_cp(self):
-        interface_vpp = f'{interface},vpp-cp=true'
-
         self.basic_config()
-        self.set(['interface', interface, 'vpp-cp'])
         self.cli_commit()
 
-        # Validate configuration values
-        conf = ConfigParser(allow_no_value=True, delimiters='=')
-        conf.read(self._config_file)
+        self.set(['interface', interface, 'vpp-cp'])
 
-        # Validate configuration
-        self.assertEqual(conf['pppoe']['interface'], interface_vpp)
+        # vpp-cp require VPP service to be started and interface is configured in VPP
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        # All other checks for PPPoE control-plane integration
+        # with VPP are verified in test_vpp.py
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7796
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set service pppoe-server authentication mode 'noauth'
set service pppoe-server client-ip-pool first range '100.64.0.1-100.64.0.100'
set service pppoe-server default-pool 'first'
set service pppoe-server gateway-address '100.64.0.1'
set service pppoe-server interface eth1 vpp-cp

vyos@vyos# commit
[ service pppoe-server ]
PPPoE control-plane integration with VPP is enabled on interface(s) eth1
but VPP service was not started
[[service pppoe-server]] failed
Commit failed
[edit]
vyos@vyos# set vpp settings interface eth1 driver dpdk
[edit]
vyos@vyos# commit
[ service pppoe-server ]

[edit]
vyos@vyos#  sud vppctl show pppoe control-plane binding
Dataplane Interface Control Interface
------------------- -----------------
eth1                tap4096

vyos@vyos:~$ vyos@vyos:~$  /usr/libexec/vyos/tests/smoke/cli/test_service_pppoe-server.py
test_accel_ipv4_pool (__main__.TestServicePPPoEServer.test_accel_ipv4_pool) ... ok
test_accel_ipv6_pool (__main__.TestServicePPPoEServer.test_accel_ipv6_pool) ... ok
test_accel_limits (__main__.TestServicePPPoEServer.test_accel_limits) ... ok
test_accel_local_authentication (__main__.TestServicePPPoEServer.test_accel_local_authentication) ... ok
test_accel_log_level (__main__.TestServicePPPoEServer.test_accel_log_level) ... ok
test_accel_name_servers (__main__.TestServicePPPoEServer.test_accel_name_servers) ... ok
test_accel_next_pool (__main__.TestServicePPPoEServer.test_accel_next_pool) ... ok
test_accel_ppp_options (__main__.TestServicePPPoEServer.test_accel_ppp_options) ... ok
test_accel_radius_authentication (__main__.TestServicePPPoEServer.test_accel_radius_authentication) ... ok
test_accel_shaper (__main__.TestServicePPPoEServer.test_accel_shaper) ... ok
test_accel_snmp (__main__.TestServicePPPoEServer.test_accel_snmp) ... ok
test_accel_vpp_cp (__main__.TestServicePPPoEServer.test_accel_vpp_cp) ... ok
test_accel_wins_server (__main__.TestServicePPPoEServer.test_accel_wins_server) ... ok
test_pppoe_limits (__main__.TestServicePPPoEServer.test_pppoe_limits) ... ok
test_pppoe_server_accept_service (__main__.TestServicePPPoEServer.test_pppoe_server_accept_service) ... ok
test_pppoe_server_any_login (__main__.TestServicePPPoEServer.test_pppoe_server_any_login) ... ok
test_pppoe_server_authentication_protocols (__main__.TestServicePPPoEServer.test_pppoe_server_authentication_protocols) ... ok
test_pppoe_server_pado_delay (__main__.TestServicePPPoEServer.test_pppoe_server_pado_delay) ... ok
test_pppoe_server_shaper (__main__.TestServicePPPoEServer.test_pppoe_server_shaper) ... ok
test_pppoe_server_vlan (__main__.TestServicePPPoEServer.test_pppoe_server_vlan) ... ok

----------------------------------------------------------------------
Ran 20 tests in 141.096s

OK

vyos@vyos:~$  /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... skipped 'Skipping temporary bonding, sometimes get recursion T7117'
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... ok
test_14_mem_default_hugepage (__main__.TestVPP.test_14_mem_default_hugepage) ... ok
test_15_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_15_vpp_ipsec_xfrm_nl) ... ok
test_16_vpp_cgnat (__main__.TestVPP.test_16_vpp_cgnat) ... ok
test_17_vpp_nat (__main__.TestVPP.test_17_vpp_nat) ... ok
test_18_vpp_sflow (__main__.TestVPP.test_18_vpp_sflow) ... ok
test_19_resource_limits (__main__.TestVPP.test_19_resource_limits) ... ok
test_20_vpp_pppoe_mapping (__main__.TestVPP.test_20_vpp_pppoe_mapping) ... ok

----------------------------------------------------------------------
Ran 22 tests in 531.117s

OK (skipped=2)
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
