### PR TITLE
container: T7681: fix multiple name servers

### DIFF
--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -117,13 +117,14 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
     def test_name_server(self):
         cont_name = 'dns-test'
         net_name = 'net-test'
-        name_server = '192.168.0.1'
+        name_servers = ['192.168.0.1', '192.168.0.2']
         prefix = '192.0.2.0/24'
 
         self.cli_set(base_path + ['network', net_name, 'prefix', prefix])
 
         self.cli_set(base_path + ['name', cont_name, 'image', busybox_image])
-        self.cli_set(base_path + ['name', cont_name, 'name-server', name_server])
+        for name_server in name_servers:
+            self.cli_set(base_path + ['name', cont_name, 'name-server', name_server])
         self.cli_set(
             base_path
             + [
@@ -144,7 +145,7 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         n = cmd_to_json(f'sudo podman inspect {cont_name}')
-        self.assertEqual(n['HostConfig']['Dns'][0], name_server)
+        self.assertEqual(n['HostConfig']['Dns'], name_servers)
 
         tmp = cmd(f'sudo podman exec -it {cont_name} cat /etc/resolv.conf')
         self.assertIn(name_server, tmp)

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -443,10 +443,14 @@ def generate_run_arguments(name, container_config, host_ident):
     if 'allow_host_pid' in container_config:
       host_pid = '--pid host'
 
-    name_server = ''
+    name_server = []
     if 'name_server' in container_config:
         for ns in container_config['name_server']:
-            name_server += f'--dns {ns}'
+            name_server.append(f'--dns {ns}')
+    if name_server:
+        name_server = ' '.join(name_server)
+    else:
+        name_server = ''
 
     container_base_cmd = f'--detach --interactive --tty --replace {capabilities} {privileged} --cpus {cpu_quota} {sysctl_opt} ' \
                          f'--memory {memory}m --shm-size {shared_memory}m --memory-swap 0 --restart {restart} --log-driver={log_driver} ' \


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
The `--dns` option in the `run_args` was missing a space between `--dns` calls when there were multiple name servers configured. This was corrected.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7681
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
#### Configure container with multiple `name-server` options:
```
set container name alpine allow-host-networks
set container name alpine image 'alpine'
set container name alpine name-server '4.2.2.2'
set container name alpine name-server '4.2.2.3'
```
#### Check container for multiple DNS servers configured:
```
vyos@vyos# sudo podman inspect alpine | jq '.[].HostConfig.Dns'
[
  "4.2.2.2",
  "4.2.2.3"
]
```
#### Smoketest results:
```
test_name_server (__main__.TestContainer.test_name_server) ... ok

----------------------------------------------------------------------
Ran 1 test in 26.400s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
