### PR TITLE
T7773: VPP move crypto engines to crypto-engines template section

### DIFF
--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -109,15 +109,21 @@ plugins {
     # Secure
     # plugin ikev2_plugin.so { enable }
     # plugin dns_plugin.so { enable } # Probably required for FQDN peers
-{% if ipsec is vyos_defined %}
-    plugin crypto_ipsecmb_plugin.so { enable }
-    plugin crypto_native_plugin.so { enable }
-    plugin crypto_openssl_plugin.so { enable }
-{% endif %}
     # plugin wireguard_plugin.so { enable }
     # ACL
     plugin acl_plugin.so { enable }
 }
+
+
+crypto-engines {
+    default { disable }
+{% if ipsec is vyos_defined %}
+    ipsecmb { enable }
+    native { enable }
+    openssl { enable }
+{% endif %}
+}
+
 
 linux-cp {
     lcp-sync


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
VPP 25.06 introduces a new format for crypto engines configuration https://github.com/FDio/vpp/commit/f479eeb76
Update the template to account for this change.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7773

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
set system option kernel cpu disable-nmi-watchdog
set system option kernel disable-hpet
set system option kernel disable-mce
set system option kernel disable-softlockup
set system option kernel memory default-hugepage-size '2M'
set system option kernel memory disable-numa-balancing
set system option kernel memory hugepage-size 2M hugepage-count '9500'
set system sysctl parameter net.core.rmem_default value '8388608'
set system sysctl parameter net.core.rmem_max value '16777216'
set system sysctl parameter net.netfilter.nf_conntrack_buckets value '262144'
set system sysctl parameter net.netfilter.nf_conntrack_generic_timeout value '60'
set system sysctl parameter net.netfilter.nf_conntrack_icmp_timeout value '10'
set system sysctl parameter net.netfilter.nf_conntrack_icmpv6_timeout value '10'
set system sysctl parameter net.netfilter.nf_conntrack_tcp_timeout_close_wait value '20'
set system sysctl parameter net.netfilter.nf_conntrack_tcp_timeout_established value '1800'
set system sysctl parameter net.netfilter.nf_conntrack_tcp_timeout_fin_wait value '30'
set system sysctl parameter net.netfilter.nf_conntrack_tcp_timeout_syn_recv value '30'
set system sysctl parameter net.netfilter.nf_conntrack_tcp_timeout_syn_sent value '60'
set system sysctl parameter net.netfilter.nf_conntrack_tcp_timeout_time_wait value '120'
set system sysctl parameter net.netfilter.nf_conntrack_udp_timeout_stream value '60'
set vpp settings interface eth0 driver 'dpdk'
set vpp settings interface eth1 dpdk-options promisc
set vpp settings interface eth1 driver 'dpdk'
set vpp settings memory main-heap-page-size '2M'
set vpp settings memory main-heap-size '4G'
set vpp settings statseg page-size '2M'
set vpp settings statseg size '1G'
set vpp settings unix poll-sleep-usec '222'

```
Check:
```
vyos@r14# sudo vppctl show crypto engines
Name                Prio    Description
ipsecmb             80      Intel(R) Multi-Buffer Crypto for IPsec Library2.0.0
native              100     Native ISA Optimized Crypto
openssl             50      OpenSSL
[edit]
vyos@r14# 

```
Smoketest, resource limits fails but not due to this PR
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... skipped 'Skipping temporary bonding, sometimes get recursion T7117'
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... ok
test_14_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_14_vpp_ipsec_xfrm_nl) ... ok
test_15_vpp_cgnat (__main__.TestVPP.test_15_vpp_cgnat) ... ok
test_16_vpp_nat (__main__.TestVPP.test_16_vpp_nat) ... ok
test_17_vpp_sflow (__main__.TestVPP.test_17_vpp_sflow) ... ok
test_18_resource_limits (__main__.TestVPP.test_18_resource_limits) ... FAIL
test_18_resource_limits (__main__.TestVPP.test_18_resource_limits) ... FAIL
test_19_vpp_pppoe_mapping (__main__.TestVPP.test_19_vpp_pppoe_mapping) ... ok

======================================================================
FAIL: test_18_resource_limits (__main__.TestVPP.test_18_resource_limits)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/libexec/vyos/tests/smoke/cli/test_vpp.py", line 1406, in test_18_resource_limits
    self.assertEqual(sysctl_read('kernel.shmmax'), '8589934592')
AssertionError: '19922944000' != '8589934592'
- 19922944000
+ 8589934592


======================================================================
FAIL: test_18_resource_limits (__main__.TestVPP.test_18_resource_limits)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/libexec/vyos/tests/smoke/cli/test_vpp.py", line 99, in tearDown
    self.assertTrue(process_named_running(PROCESS_NAME))
AssertionError: None is not true

----------------------------------------------------------------------
Ran 21 tests in 345.224s

FAILED (failures=2, skipped=2)
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
