### PR TITLE
container: T7863: Add user-defined MAC option for containers

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -312,12 +312,23 @@
                   <multi/>
                 </properties>
               </leafNode>
-              #include <include/interface/mac.xml.i>
-              <leafNode name="mac-auto">
+              <leafNode name="mac">
                 <properties>
-                  <help>Generate a random MAC address for the container</help>
-                  <valueless/>
+                  <help>Media Access Control (MAC) address</help>
+                  <valueHelp>
+                    <format>macaddr</format>
+                    <description>Hardware (MAC) address</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>auto</format>
+                    <description>Generate a random MAC address for the container</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="mac-address"/>
+                    <regex>(auto)</regex>
+                  </constraint>
                 </properties>
+                <defaultValue>auto</defaultValue>
               </leafNode>
             </children>
           </tagNode>

--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -312,6 +312,13 @@
                   <multi/>
                 </properties>
               </leafNode>
+              #include <include/interface/mac.xml.i>
+              <leafNode name="mac-auto">
+                <properties>
+                  <help>Generate a random MAC address for the container</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
             </children>
           </tagNode>
           <tagNode name="port">

--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -224,6 +224,29 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         self.assertEqual(n['subnets'][0]['subnet'], '10.0.2.0/24')
         self.assertEqual(n['subnets'][0]['gateway'], '10.0.2.1')
 
+    def test_user_defined_mac(self):
+        # Bridge Network
+        self.cli_set(base_path + ['network', 'bridge1', 'prefix', '10.0.1.0/24'])
+        self.cli_set(base_path + ['network', 'bridge1', 'type', 'bridge'])
+
+        self.cli_set(base_path + ['name', "test1", 'image', busybox_image])
+        self.cli_set(base_path + ['name', "test1", 'network', 'bridge1', 'address', '10.0.1.11'])
+        self.cli_set(base_path + ['name', "test1", 'network', 'bridge1', 'mac', '02:00:00:00:00:01'])
+
+        self.cli_set(base_path + ['name', "test2", 'image', busybox_image])
+        self.cli_set(base_path + ['name', "test2", 'network', 'bridge1', 'address', '10.0.1.12'])
+        self.cli_set(base_path + ['name', "test2", 'network', 'bridge1', 'mac', '02:00:00:00:00:02'])
+
+        self.cli_set(base_path + ['name', "test3", 'image', busybox_image])
+        self.cli_set(base_path + ['name', "test3", 'network', 'bridge1', 'address', '10.0.1.13'])
+        self.cli_set(base_path + ['name', "test3", 'network', 'bridge1', 'mac-auto'])
+        self.cli_commit()
+
+        n = cmd_to_json(f'sudo podman container inspect test1')
+        self.assertEqual(n['NetworkSettings']['Networks']['bridge1']['MacAddress'], '02:00:00:00:00:01')
+        n = cmd_to_json(f'sudo podman container inspect test2')
+        self.assertEqual(n['NetworkSettings']['Networks']['bridge1']['MacAddress'], '02:00:00:00:00:02')
+    
     def test_ipv4_network(self):
         prefix = '192.0.2.0/24'
         base_name = 'ipv4'

--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -236,10 +236,6 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['name', "test2", 'image', busybox_image])
         self.cli_set(base_path + ['name', "test2", 'network', 'bridge1', 'address', '10.0.1.12'])
         self.cli_set(base_path + ['name', "test2", 'network', 'bridge1', 'mac', '02:00:00:00:00:02'])
-
-        self.cli_set(base_path + ['name', "test3", 'image', busybox_image])
-        self.cli_set(base_path + ['name', "test3", 'network', 'bridge1', 'address', '10.0.1.13'])
-        self.cli_set(base_path + ['name', "test3", 'network', 'bridge1', 'mac-auto'])
         self.cli_commit()
 
         n = cmd_to_json(f'sudo podman container inspect test1')

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -30,6 +30,8 @@ from vyos.configdict import node_changed
 from vyos.configdict import is_node_changed
 from vyos.configverify import verify_vrf
 from vyos.ifconfig import Interface
+from vyos.utils.configfs import delete_cli_node
+from vyos.utils.configfs import add_cli_node
 from vyos.utils.cpu import get_core_count
 from vyos.utils.file import write_file
 from vyos.utils.dict import dict_search
@@ -117,6 +119,10 @@ def verify(container):
 
     # Add new container
     if 'name' in container:
+        net_dict = {}
+        net_dict['mac'] = {}
+        net_dict['address'] = {}
+
         for name, container_config in container['name'].items():
             # Container image is a mandatory option
             if 'image' not in container_config:
@@ -155,6 +161,16 @@ def verify(container):
                 if 'name_server' in container_config and 'no_name_server' not in container['network'][network_name]:
                     raise ConfigError(f'Setting name server has no effect when attached container network has DNS enabled!')
 
+                mac = dict_search(f'network.{network_name}.mac', container_config)
+                mac_auto = dict_search(f'network.{network_name}.mac_auto', container_config)
+                if all((mac, mac_auto is not None)):
+                    raise ConfigError(f'Cannot set both "mac" and "mac-auto" for container "{name}"!')
+                
+                if mac:
+                    if mac in net_dict['mac'].keys():
+                        raise ConfigError(f'MAC address "{mac}" is already used by container "{net_dict["mac"][mac]}"!')
+                    net_dict['mac'][mac] = name
+
                 if 'address' in container_config['network'][network_name]:
                     cnt_ipv4 = 0
                     cnt_ipv6 = 0
@@ -181,6 +197,10 @@ def verify(container):
                         if ip_address(address) == ip_network(network)[1]:
                             raise ConfigError(f'IP address "{address}" can not be used for a container, ' \
                                               'reserved for the container engine!')
+                        
+                        if address in net_dict['address'].keys():
+                            raise ConfigError(f'IP address "{address}" is already used by container "{net_dict["address"][address]}"!')
+                        net_dict['address'][address] = name
 
                     if cnt_ipv4 > 1 or cnt_ipv6 > 1:
                         raise ConfigError(f'Only one IP address per address family can be used for ' \
@@ -477,6 +497,7 @@ def generate_run_arguments(name, container_config, host_ident):
     addr_info = ''
     networks = ",".join(container_config['network'])
     for network in container_config['network']:
+        network_name = network
         if 'address' not in container_config['network'][network]:
             continue
         for address in container_config['network'][network]['address']:
@@ -487,7 +508,21 @@ def generate_run_arguments(name, container_config, host_ident):
 
         addr_info = ''.join(container_config['network'][network]['address'])
 
-    mac_address = f'--mac-address {gen_mac(name, addr_info, host_ident)}'
+    get_mac = dict_search(f'network.{network_name}.mac', container_config)
+    if get_mac:
+        mac_add = get_mac
+    else:
+        mac_add = gen_mac(name, addr_info, host_ident)
+
+    mac_address = f'--mac-address {mac_add}'
+
+    # Replace mac-auto with the generated mac address
+    if dict_search(f'network.{network_name}.mac_auto', container_config) is not None:
+        del_mac_auto = ['container', 'name', name, 'network', network_name, 'mac-auto']
+        add_static_mac = ['container', 'name', name, 'network', network_name, 'mac']
+
+        delete_cli_node(del_mac_auto)
+        add_cli_node(add_static_mac, value=mac_add)
 
     return f'{container_base_cmd} --no-healthcheck --net {networks} {ip_param} {mac_address} {entrypoint} {image} {command} {command_arguments}'.strip()
 

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -162,14 +162,12 @@ def verify(container):
                     raise ConfigError(f'Setting name server has no effect when attached container network has DNS enabled!')
 
                 mac = dict_search(f'network.{network_name}.mac', container_config)
-                mac_auto = dict_search(f'network.{network_name}.mac_auto', container_config)
-                if all((mac, mac_auto is not None)):
-                    raise ConfigError(f'Cannot set both "mac" and "mac-auto" for container "{name}"!')
                 
                 if mac:
                     if mac in net_dict['mac'].keys():
                         raise ConfigError(f'MAC address "{mac}" is already used by container "{net_dict["mac"][mac]}"!')
-                    net_dict['mac'][mac] = name
+                    if mac != 'auto':
+                        net_dict['mac'][mac] = name
 
                 if 'address' in container_config['network'][network_name]:
                     cnt_ipv4 = 0
@@ -509,20 +507,19 @@ def generate_run_arguments(name, container_config, host_ident):
         addr_info = ''.join(container_config['network'][network]['address'])
 
     get_mac = dict_search(f'network.{network_name}.mac', container_config)
-    if get_mac:
-        mac_add = get_mac
-    else:
+    if get_mac == 'auto':
         mac_add = gen_mac(name, addr_info, host_ident)
+    else:
+        mac_add = get_mac
 
     mac_address = f'--mac-address {mac_add}'
 
     # Replace mac-auto with the generated mac address
-    if dict_search(f'network.{network_name}.mac_auto', container_config) is not None:
-        del_mac_auto = ['container', 'name', name, 'network', network_name, 'mac-auto']
-        add_static_mac = ['container', 'name', name, 'network', network_name, 'mac']
+    if dict_search(f'network.{network_name}.mac', container_config) == 'auto':
+        mac_config_path = ['container', 'name', name, 'network', network_name, 'mac']
 
-        delete_cli_node(del_mac_auto)
-        add_cli_node(add_static_mac, value=mac_add)
+        delete_cli_node(mac_config_path)
+        add_cli_node(mac_config_path, value=mac_add)
 
     return f'{container_base_cmd} --no-healthcheck --net {networks} {ip_param} {mac_address} {entrypoint} {image} {command} {command_arguments}'.strip()
 

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -161,8 +161,7 @@ def verify(container):
                 if 'name_server' in container_config and 'no_name_server' not in container['network'][network_name]:
                     raise ConfigError(f'Setting name server has no effect when attached container network has DNS enabled!')
 
-                mac = dict_search(f'network.{network_name}.mac', container_config)
-                
+                mac = dict_search(f'network.{network_name}.mac', container_config)                
                 if mac:
                     if mac in net_dict['mac'].keys():
                         raise ConfigError(f'MAC address "{mac}" is already used by container "{net_dict["mac"][mac]}"!')
@@ -507,7 +506,7 @@ def generate_run_arguments(name, container_config, host_ident):
         addr_info = ''.join(container_config['network'][network]['address'])
 
     get_mac = dict_search(f'network.{network_name}.mac', container_config)
-    if get_mac == 'auto':
+    if get_mac == 'auto' or get_mac is None:
         mac_add = gen_mac(name, addr_info, host_ident)
     else:
         mac_add = get_mac
@@ -515,7 +514,7 @@ def generate_run_arguments(name, container_config, host_ident):
     mac_address = f'--mac-address {mac_add}'
 
     # Replace mac-auto with the generated mac address
-    if dict_search(f'network.{network_name}.mac', container_config) == 'auto':
+    if get_mac == 'auto':
         mac_config_path = ['container', 'name', name, 'network', network_name, 'mac']
 
         delete_cli_node(mac_config_path)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Added the ability configure a user-defined MAC address for containers.
Added missing error-handling for duplicate IP addresses assigned to containers.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7863
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
### User-Defined MAC
#### Configure a container with a MAC address:
```
set container name test image 'alpine'
set container name test network test address '10.0.101.138'
set container name test network test mac 'aa:bb:cc:dd:ee:f0'
```
#### Verify container has correct MAC address
```
vyos@vyos# run connect container test
/ # ifconfig eth0 | grep HWaddr
eth0      Link encap:Ethernet  HWaddr AA:BB:CC:DD:EE:F0
```
### Persistent auto-generated MAC address
#### Configure a container with `mac-auto`
```
set container name test image 'alpine'
set container name test network test address '10.0.101.138'
set container name test network test mac-auto
```
#### Verify config has hard-coded MAC address (this was generated and applied to the actual config)
```
vyos@vyos# show container name test
 image alpine
 network test {
     address 10.0.101.138
     mac 02:8a:cc:40:b3:18
 }
```
### Smoketest results:
```
test_api_socket (__main__.TestContainer.test_api_socket) ... ok
test_basic (__main__.TestContainer.test_basic) ... ok
test_cpu_limit (__main__.TestContainer.test_cpu_limit) ... ok
test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... ok
test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... ok
test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... ok
test_name_server (__main__.TestContainer.test_name_server) ... ok
test_network_mtu (__main__.TestContainer.test_network_mtu) ... ok
test_network_types (__main__.TestContainer.test_network_types) ... ok
test_no_name_server (__main__.TestContainer.test_no_name_server) ... ok
test_uid_gid (__main__.TestContainer.test_uid_gid) ... ok
test_user_defined_mac (__main__.TestContainer.test_user_defined_mac) ... ok

----------------------------------------------------------------------
Ran 12 tests in 719.660s

OK

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
