### PR TITLE
T7801: VPP fails to start with logging level set to 'Error'

### DIFF
--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -725,7 +725,7 @@
               <properties>
                 <help>default-log-level</help>
                 <completionHelp>
-                  <list>alert crit debug disabled emerg err info notice warn</list>
+                  <list>alert crit debug disabled emerg error info notice warn</list>
                 </completionHelp>
                 <valueHelp>
                   <format>alert</format>
@@ -748,7 +748,7 @@
                   <description>Emergency</description>
                 </valueHelp>
                 <valueHelp>
-                  <format>err</format>
+                  <format>error</format>
                   <description>Error</description>
                 </valueHelp>
                 <valueHelp>
@@ -764,7 +764,7 @@
                   <description>Warning</description>
                 </valueHelp>
                 <constraint>
-                  <regex>(alert|crit|debug|disabled|emerg|err|info|notice|warn)</regex>
+                  <regex>(alert|crit|debug|disabled|emerg|error|info|notice|warn)</regex>
                 </constraint>
               </properties>
             </leafNode>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7801
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set vpp settings interface eth1 driver dpdk
set vpp settings logging default-log-level error

vyos@vyos# commit
[ vpp ]
WARNING: offload option in eth1 settings is not supported by VPP interfaces. It will be ignored.

[edit]
vyos@vyos# sudo vppctl show logging conf
Buffer Size:         512 entries
Defaults:
  Log Level:         error
  Syslog Log Level:  error
  Rate Limit:        50 msgs/sec

Class/Subclass         Level          Syslog Level   Rate Limit
plugin
  load                 notice         warn           2147483647
vfio
  default              error          error          50
avf
  stats                error          error          50
  default              error          error          50
session
  sdl                  error          error          50
  api                  error          error          50
  rt                   error          error          50
dev
  platform             error          error          50

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
