### PR TITLE
T7836: move bind mount of /config to vyos-1x

### DIFF
--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -314,6 +314,17 @@ bind_mount_boot ()
     fi
 }
 
+bind_mount_slash_config ()
+{
+    if [ -d /opt/vyatta/etc/config ]
+    then
+        if [ ! -d /config ] ; then
+            mkdir /config
+        fi
+        mount --bind /opt/vyatta/etc/config /config
+    fi
+}
+
 clear_or_override_config_files ()
 {
     for conf in snmp/snmpd.conf snmp/snmptrapd.conf snmp/snmp.conf \
@@ -586,6 +597,8 @@ start ()
     done
 
     bind_mount_boot
+
+    disabled bind_mount_slash_config || bind_mount_slash_config
 
     disabled configure || load_bootfile || overall_status=1
     log_end_msg $?

--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -120,7 +120,6 @@ mount_encrypted_config() {
                 return 1
             fi
 
-            mount /dev/mapper/vyos_config /config
             mount /dev/mapper/vyos_config $vyatta_sysconfdir/config
 
             echo "Mounted encrypted config volume"
@@ -143,7 +142,6 @@ unmount_encrypted_config() {
                 return
             fi
 
-            umount /config
             umount $vyatta_sysconfdir/config
 
             cryptsetup close vyos_config


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

NOTE: This will need to be merged along with https://github.com/vyos/live-boot/pull/8
For success of the tpmtest, the modifications in https://github.com/vyos/vyos-build/pull/1039 are not strictly required, but do enforce naming consistency.

We are removing the bind mount construction from the initrd components in live-boot, as:
- it is not needed before initialization in the vyos-router script
- does not correctly update inodes on libc rename
- fails on the livecd: /var/log/live/boot.log on the livecd contains
`Begin: Configuring VyOS config path ... mount: mounting /root/lib/live/rw/config on /root/opt/vyatta/etc/config failed: No such file or directory`
which has necessitated workarounds, e.g., https://vyos.dev/T5524

During the interval between merges of the this PR and the companion PR https://github.com/vyos/live-boot/pull/8, one would expect to see the following:
This PR merged first: one would expect a recurrence of https://vyos.dev/T668
This PR merged second: an empty /config on installed image --- image will boot and all smoketests pass except for
https://github.com/vyos/vyos-1x/blob/current/smoketest/scripts/cli/test_service_dns_dynamic.py#L206-L212

NOTE: tests below do not reflect tests run will both companion PRs.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/live-boot/pull/8
https://github.com/vyos/vyos-build/pull/1039

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
