### PR TITLE
T5942: Make failover support dhcp-interface

### DIFF
--- a/interface-definitions/include/dhcp-interface-multi.xml.i
+++ b/interface-definitions/include/dhcp-interface-multi.xml.i
@@ -1,18 +1,8 @@
 <!-- include start from dhcp-interface-multi.xml.i -->
-<leafNode name="dhcp-interface">
-  <properties>
-    <help>DHCP interface supplying next-hop IP address</help>
-    <completionHelp>
-      <script>${vyos_completion_dir}/list_interfaces</script>
-    </completionHelp>
-    <valueHelp>
-      <format>txt</format>
-      <description>DHCP interface name</description>
-    </valueHelp>
-    <constraint>
-      #include <include/constraint/interface-name.xml.i>
-    </constraint>
-    <multi/>
-  </properties>
+    <leafNode name="dhcp-interface">
+      <properties>
+        #include <include/dhcp-interface-properties.xml.i>
+        <multi/>
+      </properties>
 </leafNode>
 <!-- include end -->

--- a/interface-definitions/include/dhcp-interface-properties.xml.i
+++ b/interface-definitions/include/dhcp-interface-properties.xml.i
@@ -1,0 +1,13 @@
+<!-- include end -->
+        <help>DHCP interface supplying next-hop IP address</help>
+        <completionHelp>
+          <script>${vyos_completion_dir}/list_interfaces</script>
+        </completionHelp>
+        <valueHelp>
+          <format>txt</format>
+          <description>DHCP interface name</description>
+        </valueHelp>
+        <constraint>
+          #include <include/constraint/interface-name.xml.i>
+        </constraint>
+<!-- include end -->

--- a/interface-definitions/include/dhcp-interface.xml.i
+++ b/interface-definitions/include/dhcp-interface.xml.i
@@ -1,15 +1,7 @@
+<!-- include start from dhcp-interface.xml.i -->
     <leafNode name="dhcp-interface">
       <properties>
-        <help>DHCP interface supplying next-hop IP address</help>
-        <completionHelp>
-          <script>${vyos_completion_dir}/list_interfaces</script>
-        </completionHelp>
-        <valueHelp>
-          <format>txt</format>
-          <description>DHCP interface name</description>
-        </valueHelp>
-        <constraint>
-          #include <include/constraint/interface-name.xml.i>
-        </constraint>
+        #include <include/dhcp-interface-properties.xml.i>
       </properties>
     </leafNode>
+<!-- include end -->

--- a/interface-definitions/include/failover/common-failover.xml.i
+++ b/interface-definitions/include/failover/common-failover.xml.i
@@ -1,0 +1,105 @@
+<!-- include start from include/failover/common-failover.xml.i -->
+<children>
+  <node name="check">
+    <properties>
+      <help>Check target options</help>
+    </properties>
+    <children>
+      <leafNode name="policy">
+        <properties>
+          <help>Policy for check targets</help>
+          <completionHelp>
+            <list>any-available all-available</list>
+          </completionHelp>
+          <valueHelp>
+            <format>all-available</format>
+            <description>All targets must be alive</description>
+          </valueHelp>
+          <valueHelp>
+            <format>any-available</format>
+            <description>Any target must be alive</description>
+          </valueHelp>
+          <constraint>
+            <regex>(all-available|any-available)</regex>
+          </constraint>
+        </properties>
+        <defaultValue>any-available</defaultValue>
+      </leafNode>
+      #include <include/port-number.xml.i>
+      <tagNode name="target">
+        <properties>
+          <help>Check target address</help>
+          <valueHelp>
+            <format>ipv4</format>
+            <description>Address to check</description>
+          </valueHelp>
+          <constraint>
+            <validator name="ipv4-address"/>
+          </constraint>
+        </properties>
+        <children>
+          #include <include/interface/vrf.xml.i>
+          #include <include/generic-interface.xml.i>
+        </children>
+      </tagNode>
+      <leafNode name="timeout">
+        <properties>
+          <help>Timeout between checks</help>
+          <valueHelp>
+            <format>u32:1-300</format>
+            <description>Timeout in seconds between checks</description>
+          </valueHelp>
+          <constraint>
+            <validator name="numeric" argument="--range 1-255"/>
+          </constraint>
+        </properties>
+        <defaultValue>10</defaultValue>
+      </leafNode>
+      <leafNode name="type">
+        <properties>
+          <help>Check type</help>
+          <completionHelp>
+            <list>arp icmp tcp</list>
+          </completionHelp>
+          <valueHelp>
+            <format>arp</format>
+            <description>Check target by ARP</description>
+          </valueHelp>
+          <valueHelp>
+            <format>icmp</format>
+            <description>Check target by ICMP</description>
+          </valueHelp>
+          <valueHelp>
+            <format>tcp</format>
+            <description>Check target by TCP</description>
+          </valueHelp>
+          <constraint>
+            <regex>(arp|icmp|tcp)</regex>
+          </constraint>
+        </properties>
+        <defaultValue>icmp</defaultValue>
+      </leafNode>
+    </children>
+  </node>
+  #include <include/generic-interface.xml.i>
+  <leafNode name="metric">
+    <properties>
+      <help>Route metric for this gateway</help>
+      <valueHelp>
+        <format>u32:1-255</format>
+        <description>Route metric</description>
+      </valueHelp>
+      <constraint>
+        <validator name="numeric" argument="--range 1-255"/>
+      </constraint>
+    </properties>
+    <defaultValue>1</defaultValue>
+  </leafNode>
+  <leafNode name="onlink">
+    <properties>
+      <help>The next hop is directly connected to the interface, even if it does not match interface prefix</help>
+      <valueless/>
+    </properties>
+  </leafNode>
+</children>
+<!-- include end -->

--- a/interface-definitions/include/failover/protocol-common-config.xml.i
+++ b/interface-definitions/include/failover/protocol-common-config.xml.i
@@ -22,109 +22,13 @@
           <validator name="ipv4-address"/>
         </constraint>
       </properties>
-      <children>
-        <node name="check">
-          <properties>
-            <help>Check target options</help>
-          </properties>
-          <children>
-            <leafNode name="policy">
-              <properties>
-                <help>Policy for check targets</help>
-                <completionHelp>
-                  <list>any-available all-available</list>
-                </completionHelp>
-                <valueHelp>
-                  <format>all-available</format>
-                  <description>All targets must be alive</description>
-                </valueHelp>
-                <valueHelp>
-                  <format>any-available</format>
-                  <description>Any target must be alive</description>
-                </valueHelp>
-                <constraint>
-                  <regex>(all-available|any-available)</regex>
-                </constraint>
-              </properties>
-              <defaultValue>any-available</defaultValue>
-            </leafNode>
-            #include <include/port-number.xml.i>
-            <tagNode name="target">
-              <properties>
-                <help>Check target address</help>
-                <valueHelp>
-                  <format>ipv4</format>
-                  <description>Address to check</description>
-                </valueHelp>
-                <constraint>
-                  <validator name="ipv4-address"/>
-                </constraint>
-              </properties>
-              <children>
-                #include <include/interface/vrf.xml.i>
-                #include <include/generic-interface.xml.i>
-              </children>
-            </tagNode>
-            <leafNode name="timeout">
-              <properties>
-                <help>Timeout between checks</help>
-                <valueHelp>
-                  <format>u32:1-300</format>
-                  <description>Timeout in seconds between checks</description>
-                </valueHelp>
-                <constraint>
-                  <validator name="numeric" argument="--range 1-255"/>
-                </constraint>
-              </properties>
-              <defaultValue>10</defaultValue>
-            </leafNode>
-            <leafNode name="type">
-              <properties>
-                <help>Check type</help>
-                <completionHelp>
-                  <list>arp icmp tcp</list>
-                </completionHelp>
-                <valueHelp>
-                  <format>arp</format>
-                  <description>Check target by ARP</description>
-                </valueHelp>
-                <valueHelp>
-                  <format>icmp</format>
-                  <description>Check target by ICMP</description>
-                </valueHelp>
-                <valueHelp>
-                  <format>tcp</format>
-                  <description>Check target by TCP</description>
-                </valueHelp>
-                <constraint>
-                  <regex>(arp|icmp|tcp)</regex>
-                </constraint>
-              </properties>
-              <defaultValue>icmp</defaultValue>
-            </leafNode>
-          </children>
-        </node>
-        #include <include/generic-interface.xml.i>
-        <leafNode name="metric">
-          <properties>
-            <help>Route metric for this gateway</help>
-            <valueHelp>
-              <format>u32:1-255</format>
-              <description>Route metric</description>
-            </valueHelp>
-            <constraint>
-              <validator name="numeric" argument="--range 1-255"/>
-            </constraint>
-          </properties>
-          <defaultValue>1</defaultValue>
-        </leafNode>
-        <leafNode name="onlink">
-          <properties>
-            <help>The next hop is directly connected to the interface, even if it does not match interface prefix</help>
-            <valueless/>
-          </properties>
-        </leafNode>
-      </children>
+      #include <include/failover/common-failover.xml.i>
+    </tagNode>
+    <tagNode name="dhcp-interface">
+      <properties>
+        #include <include/dhcp-interface-properties.xml.i>
+      </properties>
+      #include <include/failover/common-failover.xml.i>
     </tagNode>
   </children>
 </tagNode>

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -422,21 +422,25 @@ def is_file(filename):
 
 @register_filter('get_dhcp_router')
 def get_dhcp_router(interface):
-    """ Static routes can point to a router received by a DHCP reply. This
+    """Static routes can point to a router received by a DHCP reply. This
     helper is used to get the current default router from the DHCP reply.
 
-    Returns False of no router is found, returns the IP address as string if
+    Returns None if no router is found, returns the IP address as string if
     a router is found.
     """
-    lease_file = directories['isc_dhclient_dir'] + f'/dhclient_{interface}.leases'
+    lease_file = directories['isc_dhclient_dir'] + f'/dhclient_{interface}.lease'
     if not os.path.exists(lease_file):
         return None
 
     from vyos.utils.file import read_file
     for line in read_file(lease_file).splitlines():
-        if 'option routers' in line:
-            (_, _, address) = line.split()
-            return address.rstrip(';')
+        if 'new_routers' in line:
+            (_, address, _) = line.split("'")
+            if not address:
+                return None
+            # Take first one if there are several
+            address = address.split()[0]
+            return address
 
 @register_filter('natural_sort')
 def natural_sort(iterable):


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Make failover support dhcp-interface

* Refactor XML a little: move common dhcp-interface properties to separate include file
* Add failover support for dhcp-interface
* Add test for DHCP in failover protocol
* Change vyos.template.get_dhcp_router to use '*.lease' file instead of '.leases' file - in 'leases' there can be several last leases and current one may not be the first one in file

Command sample:

```
    set protocols failover route 203.0.113.0/24 dhcp-interface eth1 interface eth1
    set protocols failover route 203.0.113.0/24 dhcp-interface eth1 metric 30
    set protocols failover route 203.0.113.0/24 dhcp-interface eth1 check target 10.25.0.47
    set protocols failover route 203.0.113.0/24 dhcp-interface eth1 check timeout 1
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T5942

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

I've added test case:

```
$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_failover.py
test_01_basic (__main__.TestProtocolsFailover.test_01_basic) ... ok
test_02_vrf (__main__.TestProtocolsFailover.test_02_vrf) ... ok
test_03_config (__main__.TestProtocolsFailover.test_03_config) ... ok
test_04_dhcp (__main__.TestProtocolsFailover.test_04_dhcp) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation (https://docs.vyos.io/en/latest/configuration/protocols/failover.html)
- [ ] I have updated the documentation accordingly