### PR TITLE
T7861: System options CPU vendor_id bug for some platforms

### DIFF
--- a/src/conf_mode/system_option.py
+++ b/src/conf_mode/system_option.py
@@ -109,7 +109,8 @@ def verify(options):
                     )
 
     if 'kernel' in options:
-        cpu_vendor = get_cpus()[0]['vendor_id']
+        _cpu_info = get_cpus()[0]
+        cpu_vendor = _cpu_info.get('vendor_id', 'unknown')
         if 'amd_pstate_driver' in options['kernel'] and cpu_vendor != 'AuthenticAMD':
             raise ConfigError(
                 f'AMD pstate driver cannot be used with "{cpu_vendor}" CPU!'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Some platforms do not have `vendor_id` for the CPU information.
 These cause `KeyError: vendor_id' errors while committing `system option kernel memory` settings.
Fix this.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7861

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
On the ARM platform:
```
vyos@VyOS-for-Smoke-Tests# set system option kernel memory hugepage-size 2M hugepage-count 2048
[edit]
vyos@VyOS-for-Smoke-Tests# commit
[ system option ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 145, in run_script
    script.verify(c)
  File "/usr/libexec/vyos/conf_mode/system_option.py", line 112, in verify
    cpu_vendor = get_cpus()[0]['vendor_id']
                 ~~~~~~~~~~~~~^^^^^^^^^^^^^
KeyError: 'vendor_id'

[[system option]] failed
Commit failed
[edit]
vyos@VyOS-for-Smoke-Tests# 

```
Smoketests:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_option.py
test_ctrl_alt_delete (__main__.TestSystemOption.test_ctrl_alt_delete) ... ok
test_kernel_options (__main__.TestSystemOption.test_kernel_options) ... ok
test_performance (__main__.TestSystemOption.test_performance) ... ok
test_reboot_on_panic (__main__.TestSystemOption.test_reboot_on_panic) ... ok
test_ssh_client_options (__main__.TestSystemOption.test_ssh_client_options) ... ok

----------------------------------------------------------------------
Ran 5 tests in 33.127s

OK
vyos@r14:~$ 

```
CPU
```
vyos@VyOS-for-Smoke-Tests# cat /proc/cpuinfo
processor	: 0
BogoMIPS	: 243.75
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm lrcpc dcpop asimddp
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x3
CPU part	: 0xd0c
CPU revision	: 1
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
