### PR TITLE
syslog: T4251: Add TLS support to syslog

### DIFF
--- a/data/templates/rsyslog/rsyslog.conf.j2
+++ b/data/templates/rsyslog/rsyslog.conf.j2
@@ -92,6 +92,7 @@ if prifilt("{{ tmp | join(',') }}") then {
 {%                 set _ = tmp.append(facility.replace('all', '*') ~ "." ~ facility_options.level.replace('all', 'debug')) %}
 {%             endfor %}
 {%             set _ = tmp.sort() %}
+{%             set tls = remote_options.tls %}
 # Remote syslog to {{ remote_name }}
 if prifilt("{{ tmp | join(',') }}") then {
     action(
@@ -100,7 +101,7 @@ if prifilt("{{ tmp | join(',') }}") then {
         target="{{ remote_name }}"
         # Port on the remote syslog server
         port="{{ remote_options.port }}"
-        protocol="{{ remote_options.protocol }}"
+        protocol="{{ 'tcp' if tls.enable is vyos_defined else remote_options.protocol }}"
 {%             if remote_options.format.include_timezone is vyos_defined %}
         template="RSYSLOG_SyslogProtocol23Format"
 {%             endif %}
@@ -110,6 +111,31 @@ if prifilt("{{ tmp | join(',') }}") then {
 {%             endif %}
 {%             if remote_options.vrf is vyos_defined %}
         Device="{{ remote_options.vrf }}"
+{%             endif %}
+{%             if tls.enable is vyos_defined %}
+{%                 set auth_mode = tls.auth_mode %}
+        # Specify the use of the OpenSSL TLS driver for this action
+        StreamDriver="ossl"
+        # Set mode to TLS-only connections (do not accept plain TCP)
+        StreamDriverMode="1"
+        # Select the authentication mode
+        StreamDriverAuthMode="{{ auth_mode if auth_mode == 'anon' else 'x509/' + auth_mode }}"
+{%                 if tls.permitted_peers is vyos_defined and auth_mode in ('fingerprint', 'name') %}
+        # Only include permitted peers (list of allowed fingerprints or names)
+        StreamDriverPermittedPeers="{{ tls.permitted_peers }}"
+{%                 endif %}
+{%                 if tls.ca_certificate_path is vyos_defined %}
+        # Include the path to the CA certificate file
+        StreamDriver.CAFile="{{ tls.ca_certificate_path }}"
+{%                 endif %}
+{%                 if tls.certificate_path is vyos_defined %}
+        # Include the path to the client's certificate
+        StreamDriver.CertFile="{{ tls.certificate_path }}"
+{%                 endif %}
+{%                 if tls.certificate_key_path is vyos_defined %}
+        # Include the path to the client's private key
+        StreamDriver.KeyFile="{{ tls.certificate_key_path }}"
+{%                 endif %}
 {%             endif %}
     )
 }

--- a/debian/control
+++ b/debian/control
@@ -326,6 +326,7 @@ Depends:
 # End "vpn openconnect"
 # For "system syslog"
   rsyslog,
+  rsyslog-openssl,
 # End "system syslog"
 # For "system option keyboard-layout"
   kbd,

--- a/interface-definitions/system_syslog.xml.in
+++ b/interface-definitions/system_syslog.xml.in
@@ -65,6 +65,60 @@
               #include <include/protocol-tcp-udp.xml.i>
               #include <include/source-address-ipv4-ipv6.xml.i>
               #include <include/interface/vrf.xml.i>
+              <node name="tls">
+                <properties>
+                  <help>Transport Layer Security (TLS) options for secure syslog</help>
+                </properties>
+                <children>
+                  <leafNode name="enable">
+                    <properties>
+                      <help>Enable TLS encryption for log transmission to this remote syslog server</help>
+                      <valueless/>
+                    </properties>
+                  </leafNode>
+                  <!-- CA cert help should describe trust anchor for server/client validation -->
+                  #include <include/pki/ca-certificate.xml.i>
+                  <!-- Certificate help should specify identity for mutual authentication -->
+                  #include <include/pki/certificate.xml.i>
+                  <leafNode name="auth-mode">
+                    <properties>
+                      <help>Specify the authentication and verification method for the remote peer's certificate during the TLS handshake</help>
+                      <completionHelp>
+                        <list>anon fingerprint certvalid name</list>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>anon</format>
+                        <description>Allow encrypted connection without verifying the peer's identity (anonymous TLS)</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>fingerprint</format>
+                        <description>Authenticate peer by matching its certificate fingerprint to a configured, permitted list (`permitted-peers` option)</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>certvalid</format>
+                        <description>Authenticate peer if it presents a certificate signed by a trusted CA</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>name</format>
+                        <description>Authenticate peer by verifying its certificate subject name against a configured value (`permitted-peers` option)</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>(anon|fingerprint|certvalid|name)</regex>
+                      </constraint>
+                    </properties>
+                    <defaultValue>anon</defaultValue>
+                  </leafNode>
+                  <leafNode name="permitted-peers">
+                    <properties>
+                      <help>Comma-separated list of allowed peer certificate fingerprints or subject names</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Comma-separated fingerprints or peer names.\nFor example:\n - 'SHA1:DD:23:E3:E7:70:F5:B4:13:44:16:78:A5:5A:8C:39:48:53:A6:DD:25,SHA256:10:C4:26:1D:CB:3C:AB:12:DB:1A:F0:47:37:AE:6D:D2:DE:66:B5:71:B7:2E:5B:BB:AE:0C:7E:7F:5F:0D:E9:64'\n - 'logs.example.com'</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
             </children>
           </tagNode>
           <node name="local">


### PR DESCRIPTION
## Change summary
Add TLS support for remote syslog by extending the CLI and backend to support configuration of CA certificates, client certificates, keys, and authentication modes.

This update integrates with the PKI subsystem for certificate management, ensures proper validation of protocol settings when TLS is enabled, and generates secure rsyslog configuration for forwarding logs over TLS.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T4251

## Related PR(s)
* https://github.com/vyos/vyos-documentation/pull/1686

## How to test / Smoketest result

### Manual tests:

#### Step 1. Prepare `rsyslog.conf` for the test server
```
$ cat rsyslog.conf
global(
  DefaultNetstreamDriver="gtls"
  DefaultNetstreamDriverCAFile="/etc/rsyslog.d/ca.crt"
  DefaultNetstreamDriverCertFile="/etc/rsyslog.d/server.crt"
  DefaultNetstreamDriverKeyFile="/etc/rsyslog.d/server.key"
)
module(
  load="imtcp"
  StreamDriver.Name="gtls"
  StreamDriver.Mode="1"
  StreamDriver.Authmode="x509/certvalid"
)
input(
  type="imtcp"
  port="6514"
)
*.* /var/log/received.log
```

#### Step 2. Using `docker` prepare rsyslog server
```
$ cat Dockerfile
FROM rsyslog/rsyslog
RUN apt-get update && \
    apt-get install -y --no-install-recommends \
        rsyslog-gnutls \
        rsyslog-openssl \
        ca-certificates \
        iputils-ping \
        openssl \
    && apt-get clean && \
    rm -rf /var/lib/apt/lists/*
WORKDIR /etc/rsyslog.d
RUN echo Create CA... && \
    openssl req -x509 -nodes -days 730 -newkey rsa:2048 \
        -keyout ca.key -out ca.crt -subj "/CN=TestCA" && \
    echo Generate server key and CSR... && \
    openssl req -nodes -newkey rsa:2048 \
        -keyout server.key -out server.csr -subj "/CN=rsyslog-server" && \
    echo Sign server cert with CA... && \
    openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key \
        -CAcreateserial -out server.crt -days 730 && \
    echo Generate client key and CSR... && \
    openssl req -nodes -newkey rsa:2048 \
        -keyout client.key -out client.csr -subj "/CN=rsyslog-client" && \
    echo Sign client cert with CA... && \
    openssl x509 -req -in client.csr -CA ca.crt -CAkey ca.key \
        -CAcreateserial -out client.crt -days 730
COPY ./rsyslog.conf /etc/rsyslog.conf
EXPOSE 6514
WORKDIR /var/log
RUN touch received.log
```

#### Step 3. Build and run rsyslog server
```
$ docker build -t rsyslog_tls .
$ docker run --rm -d -p 6514:6514 --name rsyslog_tls rsyslog_tls
```

#### Step 4. Copy CA and generated client certificate for VyOS instance
```
$ docker cp rsyslog_tls:/etc/rsyslog.d/ca.crt .
$ docker cp rsyslog_tls:/etc/rsyslog.d/client.crt .
$ docker cp rsyslog_tls:/etc/rsyslog.d/client.key .
```

#### Step 5. Configure VyOS instance using the certificate
```
configure
set pki ca my-ca certificate "$(tail -n +2 ca.crt | head -n -1 | tr -d '\n')"
set pki certificate syslog-client certificate "$(tail -n +2 client.crt | head -n -1 | tr -d '\n')"
set pki certificate syslog-client private key "$(sudo tail -n +2 client.key | head -n -1 | tr -d '\n')"

set system syslog remote <address> facility all level debug
set system syslog remote <address> port 6514
set system syslog remote <address> protocol tcp
set system syslog remote <address> tls enable
set system syslog remote <address> tls ca-certificate my-ca
set system syslog remote <address> tls certificate syslog-client
set system syslog remote <address> tls auth-mode name
set system syslog remote <address> tls permitted-peers 'rsyslog-server'
commit
```

#### Step 6. Verify configuration
```
# Check status of rsyslog service
vyos@f7f796d88e82# systemctl status rsyslog
* rsyslog.service - System Logging Service
     Loaded: loaded (/lib/systemd/system/rsyslog.service; enabled; preset: enabled)
...

# Send log message from VyOS instance
vyos@f7f796d88e82# logger "Test log message using TLS connection"
vyos@f7f796d88e82# exit

# Read last log messages using rsyslog server
$ docker exec -it rsyslog_tls tail -f received.log
...
2025-09-19T15:10:48+00:00 f7f796d88e82 vyos: Test log message using TLS connection
2025-09-19T15:10:48+00:00 f7f796d88e82 vyos[3222]: Test log message using TLS connection
```

### Smoke tests:
```
root@0a710c06fb73:/vyos/vyos-build# make test MATCH="syslog"
...
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_system_syslog.py
DEBUG - test_basic (__main__.TestRSYSLOGService.test_basic) ... ok
DEBUG - test_console (__main__.TestRSYSLOGService.test_console) ... ok
DEBUG - test_remote (__main__.TestRSYSLOGService.test_remote) ... ok
DEBUG - test_remote_tls (__main__.TestRSYSLOGService.test_remote_tls) ... ok
DEBUG - test_vrf_source_address (__main__.TestRSYSLOGService.test_vrf_source_address) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 5 tests in 28.918s
DEBUG -
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
