### PR TITLE
T7850: make op_mode_config_dict edit level aware

### DIFF
--- a/python/vyos/configquery.py
+++ b/python/vyos/configquery.py
@@ -39,6 +39,7 @@ from vyos.xml_ref import is_tag
 from vyos.base import Warning
 from vyos.utils.backend import vyconf_backend
 from vyos.configsource import ConfigSourceVyconfSession
+from vyos.utils.list import list_strip
 
 config_file = os.path.join(directories['config'], 'config.boot')
 
@@ -199,9 +200,19 @@ def op_mode_config_dict(
 ):
     if path is None:
         path = []
+
     command = ['/bin/cli-shell-api', '--show-active-only', 'showConfig']
 
-    rc, out = op_mode_run(command + path)
+    edit_level = os.environ.get('VYATTA_EDIT_LEVEL', '')
+    if edit_level:
+        tmp = edit_level.split('/')
+        edit_path = [el for el in tmp if el]
+        relative_path = list_strip(path, edit_path)
+    else:
+        relative_path = path
+
+    rc, out = op_mode_run(command + relative_path)
+
     if rc == cli_shell_api_err.VYOS_EMPTY_CONFIG:
         out = ''
     if rc == cli_shell_api_err.VYOS_INVALID_PATH:

--- a/python/vyos/utils/list.py
+++ b/python/vyos/utils/list.py
@@ -18,3 +18,26 @@ def is_list_equal(first: list, second: list) -> bool:
     if len(first) != len(second) or len(first) == 0:
         return False
     return sorted(first) == sorted(second)
+
+
+def list_strip(lst: list, sub: list, right: bool = False) -> list:
+    """Remove list 'sub' from beginning (right=False), resp., end of list 'lst'"""
+
+    if not right:
+        while sub:
+            if lst[:1] == sub[:1]:
+                lst = lst[1:]
+                sub = sub[1:]
+            else:
+                lst = []
+                sub = []
+    else:
+        while sub:
+            if lst[-1:] == sub[-1:]:
+                lst = lst[:-1]
+                sub = sub[:-1]
+            else:
+                lst = []
+                sub = []
+
+    return lst

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -24,3 +24,15 @@ class TestVyOSUtils(TestCase):
     def test_sysctl_read(self):
         from vyos.utils.system import sysctl_read
         self.assertEqual(sysctl_read('net.ipv4.conf.lo.forwarding'), '1')
+
+    def test_list_strip(self):
+        from vyos.utils.list import list_strip
+
+        lst = ['a', 'b', 'c', 'd', 'e']
+        sub = ['a', 'b']
+        rsb = ['d', 'e']
+        non = ['a', 'e']
+        self.assertEqual(list_strip(lst, sub), ['c', 'd', 'e'])
+        self.assertEqual(list_strip(lst, rsb, right=True), ['a', 'b', 'c'])
+        self.assertEqual(list_strip(lst, non), [])
+        self.assertEqual(list_strip(sub, lst), [])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

A simple extension to allow op_mode_config_dict to be edit-level aware when called from within a config session with, say,
`vyos@vyos# run some op path`

Recall that `op_mode_config_dict` is an isolated function to provide a (slightly) faster config dict at a path, when one does not need the full capability, and overhead, of Config instantiation. This PR is provided as more of a feature request than a bug fix, since `op_mode_config_dict` is not an extensible solution, and has limited usefulness until we can drop the overhead of _any_ call to `cli-shell-api.`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): feature request

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
