### PR TITLE
T7805: VPP remove unused 'default-hugepage-size' from memory section and restrict page sizes in xml

### DIFF
--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -160,9 +160,6 @@ memory {
 {%     if memory.main_heap_page_size is vyos_defined %}
     main-heap-page-size {{ memory.main_heap_page_size }}
 {%     endif %}
-{%     if memory.default_hugepage_size is vyos_defined %}
-    default-hugepage-size {{ memory.default_hugepage_size }}
-{%     endif %}
 }
 {% endif %}
 

--- a/interface-definitions/include/unformat_log2_page_size.xml.i
+++ b/interface-definitions/include/unformat_log2_page_size.xml.i
@@ -1,17 +1,20 @@
 <!-- include start from unformat_log2_page_size.xml.i -->
 <completionHelp>
-  <list>default default-hugepage</list>
-  <script>sudo ${vyos_completion_dir}/list_mem_page_size.py</script>
+  <list>4K 2M 1G</list>
 </completionHelp>
 <valueHelp>
-  <format>default</format>
-  <description>Default</description>
+  <format>4K</format>
+  <description>4 kilobytes</description>
 </valueHelp>
 <valueHelp>
-  <format>default-hugepage</format>
-  <description>Default huge-page</description>
+  <format>2M</format>
+  <description>2 megabytes</description>
+</valueHelp>
+<valueHelp>
+  <format>1G</format>
+  <description>1 gigabyte</description>
 </valueHelp>
 <constraint>
-  <regex>(default|default-hugepage|4K|8K|1024K|64K|256K|2048K|4096K|16384K|262144K|1048576K|16777216K|1M|2M|4M|16M|256M|1024M|16384M|1G|16G)</regex>
+  <regex>(4K|2M|1G)</regex>
 </constraint>
 <!-- include end -->

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -392,7 +392,7 @@
                   <help>Set the page-size for buffer allocation</help>
                   #include <include/unformat_log2_page_size.xml.i>
                 </properties>
-                <defaultValue>default</defaultValue>
+                <defaultValue>2M</defaultValue>
               </leafNode>
             </children>
           </node>
@@ -786,15 +786,6 @@
               <properties>
                 <help>Main heap page size</help>
                 #include <include/unformat_log2_page_size.xml.i>
-              </properties>
-              <defaultValue>2M</defaultValue>
-            </leafNode>
-            <leafNode name="default-hugepage-size">
-              <properties>
-                <help>Default hugepage size</help>
-                <completionHelp>
-                  <script>sudo ${vyos_completion_dir}/list_mem_page_size.py --hugepage_only True </script>
-                </completionHelp>
               </properties>
               <defaultValue>2M</defaultValue>
             </leafNode>

--- a/python/vyos/vpp/config_resource_checks/memory.py
+++ b/python/vyos/vpp/config_resource_checks/memory.py
@@ -21,10 +21,7 @@ import re
 import psutil
 
 from vyos.utils.process import cmd
-from vyos.vpp.utils import (
-    human_memory_to_bytes,
-    human_page_memory_to_bytes,
-)
+from vyos.vpp.utils import human_memory_to_bytes
 from vyos.vpp.config_resource_checks.resource_defaults import default_resource_map
 
 
@@ -53,7 +50,7 @@ def get_hugepages_info() -> dict:
 
     for entry in os.listdir(base_path):
         page_size_kb = entry[10:]
-        page_size = human_page_memory_to_bytes(page_size_kb)
+        page_size = human_memory_to_bytes(page_size_kb)
         key = classify_page_size(page_size)
         info[key] = {}
 
@@ -94,44 +91,30 @@ def get_numa_count():
 
 
 def buffer_page_size(settings: dict) -> int:
-    page_size = settings.get('buffers', {}).get('page_size', 'default')
-    return human_page_memory_to_bytes(page_size)
+    page_size = settings.get('buffers', {}).get('page_size')
+    return human_memory_to_bytes(page_size)
 
 
 def buffer_size(settings: dict) -> int:
     numa_count = get_numa_count()
-    buffers_per_numa = int(
-        settings.get('buffers', {}).get(
-            'buffers_per_numa', default_resource_map.get('buffers_per_numa')
-        )
-    )
-    data_size = int(
-        settings.get('buffers', {}).get(
-            'data_size', default_resource_map.get('data_size')
-        )
-    )
+    buffers_per_numa = int(settings.get('buffers').get('buffers_per_numa'))
+    data_size = int(settings.get('buffers').get('data_size'))
     buffers_memory = buffers_per_numa * data_size * numa_count
     return buffers_memory
 
 
 def main_heap_page_size(settings: dict) -> int:
-    heap_page_size = settings.get('memory', {}).get(
-        'main_heap_page_size', default_resource_map.get('main_heap_page_size')
-    )
-    return human_page_memory_to_bytes(heap_page_size)
+    heap_page_size = settings.get('memory').get('main_heap_page_size')
+    return human_memory_to_bytes(heap_page_size)
 
 
 def memory_main_heap(settings: dict) -> int:
-    heap_size = settings.get('memory', {}).get(
-        'main_heap_size', default_resource_map.get('main_heap_size')
-    )
+    heap_size = settings.get('memory').get('main_heap_size')
     return human_memory_to_bytes(heap_size)
 
 
 def ipv6_heap_size(settings: dict) -> int:
-    heap_size = settings.get('ipv6', {}).get(
-        'heap_size', default_resource_map.get('ipv6_heap_size')
-    )
+    heap_size = settings.get('ipv6').get('heap_size')
     return human_memory_to_bytes(heap_size)
 
 
@@ -140,15 +123,13 @@ def total_heap_size(heap_size: int, heap_page_size: int) -> int:
 
 
 def statseg_size(settings: dict) -> int:
-    statseg_memory = settings.get('statseg', {}).get(
-        'size', default_resource_map.get('statseg_heap_size')
-    )
+    statseg_memory = settings.get('statseg').get('size')
     return human_memory_to_bytes(statseg_memory)
 
 
 def statseg_page_size(settings: dict) -> int:
-    page_size = settings.get('statseg', {}).get('page_size')
-    return human_page_memory_to_bytes(page_size)
+    page_size = settings.get('statseg').get('page_size')
+    return human_memory_to_bytes(page_size)
 
 
 def total_statseg_size(_statseg_size: int, _statseg_page: int) -> int:

--- a/python/vyos/vpp/config_resource_checks/resource_defaults.py
+++ b/python/vyos/vpp/config_resource_checks/resource_defaults.py
@@ -18,26 +18,12 @@
 
 
 default_resource_map = {
-    # Default amount of buffers per NUMA (populated CPU socket)
-    'buffers_per_numa': 16384,
-    # Default size of buffer (in bytes)
-    'data_size': 2048,
-    # Default hugepage size for VPP
-    'hugepage_size': '2M',
-    # Default amount of memory allocated for VPP exclusive usage
-    'main_heap_size': '3G',
-    # Default main heap page size
-    'main_heap_page_size': '2M',
     # Default size of buffers transferred via netlink
     'netlink_rx_buffer_size': 212992,
-    # Default amount of memory allocated for VPP stats segment usage
-    'statseg_heap_size': '128M',
     # Minimal amount of memory required to start VPP
     'min_memory': '8G',
     # Minimal number of physical CPU cores required to start VPP
     'min_cpus': 4,
     # Reserve at least 2 physical cores
     'reserved_cpu_cores': 2,
-    # Default heap size for IPv6
-    'ipv6_heap_size': '32M',
 }

--- a/python/vyos/vpp/utils.py
+++ b/python/vyos/vpp/utils.py
@@ -330,23 +330,6 @@ def bytes_to_human_memory(value: int, unit: str) -> str | None:
     return f'{val}{unit}' if val else None
 
 
-def human_page_memory_to_bytes(value: str) -> int:
-    """
-    Convert a human-readable vpp page size format to a byte value.
-
-    :param value: The string memory size in vpp human-readable format.
-    :return: A int representing the value.
-    """
-    default = {
-        'default': get_default_page_size,
-        'default-hugepage': get_default_hugepage_size,
-    }
-    try:
-        return default[value]()
-    except KeyError:
-        return human_memory_to_bytes(value)
-
-
 class EthtoolGDrvinfo:
     """Return interface details like `ethtol -i` does"""
 

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -19,7 +19,6 @@
 
 import os
 import re
-import sys
 import unittest
 from collections import defaultdict
 
@@ -32,10 +31,6 @@ from vyos.utils.process import process_named_running
 from vyos.utils.file import read_file
 from vyos.utils.process import rc_cmd
 from vyos.utils.system import sysctl_read
-from vyos.vpp.utils import human_page_memory_to_bytes
-
-sys.path.append(os.getenv('vyos_completion_dir'))
-from list_mem_page_size import list_mem_page_size
 
 PROCESS_NAME = 'vpp_main'
 VPP_CONF = '/run/vpp/vpp.conf'
@@ -1201,10 +1196,8 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
             self.assertIn(config_entry, config)
 
     def test_13_1_buffer_page_size(self):
-        sizes = ['default', 'default-hugepage'] + list_mem_page_size()
+        sizes = ['4K', '2M']
         for size in sizes:
-            if human_page_memory_to_bytes(size) >= 1 << 30:
-                continue
             self.cli_set(base_path + ['settings', 'buffers', 'page-size', size])
             self.cli_commit()
 
@@ -1212,10 +1205,8 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
             self.assertEqual(conf['buffers']['page-size'], size)
 
     def test_13_2_statseg_page_size(self):
-        sizes = ['default', 'default-hugepage'] + list_mem_page_size()
+        sizes = ['4K', '2M']
         for size in sizes:
-            if human_page_memory_to_bytes(size) >= 1 << 30:
-                continue
             self.cli_set(base_path + ['settings', 'statseg', 'page-size', size])
             self.cli_commit()
 
@@ -1223,10 +1214,8 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
             self.assertEqual(conf['statseg']['page-size'], size)
 
     def test_13_3_mem_page_size(self):
-        sizes = ['default', 'default-hugepage'] + list_mem_page_size()
+        sizes = ['4K', '2M']
         for size in sizes:
-            if human_page_memory_to_bytes(size) >= 1 << 30:
-                continue
             self.cli_set(
                 base_path + ['settings', 'memory', 'main-heap-page-size', size]
             )
@@ -1235,20 +1224,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
             conf = get_vpp_config()
             self.assertEqual(conf['memory']['main-heap-page-size'], size)
 
-    def test_14_mem_default_hugepage(self):
-        sizes = list_mem_page_size(hugepage_only=True)
-        for size in sizes:
-            if human_page_memory_to_bytes(size) >= 1 << 30:
-                continue
-            self.cli_set(
-                base_path + ['settings', 'memory', 'default-hugepage-size', size]
-            )
-            self.cli_commit()
-
-            conf = get_vpp_config()
-            self.assertEqual(conf['memory']['default-hugepage-size'], size)
-
-    def test_15_vpp_ipsec_xfrm_nl(self):
+    def test_14_vpp_ipsec_xfrm_nl(self):
         base_ipsec = base_path + ['settings', 'ipsec']
         batch_delay = '250'
         batch_size = '150'
@@ -1280,7 +1256,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         config = read_file(VPP_CONF)
         self.assertIn('interface ipip', config)
 
-    def test_16_vpp_cgnat(self):
+    def test_15_vpp_cgnat(self):
         base_cgnat = base_path + ['nat', 'cgnat']
         iface_out = 'eth0'
         iface_inside = 'eth1'
@@ -1319,7 +1295,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'tcp transitory timeout: {timeout_tcp_trans}sec', out)
         self.assertIn(f'icmp timeout: {timeout_icmp}sec', out)
 
-    def test_17_vpp_nat(self):
+    def test_16_vpp_nat(self):
         base_nat = base_path + ['nat44']
         base_nat_settings = base_path + ['settings', 'nat44']
         exclude_local_addr = '100.64.0.52'
@@ -1394,7 +1370,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         _, out = rc_cmd('sudo vppctl show nat44 summary')
         self.assertIn(f'max translations per thread: {sess_limit} fib 0', out)
 
-    def test_18_vpp_sflow(self):
+    def test_17_vpp_sflow(self):
         base_sflow = ['system', 'sflow']
 
         self.cli_set(base_path + ['sflow', 'interface', interface])
@@ -1418,7 +1394,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(base_sflow)
         self.cli_commit()
 
-    def test_19_resource_limits(self):
+    def test_18_resource_limits(self):
         max_map_count = '100000'
         shmmax = '55555555555555'
         hr_path = ['system', 'option', 'resource-limits']
@@ -1445,7 +1421,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.assertEqual(sysctl_read('vm.max_map_count'), '65530')
         self.assertEqual(sysctl_read('kernel.shmmax'), '8589934592')
 
-    def test_20_vpp_pppoe_mapping(self):
+    def test_19_vpp_pppoe_mapping(self):
         config_file = '/run/accel-pppd/pppoe.conf'
         pool = "TEST-POOL"
         vni = '23'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): structurization

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7805
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
documentation https://github.com/vyos/vyos-documentation/pull/1685
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# set vpp settings memory
Possible completions:
   main-heap-page-size  Main heap page size (default: 2M)
   main-heap-size       Main heap size (default: 3G)


[edit]
vyos@vyos# set vpp settings memory main-heap-page-size
Possible completions:
   4K                   4 kilobytes
   2M                   2 megabytes (default)
   1G                   1 gigabyte


vyos@vyos:~$  /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... skipped 'Skipping temporary bonding, sometimes get recursion T7117'
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... ok
test_14_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_14_vpp_ipsec_xfrm_nl) ... ok
test_15_vpp_cgnat (__main__.TestVPP.test_15_vpp_cgnat) ... ok
test_16_vpp_nat (__main__.TestVPP.test_16_vpp_nat) ... ok
test_17_vpp_sflow (__main__.TestVPP.test_17_vpp_sflow) ... ok
test_18_resource_limits (__main__.TestVPP.test_18_resource_limits) ... ok

----------------------------------------------------------------------
Ran 20 tests in 404.396s

OK (skipped=2)
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
