### PR TITLE
kea: T7854: Use helper for Kea VRF systemd units

### DIFF
--- a/src/etc/sudoers.d/vyos
+++ b/src/etc/sudoers.d/vyos
@@ -47,9 +47,6 @@ Cmnd_Alias DIAGNOSTICS = /bin/ip vrf exec * /bin/ping *,       \
                          /usr/libexec/vyos/op_mode/*
 Cmnd_Alias KEA_IP6_ROUTES = /sbin/ip -6 route replace *,\
                            /sbin/ip -6 route del *
-Cmnd_Alias KEA_DHCP = /bin/ip vrf exec * /usr/sbin/kea-dhcp*,\
-                      /usr/bin/chown * /var/run/kea/*,\
-                      /usr/bin/chown * /run/kea/*
 %operator ALL=NOPASSWD: DATE, IPTABLES, ETHTOOL, IPFLUSH, HWINFO, \
 			PPPOE_CMDS, PCAPTURE, /usr/sbin/wanpipemon, \
                         DMIDECODE, DISK, CONNTRACK, IP6TABLES,  \
@@ -65,4 +62,3 @@ Cmnd_Alias KEA_DHCP = /bin/ip vrf exec * /usr/sbin/kea-dhcp*,\
 %sudo ALL=NOPASSWD: /usr/bin/mokutil
 
 _kea ALL=NOPASSWD: KEA_IP6_ROUTES
-_kea ALL=NOPASSWD:SETENV: KEA_DHCP

--- a/src/etc/systemd/system/isc-kea-dhcp-ddns-server@.service
+++ b/src/etc/systemd/system/isc-kea-dhcp-ddns-server@.service
@@ -5,17 +5,10 @@ Wants=network-online.target
 After=vyos-router.service
 
 [Service]
-User=_kea
+User=root
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 Environment="KEA_LOCKFILE_DIR=/run/lock/kea"
-ConfigurationDirectory=kea
-RuntimeDirectory=kea lock/kea
-RuntimeDirectoryPreserve=yes
-LogsDirectory=kea
-LogsDirectoryMode=0750
-StateDirectory=kea
-ExecStart=sudo /bin/ip vrf exec %i /usr/sbin/kea-dhcp-ddns -c /var/run/kea/kea-%i-dhcp-ddns.conf
-ExecStartPost=/bin/sh -c 'sleep 10 && sudo /usr/bin/chown _kea:_kea /var/run/kea/kea-%i-dhcp-ddns* && sudo /usr/bin/chown _kea:_kea /run/kea/logger_lockfile'
+ExecStart=/usr/libexec/vyos/system/kea-vrf-helper %i  /usr/sbin/kea-dhcp-ddns -c /var/run/kea/kea-%i-dhcp-ddns.conf
 Restart=on-failure
 
 [Install]

--- a/src/etc/systemd/system/isc-kea-dhcp4-server@.service
+++ b/src/etc/systemd/system/isc-kea-dhcp4-server@.service
@@ -5,21 +5,12 @@ Wants=network-online.target
 After=vyos-router.service
 
 [Service]
-User=_kea
+User=root
 AmbientCapabilities=CAP_NET_BIND_SERVICE CAP_NET_RAW
 Environment="KEA_DHCP_DATA_DIR=/config/dhcp"
 Environment="KEA_HOOK_SCRIPTS_PATH=/usr/libexec/vyos/system"
 Environment="KEA_LOCKFILE_DIR=/run/lock/kea"
-ConfigurationDirectory=kea
-ConfigurationDirectoryMode=0750
-RuntimeDirectory=kea lock/kea
-RuntimeDirectoryPreserve=yes
-RuntimeDirectoryMode=0750
-LogsDirectory=kea
-LogsDirectoryMode=0750
-StateDirectory=kea
-ExecStart=sudo -E /bin/ip vrf exec %i /usr/sbin/kea-dhcp4 -c /var/run/kea/kea-%i-dhcp4.conf
-ExecStartPost=/bin/sh -c 'sleep 10 && sudo /usr/bin/chown _kea:_kea /var/run/kea/dhcp4-%i-ctrl* && sudo /usr/bin/chown _kea:_kea /var/run/kea/kea-%i-dhcp4* && sudo /usr/bin/chown _kea:_kea /run/kea/logger_lockfile'
+ExecStart=/usr/libexec/vyos/system/kea-vrf-helper %i /usr/sbin/kea-dhcp4 -c /var/run/kea/kea-%i-dhcp4.conf
 Restart=on-failure
 
 [Install]

--- a/src/etc/systemd/system/isc-kea-dhcp6-server@.service
+++ b/src/etc/systemd/system/isc-kea-dhcp6-server@.service
@@ -5,21 +5,12 @@ Wants=network-online.target
 After=vyos-router.service
 
 [Service]
-User=_kea
+User=root
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 Environment="KEA_DHCP_DATA_DIR=/config/dhcp"
 Environment="KEA_HOOK_SCRIPTS_PATH=/usr/libexec/vyos/system"
 Environment="KEA_LOCKFILE_DIR=/run/lock/kea"
-ConfigurationDirectory=kea
-ConfigurationDirectoryMode=0750
-RuntimeDirectory=kea lock/kea
-RuntimeDirectoryPreserve=yes
-RuntimeDirectoryMode=0750
-LogsDirectory=kea
-LogsDirectoryMode=0750
-StateDirectory=kea
-ExecStart=sudo -E /bin/ip vrf exec %i /usr/sbin/kea-dhcp6 -c /var/run/kea/kea-%i-dhcp6.conf
-ExecStartPost=/bin/sh -c 'sleep 10 && sudo /usr/bin/chown _kea:_kea /var/run/kea/dhcp6-%i-ctrl* && sudo /usr/bin/chown _kea:_kea /var/run/kea/kea-%i-dhcp6* && sudo /usr/bin/chown _kea:_kea /run/kea/logger_lockfile'
+ExecStart=/usr/libexec/vyos/system/kea-vrf-helper %i /usr/sbin/kea-dhcp6 -c /var/run/kea/kea-%i-dhcp6.conf
 Restart=on-failure
 
 [Install]

--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -504,6 +504,18 @@ start ()
     nfct helper add tns inet6 tcp
     nft --file /usr/share/vyos/vyos-firewall-init.conf || log_failure_msg "could not initiate firewall rules"
 
+    # Create needed kea directories
+    mkdir -p /var/run/kea /run/lock/kea
+    chmod 750 /var/run/kea /run/lock/kea
+    chown _kea:_kea /var/run/kea /run/lock/kea
+    if [ -d /opt/vyatta/etc/config ]; then
+        if [ ! -d /opt/vyatta/etc/config/dhcp ]; then
+            mkdir /opt/vyatta/etc/config/dhcp
+            chmod 750 /opt/vyatta/etc/config/dhcp
+            chown _kea:vyattacfg /opt/vyatta/etc/config/dhcp
+        fi
+    fi
+
     # Ensure rsyslog is the default syslog daemon
     SYSTEMD_SYSLOG="/etc/systemd/system/syslog.service"
     SYSTEMD_RSYSLOG="/lib/systemd/system/rsyslog.service"

--- a/src/system/kea-vrf-helper
+++ b/src/system/kea-vrf-helper
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+VRF=$1
+shift
+
+export KEA_DHCP_DATA_DIR=/config/dhcp
+export KEA_HOOK_SCRIPTS_PATH=/usr/libexec/vyos/system
+export KEA_LOCKFILE_DIR=/run/lock/kea
+
+ip vrf exec $VRF \
+    setpriv --reuid=_kea --regid=_kea --init-groups \
+        --inh-caps +net_bind_service,+net_raw \
+        --ambient-caps +net_bind_service,+net_raw \
+        $@


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Update Kea VRF systemd units to use a script to enter VRF context and drop privileges.

- Resolves service crash from post-exec failure
- Removes need for sudo and post-exec sleep/chmod script

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_vrf.py
DEBUG - test_dhcp_single_pool (__main__.VRFTest.test_dhcp_single_pool) ... ok
DEBUG - test_dhcpv6_single_pool (__main__.VRFTest.test_dhcpv6_single_pool) ... ok
DEBUG - test_vrf_assign_interface (__main__.VRFTest.test_vrf_assign_interface) ... ok
DEBUG - test_vrf_bind_all (__main__.VRFTest.test_vrf_bind_all) ... ok
DEBUG - test_vrf_conntrack (__main__.VRFTest.test_vrf_conntrack) ... ok
DEBUG - test_vrf_disable_forwarding (__main__.VRFTest.test_vrf_disable_forwarding) ... ok
DEBUG - test_vrf_ip_ipv6_nht (__main__.VRFTest.test_vrf_ip_ipv6_nht) ... ok
DEBUG - test_vrf_ip_ipv6_protocol_non_existing_route_map (__main__.VRFTest.test_vrf_ip_ipv6_protocol_non_existing_route_map) ... ok
DEBUG - test_vrf_ip_protocol_route_map (__main__.VRFTest.test_vrf_ip_protocol_route_map) ... ok
DEBUG - test_vrf_ipv6_protocol_route_map (__main__.VRFTest.test_vrf_ipv6_protocol_route_map) ... ok
DEBUG - test_vrf_link_local_ip_addresses (__main__.VRFTest.test_vrf_link_local_ip_addresses) ... ok
DEBUG - test_vrf_loopbacks_ips (__main__.VRFTest.test_vrf_loopbacks_ips) ... ok
DEBUG - test_vrf_static_route (__main__.VRFTest.test_vrf_static_route) ... ok
DEBUG - test_vrf_table_id_is_unalterable (__main__.VRFTest.test_vrf_table_id_is_unalterable) ... ok
DEBUG - test_vrf_vni_add_change_remove (__main__.VRFTest.test_vrf_vni_add_change_remove) ... ok
DEBUG - test_vrf_vni_and_table_id (__main__.VRFTest.test_vrf_vni_and_table_id) ... ok
DEBUG - test_vrf_vni_duplicates (__main__.VRFTest.test_vrf_vni_duplicates) ... ok
DEBUG - 
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 17 tests in 353.460s
DEBUG - 
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
