### PR TITLE
pki: T7885: check_port_availability() can't be used during system boot

### DIFF
--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -67,6 +67,7 @@ import json
 from typing import Union
 
 import vyos.configtree
+from vyos.base import Warning
 from vyos.xml_ref import multi_to_list
 from vyos.xml_ref import from_source
 from vyos.xml_ref import ext_dict_merge
@@ -121,7 +122,7 @@ def config_dict_mangle_acme(name, cli_dict):
             # install ACME based PEM keys into "regular" CLI config keys
             cli_dict.update({'certificate' : cert_base64, 'private' : {'key' : key_base64}})
     except:
-        raise ConfigError(f'Unable to load ACME certificates for "{name}"!')
+        Warning(f'Unable to load ACME certificates for "{name}"!')
 
     return cli_dict
 

--- a/src/conf_mode/pki.py
+++ b/src/conf_mode/pki.py
@@ -265,11 +265,18 @@ def get_config(config=None):
                 continue
             if not dict_search('system.load_balancing.haproxy', pki):
                 continue
+            # Determine which service depends on ACME issued certificates
             used_by = []
+            # We start with HAProxy
             for cert_list, _ in dict_search_recursive(
                 pki['system']['load_balancing']['haproxy'], 'certificate'):
                 if name in cert_list:
                     used_by.append('haproxy')
+            # Check if OpenConnect consumes an ACME certificate
+            tmp = dict_search('system.vpn.openconnect.ssl.certificate', pki)
+            if tmp and tmp in cert_list:
+                used_by.append('openconnect')
+
             if used_by:
                 pki['certificate'][name]['acme'].update({'used_by': used_by})
 

--- a/src/conf_mode/pki.py
+++ b/src/conf_mode/pki.py
@@ -185,7 +185,7 @@ def get_config(config=None):
             pki.update({'changed':{}})
         pki['changed'].update({key.replace('-', '_') : tmp})
 
-    # We only merge on the defaults of there is a configuration at all
+    # We only merge on the defaults if there is a configuration at all
     if conf.exists(base):
         # We have gathered the dict representation of the CLI, but there are default
         # options which we need to update into the dictionary retrived.
@@ -369,7 +369,12 @@ def verify(pki):
                     listen_address = cert_conf['acme']['listen_address']
 
                 if 'used_by' not in cert_conf['acme']:
-                    if not check_port_availability(listen_address, 80):
+                    # A call to check_port_availability() will always fail during system
+                    # boot when listen_address is set and the address is not yet assigned
+                    # to an interface. This happens b/c PKI subsystem is called prior
+                    # to any inteface - e.g. ethernet - and thus the OS will always
+                    # be unable to bind() a socket() to a non existing IP address.
+                    if boot_configuration_complete() and not check_port_availability(listen_address, 80):
                         raise ConfigError('Port 80 is already in use and not available '\
                                           f'to provide ACME challenge for "{name}"!')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Multiple related fixes for system startup and ACME based certificates.

A call to `check_port_availability()` will always fail during system boot when listen_address is set and the address is not yet assigned to an interface. This happens b/c PKI subsystem is called prior to any interface - e.g. ethernet - and thus the OS will always be unable to `bind()` a `socket()` to a non existing IP address.

Assume someone deleted the certbot_config folder, `renew certbot force` alone will not work as there are no configuration files left to know what to renew. Re-run CLI PKI helper to initially request certificates via ACME again. This "should" (famous last words) never be the case - but sometimes the universe has a bad time.

If `/config/auth/letsencrypt` is missing, ACME certificate data can't be merged into the VyOS configuration, preventing interface (e.g., ethernet) setup during boot. This change ensures basic IP connectivity is established, allowing remote management instead of leaving the system entirely inaccessible. This is not what we will expect but if a user deletes `/config/auth/letsencrypt` - this is what will happen.



## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7885

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
vyos@vyos:~$ sudo rm -rf /config/auth/letsencrypt
vyos@vyos:~$ renew certbot force

WARNING: Directory "/config/auth/letsencrypt" missing. Reinitializing
PKI subsystem...


- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Processing /config/auth/letsencrypt/renewal/VYOS.conf
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Renewing an existing certificate for VYOS

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Congratulations, all renewals succeeded:
  /config/auth/letsencrypt/live/VYOS/fullchain.pem (success)
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Hook 'post-hook' ran with output:
 Updating certificates in /etc/ssl/certs...
 0 added, 0 removed; done.
 Running hooks in /etc/ca-certificates/update.d...
 done.
```

Also use this CLI config
```
set pki certificate vpn.xxx.net acme domain-name 'r1.vyos.net'
set pki certificate vpn.xxx.net acme email 'acme-test@vyos.net'
set pki certificate vpn.xxx.net acme listen-address '1.2.3.4'
set pki certificate vpn.xxx.net acme url 'https://acme-staging-v02.api.letsencrypt.org/directory'
```

Save the configuration and reboot the system - no config error must happen

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
