### PR TITLE
T7815: VPP: NAT44 rules with port requires protocol specification and vice versa

### DIFF
--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -1323,6 +1323,13 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.cli_set(
             base_nat + ['exclude', 'rule', '100', 'local-port', exclude_local_port]
         )
+
+        # cannot set local-port without specifying protocol
+        # expect raise ConfigError
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_set(base_nat + ['exclude', 'rule', '100', 'protocol', 'tcp'])
         self.cli_set(
             base_nat + ['static', 'rule', '100', 'external', 'address', static_ext_addr]
         )

--- a/src/conf_mode/vpp_nat.py
+++ b/src/conf_mode/vpp_nat.py
@@ -257,6 +257,12 @@ def verify(config):
                     'both be specified, or neither must be specified'
                 )
 
+            # Either both protocol and ports are set, or both no protocol and no ports
+            if (rule_config['protocol'] != 'all') != has_local_port:
+                raise ConfigError(
+                    f'{error_msg} protocol and ports must either both be specified or both omitted'
+                )
+
             ext_address = rule_config['external']['address']
             port = rule_config['external'].get('port')
             local_address = rule_config['local']['address']
@@ -333,6 +339,12 @@ def verify(config):
             ):
                 raise ConfigError(
                     f'{rule_config["external_interface"]} must be a VPP interface for exclude rule {rule}'
+                )
+
+            # Either both protocol and local-port are set, or both no protocol and no port
+            if (rule_config['protocol'] != 'all') != ('local_port' in rule_config):
+                raise ConfigError(
+                    f'Protocol and local-port must either both be specified or both omitted for exclude rule {rule}'
                 )
 
 


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7815
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set vpp settings interface eth0 driver dpdk
set vpp settings interface eth1 driver dpdk

set vpp nat44 interface inside eth0
set vpp nat44 interface outside eth1
set vpp nat44 address-pool translation interface eth1
set vpp nat44 static rule 10 local address 10.0.2.1
set vpp nat44 static rule 10 external address 192.0.2.10
set vpp nat44 static rule 10 protocol tcp


vyos@vyos# commit
[ vpp ]
WARNING: offload option in eth0 settings is not supported by VPP interfaces. It will be ignored.
WARNING: offload option in eth1 settings is not supported by VPP interfaces. It will be ignored.

[ vpp nat44 ]
Configuration error in static rule 10: protocol and ports must either
both be specified or both omitted
[[vpp nat44]] failed
Commit failed

set vpp nat44 static rule 10 local  port 22
set vpp nat44 static rule 10 external port 22

vyos@vyos# commit
[edit]
vyos@vyos# sudo vppctl show nat44 static map
NAT44 static mappings:
 TCP local 10.0.2.1:22 external 192.0.2.1:22 vrf 0

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
