### PR TITLE
T7750: VPP: CGNAT commit failure with vpptunX interface

### DIFF
--- a/data/config-mode-dependencies/vyos-vpp.json
+++ b/data/config-mode-dependencies/vyos-vpp.json
@@ -65,6 +65,9 @@
         "vpp_nat": ["vpp_nat"],
         "vpp_nat_cgnat": ["vpp_nat_cgnat"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
+    },
+    "vpp_kernel_interfaces": {
+        "vpp_nat_cgnat": ["vpp_nat_cgnat"]
     }
 }
 

--- a/python/vyos/vpp/nat/det44.py
+++ b/python/vyos/vpp/nat/det44.py
@@ -44,10 +44,10 @@ class Det44:
             is_add=True,
         )
 
-    def delete_det44_interface_outside(self, interface_out):
+    def delete_det44_interface_outside(self, interface_out_index):
         """Delete DET44 outside interface"""
         self.vpp.api.det44_interface_add_del_feature(
-            sw_if_index=self.vpp.get_sw_if_index(interface_out),
+            sw_if_index=interface_out_index,
             is_inside=False,
             is_add=False,
         )
@@ -60,10 +60,10 @@ class Det44:
             is_add=True,
         )
 
-    def delete_det44_interface_inside(self, interface_in):
+    def delete_det44_interface_inside(self, interface_in_index):
         """Delete DET44 inside interface"""
         self.vpp.api.det44_interface_add_del_feature(
-            sw_if_index=self.vpp.get_sw_if_index(interface_in),
+            sw_if_index=interface_in_index,
             is_inside=True,
             is_add=False,
         )
@@ -104,3 +104,17 @@ class Det44:
             tcp_established=tcp_established,
             tcp_transitory=tcp_transitory,
         )
+
+    def get_det44_interfaces_outside(self):
+        ifaces_outside = []
+        for iface in self.vpp.api.det44_interface_dump():
+            if iface.is_outside:
+                ifaces_outside.append(iface.sw_if_index)
+        return ifaces_outside
+
+    def get_det44_interfaces_inside(self):
+        ifaces_inside = []
+        for iface in self.vpp.api.det44_interface_dump():
+            if iface.is_inside:
+                ifaces_inside.append(iface.sw_if_index)
+        return ifaces_inside

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -373,6 +373,11 @@ def get_config(config=None):
             eth_ifaces_persist[iface]['bus_id'] = control_host.get_bus_name(iface)
             eth_ifaces_persist[iface]['dev_id'] = control_host.get_dev_id(iface)
 
+    # kernel-interfaces dependency
+    if effective_config.get('kernel_interfaces'):
+        for iface in config.get('kernel_interfaces', {}):
+            set_dependents('vpp_kernel_interface', conf, iface)
+
     # NAT dependency
     if conf.exists(['vpp', 'nat44']):
         set_dependents('vpp_nat', conf)

--- a/src/conf_mode/vpp_kernel-interfaces.py
+++ b/src/conf_mode/vpp_kernel-interfaces.py
@@ -19,6 +19,7 @@
 import os
 
 from vyos.config import Config
+from vyos.configdep import set_dependents, call_dependents
 from vyos.configdict import leaf_node_changed
 from vyos.configdict import node_changed
 from vyos import ConfigError
@@ -78,6 +79,9 @@ def get_config(config=None) -> dict:
     vlans_removed = node_changed(conf, base + [ifname, 'vif'])
     if vlans_removed:
         config['vlans_removed'] = vlans_removed
+
+    if conf.exists(['vpp', 'nat', 'cgnat']):
+        set_dependents('vpp_nat_cgnat', conf)
 
     config['ifname'] = ifname
 
@@ -184,6 +188,8 @@ def apply(config):
         vpp_control = VPPControl()
         lcp_name = vpp_control.lcp_pair_find(kernel_name=ifname).get('vpp_name_kernel')
         vpp_control.iface_rxmode(lcp_name, rx_mode)
+
+    call_dependents()
 
     return None
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Allow using bond interfaces in CGNAT. Improve interface cleanup to rely
on VPP API queries, as VPP config changes may modify interface indexes

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7750
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
We should use VPP interface for CGNAT (not kernel vpptunX)
```
set vpp settings interface eth0 driver dpdk
set vpp settings interface eth1 driver dpdk

set vpp interfaces bonding bond0 kernel-interface vpptun10
set vpp interfaces bonding bond0 member interface eth0
set vpp interfaces bonding bond0 member interface eth1
set vpp interfaces bonding bond0 mode 802.3ad

set vpp kernel-interfaces vpptun10 vif 144 address 172.29.49.2/30
set vpp kernel-interfaces vpptun10 vif 145 address 206.0.9.22/30

set vpp nat cgnat interface inside bond0.144
set vpp nat cgnat interface outside  bond0.145
set vpp nat cgnat rule 10 inside-prefix 100.99.0.0/24
set vpp nat cgnat rule 10 outside-prefix 206.0.15.248/29
```
Before the fix:
```
vyos@vyos# commit
[ vpp nat cgnat ]
bond0.144 must be a VPP interface for inside CGNAT interface
[[vpp nat cgnat]] failed
Commit failed
[edit]
```
With the fix:
```
vyos@vyos# commit
[edit]
vyos@vyos# sudo vppctl show det44 interfaces
DET44 interfaces:
 BondEthernet0.144 in
 BondEthernet0.145 out
[edit]
```

```
vyos@vyos#    /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... skipped 'Skipping temporary bonding, sometimes get recursion'
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... ok
test_14_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_14_vpp_ipsec_xfrm_nl) ... ok
test_15_1_vpp_cgnat (__main__.TestVPP.test_15_1_vpp_cgnat) ... ok
test_15_2_vpp_cgnat_bond_with_vifs (__main__.TestVPP.test_15_2_vpp_cgnat_bond_with_vifs) ... ok
test_16_vpp_nat (__main__.TestVPP.test_16_vpp_nat) ... ok
test_17_vpp_sflow (__main__.TestVPP.test_17_vpp_sflow) ... ok
test_18_resource_limits (__main__.TestVPP.test_18_resource_limits) ... ok
test_19_vpp_pppoe_mapping (__main__.TestVPP.test_19_vpp_pppoe_mapping) ... ok

----------------------------------------------------------------------
Ran 22 tests in 664.105s

OK (skipped=2)
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
