### PR TITLE
T7818: remove uneeded calls of get_cli_kernel_options causing regression

### DIFF
--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -1113,9 +1113,6 @@ def add_image(image_path: str, vrf: str = None, username: str = '',
 
                 # Now remove from current image
                 Path('/opt/vyatta/etc/config/first_boot').unlink()
-
-                cmdline_options = get_cli_kernel_options(
-                    f'/opt/vyatta/etc/config/config.boot')
             else:
                 print('Copying configuration directory')
                 # copytree preserves perms but not ownership:
@@ -1129,17 +1126,11 @@ def add_image(image_path: str, vrf: str = None, username: str = '',
                 # This can be used for a future automatic rollback into the old image.
                 tmp = {'previous_image' : image.get_running_image()}
                 write_file(f'{target_config_dir}/first_boot', dumps(tmp))
-
-                cmdline_options = get_cli_kernel_options(
-                    f'{target_config_dir}/config.boot')
         else:
             Path(target_config_dir).mkdir(parents=True)
             chown(target_config_dir, group='vyattacfg')
             chmod_2775(target_config_dir)
             Path(f'{target_config_dir}/.vyatta_config').touch()
-
-            cmdline_options = get_cli_kernel_options(
-                f'{target_config_dir}/config.boot')
 
         target_ssh_dir: str = f'{root_dir}/boot/{image_name}/rw/etc/ssh/'
         if no_prompt or copy_ssh_host_keys():


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The PR https://github.com/vyos/vyos-1x/pull/4669 reintroduced unconditional calls to `get_cli_kernel_options`, leading to a regression of the fix in T7818. Remove unneeded calls.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
