### PR TITLE
dhcp-server: T7723: add DHCP Option 26 (interface MTU)

### DIFF
--- a/interface-definitions/include/dhcp/option-v4.xml.i
+++ b/interface-definitions/include/dhcp/option-v4.xml.i
@@ -83,6 +83,18 @@
         </constraint>
       </properties>
     </leafNode>
+    <leafNode name="interface-mtu">
+      <properties>
+        <help>Interface MTU</help>
+        <valueHelp>
+          <format>u16:576-9000</format>
+          <description>Client interface MTU</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 576-9000"/>
+        </constraint>
+      </properties>
+    </leafNode>
     <leafNode name="ip-forwarding">
       <properties>
         <help>Enable IP forwarding on client</help>

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -45,6 +45,7 @@ kea4_options = {
     'ipv6_only_preferred': 'v6-only-preferred',
     'captive_portal': 'v4-captive-portal',
     'capwap_controller': 'capwap-ac-v4',
+    'interface_mtu': 'interface-mtu',
 }
 
 kea6_options = {

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -224,6 +224,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         server_identifier = bootfile_server
         ipv6_only_preferred = '300'
         capwap_access_controller = '192.168.2.125'
+        interface_mtu = '1420'
 
         pool = base_path + ['shared-network-name', shared_net_name, 'subnet', subnet]
         self.cli_set(pool + ['subnet-id', '1'])
@@ -232,6 +233,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.cli_set(pool + ['option', 'name-server', dns_1])
         self.cli_set(pool + ['option', 'name-server', dns_2])
         self.cli_set(pool + ['option', 'domain-name', domain_name])
+        self.cli_set(pool + ['option', 'interface-mtu', interface_mtu])
         self.cli_set(pool + ['option', 'ip-forwarding'])
         self.cli_set(pool + ['option', 'smtp-server', smtp_server])
         self.cli_set(pool + ['option', 'pop-server', smtp_server])
@@ -363,6 +365,11 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
             obj,
             ['Dhcp4', 'shared-networks', 0, 'subnet4', 0, 'option-data'],
             {'name': 'ip-forwarding', 'data': 'true'},
+        )
+        self.verify_config_object(
+            obj,
+            ['Dhcp4', 'shared-networks', 0, 'subnet4', 0, 'option-data'],
+            {'name': 'interface-mtu', 'data': interface_mtu},
         )
 
         # Time zone


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary

Support DHCP v4 option 26 - interface MTU

- Add interface-mtu to option-v4.xml.i
- Add interface_mtu -> interface-mtu translation in python/vyos/kea.py
- Add to smoke tests

Note, I have not actually run the smoke tests yet, I need to set up an environment to test in

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

- https://vyos.dev/T7723

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

None

## How to test / Smoketest result

Enhancements were made to the existing `test_service_dhcp-server.py` script. I have not tested yet as I don't have an environment set up


## Checklist:

<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
