### PR TITLE
T7855: redirect stdout and catch exceptions on frr render

### DIFF
--- a/src/services/vyos-commitd
+++ b/src/services/vyos-commitd
@@ -288,6 +288,37 @@ def run_script(script_name: str, config: Config, args: list) -> tuple[bool, str]
     return True, ''
 
 
+def call_frr_render(frr, config):
+    # pylint: disable=redefined-outer-name
+    def _call_frr_render(frr, config):
+        # pylint: disable=broad-exception-caught
+        try:
+            tmp = get_frrender_dict(config)
+            if frr.generate(tmp):
+                # only apply a new FRR configuration if anything changed
+                # in comparison to the previous applied configuration
+                frr.apply()
+
+        except ConfigError as e:
+            logger.error(e)
+            return False, str(e)
+        except Exception:
+            tb = traceback.format_exc()
+            logger.error(tb)
+            return False, tb
+
+        return True, ''
+
+    with redirect_stdout(io.StringIO()) as o:
+        result, err_out = _call_frr_render(frr, config)
+    amb_out = o.getvalue()
+    o.close()
+
+    out = amb_out + err_out
+
+    return result, out
+
+
 def process_call_data(call: Call, config: Config, last: bool = False) -> None:
     # pylint: disable=too-many-locals
 
@@ -319,8 +350,6 @@ def process_call_data(call: Call, config: Config, last: bool = False) -> None:
 
     out = amb_out + err_out
 
-    call.set_reply(success, out)
-
     logger.info(f'[{script_name}] {out}')
 
     if last:
@@ -328,11 +357,11 @@ def process_call_data(call: Call, config: Config, last: bool = False) -> None:
         logger.debug(f'scripts_called: {scripts_called}')
 
     if last and success:
-        tmp = get_frrender_dict(config)
-        if frr.generate(tmp):
-            # only apply a new FRR configuration if anything changed
-            # in comparison to the previous applied configuration
-            frr.apply()
+        s, o = call_frr_render(frr, config)
+        success = s
+        out = out + o
+
+    call.set_reply(success, out)
 
 
 def process_session_data(session: Session) -> Session:

--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -276,6 +276,36 @@ def process_node_data(config, data, _last: bool = False) -> tuple[Response, str]
     return result, out
 
 
+def call_frr_render(frr, config):
+    def _call_frr_render(frr, config):
+        # pylint: disable=broad-exception-caught
+        try:
+            tmp = get_frrender_dict(config)
+            if frr.generate(tmp):
+                # only apply a new FRR configuration if anything changed
+                # in comparison to the previous applied configuration
+                frr.apply()
+
+        except ConfigError as e:
+            logger.error(e)
+            return Response.ERROR_COMMIT_APPLY, str(e)
+        except Exception:
+            tb = traceback.format_exc()
+            logger.error(tb)
+            return Response.ERROR_COMMIT_APPLY, tb
+
+        return Response.SUCCESS, ''
+
+    with redirect_stdout(io.StringIO()) as o:
+        result, err_out = _call_frr_render(frr, config)
+    amb_out = o.getvalue()
+    o.close()
+
+    out = amb_out + err_out
+
+    return result, out
+
+
 def send_result(sock, err, msg):
     err_no = err.value
     err_name = err.name
@@ -345,17 +375,16 @@ if __name__ == '__main__':
             config = initialization(socket)
         elif message['type'] == 'node':
             res, out = process_node_data(config, message['data'], message['last'])
-            send_result(socket, res, out)
 
             if message['last'] and config:
                 scripts_called = getattr(config, 'scripts_called', [])
                 logger.debug(f'scripts_called: {scripts_called}')
 
                 if res == Response.SUCCESS:
-                    tmp = get_frrender_dict(config)
-                    if frr.generate(tmp):
-                        # only apply a new FRR configuration if anything changed
-                        # in comparison to the previous applied configuration
-                        frr.apply()
+                    r, o = call_frr_render(frr, config)
+                    res = r
+                    out = out + o
+
+            send_result(socket, res, out)
         else:
             logger.critical(f'Unexpected message: {message}')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The FRRender class methods `generate` and `apply` are called once at the end of the commit queue under vyos-configd (respectively, vyos-commitd). Catch exceptions and redirect stdout (for example, debug output) produced by these methods, as is done for the stages of config mode scripts.

A simple example to indicate the changes with respect to debug output:

Before this PR, one will see only the output from the call to `get_frrender_dict` in the config-mode script policy.py `get_config`:

```
vyos@vyos:~$ config
[edit]
vyos@vyos# touch /tmp/vyos.frr.debug
[edit]
vyos@vyos# set policy local-route rule 50 set table '23'
[edit]
vyos@vyos# set policy local-route rule 50 source address '203.0.113.1'
[edit]
vyos@vyos# commit
[ policy ]
---- get_frrender_dict(<vyos.config.Config object at 0x7f704c20b010>) ----
{'ip': {'afi': 'ip', 'arp': {'table_size': '8192'}},
 'ipv6': {'afi': 'ipv6', 'neighbor': {'table_size': '8192'}},
 'policy': {'local_route': {'rule': {'50': {'set': {'table': '23'},
                                            'source': {'address': ['203.0.113.1']}}}}},
 'static': {'dhcp': {'eth0': {'dhcp_options': {'default_route_distance': '210'}}}}}
-----------------------------------

[edit]
vyos@vyos#
```

With this PR one will see the above as well as the full debug output (hence the repeating of lines
`---- get_frrender_dict ...`):

```
vyos@vyos:~$ config
[edit]
vyos@vyos# touch /tmp/vyos.frr.debug
[edit]
vyos@vyos# set policy local-route rule 50 set table '23'
[edit]
vyos@vyos# set policy local-route rule 50 source address '203.0.113.1'
[edit]
vyos@vyos# commit
[ policy ]
---- get_frrender_dict(<vyos.config.Config object at 0x7f03e6eb6510>) ----
{'ip': {'afi': 'ip', 'arp': {'table_size': '8192'}},
 'ipv6': {'afi': 'ipv6', 'neighbor': {'table_size': '8192'}},
 'policy': {'local_route': {'rule': {'50': {'set': {'table': '23'},
                                            'source': {'address': ['203.0.113.1']}}}}},
 'static': {'dhcp': {'eth0': {'dhcp_options': {'default_route_distance': '210'}}}}}
-----------------------------------

[ policy local-route ]
---- get_frrender_dict(<vyos.config.Config object at 0x7f03e6eb6510>) ----
{'ip': {'afi': 'ip', 'arp': {'table_size': '8192'}},
 'ipv6': {'afi': 'ipv6', 'neighbor': {'table_size': '8192'}},
 'policy': {'local_route': {'rule': {'50': {'set': {'table': '23'},
                                            'source': {'address': ['203.0.113.1']}}}}},
 'static': {'dhcp': {'eth0': {'dhcp_options': {'default_route_distance': '210'}}}}}
-----------------------------------
FRR:        START CONFIGURATION RENDERING
!
log syslog
log facility local7
!
!
!
!
!
!
!
!
!
!
ip  route 0.0.0.0/0 192.168.122.1 eth0 tag 210 210
!
!
!
!
ip forwarding
!
!
!
!
!
ipv6 forwarding
!
!
!
!
FRR:        RENDERING CONFIG COMPLETE
FRR: reloading configuration - tries: 1 | Python class ID: 139654779941264
...
```
etc.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
