### PR TITLE
T7859: VPP de-hardcode plugin path

### DIFF
--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -82,7 +82,6 @@ physmem {
 {% endif %}
 
 plugins {
-    path /usr/lib/x86_64-linux-gnu/vpp_plugins/
     plugin default { disable }
     plugin af_xdp_plugin.so { enable }
     plugin avf_plugin.so { enable }


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
De-hardcode plugin path allows starting VPP on different ARCHs
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7859

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
vyos@r14:~$ show conf com | match vpp
set vpp settings interface eth0 driver 'dpdk'
set vpp settings interface eth1 dpdk-options promisc
set vpp settings interface eth1 driver 'dpdk'
set vpp settings memory main-heap-page-size '2M'
set vpp settings memory main-heap-size '4G'
set vpp settings statseg page-size '2M'
set vpp settings statseg size '1G'
set vpp settings unix poll-sleep-usec '222'
vyos@r14:~$ 
vyos@r14:~$ sudo vppctl show plugins
 Plugin path is: /usr/lib/x86_64-linux-gnu/vpp_plugins

     Plugin                                   Version                          Description
  1. avf_plugin.so                            25.06.0-24~g2f6a1f164-dirty      Intel Adaptive Virtual Function (AVF) Device Driver
  2. pppoe_plugin.so                          25.06.0-24~g2f6a1f164-dirty      PPP over Ethernet (PPPoE)
  3. sflow_plugin.so                          25.06.0-24~g2f6a1f164-dirty      sFlow random packet sampling
  4. dpdk_plugin.so                           25.06.0-24~g2f6a1f164-dirty      Data Plane Development Kit (DPDK)
  5. geneve_plugin.so                         25.06.0-24~g2f6a1f164-dirty      GENEVE Tunnels
  6. det44_plugin.so                          25.06.0-24~g2f6a1f164-dirty      Deterministic NAT (CGN)
  7. af_xdp_plugin.so                         25.06.0-24~g2f6a1f164-dirty      AF_XDP Device Plugin
  8. linux_nl_plugin.so                       25.06.0-24~g2f6a1f164-dirty      linux Control Plane - Netlink listener
  9. nat44_ei_plugin.so                       25.06.0-24~g2f6a1f164-dirty      IPv4 Endpoint-Independent NAT (NAT44 EI)
 10. acl_plugin.so                            25.06.0-24~g2f6a1f164-dirty      Access Control Lists (ACL)
 11. lacp_plugin.so                           25.06.0-24~g2f6a1f164-dirty      Link Aggregation Control Protocol (LACP)
 12. gre_plugin.so                            25.06.0-24~g2f6a1f164-dirty      Generic Routing Encapsulation (GRE) plugin
 13. vxlan_plugin.so                          25.06.0-24~g2f6a1f164-dirty      VxLan Tunnels
 14. linux_cp_plugin.so                       25.06.0-24~g2f6a1f164-dirty      Linux Control Plane - Interface Mirror
 15. vmxnet3_plugin.so                        25.06.0-24~g2f6a1f164-dirty      VMWare Vmxnet3 Device Driver
 16. nat_plugin.so                            25.06.0-24~g2f6a1f164-dirty      Network Address Translation (NAT)
vyos@r14:~$ 

vyos@r14# cat /run/vpp/vpp.conf | grep plugins -A 3
plugins {
    plugin default { disable }
    plugin af_xdp_plugin.so { enable }
    plugin avf_plugin.so { enable }
   ...
[edit]
vyos@r14# 

```
Also checked on ARM
```
sudo sysctl -w vm.nr_hugepages=4000

vyos@VyOS-for-Smoke-Tests# compare 
+ vpp {
+     settings {
+         interface eth1 {
+             driver "dpdk"
+         }
+         unix {
+             poll-sleep-usec "222"
+         }
+     }
+ }

[edit]
vyos@VyOS-for-Smoke-Tests# 
check
vyos@VyOS-for-Smoke-Tests# run show vpp interfaces 
Kernel    Dataplane    Type    IP Address    MAC                  MTU  State
--------  -----------  ------  ------------  -----------------  -----  -------
          eth1         dpdk                  06:22:c0:87:dc:d5   1500  up
          local0       local                 00:00:00:00:00:00      0  down
eth1      tap4096      virtio                02:fe:0c:1f:24:03   9000  up
[edit]
vyos@VyOS-for-Smoke-Tests# 
[edit]
vyos@VyOS-for-Smoke-Tests# sudo vppctl show plugins
 Plugin path is: /usr/lib/aarch64-linux-gnu/vpp_plugins

     Plugin                                   Version                          Description
  1. avf_plugin.so                            25.06.0-22~gf6a00e82f-dirty      Intel Adaptive Virtual Function (AVF) Device Driver
  2. pppoe_plugin.so                          25.06.0-22~gf6a00e82f-dirty      PPP over Ethernet (PPPoE)
  3. sflow_plugin.so                          25.06.0-22~gf6a00e82f-dirty      sFlow random packet sampling
  4. dpdk_plugin.so                           25.06.0-22~gf6a00e82f-dirty      Data Plane Development Kit (DPDK)
  5. geneve_plugin.so                         25.06.0-22~gf6a00e82f-dirty      GENEVE Tunnels
  6. det44_plugin.so                          25.06.0-22~gf6a00e82f-dirty      Deterministic NAT (CGN)
  7. af_xdp_plugin.so                         25.06.0-22~gf6a00e82f-dirty      AF_XDP Device Plugin
  8. linux_nl_plugin.so                       25.06.0-22~gf6a00e82f-dirty      linux Control Plane - Netlink listener
  9. nat44_ei_plugin.so                       25.06.0-22~gf6a00e82f-dirty      IPv4 Endpoint-Independent NAT (NAT44 EI)
 10. acl_plugin.so                            25.06.0-22~gf6a00e82f-dirty      Access Control Lists (ACL)
 11. lacp_plugin.so                           25.06.0-22~gf6a00e82f-dirty      Link Aggregation Control Protocol (LACP)
 12. gre_plugin.so                            25.06.0-22~gf6a00e82f-dirty      Generic Routing Encapsulation (GRE) plugin
 13. vxlan_plugin.so                          25.06.0-22~gf6a00e82f-dirty      VxLan Tunnels
 14. linux_cp_plugin.so                       25.06.0-22~gf6a00e82f-dirty      Linux Control Plane - Interface Mirror
 15. vmxnet3_plugin.so                        25.06.0-22~gf6a00e82f-dirty      VMWare Vmxnet3 Device Driver
 16. nat_plugin.so                            25.06.0-22~gf6a00e82f-dirty      Network Address Translation (NAT)
[edit]
vyos@VyOS-for-Smoke-Tests# 
vyos@VyOS-for-Smoke-Tests# run show version 
Version:          VyOS 2025.09.14-0044-rolling
Release train:    current
Release flavor:   aws

Built by:         autobuild@vyos.net
Built on:         Sun 14 Sep 2025 00:44 UTC
Build UUID:       f76792ed-3f6a-461e-9ce0-3a1e768d0e1a
Build commit ID:  1a6747b038ea49

Architecture:     aarch64
Boot via:         installed image
System type:      bare metal
Secure Boot:      disabled
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
