### PR TITLE
op-mode: T7516: fix reset ip bgp base commands

### DIFF
--- a/op-mode-definitions/reset-ip-bgp.xml.in
+++ b/op-mode-definitions/reset-ip-bgp.xml.in
@@ -16,7 +16,7 @@
                     <script>${vyos_completion_dir}/list_bgp_neighbors.sh --ipv4</script>
                   </completionHelp>
                 </properties>
-                <command>${vyos_op_scripts_dir}/reset_bgp.py --command="$*"</command>
+                <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
                 <children>
                   #include <include/bgp/reset-bgp-neighbor-options.xml.i>
                 </children>
@@ -25,7 +25,7 @@
                 <properties>
                   <help>Clear all BGP peering sessions</help>
                 </properties>
-                <command>${vyos_op_scripts_dir}/reset_bgp.py --command="$*"</command>
+                <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
                 <children>
                   #include <include/bgp/reset-bgp-neighbor-options.xml.i>
                 </children>
@@ -39,9 +39,9 @@
                 </properties>
                 <standalone>
                   <help>Clear BGP route flap dampening information</help>
-                  <command>${vyos_op_scripts_dir}/reset_bgp.py --command="$*"</command>
+                  <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
                 </standalone>
-                <command>${vyos_op_scripts_dir}/reset_bgp.py --command="$*"</command>
+                <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
                 <children>
                   <virtualTagNode>
                     <properties>
@@ -50,7 +50,7 @@
                         <list>&lt;x.x.x.x&gt;</list>
                       </completionHelp>
                     </properties>
-                    <command>${vyos_op_scripts_dir}/reset_bgp.py --command="$*"</command>
+                    <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
                   </virtualTagNode>
                 </children>
               </tagNode>
@@ -68,7 +68,7 @@
                     <properties>
                       <help>Clear all BGP peering sessions for vrf</help>
                     </properties>
-                    <command>${vyos_op_scripts_dir}/reset_bgp.py --command="$*"</command>
+                    <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
                     <children>
                       #include <include/bgp/reset-bgp-neighbor-options.xml.i>
                     </children>
@@ -80,7 +80,7 @@
                         <list>&lt;x.x.x.x&gt;</list>
                       </completionHelp>
                     </properties>
-                    <command>${vyos_op_scripts_dir}/reset_bgp.py --command="$*"</command>
+                    <command>${vyos_op_scripts_dir}/bgp.py reset --command="$*"</command>
                     <children>
                       #include <include/bgp/reset-bgp-neighbor-options.xml.i>
                     </children>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
This is a fix for https://github.com/vyos/vyos-1x/pull/4709. In that, an incorrect script name was called for the following commands:
```
reset ip bgp <address>
reset ip bgp all
reset ip bgp dampening
reset ip bgp dampening <address>
reset ip bgp vrf <vrf-name> all
reset ip bgp vrf <vrf-name> <address>
```
All of the sub-options like soft/in/out worked correctly, it was just the base commands. All of the `reset bgp` hierarchy already had calls for the correct script.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7516
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
#### Before fix:
```
vyos@vyos:~$ reset ip bgp all
sudo: /usr/libexec/vyos/op_mode/reset_bgp.py: command not found
```
#### After fix:
Command executes correctly:
```
vyos@vyos:~$ reset ip bgp all
vyos@vyos:~$
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
