### PR TITLE
vyos-dhcp: T7895: rename "DHCP Server" column to "Lease Time"

### DIFF
--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -576,7 +576,7 @@ def _get_formatted_client_leases(lease_data):
         if 'new_dhcp_server_identifier' in lease:
             data_entries.append(['DHCP Server', lease['new_dhcp_server_identifier']])
         if 'new_dhcp_lease_time' in lease:
-            data_entries.append(['DHCP Server', lease['new_dhcp_lease_time']])
+            data_entries.append(['Lease Time', lease['new_dhcp_lease_time']])
         if 'vrf' in lease:
             data_entries.append(['VRF', lease['vrf']])
         if 'last_update' in lease:


### PR DESCRIPTION
## Change summary
`show dhcp client leases interface {interface}` produces data with invalid name of column:
```
vyos@r14:~$ show dhcp client leases interface eth2 
Interface    eth2
IP address   192.168.122.145                [Active]
Subnet Mask  255.255.255.0
Domain Name
Router       192.168.122.1
Name Server  192.168.122.1
DHCP Server  192.168.122.1
DHCP Server  3600
VRF          default
Last Update  Wed Oct 01 15:35:05 EEST 2025
Expiry       Wed Oct 01 16:35:04 EEST 2025
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7895

## Related PR(s)
* https://github.com/vyos/vyos-1x/pull/4679

## How to test / Smoketest result
```
vyos@r14:~$ show conf com | match eth2
set interfaces ethernet eth2 address 'dhcp'
set interfaces ethernet eth2 hw-id '52:54:00:d9:5e:73'
vyos@r14:~$ 
vyos@r14:~$ show dhcp client leases interface eth2 
Interface    eth2
IP address   192.168.122.145                [Active]
Subnet Mask  255.255.255.0
Domain Name
Router       192.168.122.1
Name Server  192.168.122.1
DHCP Server  192.168.122.1
Lease Time   3600
VRF          default
Last Update  Wed Oct 01 15:35:05 EEST 2025
Expiry       Wed Oct 01 16:35:04 EEST 2025

vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
