### PR TITLE
T7800: VPP: Bonding interface fails when change vpp configuration

### DIFF
--- a/python/vyos/vpp/interface/bond.py
+++ b/python/vyos/vpp/interface/bond.py
@@ -116,3 +116,7 @@ class BondInterface(Interface):
             a.kernel_delete()
         """
         self.vpp.lcp_pair_del(self.ifname, self.kernel_interface)
+
+    def lcp_pair_exists(self):
+        """Check if LCP pair exists"""
+        return bool(self.vpp.lcp_pair_find(self.kernel_interface))

--- a/src/conf_mode/vpp_interfaces_bonding.py
+++ b/src/conf_mode/vpp_interfaces_bonding.py
@@ -195,7 +195,7 @@ def apply(config):
         for member in members:
             i.detach_member(interface=member)
 
-        if 'kernel_interface' in config['effective']:
+        if 'kernel_interface' in config['effective'] and i.lcp_pair_exists():
             i.kernel_delete()
         # Delete bonding interface
         i.delete()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7800
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Before the fix:
```
set vpp settings interface eth1 driver dpdk
commit
set vpp interfaces bonding bond0 kernel-interface vpptun0
set vpp interfaces bonding bond0 member interface eth1
commit
set vpp settings unix poll-sleep-usec 222

vyos@vyos# commit
[ vpp ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 156, in run_script
    script.apply(c)
  File "/usr/libexec/vyos/conf_mode/vpp.py", line 724, in apply
    call_dependents()
  File "/usr/lib/python3/dist-packages/vyos/configdep.py", line 172, in call_dependents
    f()
  File "/usr/lib/python3/dist-packages/vyos/configdep.py", line 141, in func_impl
    run_conditionally(target, tag_value, config)
  File "/usr/lib/python3/dist-packages/vyos/configdep.py", line 132, in run_conditionally
    run_config_mode_script(target, config)
  File "/usr/lib/python3/dist-packages/vyos/configdep.py", line 111, in run_config_mode_script
    mod.apply(c)
  File "/usr/libexec/vyos/conf_mode/vpp_interfaces_bonding.py", line 199, in apply
    i.kernel_delete()
  File "/usr/lib/python3/dist-packages/vyos/vpp/interface/bond.py", line 118, in kernel_delete
    self.vpp.lcp_pair_del(self.ifname, self.kernel_interface)
  File "/usr/lib/python3/dist-packages/vyos/vpp/control_vpp.py", line 80, in check_retval_wrapper
    if not return_value.retval == 0:
           ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'retval'

[[vpp]] failed
Commit failed
Traceback (most recent call last):
  File "/usr/libexec/vyos/reset_section.py", line 116, in <module>
    session.commit()
  File "/usr/lib/python3/dist-packages/vyos/configsession.py", line 315, in commit
    out = self.__run_command([COMMIT])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/configsession.py", line 242, in __run_command
    raise ConfigSessionError(output)
vyos.configsession.ConfigSessionError: [ vpp ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 156, in run_script
    script.apply(c)
  File "/usr/libexec/vyos/conf_mode/vpp.py", line 600, in apply
    initialize_interface(
  File "/usr/libexec/vyos/conf_mode/vpp.py", line 534, in initialize_interface
    iface_new_name: str = control_host.get_eth_name(iface_config['dev_id'])
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/vpp/control_host.py", line 227, in get_eth_name
    raise FileNotFoundError(
FileNotFoundError: A device with ID 0000:00:05.0 not found in ethernet interfaces

delete [ vpp ] failed
Commit failed
```
After fix:
```
set vpp settings interface eth1 driver dpdk
set vpp interfaces bonding bond0 kernel-interface vpptun10
set vpp interfaces bonding bond0 member interface eth1
commit
set vpp settings unix poll-sleep-usec 222

vyos@vyos# commit
[edit]
vyos@vyos# 
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
