### PR TITLE
l2tpv3: T7721: fix show l2tpv3 interface information

### DIFF
--- a/python/vyos/ifconfig/l2tpv3.py
+++ b/python/vyos/ifconfig/l2tpv3.py
@@ -48,7 +48,7 @@ class L2TPv3If(Interface):
     definition = {
         **Interface.definition,
         **{
-            'section': 'l2tpeth',
+            'section': 'l2tpv3',
             'prefixes': ['l2tpeth', ],
             'bridgeable': True,
         }


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
To fix command "show interfaces l2tpv3" not showing any l2tpv3 interfaces

- updated section name to match the l2tpv3 interface in class L2TPv3If definition

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7721

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

1. create the l2tpv3 interfaces
```
set interfaces l2tpv3 l2tpeth0 address '1.0.0.1/30'
set interfaces l2tpv3 l2tpeth0 description 'test'
set interfaces l2tpv3 l2tpeth0 encapsulation 'ip'
set interfaces l2tpv3 l2tpeth0 peer-session-id '1'
set interfaces l2tpv3 l2tpeth0 peer-tunnel-id '1'
set interfaces l2tpv3 l2tpeth0 remote '10.0.2.1'
set interfaces l2tpv3 l2tpeth0 session-id '1'
set interfaces l2tpv3 l2tpeth0 source-address '10.0.2.15'
set interfaces l2tpv3 l2tpeth0 tunnel-id '1'
set interfaces l2tpv3 l2tpeth1 address '2.0.0.1/30'
set interfaces l2tpv3 l2tpeth1 description 'bridge-port'
set interfaces l2tpv3 l2tpeth1 peer-session-id '2'
set interfaces l2tpv3 l2tpeth1 peer-tunnel-id '2'
set interfaces l2tpv3 l2tpeth1 remote '10.0.2.1'
set interfaces l2tpv3 l2tpeth1 session-id '2'
set interfaces l2tpv3 l2tpeth1 source-address '10.0.2.15'
set interfaces l2tpv3 l2tpeth1 tunnel-id '2'
```
2. run CLI "show interface l2tpv3" and with its sub-command
```
wolf@vyos:~$ show interfaces l2tpv3 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
l2tpeth0         1.0.0.1/30                        u/u  test
l2tpeth1         2.0.0.1/30                        u/u  bridge-port
wolf@vyos:~$ show interfaces l2tpv3 l2tpeth0
l2tpeth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1488 qdisc fq_codel state UNKNOWN group default qlen 1000
    link/ether 06:42:16:d6:23:fe brd ff:ff:ff:ff:ff:ff
    inet 1.0.0.1/30 brd 1.0.0.3 scope global l2tpeth0
       valid_lft forever preferred_lft forever
    inet6 fe80::442:16ff:fed6:23fe/64 scope link
       valid_lft forever preferred_lft forever
    Description: test

    RX:  bytes  packets  errors  dropped  overrun       mcast
             0        0       0        0        0           0
    TX:  bytes  packets  errors  dropped  carrier  collisions
           926        9       0        0        0           0
wolf@vyos:~$ show interfaces l2tpv3 l2tpeth1 brief 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
l2tpeth1         2.0.0.1/30                        u/u  bridge-port
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
