### PR TITLE
boot-config-loader: T7889: Inform user during login of config-load issues

### DIFF
--- a/src/helpers/vyos-boot-config-loader.py
+++ b/src/helpers/vyos-boot-config-loader.py
@@ -13,8 +13,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
-#
 
 import os
 import sys
@@ -23,10 +21,13 @@ import grp
 import traceback
 from datetime import datetime
 
-from vyos.defaults import directories, config_status
-from vyos.configsession import ConfigSession, ConfigSessionError
+from vyos.defaults import directories
+from vyos.defaults import config_status
+from vyos.configsession import ConfigSession
+from vyos.configsession import ConfigSessionError
 from vyos.configtree import ConfigTree
 from vyos.utils.process import cmd
+from vyos.utils.file import write_file
 
 STATUS_FILE = config_status
 TRACE_FILE = '/tmp/boot-config-trace'
@@ -68,16 +69,16 @@ def trace_to_file(trace_file_name):
         print('{0}'.format(e))
 
 def failsafe(config_file_name):
-    fail_msg = """
+    fail_msg = f"""
     !!!!!
     There were errors loading the configuration
-    Please examine the errors in
-    {0}
-    and correct
+    Please examine the errors in:
+    {TRACE_FILE}
     !!!!!
-    """.format(TRACE_FILE)
+    """
 
     print(fail_msg, file=sys.stderr)
+    write_file('/run/motd.d/9999-boot-config-error', fail_msg)
 
     users = [x[0] for x in pwd.getpwall()]
     if 'vyos' in users:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

As T7885 turns out to be a config load related bug the user will only be informed when entering conf mode that something is off.

```
vyos@vyos:~$ configure
WARNING: There was a config error on boot: saving the configuration now could overwrite data.
You may want to check and reload the boot config
```

More information is displayed on `tty0` of the router - but not everyone has access to `tty0`. This change is about copying the message displayed on `tty0` to the MOTD system.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7889

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->


```
Welcome to VyOS!

   ┌── ┐
   . VyOS 2025.09.27-0018-rolling
   └ ──┘  current

 * Documentation:  https://docs.vyos.io/en/latest
 * Project news:   https://blog.vyos.io
 * Bug reports:    https://vyos.dev

You can change this banner using "set system login banner post-login" command.

VyOS is a free software distribution that includes multiple components,
you can check individual component licenses under /usr/share/doc/*/copyright

---
WARNING: This VyOS system is not a stable long-term support version and
         is not intended for production use.



    !!!!!
    There were errors loading the configuration
    Please examine the errors in:
    /tmp/boot-config-trace
    !!!!!
    
Last login: Tue Sep 30 21:00:59 2025 from 2003:ec:707:b0a:7y::x
vyos@vyos:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
