### PR TITLE
firewall: T7781: Firewall chains are created when unneeded

### DIFF
--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -34,13 +34,13 @@ table ip6 raw {
 delete table ip vyos_filter
 {% endif %}
 table ip vyos_filter {
-{% if ipv4 is vyos_defined %}
-{%     if flowtable is vyos_defined %}
-{%         for name, flowtable_conf in flowtable.items() %}
+{% if flowtable is vyos_defined %}
+{%     for name, flowtable_conf in flowtable.items() %}
 {{ offload_tmpl.flowtable(name, flowtable_conf) }}
-{%         endfor %}
-{%     endif %}
+{%     endfor %}
+{% endif %}
 
+{% if ipv4 is vyos_defined %}
 {%     set ns = namespace(sets=[]) %}
 {%     if ipv4.forward is vyos_defined %}
 {%         for prior, conf in ipv4.forward.items() %}
@@ -222,13 +222,13 @@ table ip vyos_filter {
 delete table ip6 vyos_filter
 {% endif %}
 table ip6 vyos_filter {
-{% if ipv6 is vyos_defined %}
-{%     if flowtable is vyos_defined %}
-{%         for name, flowtable_conf in flowtable.items() %}
+{% if flowtable is vyos_defined %}
+{%     for name, flowtable_conf in flowtable.items() %}
 {{ offload_tmpl.flowtable(name, flowtable_conf) }}
-{%         endfor %}
-{%     endif %}
+{%     endfor %}
+{% endif %}
 
+{% if ipv6 is vyos_defined %}
 {%     set ns = namespace(sets=[]) %}
 {%     if ipv6.forward is vyos_defined %}
 {%         for prior, conf in ipv6.forward.items() %}

--- a/interface-definitions/include/firewall/default-action-base-chains.xml.i
+++ b/interface-definitions/include/firewall/default-action-base-chains.xml.i
@@ -17,6 +17,5 @@
       <regex>(drop|accept)</regex>
     </constraint>
   </properties>
-  <defaultValue>accept</defaultValue>
 </leafNode>
 <!-- include end -->

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -600,7 +600,7 @@ def nft_rule(rule_conf, fw_hook, fw_name, rule_id, ip_name='ip'):
 @register_filter('nft_default_rule')
 def nft_default_rule(fw_conf, fw_name, family):
     output = ['counter']
-    default_action = fw_conf['default_action']
+    default_action = fw_conf.get('default_action', 'accept')
     #family = 'ipv6' if ipv6 else 'ipv4'
 
     if 'default_log' in fw_conf:

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -650,6 +650,14 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['firewall', 'global-options', 'state-policy', 'related', 'action', 'accept'])
         self.cli_set(['firewall', 'global-options', 'state-policy', 'invalid', 'action', 'drop'])
 
+        self.cli_set(['firewall', 'ipv4', 'input', 'filter', 'rule', '1', 'action', 'accept'])
+        self.cli_set(['firewall', 'ipv4', 'input', 'filter', 'rule', '1', 'protocol', 'tcp'])
+        self.cli_set(['firewall', 'ipv4', 'input', 'filter', 'rule', '1', 'destination', 'port', '22'])
+
+        self.cli_set(['firewall', 'ipv4', 'forward', 'filter', 'rule', '1', 'action', 'accept'])
+        self.cli_set(['firewall', 'ipv4', 'forward', 'filter', 'rule', '1', 'protocol', 'tcp'])
+        self.cli_set(['firewall', 'ipv4', 'forward', 'filter', 'rule', '1', 'destination', 'port', '22'])
+
         self.cli_commit()
 
         nftables_search = [
@@ -766,6 +774,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['firewall', 'bridge', 'prerouting', 'filter', 'rule', '2', 'ethernet-type', 'arp'])
         self.cli_set(['firewall', 'bridge', 'prerouting', 'filter', 'rule', '2', 'action', 'accept'])
 
+        self.cli_set(['firewall', 'bridge', 'output', 'filter', 'rule', '1', 'action', 'accept'])
 
         self.cli_commit()
 

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -539,11 +539,11 @@ def verify(firewall):
             for chain in ['name','forward','input','output', 'prerouting']:
                 if chain in firewall[family]:
                     for priority, priority_conf in firewall[family][chain].items():
-                        if 'jump' in priority_conf['default_action'] and 'default_jump_target' not in priority_conf:
+                        if 'jump' in priority_conf.get('default_action', []) and 'default_jump_target' not in priority_conf:
                             raise ConfigError('default-action set to jump, but no default-jump-target specified')
                         if 'default_jump_target' in priority_conf:
                             target = priority_conf['default_jump_target']
-                            if 'jump' not in priority_conf['default_action']:
+                            if 'jump' not in priority_conf.get('default_action', []):
                                 raise ConfigError('default-jump-target defined, but default-action jump needed and it is not defined')
                             if priority_conf['default_jump_target'] == priority:
                                 raise ConfigError(f'Loop detected on default-jump-target.')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
This fixes incorrect behavior where the `input/output/forward/prerouting/etc...` chains were created regardless if a user configured them or not. The checks to prevent this were already present in the `nftables.j2` Jinja2 template, but it was being skipped due to the `<defaultValue>` field for `default-action` making the checks always pass.

This behavior would cause filtering to occur on traffic when there was no intention to filter, effectively slowing down processing.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7781
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Configure a single chain:
```
vyos@vyos# set firewall ipv4 output filter rule 1 action accept 
vyos@vyos# commit
```
### Check the chains that are created:
#### Before fix:
```
vyos@vyos# sudo nft list table vyos_filter
table ip vyos_filter {
        chain VYOS_FORWARD_filter {
                type filter hook forward priority filter; policy accept;
                counter packets 0 bytes 0 accept comment "FWD-filter default-action accept"
        }

        chain VYOS_INPUT_filter {
                type filter hook input priority filter; policy accept;
                counter packets 0 bytes 0 accept comment "INP-filter default-action accept"
        }

        chain VYOS_OUTPUT_filter {
                type filter hook output priority filter; policy accept;
                counter packets 0 bytes 0 accept comment "ipv4-OUT-filter-1"
                counter packets 0 bytes 0 accept comment "OUT-filter default-action accept"
        }

        chain VYOS_OUTPUT_raw {
                type filter hook output priority raw; policy accept;
                counter packets 0 bytes 0 accept comment "OUT-raw default-action accept"
        }

        chain VYOS_PREROUTING_raw {
                type filter hook prerouting priority raw; policy accept;
                counter packets 0 bytes 0 accept comment "PRE-raw default-action accept"
        }

        chain VYOS_FRAG_MARK {
                type filter hook prerouting priority -450; policy accept;
                ip frag-off & 0x3fff != 0x0 meta mark set 0x000ffff1 return
        }
}
```
#### After fix:
```
vyos@vyos# sudo nft list table vyos_filter
table ip vyos_filter {
        chain VYOS_OUTPUT_filter {
                type filter hook output priority filter; policy accept;
                counter packets 370 bytes 38689 accept comment "ipv4-OUT-filter-1"
                counter packets 0 bytes 0 accept comment "OUT-filter default-action accept"
        }

        chain VYOS_FRAG_MARK {
                type filter hook prerouting priority -450; policy accept;
                ip frag-off & 0x3fff != 0x0 meta mark set 0x000ffff1 return
        }
}

```
#### Smoketest results:
```
test_bridge_firewall (__main__.TestFirewall.test_bridge_firewall) ... ok
test_cyclic_jump_validation (__main__.TestFirewall.test_cyclic_jump_validation) ... ok
test_disable_conntrack_per_chain (__main__.TestFirewall.test_disable_conntrack_per_chain) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
test_geoip (__main__.TestFirewall.test_geoip) ... ok
test_gre_match (__main__.TestFirewall.test_gre_match) ... ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipsec_metadata_match (__main__.TestFirewall.test_ipsec_metadata_match) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_dynamic_groups (__main__.TestFirewall.test_ipv4_dynamic_groups) ... ok
test_ipv4_global_state (__main__.TestFirewall.test_ipv4_global_state) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_remote_group (__main__.TestFirewall.test_ipv4_remote_group) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_dynamic_groups (__main__.TestFirewall.test_ipv6_dynamic_groups) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_ipv6_remote_group (__main__.TestFirewall.test_ipv6_remote_group) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
test_remote_group (__main__.TestFirewall.test_remote_group) ... ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_timeout_sysctl (__main__.TestFirewall.test_timeout_sysctl) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... ok
test_zone_with_vrf (__main__.TestFirewall.test_zone_with_vrf) ... ok

----------------------------------------------------------------------
Ran 29 tests in 562.998s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
