### PR TITLE
T7839: add deprecation warning for ssh-dss keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,10 +111,10 @@ check_migration_scripts_executable:
 
 .PHONE: pylint
 pylint: interface_definitions
-	@echo Running "pylint --errors-only ..."
-	@PYTHONPATH=python/ pylint --errors-only $(shell git ls-files python/vyos/ifconfig/*.py python/vyos/utils/*.py src/conf_mode/*.py src/op_mode/*.py src/migration-scripts src/services/vyos*)
-	@echo Running "pylint to check for unused imports ..."
-	@PYTHONPATH=python/ pylint --disable=all --enable=W0611 $(shell git ls-files *.py src/migration-scripts src/services)
+	@echo Running "pylint ..."
+	@set -e; \
+	PYTHONPATH=python/ pylint --errors-only $(shell git ls-files python/vyos/ifconfig/*.py python/vyos/utils/*.py src/conf_mode/*.py src/op_mode/*.py src/migration-scripts src/services/vyos*); \
+	PYTHONPATH=python/ pylint --disable=all --enable=W0611 $(shell git ls-files *.py src/migration-scripts src/services)
 
 .PHONY: j2lint
 j2lint:

--- a/data/templates/login/motd_user_dsa_warning.j2
+++ b/data/templates/login/motd_user_dsa_warning.j2
@@ -6,7 +6,7 @@
 {%                 if key_options.type is vyos_defined('ssh-dss') %}
 {%                     if ns.gen_header %}
 {%                         set ns.gen_header = False %}
-
+---
 {{ ssh_dsa_deprecation_warning | wordwrap(72) }}
 
 {%                     endif %}

--- a/data/templates/login/motd_user_dsa_warning.j2
+++ b/data/templates/login/motd_user_dsa_warning.j2
@@ -1,0 +1,18 @@
+{% if user is vyos_defined %}
+{%     set ns = namespace (gen_header = True) %}
+{%     for user, user_config in user.items() %}
+{%         if user_config.authentication.public_keys is vyos_defined %}
+{%             for key, key_options in user_config.authentication.public_keys.items() %}
+{%                 if key_options.type is vyos_defined('ssh-dss') %}
+{%                     if ns.gen_header %}
+{%                         set ns.gen_header = False %}
+
+{{ ssh_dsa_deprecation_warning | wordwrap(72) }}
+
+{%                     endif %}
+User "{{ user }}" with deprecated public-key named: {{ key }}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%     endfor %}
+{% endif %}

--- a/data/templates/ssh/motd_ssh_dsa_warning.j2
+++ b/data/templates/ssh/motd_ssh_dsa_warning.j2
@@ -1,0 +1,8 @@
+{% if hostkey_algorithm is vyos_defined %}
+{%     set tmp = hostkey_algorithm | select("in", deprecated_algos) %}
+{%     if tmp %}
+{%         set tmp = ssh_dsa_deprecation_warning ~ ' ' ~  tmp | join(', ') %}
+---
+{{ tmp | wordwrap(72) }}
+{%     endif %}
+{% endif %}

--- a/python/vyos/defaults.py
+++ b/python/vyos/defaults.py
@@ -90,3 +90,8 @@ commit_hooks = {'pre': '/etc/commit/pre-hooks.d',
                }
 
 airbag_noteworthy_size = 20
+
+SSH_DSA_DEPRECATION_WARNING: str = \
+'Support for SSH-DSA keys is deprecated and will be removed in VyOS 1.6. ' \
+'Please update affected keys to a supported algorithm (e.g., RSA, ECDSA or ' \
+'ED25519) to avoid authentication failures after the upgrade.'

--- a/src/conf_mode/system_login.py
+++ b/src/conf_mode/system_login.py
@@ -33,6 +33,7 @@ from vyos.config import Config
 from vyos.configdep import set_dependents
 from vyos.configdep import call_dependents
 from vyos.configverify import verify_vrf
+from vyos.defaults import SSH_DSA_DEPRECATION_WARNING
 from vyos.template import render
 from vyos.template import is_ipv4
 from vyos.utils.auth import EPasswdStrength
@@ -56,7 +57,7 @@ radius_config_file = "/etc/pam_radius_auth.conf"
 tacacs_pam_config_file = "/etc/tacplus_servers"
 tacacs_nss_config_file = "/etc/tacplus_nss.conf"
 nss_config_file = "/etc/nsswitch.conf"
-login_motd_dsa_warning = r'/run/motd.d/90-vyos-user-dsa-deprecation-warning'
+login_motd_dsa_warning = r'/run/motd.d/92-vyos-user-dsa-deprecation-warning'
 
 # Minimum UID used when adding system users
 MIN_USER_UID: int = 1000
@@ -77,11 +78,8 @@ SYSTEM_USER_SKIP_LIST: list = ['radius_user', 'radius_priv_user', 'tacacs0', 'ta
                               'tacacs12', 'tacacs13', 'tacacs14', 'tacacs15']
 
 # As of OpenSSH 9.8p1 in Debian trixie, DSA keys are no longer supported
-SSH_DSA_DEPRECATION_WARNING: str = \
-'The following users are using SSH-DSS keys for authentication. Support for ' \
-'SSH-DSS keys is deprecated and will be removed in VyOS 1.6. Please update ' \
-'affected user keys to a supported algorithm (e.g., RSA, ECDSA, or ED25519) ' \
-'to avoid authentication failures after the upgrade.'
+SSH_DSA_DEPRECATION_WARNING: str = f'{SSH_DSA_DEPRECATION_WARNING} '\
+'The following users are using SSH-DSS keys for authentication.'
 
 def get_local_users(min_uid=MIN_USER_UID, max_uid=MAX_USER_UID):
     """Return list of dynamically allocated users (see Debian Policy Manual)"""


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

OpenSSH in Debian Trixie has removed support for ssh-dss (DSA) keys, which will prevent users with such keys from logging in after upgrade. To avoid lockouts, add a loud deprecation warning when users log in using a DSA key. This warning
advises affected users to replace their keys with a supported algorithm (e.g., ed25519 or RSA) before the upgrade.

Deprecation warning will be displayed during "commit" but also as MOTD to inform on this issue during every login.

```
DEPRECATION WARNING: Support for SSH-DSA keys is deprecated and will
be removed in VyOS 1.6. Please update affected keys to a supported
algorithm (e.g., RSA, ECDSA or ED25519) to avoid authentication
failures after the upgrade. The following hostkey-algorithms are in
use: ssh-dss, ssh-dss-cert-v01@openssh.com
```

```
DEPRECATION WARNING: Support for SSH-DSA keys is deprecated and will
be removed in VyOS 1.6. Please update affected keys to a supported
algorithm (e.g., RSA, ECDSA or ED25519) to avoid authentication
failures after the upgrade. The following users are using SSH-DSS keys
for authentication.

User "vyos" with deprecated public-key named: foo
```

On Login it will look like:
<img width="649" height="558" alt="image" src="https://github.com/user-attachments/assets/7e406313-2992-4023-ad11-906981eb70d7" />


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7787

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
