### PR TITLE
frr_exporter: T7851: export IPv6 BGP sessions

### DIFF
--- a/data/templates/prometheus/frr_exporter.service.j2
+++ b/data/templates/prometheus/frr_exporter.service.j2
@@ -9,6 +9,7 @@ After=network.target
 User=frr
 {% endif %}
 ExecStart={{ vrf_command }}/usr/sbin/frr_exporter \
+          --collector.bgp6 \
 {% if listen_address is vyos_defined %}
 {%     for address in listen_address %}
         --web.listen-address={{ address | bracketize_ipv6 }}:{{ port }}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
This PR enables the export of IPv6 BGP sessions by frr_exporter

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7851

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
As I did not find out how to build an ISO from my developement branch I simply tested this on Stream Q2 by adding the change to the systemd unit there by running `systemctl edit --runtime frr_exporter.`

```
### Editing /run/systemd/system/frr_exporter.service.d/override.conf
### Anything between here and the comment below will become the new contents of the file

[Service]
ExecStart=
ExecStart=/usr/sbin/frr_exporter \
        --collector.bgp6 \
        --web.listen-address=:9342

### Lines below this comment will be discarded

### /etc/systemd/system/frr_exporter.service
# [Unit]
# Description=FRR Exporter
# Documentation=https://github.com/tynany/frr_exporter
# After=network.target
#
# [Service]
# User=frr
# ExecStart=/usr/sbin/frr_exporter \
#         --web.listen-address=:9342
# [Install]
# WantedBy=multi-user.target
```

After restarting `frr_exporter` the metrics now included the following:
```
# HELP frr_bgp_peer_groups_count_total Number of peer groups configured.
# TYPE frr_bgp_peer_groups_count_total gauge
frr_bgp_peer_groups_count_total{afi="ipv6",local_as="213422",safi="unicast",vrf="net"} 1
# HELP frr_bgp_peer_groups_memory_bytes Memory consumed by peer groups.
# TYPE frr_bgp_peer_groups_memory_bytes gauge
frr_bgp_peer_groups_memory_bytes{afi="ipv6",local_as="213422",safi="unicast",vrf="net"} 64
# HELP frr_bgp_peer_message_received_total Number of received messages.
# TYPE frr_bgp_peer_message_received_total counter
frr_bgp_peer_message_received_total{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::1:5",peer_as="213292",safi="unicast",vrf="net"} 9619
frr_bgp_peer_message_received_total{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::1:7",peer_as="213036",safi="unicast",vrf="net"} 266
frr_bgp_peer_message_received_total{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::c122:cbc1",peer_as="214591",safi="unicast",vrf="net"} 11141
frr_bgp_peer_message_received_total{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::c122:cbc2",peer_as="214591",safi="unicast",vrf="net"} 11155
frr_bgp_peer_message_received_total{afi="ipv6",local_as="213422",peer="2a0c:2f07:9459::b18",peer_as="212232",safi="unicast",vrf="net"} 12824
frr_bgp_peer_message_received_total{afi="ipv6",local_as="213422",peer="2a0c:9a40:a005::269",peer_as="209533",safi="unicast",vrf="net"} 1.0937104e+07
frr_bgp_peer_message_received_total{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::c1:1",peer_as="213416",safi="unicast",vrf="net"} 9625
frr_bgp_peer_message_received_total{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::cc:0",peer_as="213422",safi="unicast",vrf="net"} 7.8478905e+07
frr_bgp_peer_message_received_total{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::cc:1",peer_as="213422",safi="unicast",vrf="net"} 1.58556332e+08
frr_bgp_peer_message_received_total{afi="ipv6",local_as="213422",peer="2a11:6c7:f00:194::1",peer_as="212895",safi="unicast",vrf="net"} 9.859711e+06
# HELP frr_bgp_peer_message_sent_total Number of sent messages.
# TYPE frr_bgp_peer_message_sent_total counter
frr_bgp_peer_message_sent_total{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::1:5",peer_as="213292",safi="unicast",vrf="net"} 1.3391577e+07
frr_bgp_peer_message_sent_total{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::1:7",peer_as="213036",safi="unicast",vrf="net"} 388517
frr_bgp_peer_message_sent_total{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::c122:cbc1",peer_as="214591",safi="unicast",vrf="net"} 14351
frr_bgp_peer_message_sent_total{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::c122:cbc2",peer_as="214591",safi="unicast",vrf="net"} 14351
frr_bgp_peer_message_sent_total{afi="ipv6",local_as="213422",peer="2a0c:2f07:9459::b18",peer_as="212232",safi="unicast",vrf="net"} 1.3753067e+07
frr_bgp_peer_message_sent_total{afi="ipv6",local_as="213422",peer="2a0c:9a40:a005::269",peer_as="209533",safi="unicast",vrf="net"} 62430
frr_bgp_peer_message_sent_total{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::c1:1",peer_as="213416",safi="unicast",vrf="net"} 14357
frr_bgp_peer_message_sent_total{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::cc:0",peer_as="213422",safi="unicast",vrf="net"} 2.8626342e+07
frr_bgp_peer_message_sent_total{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::cc:1",peer_as="213422",safi="unicast",vrf="net"} 5.9969255e+07
frr_bgp_peer_message_sent_total{afi="ipv6",local_as="213422",peer="2a11:6c7:f00:194::1",peer_as="212895",safi="unicast",vrf="net"} 13499
# HELP frr_bgp_peer_prefixes_advertised_count_total Number of prefixes advertised.
# TYPE frr_bgp_peer_prefixes_advertised_count_total gauge
frr_bgp_peer_prefixes_advertised_count_total{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::1:5",peer_as="213292",safi="unicast",vrf="net"} 227699
frr_bgp_peer_prefixes_advertised_count_total{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::1:7",peer_as="213036",safi="unicast",vrf="net"} 227699
frr_bgp_peer_prefixes_advertised_count_total{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::c122:cbc1",peer_as="214591",safi="unicast",vrf="net"} 4
frr_bgp_peer_prefixes_advertised_count_total{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::c122:cbc2",peer_as="214591",safi="unicast",vrf="net"} 4
frr_bgp_peer_prefixes_advertised_count_total{afi="ipv6",local_as="213422",peer="2a0c:2f07:9459::b18",peer_as="212232",safi="unicast",vrf="net"} 227699
frr_bgp_peer_prefixes_advertised_count_total{afi="ipv6",local_as="213422",peer="2a0c:9a40:a005::269",peer_as="209533",safi="unicast",vrf="net"} 4
frr_bgp_peer_prefixes_advertised_count_total{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::c1:1",peer_as="213416",safi="unicast",vrf="net"} 4
frr_bgp_peer_prefixes_advertised_count_total{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::cc:0",peer_as="213422",safi="unicast",vrf="net"} 200978
frr_bgp_peer_prefixes_advertised_count_total{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::cc:1",peer_as="213422",safi="unicast",vrf="net"} 200978
frr_bgp_peer_prefixes_advertised_count_total{afi="ipv6",local_as="213422",peer="2a11:6c7:f00:194::1",peer_as="212895",safi="unicast",vrf="net"} 4
# HELP frr_bgp_peer_prefixes_received_count_total Number of prefixes received.
# TYPE frr_bgp_peer_prefixes_received_count_total gauge
frr_bgp_peer_prefixes_received_count_total{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::1:5",peer_as="213292",safi="unicast",vrf="net"} 1
frr_bgp_peer_prefixes_received_count_total{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::1:7",peer_as="213036",safi="unicast",vrf="net"} 1
frr_bgp_peer_prefixes_received_count_total{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::c122:cbc1",peer_as="214591",safi="unicast",vrf="net"} 161
frr_bgp_peer_prefixes_received_count_total{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::c122:cbc2",peer_as="214591",safi="unicast",vrf="net"} 160
frr_bgp_peer_prefixes_received_count_total{afi="ipv6",local_as="213422",peer="2a0c:2f07:9459::b18",peer_as="212232",safi="unicast",vrf="net"} 0
frr_bgp_peer_prefixes_received_count_total{afi="ipv6",local_as="213422",peer="2a0c:9a40:a005::269",peer_as="209533",safi="unicast",vrf="net"} 226963
frr_bgp_peer_prefixes_received_count_total{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::c1:1",peer_as="213416",safi="unicast",vrf="net"} 1
frr_bgp_peer_prefixes_received_count_total{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::cc:0",peer_as="213422",safi="unicast",vrf="net"} 26770
frr_bgp_peer_prefixes_received_count_total{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::cc:1",peer_as="213422",safi="unicast",vrf="net"} 26770
frr_bgp_peer_prefixes_received_count_total{afi="ipv6",local_as="213422",peer="2a11:6c7:f00:194::1",peer_as="212895",safi="unicast",vrf="net"} 227144
# HELP frr_bgp_peer_state State of the peer (2 = Administratively Down, 1 = Established, 0 = Down).
# TYPE frr_bgp_peer_state gauge
frr_bgp_peer_state{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::1:5",peer_as="213292",safi="unicast",vrf="net"} 1
frr_bgp_peer_state{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::1:7",peer_as="213036",safi="unicast",vrf="net"} 1
frr_bgp_peer_state{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::c122:cbc1",peer_as="214591",safi="unicast",vrf="net"} 1
frr_bgp_peer_state{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::c122:cbc2",peer_as="214591",safi="unicast",vrf="net"} 1
frr_bgp_peer_state{afi="ipv6",local_as="213422",peer="2a0c:2f07:9459::b18",peer_as="212232",safi="unicast",vrf="net"} 1
frr_bgp_peer_state{afi="ipv6",local_as="213422",peer="2a0c:9a40:a005::269",peer_as="209533",safi="unicast",vrf="net"} 1
frr_bgp_peer_state{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::c1:1",peer_as="213416",safi="unicast",vrf="net"} 1
frr_bgp_peer_state{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::cc:0",peer_as="213422",safi="unicast",vrf="net"} 1
frr_bgp_peer_state{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::cc:1",peer_as="213422",safi="unicast",vrf="net"} 1
frr_bgp_peer_state{afi="ipv6",local_as="213422",peer="2a11:6c7:f00:194::1",peer_as="212895",safi="unicast",vrf="net"} 1
# HELP frr_bgp_peer_uptime_seconds How long has the peer been up.
# TYPE frr_bgp_peer_uptime_seconds gauge
frr_bgp_peer_uptime_seconds{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::1:5",peer_as="213292",safi="unicast",vrf="net"} 576701
frr_bgp_peer_uptime_seconds{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::1:7",peer_as="213036",safi="unicast",vrf="net"} 15764
frr_bgp_peer_uptime_seconds{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::c122:cbc1",peer_as="214591",safi="unicast",vrf="net"} 576727
frr_bgp_peer_uptime_seconds{afi="ipv6",local_as="213422",peer="2001:7f8:15b:1::c122:cbc2",peer_as="214591",safi="unicast",vrf="net"} 576727
frr_bgp_peer_uptime_seconds{afi="ipv6",local_as="213422",peer="2a0c:2f07:9459::b18",peer_as="212232",safi="unicast",vrf="net"} 15834
frr_bgp_peer_uptime_seconds{afi="ipv6",local_as="213422",peer="2a0c:9a40:a005::269",peer_as="209533",safi="unicast",vrf="net"} 52918
frr_bgp_peer_uptime_seconds{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::c1:1",peer_as="213416",safi="unicast",vrf="net"} 506435
frr_bgp_peer_uptime_seconds{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::cc:0",peer_as="213422",safi="unicast",vrf="net"} 353
frr_bgp_peer_uptime_seconds{afi="ipv6",local_as="213422",peer="2a0f:85c1:b7a::cc:1",peer_as="213422",safi="unicast",vrf="net"} 509
frr_bgp_peer_uptime_seconds{afi="ipv6",local_as="213422",peer="2a11:6c7:f00:194::1",peer_as="212895",safi="unicast",vrf="net"} 519576
# HELP frr_bgp_peers_count_total Number peers configured.
# TYPE frr_bgp_peers_count_total gauge
frr_bgp_peers_count_total{afi="ipv6",local_as="213422",safi="unicast",vrf="net"} 10
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
