### PR TITLE
T7785: VPP enable L3 mode after removing interface from a bridge

### DIFF
--- a/python/vyos/vpp/interface/bridge.py
+++ b/python/vyos/vpp/interface/bridge.py
@@ -123,6 +123,7 @@ class BridgeInterface:
         else:
             member_if_index = self.vpp.get_sw_if_index(member)
 
+        # enable=0, 0 = Enable L3 mode
         return self.vpp.api.sw_interface_set_l2_bridge(
-            rx_sw_if_index=member_if_index, bd_id=0, port_type=0
+            rx_sw_if_index=member_if_index, bd_id=0, port_type=0, enable=0
         )


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Fix

We have to re-enable L3 mode for an interface after removing the interface from a bridge.
From the VPP API https://github.com/FDio/vpp/blob/1573e751c5478d3914d26cdde153390967932d6b/src/vnet/l2/l2.api#L577
```
  @param enable - Enable beige mode if not 0, else set to L3 mode

```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7785

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Add interface to a bridge and remove the bridge:
```
set interfaces ethernet eth1 address '192.0.2.1/30'
set interfaces ethernet eth1 description 'LAN'
set system option kernel cpu disable-nmi-watchdog
set system option kernel disable-hpet
set system option kernel disable-mce
set system option kernel disable-softlockup
set system option kernel memory default-hugepage-size '2M'
set system option kernel memory disable-numa-balancing
set system option kernel memory hugepage-size 2M hugepage-count '9500'
set vpp interfaces bridge br10 member interface eth1
set vpp settings interface eth1 driver 'dpdk'
set vpp settings unix poll-sleep-usec '222'
commit

delete  vpp interfaces bridge br10 
commit
```
Before the fix, L3 connectivity was broken
```
vpp# show errors 
   Count                  Node                              Reason               Severity 
         4             dpdk-input                          no error                error  
         4             arp-reply                       ARP replies sent            info   
         4             arp-reply             ARP request IP4 source address lear   info   
        79             llc-input                    unknown llc ssap/dsap          error  
        42              l2-learn                       L2 learn packets            error  
         2              l2-learn                       L2 learn misses             error  
       118              l2-input                       L2 input packets            error  
        42              l2-flood                       L2 flood packets            error  
        42              l2-flood                   L2 replication complete         error  
        76        feature-bitmap-drop           L2 feature forwarding disabled     error  
vpp# 
```
After the fix L3 connectivity works again
```
vyos@r14# delete vpp interfaces bridge 
[edit]
vyos@r14# commit
[edit]
vyos@r14# run ping 192.0.2.2 count 2
PING 192.0.2.2 (192.0.2.2) 56(84) bytes of data.
64 bytes from 192.0.2.2: icmp_seq=1 ttl=64 time=0.970 ms
64 bytes from 192.0.2.2: icmp_seq=2 ttl=64 time=0.538 ms

--- 192.0.2.2 ping statistics ---
2 packets transmitted, 2 received, 0% packet loss, time 1001ms
rtt min/avg/max/mdev = 0.538/0.754/0.970/0.216 ms
[edit]
vyos@r14# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
