### PR TITLE
op-mode: T7871: add support for op mode command argument constraints

### DIFF
--- a/python/vyos/xml_ref/op_definition.py
+++ b/python/vyos/xml_ref/op_definition.py
@@ -34,6 +34,8 @@ class NodeData:
     command: str = ''
     standalone_help_text: Optional[str] = None
     standalone_command: Optional[str] = None
+    constraints: Optional[dict] = None
+    constraint_error_message: Optional[str] = None
     path: list[str] = field(default_factory=list)
     files: list[str] = field(default_factory=list)
     children: list[tuple] = field(default_factory=list)

--- a/schema/interface_definition.rng
+++ b/schema/interface_definition.rng
@@ -2,19 +2,19 @@
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <!--
        interface_definition.rnc: VyConf reference tree XML grammar
-
+    
        Copyright VyOS maintainers and contributors <maintainers@vyos.io>
-
+    
        This library is free software; you can redistribute it and/or
        modify it under the terms of the GNU Lesser General Public
        License as published by the Free Software Foundation; either
        version 2.1 of the License, or (at your option) any later version.
-
+    
        This library is distributed in the hope that it will be useful,
        but WITHOUT ANY WARRANTY; without even the implied warranty of
        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
        Lesser General Public License for more details.
-
+    
        You should have received a copy of the GNU Lesser General Public
        License along with this library; if not, write to the Free Software
        Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301

--- a/schema/op-mode-definition.rnc
+++ b/schema/op-mode-definition.rnc
@@ -89,12 +89,12 @@ children = element children
 # Nodes may have properties
 # For simplicity, any property is allowed in any node,
 # but whether they are used or not is implementation-defined
-
-
 properties = element properties
 {
     help? &
-    completionHelp*
+    completionHelp* &
+    constraint? &
+    (element constraintErrorMessage { text })?
 }
 
 # All nodes must have "name" attribute
@@ -103,9 +103,22 @@ nodeNameAttr = attribute name
     text
 }
 
+# Tag and leaf nodes may have constraints on their names and values
+# (respectively).
+# When multiple constraints are listed, they work as logical OR
+constraint = element constraint
+{
+    ( (element regex { text }) |
+      validator )+
+}
 
-
-
+# A constraint may also use an external validator rather than regex
+validator = element validator
+{
+    ( (attribute name { text })  &
+      (attribute argument { text })? ),
+    empty
+}
 
 # help tags contains brief description of the purpose of the node
 help = element help

--- a/schema/op-mode-definition.rng
+++ b/schema/op-mode-definition.rng
@@ -2,19 +2,19 @@
 <grammar xmlns="http://relaxng.org/ns/structure/1.0">
   <!--
        interface_definition.rnc: VyConf reference tree XML grammar
-
+    
        Copyright VyOS maintainers and contributors <maintainers@vyos.io>
-
+    
        This library is free software; you can redistribute it and/or
        modify it under the terms of the GNU Lesser General Public
        License as published by the Free Software Foundation; either
        version 2.1 of the License, or (at your option) any later version.
-
+    
        This library is distributed in the hope that it will be useful,
        but WITHOUT ANY WARRANTY; without even the implied warranty of
        MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
        Lesser General Public License for more details.
-
+    
        You should have received a copy of the GNU Lesser General Public
        License along with this library; if not, write to the Free Software
        Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
@@ -178,12 +178,49 @@
         <zeroOrMore>
           <ref name="completionHelp"/>
         </zeroOrMore>
+        <optional>
+          <ref name="constraint"/>
+        </optional>
+        <optional>
+          <element name="constraintErrorMessage">
+            <text/>
+          </element>
+        </optional>
       </interleave>
     </element>
   </define>
   <!-- All nodes must have "name" attribute -->
   <define name="nodeNameAttr">
     <attribute name="name"/>
+  </define>
+  <!--
+    Tag and leaf nodes may have constraints on their names and values
+    (respectively).
+    When multiple constraints are listed, they work as logical OR
+  -->
+  <define name="constraint">
+    <element name="constraint">
+      <oneOrMore>
+        <choice>
+          <element name="regex">
+            <text/>
+          </element>
+          <ref name="validator"/>
+        </choice>
+      </oneOrMore>
+    </element>
+  </define>
+  <!-- A constraint may also use an external validator rather than regex -->
+  <define name="validator">
+    <element name="validator">
+      <interleave>
+        <attribute name="name"/>
+        <optional>
+          <attribute name="argument"/>
+        </optional>
+      </interleave>
+      <empty/>
+    </element>
   </define>
   <!-- help tags contains brief description of the purpose of the node -->
   <define name="help">


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

To allow non-admin users to execute most op mode commands, we need to ensure they can't enter arguments that can lead to shell escapes.

A blanket ban on all special characters is too restrictive, so we need a way to relax it where needed.

One way to do that is to ensure that arguments follow specific formats. That can be done using constraint checks similar to those we already have in configuration mode.

We can use the same syntax as we use for configuration mode definitions, with `<regex>` and `<validator>` tags:

```
<interfaceDefinition>
  <tagNode name="ping">
    <properties>
      <help>Send Internet Control Message Protocol (ICMP) echo request</help>
      <completionHelp>
        <list>&lt;hostname&gt; &lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
      </completionHelp>
      <constraint>
        <validator name="ip-address"/>
        <validator name="fqdn"/>
      </constraint>
    </properties>
    ...
```

We can probably omit support for constraint groups until we find a real case for that.

In the cache, it's probably a good idea to keep regex and validator constraints separate so that the runner can evaluate regexes first — it can do that internally. If none of the regexes match, then it can jump to much more expensive external checks.

```
      "constraints": {
        "regexes": [],
        "validators": [
          {
            "name": "ip-address",
            "argument": null
          },
          {
            "name": "fqdn",
            "argument": null
          }
        ]
      },
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
