### PR TITLE
T7117: VPP remove skipping for the bonding smoketest

### DIFF
--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -613,7 +613,6 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(base_path + ['interfaces', 'loopback', interface_loopback])
         self.cli_commit()
 
-    @unittest.skip('Skipping temporary bonding, sometimes get recursion T7117')
     def test_06_vpp_bonding(self):
         interface_bond = 'bond23'
         interface_kernel = 'vpptun23'


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Recursion error was fixed, enable the bonding test for VPP
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Enable bonding smoketest for VPP

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
vyos@r14:~$ seq 5 | xargs -I{} -n1 -P1 sh -c '/usr/libexec/vyos/tests/smoke/cli/test_vpp.py -k test_06_vpp_bonding'
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... ok

----------------------------------------------------------------------
Ran 1 test in 23.406s

OK
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... ok

----------------------------------------------------------------------
Ran 1 test in 23.669s

OK
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... ok

----------------------------------------------------------------------
Ran 1 test in 23.550s

OK
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... ok

----------------------------------------------------------------------
Ran 1 test in 23.655s

OK
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... ok

----------------------------------------------------------------------
Ran 1 test in 23.809s

OK
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
