### PR TITLE
ssh: T7839: fix warning on deprecated algorithms during commit

### DIFF
--- a/src/conf_mode/service_ssh.py
+++ b/src/conf_mode/service_ssh.py
@@ -111,10 +111,8 @@ def verify(ssh):
         verify_pki_openssh_key(ssh, ssh['trusted_user_ca'])
 
     if 'hostkey_algorithm' in ssh:
-        tmp = any(item in deprecated_algos for item in ssh['hostkey_algorithm'])
-        if deprecated_algos:
-            tmp = ', '.join(deprecated_algos)
-            DeprecationWarning(f'{SSH_DSA_DEPRECATION_WARNING} {tmp}')
+        tmp = [algo for algo in ssh['hostkey_algorithm'] if algo in deprecated_algos]
+        if tmp: DeprecationWarning(f'{SSH_DSA_DEPRECATION_WARNING} {", ".join(tmp)}')
 
     verify_vrf(ssh)
     return None


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The list calculation of in-use but deprecated SSH hostkey algorithms was wrong. This was implemented in commit 6deda171e ("ssh: T7839: add deprecation warning for DSA hostkey-algorithm usage"). It always returned the content of the list of deprecated algorithms, but not the list of deprecated algorithms actually - in use - by the configuration. This has been corrected.

Before:
```
DEPRECATION WARNING: Support for SSH-DSA keys is deprecated and will
be removed in VyOS 1.6. Please update affected keys to a supported
algorithm (e.g., RSA, ECDSA or ED25519) to avoid authentication
failures after the upgrade. The following hostkey-algorithms are in
use: ssh-dss, ssh-dss-cert-v01@openssh.com
```

After:
```
DEPRECATION WARNING: Support for SSH-DSA keys is deprecated and will
be removed in VyOS 1.6. Please update affected keys to a supported
algorithm (e.g., RSA, ECDSA or ED25519) to avoid authentication
failures after the upgrade. The following hostkey-algorithms are in
use: ssh-dss
```

The generation of the MOTD was not affected!

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7839

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4731

## Tests

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_ssh.py
test_ssh_default (__main__.TestServiceSSH.test_ssh_default) ... ok
test_ssh_dynamic_protection (__main__.TestServiceSSH.test_ssh_dynamic_protection) ... ok
test_ssh_login (__main__.TestServiceSSH.test_ssh_login) ... ok
test_ssh_multiple_listen_addresses (__main__.TestServiceSSH.test_ssh_multiple_listen_addresses) ... ok
test_ssh_ndcpp (__main__.TestServiceSSH.test_ssh_ndcpp) ... ok
test_ssh_pubkey_accepted_algorithm (__main__.TestServiceSSH.test_ssh_pubkey_accepted_algorithm) ... ok
test_ssh_single_listen_address (__main__.TestServiceSSH.test_ssh_single_listen_address) ... ok
test_ssh_trusted_user_ca (__main__.TestServiceSSH.test_ssh_trusted_user_ca) ... ok
test_ssh_vrf_multi (__main__.TestServiceSSH.test_ssh_vrf_multi) ... ok
test_ssh_vrf_single (__main__.TestServiceSSH.test_ssh_vrf_single) ... ok

----------------------------------------------------------------------
Ran 10 tests in 49.598s

OK
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_login.py
test_add_linux_system_user (__main__.TestSystemLogin.test_add_linux_system_user) ... ok
test_delete_current_user (__main__.TestSystemLogin.test_delete_current_user) ... ok
test_pam_nologin (__main__.TestSystemLogin.test_pam_nologin) ... ok
test_radius_kernel_features (__main__.TestSystemLogin.test_radius_kernel_features) ... ok
test_system_login_max_login_session (__main__.TestSystemLogin.test_system_login_max_login_session) ... ok
test_system_login_otp (__main__.TestSystemLogin.test_system_login_otp) ... ok
test_system_login_radius_ipv4 (__main__.TestSystemLogin.test_system_login_radius_ipv4) ... ok
test_system_login_radius_ipv6 (__main__.TestSystemLogin.test_system_login_radius_ipv6) ... ok
test_system_login_tacacs (__main__.TestSystemLogin.test_system_login_tacacs) ... ok
test_system_login_user (__main__.TestSystemLogin.test_system_login_user) ... ok
test_system_login_weak_password_warning (__main__.TestSystemLogin.test_system_login_weak_password_warning) ... ok
test_system_user_ssh_key (__main__.TestSystemLogin.test_system_user_ssh_key) ... ok

----------------------------------------------------------------------
Ran 12 tests in 77.557s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
