### PR TITLE
T7890: VPP fix verify_dev_driver

### DIFF
--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -604,7 +604,7 @@ def initialize_interface(iface, driver, iface_config) -> None:
     try:
         if control_host.get_eth_driver(f'defunct_{iface}') == 'mlx5_core':
             control_host.rename_iface(f'defunct_{iface}', iface)
-    except FileNotFoundError:
+    except Exception:
         pass
 
     # Replace a driver with original for VMBus interfaces and rename it


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
The verify_dev_driver must return a bool value, but if a device does not have a PCI address (for example veth interface) it returns a Traceback

Fix this
```
>>> from vyos.vpp.config_verify import verify_dev_driver
>>> 
>>> verify_dev_driver('eth110', 'veth')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/vyos/vpp/config_verify.py", line 169, in verify_dev_driver
    driver: str = get_eth_driver(iface_name)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/vpp/control_host.py", line 273, in get_eth_driver
    raise FileNotFoundError(f'PCI device {iface} not found in ethernet interfaces')
FileNotFoundError: PCI device eth110 not found in ethernet interfaces
>>> 

vyos@r14# sudo ethtool -i eth110
driver: veth
version: 1.0
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7890

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Before fix
```
>>> from vyos.vpp.config_verify import verify_dev_driver
>>> 
>>> verify_dev_driver('eth110', 'veth')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/vyos/vpp/config_verify.py", line 169, in verify_dev_driver
    driver: str = get_eth_driver(iface_name)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/vpp/control_host.py", line 273, in get_eth_driver
    raise FileNotFoundError(f'PCI device {iface} not found in ethernet interfaces')
FileNotFoundError: PCI device eth110 not found in ethernet interfaces
>>> 

vyos@r14# sudo ethtool -i eth110
driver: veth
version: 1.0
```
After fix:
```
>>> verify_dev_driver('eth110', 'dpdk')
False
>>> 
>>> verify_dev_driver('eth110', 'xdp')
False
>>> 
>>> verify_dev_driver('eth110', 'foo')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/vyos/vpp/config_verify.py", line 178, in verify_dev_driver
    raise ConfigError(f'"Driver type {driver_type} is wrong')
vyos.base.ConfigError: "Driver type foo is wrong
>>> 

```
Before fix:
```
vyos@r14# set vpp settings interface eth110 driver xdp 
[edit]
vyos@r14# commit
[ vpp ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 145, in run_script
    script.verify(c)
  File "/usr/libexec/vyos/conf_mode/vpp.py", line 483, in verify
    if not verify_dev_driver(iface, iface_config['driver']):
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/vpp/config_verify.py", line 169, in verify_dev_driver
    driver: str = get_eth_driver(iface_name)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/vpp/control_host.py", line 273, in get_eth_driver
    raise FileNotFoundError(f'PCI device {iface} not found in ethernet interfaces')
FileNotFoundError: PCI device eth110 not found in ethernet interfaces

[[vpp]] failed
Commit failed
[edit]
vyos@r14#
```
After the fix:
```
vyos@r14# compare 
+ vpp {
+     settings {
+         interface eth110 {
+             driver "dpdk"
+         }
+         unix {
+             poll-sleep-usec "500"
+         }
+     }
+ }

[edit]
vyos@r14# commit
[ vpp ]
Driver dpdk is not compatible with interface eth110!
[[vpp]] failed
Commit failed
[edit]
vyos@r14# 
[edit]
vyos@r14# sudo ethtool -i eth110
driver: veth
version: 1.0

```

Smoketests:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... skipped 'Skipping temporary bonding, sometimes get recursion T7117'
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... ok
test_14_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_14_vpp_ipsec_xfrm_nl) ... ok
test_15_vpp_cgnat (__main__.TestVPP.test_15_vpp_cgnat) ... ok
test_16_vpp_nat (__main__.TestVPP.test_16_vpp_nat) ... ok
test_17_vpp_sflow (__main__.TestVPP.test_17_vpp_sflow) ... ok
test_18_resource_limits (__main__.TestVPP.test_18_resource_limits) ... ok
test_19_vpp_pppoe_mapping (__main__.TestVPP.test_19_vpp_pppoe_mapping) ... ok

----------------------------------------------------------------------
Ran 21 tests in 324.127s

OK (skipped=2)
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
