### PR TITLE
smoketest: T7858: add PPPoE client tests with IPv4, IPv6 and DHCPv6-PD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ check_migration_scripts_executable:
 pylint: interface_definitions
 	@echo Running "pylint ..."
 	@set -e; \
-	PYTHONPATH=python/ pylint --errors-only $(shell git ls-files python/vyos/ifconfig/*.py python/vyos/utils/*.py src/conf_mode/*.py src/op_mode/*.py src/migration-scripts src/services/vyos*); \
+	PYTHONPATH="python/:smoketest/scripts/cli/" pylint --errors-only $(shell git ls-files python/vyos/ifconfig/*.py python/vyos/utils/*.py src/conf_mode/*.py src/op_mode/*.py src/migration-scripts src/services/vyos* smoketest/scripts); \
 	PYTHONPATH=python/ pylint --disable=all --enable=W0611 $(shell git ls-files *.py src/migration-scripts src/services)
 
 .PHONY: j2lint

--- a/smoketest/scripts/cli/base_accel_ppp_test.py
+++ b/smoketest/scripts/cli/base_accel_ppp_test.py
@@ -26,6 +26,11 @@ from vyos.utils.process import cmd
 
 class BasicAccelPPPTest:
     class TestCase(VyOSUnitTestSHIM.TestCase):
+        _base_path = None
+        _config_file = None
+        _chap_secrets = None
+        _protocol_section = None
+
         @classmethod
         def setUpClass(cls):
             cls._process_name = "accel-pppd"

--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -15,9 +15,9 @@
 import re
 
 from json import loads
-from netifaces import AF_INET
-from netifaces import AF_INET6
-from netifaces import ifaddresses
+from netifaces import ifaddresses # pylint: disable = no-name-in-module
+from socket import AF_INET
+from socket import AF_INET6
 from systemd import journal
 
 from base_vyostest_shim import VyOSUnitTestSHIM

--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -160,6 +160,17 @@ class VyOSUnitTestSHIM:
                     print(f'FRR configuration still empty after {empty_retry} retires!')
             return out
 
+        def getFRRopmode(self, command : str, json : bool=False):
+            from json import loads
+            if json: command += f' json'
+            out = cmd(f'vtysh -c "{command}"')
+            if json:
+                out = loads(out)
+            if self.debug:
+                print(f'\n\ncommand "{command}" returned:\n')
+                pprint.pprint(out)
+            return out
+
         @staticmethod
         def ssh_send_cmd(command, username, password, key_filename=None,
                          hostname='localhost'):

--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -54,12 +54,16 @@ class VyOSUnitTestSHIM:
         # Time to wait after a commit to ensure the CStore is up to date
         # only required for testcases using FRR
         _commit_guard_time = 0
+
+        @staticmethod
+        def debug_on():
+            return os.path.exists('/tmp/vyos.smoketest.debug')
+
         @classmethod
         def setUpClass(cls):
             cls._session = ConfigSession(os.getpid())
             cls._session.save_config(save_config)
-            if os.path.exists('/tmp/vyos.smoketest.debug'):
-                cls.debug = True
+            cls.debug = cls.debug_on()
             pass
 
         @classmethod

--- a/smoketest/scripts/cli/test_backslash_escape.py
+++ b/smoketest/scripts/cli/test_backslash_escape.py
@@ -65,4 +65,4 @@ class TestBackslashEscape(VyOSUnitTestSHIM.TestCase):
             self.cli_commit()
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_cgnat.py
+++ b/smoketest/scripts/cli/test_cgnat.py
@@ -20,10 +20,8 @@ import unittest
 from base_vyostest_shim import VyOSUnitTestSHIM
 from vyos.configsession import ConfigSessionError
 
-
 base_path = ['nat', 'cgnat']
 nftables_cgnat_config = '/run/nftables-cgnat.nft'
-
 
 class TestCGNAT(VyOSUnitTestSHIM.TestCase):
     @classmethod
@@ -135,4 +133,4 @@ class TestCGNAT(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_config_dependency.py
+++ b/smoketest/scripts/cli/test_config_dependency.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-
 import unittest
 from time import sleep
 
@@ -23,7 +22,6 @@ from vyos.utils.process import cmd
 from vyos.configsession import ConfigSessionError
 
 from base_vyostest_shim import VyOSUnitTestSHIM
-
 
 class TestConfigDep(VyOSUnitTestSHIM.TestCase):
     @classmethod
@@ -127,4 +125,4 @@ class TestConfigDep(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_config_save.py
+++ b/smoketest/scripts/cli/test_config_save.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
 import os
 import unittest
 
@@ -23,7 +22,6 @@ from vyos.utils.config import read_saved_value
 from vyos.defaults import directories
 
 from base_vyostest_shim import VyOSUnitTestSHIM
-
 
 class TestConfigDep(VyOSUnitTestSHIM.TestCase):
     def test_disk_resident(self):

--- a/smoketest/scripts/cli/test_configd_init.py
+++ b/smoketest/scripts/cli/test_configd_init.py
@@ -17,6 +17,8 @@
 import unittest
 from time import sleep
 
+from base_vyostest_shim import VyOSUnitTestSHIM
+
 from vyos.utils.process import is_systemd_service_running
 from vyos.utils.process import cmd
 
@@ -36,4 +38,4 @@ class TestConfigdInit(unittest.TestCase):
             cmd('sudo systemctl stop vyos-configd.service')
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -480,4 +480,4 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -1455,4 +1455,4 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_high-availability_virtual-server.py
+++ b/smoketest/scripts/cli/test_high-availability_virtual-server.py
@@ -146,4 +146,4 @@ class TestHAVirtualServer(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_high-availability_vrrp.py
+++ b/smoketest/scripts/cli/test_high-availability_vrrp.py
@@ -317,4 +317,4 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_bonding.py
+++ b/smoketest/scripts/cli/test_interfaces_bonding.py
@@ -18,6 +18,7 @@ import os
 import unittest
 
 from base_interfaces_test import BasicInterfaceTest
+from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.ifconfig import Section
 from vyos.ifconfig.interface import Interface
@@ -334,4 +335,4 @@ class BondingInterfaceTest(BasicInterfaceTest.TestCase):
             id = int(id) + 1
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_bridge.py
+++ b/smoketest/scripts/cli/test_interfaces_bridge.py
@@ -17,10 +17,11 @@
 import os
 import json
 import unittest
-
-from base_interfaces_test import BasicInterfaceTest
 from copy import deepcopy
 from glob import glob
+
+from base_interfaces_test import BasicInterfaceTest
+from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.configsession import ConfigSessionError
 from vyos.ifconfig import Section
@@ -535,4 +536,4 @@ class BridgeInterfaceTest(BasicInterfaceTest.TestCase):
         self.assertEqual(tmp, '1')
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_dummy.py
+++ b/smoketest/scripts/cli/test_interfaces_dummy.py
@@ -17,6 +17,7 @@
 import unittest
 
 from base_interfaces_test import BasicInterfaceTest
+from base_vyostest_shim import VyOSUnitTestSHIM
 
 class DummyInterfaceTest(BasicInterfaceTest.TestCase):
     @classmethod
@@ -27,4 +28,4 @@ class DummyInterfaceTest(BasicInterfaceTest.TestCase):
         super(DummyInterfaceTest, cls).setUpClass()
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_ethernet.py
+++ b/smoketest/scripts/cli/test_interfaces_ethernet.py
@@ -25,6 +25,8 @@ from netifaces import AF_INET6
 from netifaces import ifaddresses
 
 from base_interfaces_test import BasicInterfaceTest
+from base_vyostest_shim import VyOSUnitTestSHIM
+
 from vyos.configsession import ConfigSessionError
 from vyos.ifconfig import Section
 from vyos.utils.file import read_file
@@ -240,4 +242,4 @@ class EthernetInterfaceTest(BasicInterfaceTest.TestCase):
         self.cli_delete(self._base_path + [interface, 'switchdev'])
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_ethernet.py
+++ b/smoketest/scripts/cli/test_interfaces_ethernet.py
@@ -20,9 +20,9 @@ import unittest
 from glob import glob
 from json import loads
 
-from netifaces import AF_INET
-from netifaces import AF_INET6
-from netifaces import ifaddresses
+from socket import AF_INET
+from socket import AF_INET6
+from netifaces import ifaddresses # pylint: disable = no-name-in-module
 
 from base_interfaces_test import BasicInterfaceTest
 from base_vyostest_shim import VyOSUnitTestSHIM

--- a/smoketest/scripts/cli/test_interfaces_geneve.py
+++ b/smoketest/scripts/cli/test_interfaces_geneve.py
@@ -20,6 +20,7 @@ from vyos.ifconfig import Interface
 from vyos.utils.network import get_interface_config
 
 from base_interfaces_test import BasicInterfaceTest
+from base_vyostest_shim import VyOSUnitTestSHIM
 
 class GeneveInterfaceTest(BasicInterfaceTest.TestCase):
     @classmethod
@@ -81,4 +82,4 @@ class GeneveInterfaceTest(BasicInterfaceTest.TestCase):
             ttl += 10
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_input.py
+++ b/smoketest/scripts/cli/test_interfaces_input.py
@@ -16,9 +16,10 @@
 
 import unittest
 
+from base_vyostest_shim import VyOSUnitTestSHIM
+
 from vyos.utils.file import read_file
 from vyos.ifconfig import Interface
-from base_vyostest_shim import VyOSUnitTestSHIM
 
 base_path = ['interfaces', 'input']
 
@@ -48,4 +49,4 @@ class InputInterfaceTest(VyOSUnitTestSHIM.TestCase):
             self.assertEqual(Interface(interface).get_alias(), f'foo-{interface}')
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_l2tpv3.py
+++ b/smoketest/scripts/cli/test_interfaces_l2tpv3.py
@@ -18,8 +18,11 @@ import json
 import unittest
 
 from base_interfaces_test import BasicInterfaceTest
+from base_vyostest_shim import VyOSUnitTestSHIM
+
 from vyos.utils.process import cmd
 from vyos.utils.kernel import unload_kmod
+
 class L2TPv3InterfaceTest(BasicInterfaceTest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -63,4 +66,4 @@ if __name__ == '__main__':
                    'l2tp_netlink', 'l2tp_core']:
         unload_kmod(module)
 
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_loopback.py
+++ b/smoketest/scripts/cli/test_interfaces_loopback.py
@@ -15,10 +15,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+from netifaces import interfaces # pylint: disable = no-name-in-module
 
 from base_interfaces_test import BasicInterfaceTest
 from base_interfaces_test import MSG_TESTCASE_UNSUPPORTED
-from netifaces import interfaces
 from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.utils.network import is_intf_addr_assigned

--- a/smoketest/scripts/cli/test_interfaces_loopback.py
+++ b/smoketest/scripts/cli/test_interfaces_loopback.py
@@ -19,6 +19,7 @@ import unittest
 from base_interfaces_test import BasicInterfaceTest
 from base_interfaces_test import MSG_TESTCASE_UNSUPPORTED
 from netifaces import interfaces
+from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.utils.network import is_intf_addr_assigned
 
@@ -57,4 +58,4 @@ class LoopbackInterfaceTest(BasicInterfaceTest.TestCase):
         self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_macsec.py
+++ b/smoketest/scripts/cli/test_interfaces_macsec.py
@@ -18,6 +18,7 @@ import re
 import unittest
 
 from base_interfaces_test import BasicInterfaceTest
+from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.configsession import ConfigSessionError
 from vyos.ifconfig import Section
@@ -269,4 +270,4 @@ class MACsecInterfaceTest(BasicInterfaceTest.TestCase):
         self.assertTrue(tmp['linkinfo']['info_data']['encrypt'])
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_openvpn.py
+++ b/smoketest/scripts/cli/test_interfaces_openvpn.py
@@ -19,7 +19,7 @@ import unittest
 
 from glob import glob
 from ipaddress import IPv4Network
-from netifaces import interfaces
+from netifaces import interfaces # pylint: disable = no-name-in-module
 
 from base_vyostest_shim import VyOSUnitTestSHIM
 

--- a/smoketest/scripts/cli/test_interfaces_openvpn.py
+++ b/smoketest/scripts/cli/test_interfaces_openvpn.py
@@ -868,4 +868,4 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_pppoe.py
+++ b/smoketest/scripts/cli/test_interfaces_pppoe.py
@@ -256,4 +256,4 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
             self.assertEqual(tmp, interface)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_pppoe.py
+++ b/smoketest/scripts/cli/test_interfaces_pppoe.py
@@ -17,13 +17,26 @@
 import unittest
 
 from psutil import process_iter
+from ipaddress import IPv4Address
+from ipaddress import IPv6Address
+from ipaddress import IPv4Network
+from ipaddress import IPv6Network
 from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.configsession import ConfigSessionError
+from vyos.utils.dict import dict_search_recursive
+from vyos.utils.network import get_interface_address
 from vyos.xml_ref import default_value
 
-config_file = '/etc/ppp/peers/{}'
-base_path = ['interfaces', 'pppoe']
+config_file: str = '/etc/ppp/peers/{}'
+base_path: list = ['interfaces', 'pppoe']
+veth_path: list = ['interfaces', 'virtual-ethernet']
+pppoe_server_path = ['service', 'pppoe-server']
+connect_timeout: int = 20
+name_servers: list = ['1.1.1.1', '2.2.2.2']
+ipv4_pool: str = '100.64.0.0/18'
+ipv6_pool: str = '2001:db8:8000::/48'
+ipv6_pool_pd: str = '2001:db8:9000::/48'
 
 def get_config_value(interface, key):
     with open(config_file.format(interface), 'r') as f:
@@ -31,6 +44,19 @@ def get_config_value(interface, key):
             if line.startswith(key):
                 return list(line.split())
     return []
+
+def wait_for_interface(interface: str, timeout=connect_timeout) -> bool:
+    """ Wait until PPPoE interface has been connected to the BRAS """
+    from time import time
+    from time import sleep
+    from vyos.utils.network import get_interface_config
+
+    start_time = time()
+    while not get_interface_config(interface):
+        sleep(0.250)
+        if time() - start_time >= timeout:
+            return False
+    return True
 
 # add a classmethod to setup a temporaray PPPoE server for "proper" validation
 class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
@@ -40,29 +66,76 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
         # ensure we can also run this test on a live system - so lets clean
         # out the current configuration :)
         cls.cli_delete(cls, base_path)
+        cls.cli_delete(cls, veth_path)
+        cls.cli_delete(cls, pppoe_server_path)
 
         cls._interfaces = ['pppoe10', 'pppoe20', 'pppoe30']
-        cls._source_interface = 'eth0'
+        cls._source_interface = 'veth102'
+        pppoe_server_interface = 'veth101'
+
+        cls.cli_set(cls, veth_path + [pppoe_server_interface, 'peer-name', cls._source_interface])
+        cls.cli_set(cls, veth_path + [cls._source_interface, 'peer-name', pppoe_server_interface])
+
+        cls.cli_set(cls, pppoe_server_path + ['authentication', 'mode', 'local'])
+        cls.cli_set(cls, pppoe_server_path + ['client-ip-pool', 'IPv4-POOL', 'range', ipv4_pool])
+        cls.cli_set(cls, pppoe_server_path + ['client-ipv6-pool', 'IPv6-POOL', 'prefix', ipv6_pool, 'mask', '64'])
+        cls.cli_set(cls, pppoe_server_path + ['client-ipv6-pool', 'IPv6-POOL', 'delegate', ipv6_pool_pd, 'delegation-prefix', '56'])
+        cls.cli_set(cls, pppoe_server_path + ['default-ipv6-pool', 'IPv6-POOL'])
+        cls.cli_set(cls, pppoe_server_path + ['default-pool', 'IPv4-POOL'])
+        cls.cli_set(cls, pppoe_server_path + ['gateway-address', '100.64.0.1'])
+        cls.cli_set(cls, pppoe_server_path + ['interface', pppoe_server_interface])
+        for ns in name_servers:
+            cls.cli_set(cls, pppoe_server_path + ['name-server', ns])
+        cls.cli_set(cls, pppoe_server_path + ['ppp-options', 'disable-ccp'])
+        cls.cli_set(cls, pppoe_server_path + ['ppp-options', 'ipv6', 'allow'])
+        cls.cli_set(cls, pppoe_server_path + ['session-control', 'disable'])
+
+        cls.u_p_dict = {}
+        for interface in cls._interfaces:
+            username = f'VyOS-user-{interface}'
+            password = f'VyOS-passwd-{interface}'
+
+            cls.cli_set(cls, pppoe_server_path + ['authentication', 'local-users',
+                        'username', username, 'password', password])
+
+            cls.u_p_dict[interface] = (username, password)
+
+        # Start PPPoE server
+        cls.cli_commit(cls)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.cli_delete(cls, base_path)
+        cls.cli_delete(cls, veth_path)
+        cls.cli_delete(cls, pppoe_server_path)
+        # Stop PPPoE server
+        cls.cli_commit(cls)
+
+        super(PPPoEInterfaceTest, cls).tearDownClass()
 
     def tearDown(self):
-        # Validate PPPoE client process
-        for interface in self._interfaces:
-            running = False
-            for proc in process_iter():
-                if interface in proc.cmdline():
-                    running = True
-                    break
-            self.assertTrue(running)
-
         self.cli_delete(base_path)
         self.cli_commit()
 
+    def _verify_interface_address(self, interface):
+        # Verify that the assigned IPv4/IPv6 addresses from the BRAS (PPPoE
+        # server) are from the assigned pools
+        for address in get_interface_address(interface):
+            if 'family' in address and address['family'] == 'inet':
+                # The PPPoE assigned IPv4 address must be from our pool
+                self.assertIn(IPv4Address(address['address']), IPv4Network(ipv4_pool))
+            elif 'family' in address and address['family'] == 'inet6':
+                # The PPPoE assigned IPv6 address must be from our pool
+                ipv6 = IPv6Address(address['address'])
+                if not ipv6.is_link_local:
+                    self.assertIn(ipv6, IPv6Network(ipv6_pool))
+
     def test_pppoe_client(self):
         # Check if PPPoE dialer can be configured and runs
+        mtu = '1400'
+
         for interface in self._interfaces:
-            user = f'VyOS-user-{interface}'
-            passwd = f'VyOS-passwd-{interface}'
-            mtu = '1400'
+            (user, passwd) = self.u_p_dict[interface]
 
             self.cli_set(base_path + [interface, 'authentication', 'username', user])
             self.cli_set(base_path + [interface, 'authentication', 'password', passwd])
@@ -79,8 +152,10 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
 
         # verify configuration file(s)
         for interface in self._interfaces:
-            user = f'VyOS-user-{interface}'
-            passwd = f'VyOS-passwd-{interface}'
+            self.assertTrue(wait_for_interface(interface),
+                            msg=f'Interface {interface} not found after {connect_timeout} seconds!')
+
+            (user, passwd) = self.u_p_dict[interface]
 
             tmp = get_config_value(interface, 'mtu')[1]
             self.assertEqual(tmp, mtu)
@@ -94,11 +169,19 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
             tmp = get_config_value(interface, 'ifname')[1]
             self.assertEqual(tmp, interface)
 
+            # Validate and verify assigned IP addresses
+            self._verify_interface_address(interface)
+
+            # validate that we have learned a default route
+            tmp = self.getFRRopmode('show ip route 0.0.0.0/0', json=True)
+            # Test if we have a default route 0.0.0.0/0 pointing to our PPPoE interface
+            tmp = dict_search_recursive(tmp, 'interfaceName')
+            self.assertTrue(any(iface == interface for (iface, _) in tmp))
+
     def test_pppoe_client_disabled_interface(self):
         # Check if PPPoE Client can be disabled
         for interface in self._interfaces:
-            user = f'VyOS-user-{interface}'
-            passwd = f'VyOS-passwd-{interface}'
+            (user, passwd) = self.u_p_dict[interface]
 
             self.cli_set(base_path + [interface, 'authentication', 'username', user])
             self.cli_set(base_path + [interface, 'authentication', 'password', passwd])
@@ -122,17 +205,15 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-
     def test_pppoe_authentication(self):
         # When username or password is set - so must be the other
         for interface in self._interfaces:
-            user = f'VyOS-user-{interface}'
-            passwd = f'VyOS-passwd-{interface}'
+            (user, passwd) = self.u_p_dict[interface]
 
             self.cli_set(base_path + [interface, 'source-interface', self._source_interface])
             self.cli_set(base_path + [interface, 'ipv6', 'address', 'autoconf'])
-
             self.cli_set(base_path + [interface, 'authentication', 'username', user])
+
             # check validate() - if user is set, so must be the password
             with self.assertRaises(ConfigSessionError):
                 self.cli_commit()
@@ -141,15 +222,23 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
+        for interface in self._interfaces:
+            self.assertTrue(wait_for_interface(interface),
+                            msg=f'Interface {interface} not found after {connect_timeout} seconds!')
+
+            # Validate and verify assigned IP addresses
+            self._verify_interface_address(interface)
+
     def test_pppoe_dhcpv6pd(self):
         # Check if PPPoE dialer can be configured with DHCPv6-PD
         address = '1'
         sla_id = '0'
-        sla_len = '8'
+
+        # verify IPv6 DHCPv6-PD assignment on one dialer interface only - to not mix things up
 
         for interface in self._interfaces:
-            user = f'VyOS-user-{interface}'
-            passwd = f'VyOS-passwd-{interface}'
+            (user, passwd) = self.u_p_dict[interface]
+            interface_id = ''.join(c for c in interface if c.isdigit())
 
             self.cli_set(base_path + [interface, 'authentication', 'username', user])
             self.cli_set(base_path + [interface, 'authentication', 'password', passwd])
@@ -158,18 +247,29 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
             self.cli_set(base_path + [interface, 'source-interface', self._source_interface])
             self.cli_set(base_path + [interface, 'ipv6', 'address', 'autoconf'])
 
+            # interface we will delegate to
+            delegate_if = f'dum{interface_id}'
+            self.cli_set(['interfaces', 'dummy', delegate_if])
+
             # prefix delegation stuff
             dhcpv6_pd_base = base_path + [interface, 'dhcpv6-options', 'pd', '0']
             self.cli_set(dhcpv6_pd_base + ['length', '56'])
-            self.cli_set(dhcpv6_pd_base + ['interface', self._source_interface, 'address', address])
-            self.cli_set(dhcpv6_pd_base + ['interface', self._source_interface, 'sla-id',  sla_id])
+            self.cli_set(dhcpv6_pd_base + ['interface', delegate_if, 'address', address])
+            self.cli_set(dhcpv6_pd_base + ['interface', delegate_if, 'sla-id',  sla_id])
+
+            address = str(int(address) + 1)
+            sla_id = str(int(sla_id) + 2)
 
         # commit changes
         self.cli_commit()
 
+        address = '1'
+        sla_id = '0'
         for interface in self._interfaces:
-            user = f'VyOS-user-{interface}'
-            passwd = f'VyOS-passwd-{interface}'
+            self.assertTrue(wait_for_interface(interface),
+                            msg=f'Interface {interface} not found after {connect_timeout} seconds!')
+
+            (user, passwd) = self.u_p_dict[interface]
             mtu_default = default_value(base_path + [interface, 'mtu'])
 
             tmp = get_config_value(interface, 'mtu')[1]
@@ -181,43 +281,88 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
             tmp = get_config_value(interface, '+ipv6 ipv6cp-use-ipaddr')
             self.assertListEqual(tmp, ['+ipv6', 'ipv6cp-use-ipaddr'])
 
+            # Validate and verify assigned IP addresses
+            self._verify_interface_address(interface)
+
+            # interface we delegated to
+            delegate_if = f'dum{interface_id}'
+            tmp = get_interface_address(delegate_if)
+            self.assertIn('addr_info', tmp)
+
+            # Verify IPv6 address received from out DHCPv6-PD
+            for addr_info in tmp['addr_info']:
+                if 'family' not in addr_info or addr_info['family'] != 'inet6':
+                    continue
+                # Skip link-local interface address
+                ipv6 = IPv6Address(addr_info['local'])
+                if ipv6.is_link_local:
+                    continue
+
+                # DHCPv6-PD assigned interface addres is of length /64
+                self.assertEqual(addr_info['prefixlen'], 64)
+                # Interface IP address must be within the PD pool
+                self.assertIn(ipv6, IPv6Network(ipv6_pool_pd))
+                # Get corresponding PD assigned prefix for this site/connection
+                pd_prefix = IPv6Network(f"{ipv6}/56", strict=False)
+                # Prefix must be within the PD pool
+                self.assertIn(pd_prefix, IPv6Network(ipv6_pool_pd))
+                # Calculate the assigned IP address from the prefix delegation
+                network_addr = str(pd_prefix.network_address) # 2001:db8:8003::
+                generated_sla_addr = network_addr[:-1] + f'{sla_id}::{address}'
+                self.assertEqual(generated_sla_addr, ipv6)
+
+                address = str(int(address) + 1)
+                sla_id = str(int(sla_id) + 2)
+
+            self.cli_delete(['interfaces', 'dummy', delegate_if])
+
     def test_pppoe_options(self):
-        # Check if PPPoE dialer can be configured with DHCPv6-PD
-        for interface in self._interfaces:
-            user = f'VyOS-user-{interface}'
-            passwd = f'VyOS-passwd-{interface}'
-            ac_name = f'AC{interface}'
-            service_name = f'SRV{interface}'
-            host_uniq = 'cafebeefBABE123456'
+        # Verify access-concentrator and service-name CLI options
 
-            self.cli_set(base_path + [interface, 'authentication', 'username', user])
-            self.cli_set(base_path + [interface, 'authentication', 'password', passwd])
-            self.cli_set(base_path + [interface, 'source-interface', self._source_interface])
+        ac_name: str = 'ACN123'
+        service_name: str = 'VyOS'
 
-            self.cli_set(base_path + [interface, 'access-concentrator', ac_name])
-            self.cli_set(base_path + [interface, 'service-name', service_name])
-            self.cli_set(base_path + [interface, 'host-uniq', host_uniq])
+        self.cli_set(pppoe_server_path + ['access-concentrator', ac_name])
+        self.cli_set(pppoe_server_path + ['service-name', service_name])
+        self.cli_commit()
+
+        # as this tests uniqueness - we only use one interface in this test
+        interface = self._interfaces[0]
+        (user, passwd) = self.u_p_dict[interface]
+
+        host_uniq = 'cafe010203'
+
+        self.cli_set(base_path + [interface, 'authentication', 'username', user])
+        self.cli_set(base_path + [interface, 'authentication', 'password', passwd])
+        self.cli_set(base_path + [interface, 'source-interface', self._source_interface])
+
+        self.cli_set(base_path + [interface, 'access-concentrator', ac_name])
+        self.cli_set(base_path + [interface, 'service-name', service_name])
+        self.cli_set(base_path + [interface, 'host-uniq', host_uniq])
 
         # commit changes
         self.cli_commit()
 
-        for interface in self._interfaces:
-            ac_name = f'AC{interface}'
-            service_name = f'SRV{interface}'
-            host_uniq = 'cafebeefBABE123456'
+        self.assertTrue(wait_for_interface(interface),
+                        msg=f'Interface {interface} not found after {connect_timeout} seconds!')
 
-            tmp = get_config_value(interface, 'pppoe-ac')[1]
-            self.assertEqual(tmp, f'"{ac_name}"')
-            tmp = get_config_value(interface, 'pppoe-service')[1]
-            self.assertEqual(tmp, f'"{service_name}"')
-            tmp = get_config_value(interface, 'pppoe-host-uniq')[1]
-            self.assertEqual(tmp, f'"{host_uniq}"')
+        tmp = get_config_value(interface, 'pppoe-ac')[1]
+        self.assertEqual(tmp, f'"{ac_name}"')
+        tmp = get_config_value(interface, 'pppoe-service')[1]
+        self.assertEqual(tmp, f'"{service_name}"')
+        tmp = get_config_value(interface, 'pppoe-host-uniq')[1]
+        self.assertEqual(tmp, f'"{host_uniq}"')
+
+        # Validate and verify assigned IP addresses
+        self._verify_interface_address(interface)
+
+        self.cli_delete(pppoe_server_path + ['access-concentrator'])
+        self.cli_delete(pppoe_server_path + ['service-name'])
 
     def test_pppoe_mtu_mru(self):
         # Check if PPPoE dialer can be configured and runs
         for interface in self._interfaces:
-            user = f'VyOS-user-{interface}'
-            passwd = f'VyOS-passwd-{interface}'
+            (user, passwd) = self.u_p_dict[interface]
             mtu = '1400'
             mru = '1300'
 
@@ -241,8 +386,10 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
 
         # verify configuration file(s)
         for interface in self._interfaces:
-            user = f'VyOS-user-{interface}'
-            passwd = f'VyOS-passwd-{interface}'
+            self.assertTrue(wait_for_interface(interface),
+                            msg=f'Interface {interface} not found after {connect_timeout} seconds!')
+
+            (user, passwd) = self.u_p_dict[interface]
 
             tmp = get_config_value(interface, 'mtu')[1]
             self.assertEqual(tmp, mtu)
@@ -254,6 +401,9 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
             self.assertEqual(tmp, passwd)
             tmp = get_config_value(interface, 'ifname')[1]
             self.assertEqual(tmp, interface)
+
+            # Validate and verify assigned IP addresses
+            self._verify_interface_address(interface)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_pseudo-ethernet.py
+++ b/smoketest/scripts/cli/test_interfaces_pseudo-ethernet.py
@@ -17,8 +17,10 @@
 import os
 import unittest
 
-from vyos.ifconfig import Section
 from base_interfaces_test import BasicInterfaceTest
+from base_vyostest_shim import VyOSUnitTestSHIM
+
+from vyos.ifconfig import Section
 
 class PEthInterfaceTest(BasicInterfaceTest.TestCase):
     @classmethod
@@ -43,4 +45,4 @@ class PEthInterfaceTest(BasicInterfaceTest.TestCase):
         super(PEthInterfaceTest, cls).setUpClass()
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_tunnel.py
+++ b/smoketest/scripts/cli/test_interfaces_tunnel.py
@@ -17,6 +17,7 @@
 import unittest
 
 from base_interfaces_test import BasicInterfaceTest
+from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.configsession import ConfigSessionError
 from vyos.utils.network import get_interface_config
@@ -410,4 +411,4 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
         self.cli_commit()
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_virtual-ethernet.py
+++ b/smoketest/scripts/cli/test_interfaces_virtual-ethernet.py
@@ -15,8 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+from netifaces import interfaces # pylint: disable = no-name-in-module
 
-from netifaces import interfaces
 from base_interfaces_test import BasicInterfaceTest
 from base_vyostest_shim import VyOSUnitTestSHIM
 

--- a/smoketest/scripts/cli/test_interfaces_virtual-ethernet.py
+++ b/smoketest/scripts/cli/test_interfaces_virtual-ethernet.py
@@ -17,9 +17,10 @@
 import unittest
 
 from netifaces import interfaces
+from base_interfaces_test import BasicInterfaceTest
+from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.utils.process import process_named_running
-from base_interfaces_test import BasicInterfaceTest
 
 class VEthInterfaceTest(BasicInterfaceTest.TestCase):
     @classmethod
@@ -55,4 +56,4 @@ class VEthInterfaceTest(BasicInterfaceTest.TestCase):
         super(VEthInterfaceTest, cls).tearDownClass()
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_vti.py
+++ b/smoketest/scripts/cli/test_interfaces_vti.py
@@ -17,6 +17,7 @@
 import unittest
 
 from base_interfaces_test import BasicInterfaceTest
+from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.ifconfig import Interface
 from vyos.utils.network import is_intf_addr_assigned
@@ -46,4 +47,4 @@ class VTIInterfaceTest(BasicInterfaceTest.TestCase):
             self.assertEqual(Interface(intf).get_admin_state(), 'down')
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_vxlan.py
+++ b/smoketest/scripts/cli/test_interfaces_vxlan.py
@@ -16,6 +16,9 @@
 
 import unittest
 
+from base_interfaces_test import BasicInterfaceTest
+from base_vyostest_shim import VyOSUnitTestSHIM
+
 from vyos.configsession import ConfigSessionError
 from vyos.ifconfig import Interface
 from vyos.ifconfig import Section
@@ -25,7 +28,6 @@ from vyos.utils.network import interface_exists
 from vyos.utils.network import get_vxlan_vlan_tunnels
 from vyos.utils.network import get_vxlan_vni_filter
 from vyos.template import is_ipv6
-from base_interfaces_test import BasicInterfaceTest
 
 def convert_to_list(ranges_to_convert):
     result_list = []
@@ -387,4 +389,4 @@ class VXLANInterfaceTest(BasicInterfaceTest.TestCase):
         self.cli_delete(['interfaces', 'bridge', bridge])
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_wireguard.py
+++ b/smoketest/scripts/cli/test_interfaces_wireguard.py
@@ -18,6 +18,8 @@ import os
 import unittest
 
 from base_interfaces_test import BasicInterfaceTest
+from base_interfaces_test import VyOSUnitTestSHIM
+
 from vyos.configsession import ConfigSessionError
 from vyos.utils.file import read_file
 from vyos.utils.process import cmd
@@ -252,4 +254,4 @@ class WireGuardInterfaceTest(BasicInterfaceTest.TestCase):
         self.assertFalse(is_systemd_service_running(domain_resolver))
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_interfaces_wireless.py
+++ b/smoketest/scripts/cli/test_interfaces_wireless.py
@@ -17,9 +17,10 @@
 import os
 import re
 import unittest
+from glob import glob
 
 from base_interfaces_test import BasicInterfaceTest
-from glob import glob
+from base_interfaces_test import VyOSUnitTestSHIM
 
 from vyos.configsession import ConfigSessionError
 from vyos.utils.file import read_file
@@ -637,4 +638,4 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
 
 if __name__ == '__main__':
     check_kmod('mac80211_hwsim')
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_load-balancing_haproxy.py
+++ b/smoketest/scripts/cli/test_load-balancing_haproxy.py
@@ -618,4 +618,4 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'server localhost 127.0.0.1:{port}', config[backend_name])
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_load-balancing_wan.py
+++ b/smoketest/scripts/cli/test_load-balancing_wan.py
@@ -427,4 +427,4 @@ echo "$ifname - $state" > {hook_output_path}
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_nat.py
+++ b/smoketest/scripts/cli/test_nat.py
@@ -331,4 +331,4 @@ class TestNAT(VyOSUnitTestSHIM.TestCase):
 
         self.verify_nftables(nftables_search, 'ip vyos_nat')
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_nat.py
+++ b/smoketest/scripts/cli/test_nat.py
@@ -18,7 +18,10 @@ import os
 import unittest
 
 from base_vyostest_shim import VyOSUnitTestSHIM
+from time import sleep
+
 from vyos.configsession import ConfigSessionError
+from vyos.utils.process import run
 
 base_path = ['nat']
 src_path = base_path + ['source']

--- a/smoketest/scripts/cli/test_nat64.py
+++ b/smoketest/scripts/cli/test_nat64.py
@@ -95,4 +95,4 @@ class TestNAT64(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_nat66.py
+++ b/smoketest/scripts/cli/test_nat66.py
@@ -267,4 +267,4 @@ class TestNAT66(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_netns.py
+++ b/smoketest/scripts/cli/test_netns.py
@@ -76,4 +76,4 @@ class NetNSTest(VyOSUnitTestSHIM.TestCase):
             self.assertFalse(is_netns_interface(interface, netns))
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_op-mode_show.py
+++ b/smoketest/scripts/cli/test_op-mode_show.py
@@ -43,4 +43,4 @@ class TestOPModeShow(VyOSUnitTestSHIM.TestCase):
         self.assertIn('VRF is not configured', tmp)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_pki.py
+++ b/smoketest/scripts/cli/test_pki.py
@@ -251,4 +251,4 @@ class TestPKI(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(['interfaces', 'ethernet', interface, 'eapol'])
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_policy.py
+++ b/smoketest/scripts/cli/test_policy.py
@@ -2051,4 +2051,4 @@ def sort_ip(output):
     return o
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_policy_local-route.py
+++ b/smoketest/scripts/cli/test_policy_local-route.py
@@ -171,4 +171,4 @@ class TestPolicyLocalRoute(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_policy_route.py
+++ b/smoketest/scripts/cli/test_policy_route.py
@@ -342,4 +342,4 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
         self.verify_nftables(nftables_search, 'ip6 vyos_mangle', args='-t')
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_babel.py
+++ b/smoketest/scripts/cli/test_protocols_babel.py
@@ -219,4 +219,4 @@ class TestProtocolsBABEL(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f' babel {type}', iface_config)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_bfd.py
+++ b/smoketest/scripts/cli/test_protocols_bfd.py
@@ -240,4 +240,4 @@ class TestProtocolsBFD(VyOSUnitTestSHIM.TestCase):
                 self.assertIn(f' profile {peer_config["profile"]}', peerconfig)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -714,10 +714,10 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
                 for table, table_config in proto_config.items():
                     self.cli_set(proto_path + [table])
                     if 'metric' in table_config:
-                        self.cli_set(proto_path + [table, 'metric'], value=table_config['metric'])
+                        self.cli_set(proto_path + [table, 'metric'], value=table_config.get('metric'))
                     if 'route_map' in table_config:
-                        self.cli_set(['policy', 'route-map', table_config['route_map'], 'rule', '10', 'action'], value='permit')
-                        self.cli_set(proto_path + [table, 'route-map'], value=table_config['route_map'])
+                        self.cli_set(['policy', 'route-map', table_config.get('route_map'), 'rule', '10', 'action'], value='permit')
+                        self.cli_set(proto_path + [table, 'route-map'], value=table_config.get('route_map'))
             else:
                 self.cli_set(proto_path)
                 if 'metric' in proto_config:
@@ -846,10 +846,10 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
                 for table, table_config in proto_config.items():
                     self.cli_set(proto_path + [table])
                     if 'metric' in table_config:
-                        self.cli_set(proto_path + [table, 'metric'], value=table_config['metric'])
+                        self.cli_set(proto_path + [table, 'metric'], value=table_config.get('metric'))
                     if 'route_map' in table_config:
-                        self.cli_set(['policy', 'route-map', table_config['route_map'], 'rule', '10', 'action'], value='permit')
-                        self.cli_set(proto_path + [table, 'route-map'], value=table_config['route_map'])
+                        self.cli_set(['policy', 'route-map', table_config.get('route_map'), 'rule', '10', 'action'], value='permit')
+                        self.cli_set(proto_path + [table, 'route-map'], value=table_config.get('route_map'))
             else:
                 self.cli_set(proto_path)
                 if 'metric' in proto_config:

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -1659,4 +1659,4 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'bmp connect {target_address} port {target_port} min-retry {min_retry} max-retry {max_retry}', frrconfig)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2, failfast=True)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_igmp-proxy.py
+++ b/smoketest/scripts/cli/test_protocols_igmp-proxy.py
@@ -93,4 +93,4 @@ class TestProtocolsIGMPProxy(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'phyint {downstream_if} downstream ratelimit 0 threshold 1', config)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_isis.py
+++ b/smoketest/scripts/cli/test_protocols_isis.py
@@ -478,4 +478,4 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f' isis fast-reroute ti-lfa level-1 node-protection link-fallback', tmp)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_mpls.py
+++ b/smoketest/scripts/cli/test_protocols_mpls.py
@@ -191,4 +191,4 @@ class TestProtocolsMPLS(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_nhrp.py
+++ b/smoketest/scripts/cli/test_protocols_nhrp.py
@@ -139,4 +139,4 @@ class TestProtocolsNHRP(VyOSUnitTestSHIM.TestCase):
         self.assertTrue(process_named_running(PROCESS_NAME))
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_openfabric.py
+++ b/smoketest/scripts/cli/test_protocols_openfabric.py
@@ -186,4 +186,4 @@ class TestProtocolsOpenFabric(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f' ip router openfabric {domain_2}', tmp)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_ospf.py
+++ b/smoketest/scripts/cli/test_protocols_ospf.py
@@ -614,4 +614,4 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f' network {network} area {area}', frrconfig)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_ospfv3.py
+++ b/smoketest/scripts/cli/test_protocols_ospfv3.py
@@ -342,4 +342,4 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f' graceful-restart helper enable {router_id}', frrconfig)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_pim.py
+++ b/smoketest/scripts/cli/test_protocols_pim.py
@@ -200,4 +200,4 @@ class TestProtocolsPIM(VyOSUnitTestSHIM.TestCase):
                     self.assertIn(f' ip igmp join-group {join}', frrconfig)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_pim6.py
+++ b/smoketest/scripts/cli/test_protocols_pim6.py
@@ -147,4 +147,4 @@ class TestProtocolsPIMv6(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f' ipv6 pim passive', config)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_rip.py
+++ b/smoketest/scripts/cli/test_protocols_rip.py
@@ -186,4 +186,4 @@ class TestProtocolsRIP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f' ip rip send version {tx_version}', frrconfig)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_ripng.py
+++ b/smoketest/scripts/cli/test_protocols_ripng.py
@@ -163,4 +163,4 @@ class TestProtocolsRIPng(VyOSUnitTestSHIM.TestCase):
         self.assertNotIn(zebra_route_map, frrconfig)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_rpki.py
+++ b/smoketest/scripts/cli/test_protocols_rpki.py
@@ -324,4 +324,4 @@ class TestProtocolsRPKI(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_segment-routing.py
+++ b/smoketest/scripts/cli/test_protocols_segment-routing.py
@@ -187,4 +187,4 @@ class TestProtocolsSegmentRouting(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_static.py
+++ b/smoketest/scripts/cli/test_protocols_static.py
@@ -652,4 +652,4 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
             sleep(0.250)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_protocols_static_arp.py
+++ b/smoketest/scripts/cli/test_protocols_static_arp.py
@@ -85,4 +85,4 @@ class TestARP(VyOSUnitTestSHIM.TestCase):
             self.assertTrue(found)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_qos.py
+++ b/smoketest/scripts/cli/test_qos.py
@@ -1324,4 +1324,4 @@ class TestQoS(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_broadcast-relay.py
+++ b/smoketest/scripts/cli/test_service_broadcast-relay.py
@@ -65,4 +65,4 @@ class TestServiceBroadcastRelay(VyOSUnitTestSHIM.TestCase):
             self.assertTrue(running)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_dhcp-relay.py
+++ b/smoketest/scripts/cli/test_service_dhcp-relay.py
@@ -120,5 +120,5 @@ class TestServiceDHCPRelay(VyOSUnitTestSHIM.TestCase):
         self.assertTrue(process_named_running(PROCESS_NAME))
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())
 

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -1434,4 +1434,4 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_dhcpv6-relay.py
+++ b/smoketest/scripts/cli/test_service_dhcpv6-relay.py
@@ -107,4 +107,4 @@ class TestServiceDHCPv6Relay(VyOSUnitTestSHIM.TestCase):
         self.assertTrue(process_named_running(PROCESS_NAME))
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_dhcpv6-server.py
+++ b/smoketest/scripts/cli/test_service_dhcpv6-server.py
@@ -290,4 +290,4 @@ class TestServiceDHCPv6Server(VyOSUnitTestSHIM.TestCase):
         self.assertTrue(process_named_running(PROCESS_NAME))
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_dns_dynamic.py
+++ b/smoketest/scripts/cli/test_service_dns_dynamic.py
@@ -360,4 +360,4 @@ class TestServiceDDNS(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(['vrf', 'name', vrf_name])
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_dns_forwarding.py
+++ b/smoketest/scripts/cli/test_service_dns_forwarding.py
@@ -341,4 +341,4 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_ipoe-server.py
+++ b/smoketest/scripts/cli/test_service_ipoe-server.py
@@ -17,8 +17,10 @@
 import re
 import unittest
 
-from collections import OrderedDict
 from base_accel_ppp_test import BasicAccelPPPTest
+from base_vyostest_shim import VyOSUnitTestSHIM
+from collections import OrderedDict
+
 from vyos.configsession import ConfigSessionError
 from vyos.utils.process import cmd
 from vyos.template import range_to_regex
@@ -326,4 +328,4 @@ delegate={delegate_2_prefix},{delegate_mask},name={pool_name}"""
         pass
 
 if __name__ == "__main__":
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_lldp.py
+++ b/smoketest/scripts/cli/test_service_lldp.py
@@ -182,4 +182,4 @@ class TestServiceLLDP(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f'configure ports {interface} lldp status rx-and-tx', config)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_mdns_repeater.py
+++ b/smoketest/scripts/cli/test_service_mdns_repeater.py
@@ -173,4 +173,4 @@ class TestServiceMDNSrepeater(VyOSUnitTestSHIM.TestCase):
         self.assertEqual(conf['server']['cache-entries-max'], cache_entries)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_monitoring_network_event.py
+++ b/smoketest/scripts/cli/test_service_monitoring_network_event.py
@@ -62,4 +62,4 @@ class TestMonitoringNetworkEvent(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_monitoring_prometheus.py
+++ b/smoketest/scripts/cli/test_service_monitoring_prometheus.py
@@ -158,4 +158,4 @@ class TestMonitoringPrometheus(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_monitoring_telegraf.py
+++ b/smoketest/scripts/cli/test_service_monitoring_telegraf.py
@@ -93,4 +93,4 @@ class TestMonitoringTelegraf(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_monitoring_zabbix-agent.py
+++ b/smoketest/scripts/cli/test_service_monitoring_zabbix-agent.py
@@ -105,4 +105,4 @@ class TestZabbixAgent(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_ndp-proxy.py
+++ b/smoketest/scripts/cli/test_service_ndp-proxy.py
@@ -66,4 +66,4 @@ class TestServiceNDPProxy(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f'ttl 30000', config) # default value
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_ntp.py
+++ b/smoketest/scripts/cli/test_service_ntp.py
@@ -261,4 +261,4 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'ptpport {default_ptp_port}', config)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_pppoe-server.py
+++ b/smoketest/scripts/cli/test_service_pppoe-server.py
@@ -17,6 +17,7 @@
 import unittest
 
 from base_accel_ppp_test import BasicAccelPPPTest
+from base_vyostest_shim import VyOSUnitTestSHIM
 
 from configparser import ConfigParser
 from vyos.utils.file import read_file
@@ -226,4 +227,4 @@ class TestServicePPPoEServer(BasicAccelPPPTest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_router-advert.py
+++ b/smoketest/scripts/cli/test_service_router-advert.py
@@ -366,4 +366,4 @@ class TestServiceRADVD(VyOSUnitTestSHIM.TestCase):
         self.assertNotIn(tmp, config)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_salt-minion.py
+++ b/smoketest/scripts/cli/test_service_salt-minion.py
@@ -102,4 +102,4 @@ class TestServiceSALT(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'source_interface_name: {interface}', conf)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_snmp.py
+++ b/smoketest/scripts/cli/test_service_snmp.py
@@ -261,4 +261,4 @@ class TestSNMPService(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_ssh.py
+++ b/smoketest/scripts/cli/test_service_ssh.py
@@ -494,4 +494,4 @@ class TestServiceSSH(VyOSUnitTestSHIM.TestCase):
         self.assertFalse(os.path.exists(f'/home/{test_user}/.ssh/authorized_principals'))
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_stunnel.py
+++ b/smoketest/scripts/cli/test_service_stunnel.py
@@ -621,4 +621,4 @@ class TestServiceStunnel(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_tftp-server.py
+++ b/smoketest/scripts/cli/test_service_tftp-server.py
@@ -148,4 +148,4 @@ class TestServiceTFTPD(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(['vrf', 'name', vrf])
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_service_webproxy.py
+++ b/smoketest/scripts/cli/test_service_webproxy.py
@@ -315,4 +315,4 @@ class TestServiceWebProxy(VyOSUnitTestSHIM.TestCase):
         self.assertTrue(process_named_running(PROCESS_NAME))
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_system_acceleration_qat.py
+++ b/smoketest/scripts/cli/test_system_acceleration_qat.py
@@ -40,4 +40,4 @@ class TestIntelQAT(VyOSUnitTestSHIM.TestCase):
             self.cli_commit()
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_system_conntrack.py
+++ b/smoketest/scripts/cli/test_system_conntrack.py
@@ -536,4 +536,4 @@ class TestSystemConntrack(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_system_flow-accounting.py
+++ b/smoketest/scripts/cli/test_system_flow-accounting.py
@@ -279,4 +279,4 @@ class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_system_frr.py
+++ b/smoketest/scripts/cli/test_system_frr.py
@@ -159,4 +159,4 @@ class TestSystemFRR(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'MAX_FDS={file_descriptors}', daemons_config)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_system_ip.py
+++ b/smoketest/scripts/cli/test_system_ip.py
@@ -150,4 +150,4 @@ class TestSystemIP(VyOSUnitTestSHIM.TestCase):
         self.assertNotIn(f'ip import-table {table_num} distance {distance}', frrconfig)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_system_ipv6.py
+++ b/smoketest/scripts/cli/test_system_ipv6.py
@@ -150,4 +150,4 @@ class TestSystemIPv6(VyOSUnitTestSHIM.TestCase):
         self.assertNotIn(f'no ipv6 nht resolve-via-default', frrconfig)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_system_lcd.py
+++ b/smoketest/scripts/cli/test_system_lcd.py
@@ -48,4 +48,4 @@ class TestSystemLCD(VyOSUnitTestSHIM.TestCase):
         self.assertTrue(process_named_running('LCDd'))
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_system_login.py
+++ b/smoketest/scripts/cli/test_system_login.py
@@ -578,4 +578,4 @@ class TestSystemLogin(VyOSUnitTestSHIM.TestCase):
         self.op_mode(['reboot', 'cancel'])
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_system_logs.py
+++ b/smoketest/scripts/cli/test_system_logs.py
@@ -114,4 +114,4 @@ class TestSystemLogs(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_system_option.py
+++ b/smoketest/scripts/cli/test_system_option.py
@@ -156,4 +156,4 @@ class TestSystemOption(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f' initcall_blacklist=acpi_cpufreq_init amd_pstate={amd_pstate_mode}', tmp)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_system_resolvconf.py
+++ b/smoketest/scripts/cli/test_system_resolvconf.py
@@ -109,4 +109,4 @@ class TestSystemResolvConf(VyOSUnitTestSHIM.TestCase):
             self.assertTrue(s not in domain_search)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_system_sflow.py
+++ b/smoketest/scripts/cli/test_system_sflow.py
@@ -152,4 +152,4 @@ class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
         self.assertIn(PROCESS_NAME, tmp)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_system_syslog.py
+++ b/smoketest/scripts/cli/test_system_syslog.py
@@ -305,4 +305,4 @@ class TestRSYSLOGService(VyOSUnitTestSHIM.TestCase):
                 self.cli_delete(['interfaces', 'dummy', f'dum{idx}'])
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -1658,4 +1658,4 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_vpn_l2tp.py
+++ b/smoketest/scripts/cli/test_vpn_l2tp.py
@@ -17,13 +17,13 @@
 import unittest
 
 from base_accel_ppp_test import BasicAccelPPPTest
+from base_vyostest_shim import VyOSUnitTestSHIM
+
 from configparser import ConfigParser
 from vyos.utils.process import cmd
 from vyos.utils.file import read_file
 
-
 swanctl_file = '/etc/swanctl/swanctl.conf'
-
 
 class TestVPNL2TPServer(BasicAccelPPPTest.TestCase):
     @classmethod
@@ -142,4 +142,4 @@ class TestVPNL2TPServer(BasicAccelPPPTest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_vpn_openconnect.py
+++ b/smoketest/scripts/cli/test_vpn_openconnect.py
@@ -265,4 +265,4 @@ class TestVPNOpenConnect(VyOSUnitTestSHIM.TestCase):
         self.assertIn('tls-priorities = "NORMAL:%SERVER_PRECEDENCE:%COMPAT:-RSA:-VERS-SSL3.0:-ARCFOUR-128:-VERS-TLS1.0:-VERS-TLS1.1:-VERS-TLS1.2"', daemon_config)
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_vpn_pptp.py
+++ b/smoketest/scripts/cli/test_vpn_pptp.py
@@ -17,6 +17,7 @@
 import unittest
 
 from base_accel_ppp_test import BasicAccelPPPTest
+from base_vyostest_shim import VyOSUnitTestSHIM
 
 class TestVPNPPTPServer(BasicAccelPPPTest.TestCase):
     @classmethod
@@ -36,4 +37,4 @@ class TestVPNPPTPServer(BasicAccelPPPTest.TestCase):
         pass
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_vpn_sstp.py
+++ b/smoketest/scripts/cli/test_vpn_sstp.py
@@ -17,6 +17,8 @@
 import unittest
 
 from base_accel_ppp_test import BasicAccelPPPTest
+from base_vyostest_shim import VyOSUnitTestSHIM
+
 from vyos.utils.file import read_file
 
 pki_path = ['pki']
@@ -87,4 +89,4 @@ class TestVPNSSTPServer(BasicAccelPPPTest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -1473,4 +1473,4 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_vrf.py
+++ b/smoketest/scripts/cli/test_vrf.py
@@ -995,4 +995,4 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(verbosity=2)
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

VyOS includes a full-featured PPPoE server (BRAS), but it was previously not exercised during embedded platform smoketests. This commit extends the smoketest suite to include a basic PPPoE server configuration.

The test starts a local PPPoE server instance that provides both IPv4 and IPv6 addresses, including DHCPv6-PD for prefix delegation. The client side attempts to establish a PPPoE session and verifies that the assigned addresses and prefixes are within the expected configured pools. Connection is established through virtual-ethernet interface pairs.

This helps ensure that core PPPoE functionality works correctly in the base system image and catches regressions early.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7858

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_pppoe.py
test_pppoe_authentication (__main__.PPPoEInterfaceTest.test_pppoe_authentication) ... ok
test_pppoe_client (__main__.PPPoEInterfaceTest.test_pppoe_client) ... ok
test_pppoe_client_disabled_interface (__main__.PPPoEInterfaceTest.test_pppoe_client_disabled_interface) ... ok
test_pppoe_dhcpv6pd (__main__.PPPoEInterfaceTest.test_pppoe_dhcpv6pd) ... ok
test_pppoe_mtu_mru (__main__.PPPoEInterfaceTest.test_pppoe_mtu_mru) ... ok
test_pppoe_options (__main__.PPPoEInterfaceTest.test_pppoe_options) ... ok

----------------------------------------------------------------------
Ran 6 tests in 31.770s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
