### PR TITLE
frr: T7664: multiple fixes for upcoming 10.4 package upgrade

### DIFF
--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -720,9 +720,11 @@ class FRRender:
         debug('FRR:        START CONFIGURATION RENDERING')
         # we can not reload an empty file, thus we always embed the marker
         output = '!\n'
+
         # Enable FRR logging
         output += 'log syslog\n'
-        output += 'log facility local7\n'
+        output += 'log facility daemon\n'
+
         # Enable SNMP agentx support
         # SNMP AgentX support cannot be disabled once enabled
         if 'snmp' in config_dict:

--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -724,6 +724,7 @@ class FRRender:
         # Enable FRR logging
         output += 'log syslog\n'
         output += 'log facility daemon\n'
+        output += 'log timestamp precision 3\n'
 
         # Enable SNMP agentx support
         # SNMP AgentX support cannot be disabled once enabled

--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -722,9 +722,13 @@ class FRRender:
         output = '!\n'
 
         # Enable FRR logging
-        output += 'log syslog\n'
         output += 'log facility daemon\n'
         output += 'log timestamp precision 3\n'
+        # Exdtend logging depending on operating mode
+        if os.path.exists(frr_debug_enable):
+            output += 'log syslog informational\n'
+        else:
+            output += 'log syslog notifications\n'
 
         # Enable SNMP agentx support
         # SNMP AgentX support cannot be disabled once enabled

--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -255,6 +255,8 @@ def get_frrender_dict(conf, argv=None) -> dict:
                                    no_tag_node_value_mangle=True,
                                    with_recursive_defaults=True)
         dict.update({'bfd' : bfd})
+    elif conf.exists_effective(bfd_cli_path):
+        dict.update({'bfd' : {'deleted' : ''}})
 
     # We need to check the CLI if the BGP node is present and thus load in all the default
     # values present on the CLI - that's why we have if conf.exists()

--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -243,6 +243,8 @@ def get_frrender_dict(conf, argv=None) -> dict:
                                      get_first_key=True,
                                      with_recursive_defaults=True)
         dict.update({'babel' : babel})
+    elif conf.exists_effective(babel_cli_path):
+        dict.update({'babel' : {'deleted' : ''}})
 
     # We need to check the CLI if the BFD node is present and thus load in all the default
     # values present on the CLI - that's why we have if conf.exists()

--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -724,11 +724,13 @@ class FRRender:
         # Enable FRR logging
         output += 'log facility daemon\n'
         output += 'log timestamp precision 3\n'
-        # Exdtend logging depending on operating mode
+        # Extend logging depending on operating mode
         if os.path.exists(frr_debug_enable):
             output += 'log syslog informational\n'
+            output += 'log unique-id\n'
         else:
             output += 'log syslog notifications\n'
+            output += 'no log unique-id\n'
 
         # Enable SNMP agentx support
         # SNMP AgentX support cannot be disabled once enabled


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

When deleting the daemon configuration, use the deleted dict element to properly inform FRR config render of absence of the configuration items. Nothing needs to be rendered.

Add `log timestamp precision 3` global configuration option

Log entries should be send to `daemon` syslog facility, rather then to `local7`


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7664

## How to test / Smoketest result

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_babel.py 
test_01_basic (__main__.TestProtocolsBABEL.test_01_basic) ... ok
test_02_redistribute (__main__.TestProtocolsBABEL.test_02_redistribute) ... ok
test_03_distribute_list (__main__.TestProtocolsBABEL.test_03_distribute_list) ... ok
test_04_interfaces (__main__.TestProtocolsBABEL.test_04_interfaces) ... ok

----------------------------------------------------------------------
Ran 4 tests in 45.592s

OK
```

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bfd.py 
test_bfd_peer (__main__.TestProtocolsBFD.test_bfd_peer) ... ok
test_bfd_profile (__main__.TestProtocolsBFD.test_bfd_profile) ... ok

----------------------------------------------------------------------
Ran 2 tests in 24.344s

OK
```

```
OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py 
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ... ok
test_bgp_02_neighbors (__main__.TestProtocolsBGP.test_bgp_02_neighbors) ... ok
test_bgp_03_peer_groups (__main__.TestProtocolsBGP.test_bgp_03_peer_groups) ... ok
test_bgp_04_afi_ipv4 (__main__.TestProtocolsBGP.test_bgp_04_afi_ipv4) ... ok
test_bgp_05_afi_ipv6 (__main__.TestProtocolsBGP.test_bgp_05_afi_ipv6) ... ok
test_bgp_06_listen_range (__main__.TestProtocolsBGP.test_bgp_06_listen_range) ... ok
test_bgp_07_l2vpn_evpn (__main__.TestProtocolsBGP.test_bgp_07_l2vpn_evpn) ... ok
test_bgp_09_distance_and_flowspec (__main__.TestProtocolsBGP.test_bgp_09_distance_and_flowspec) ... ok
test_bgp_10_vrf_simple (__main__.TestProtocolsBGP.test_bgp_10_vrf_simple) ... ok
test_bgp_11_confederation (__main__.TestProtocolsBGP.test_bgp_11_confederation) ... ok
test_bgp_12_v6_link_local (__main__.TestProtocolsBGP.test_bgp_12_v6_link_local) ... ok
test_bgp_13_vpn (__main__.TestProtocolsBGP.test_bgp_13_vpn) ... ok
test_bgp_14_remote_as_peer_group_override (__main__.TestProtocolsBGP.test_bgp_14_remote_as_peer_group_override) ... ok
test_bgp_15_local_as_ebgp (__main__.TestProtocolsBGP.test_bgp_15_local_as_ebgp) ... ok
test_bgp_16_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_16_import_rd_rt_compatibility) ... ok
test_bgp_17_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_17_import_rd_rt_compatibility) ... ok
test_bgp_18_deleting_import_vrf (__main__.TestProtocolsBGP.test_bgp_18_deleting_import_vrf) ... ok
test_bgp_19_deleting_default_vrf (__main__.TestProtocolsBGP.test_bgp_19_deleting_default_vrf) ... ok
test_bgp_20_import_rd_rt_compatibility (__main__.TestProtocolsBGP.test_bgp_20_import_rd_rt_compatibility) ... ok
test_bgp_21_import_unspecified_vrf (__main__.TestProtocolsBGP.test_bgp_21_import_unspecified_vrf) ... ok
test_bgp_22_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_22_interface_mpls_forwarding) ... ok
test_bgp_23_vrf_interface_mpls_forwarding (__main__.TestProtocolsBGP.test_bgp_23_vrf_interface_mpls_forwarding) ... ok
test_bgp_24_srv6_sid (__main__.TestProtocolsBGP.test_bgp_24_srv6_sid) ... ok
test_bgp_25_ipv4_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_25_ipv4_labeled_unicast_peer_group) ... ok
test_bgp_26_ipv6_labeled_unicast_peer_group (__main__.TestProtocolsBGP.test_bgp_26_ipv6_labeled_unicast_peer_group) ... ok
test_bgp_27_route_reflector_client (__main__.TestProtocolsBGP.test_bgp_27_route_reflector_client) ... ok
test_bgp_28_peer_group_member_all_internal_or_external (__main__.TestProtocolsBGP.test_bgp_28_peer_group_member_all_internal_or_external) ... ok
test_bgp_29_peer_group_remote_as_equal_local_as (__main__.TestProtocolsBGP.test_bgp_29_peer_group_remote_as_equal_local_as) ... ok
test_bgp_30_import_vrf_routemap (__main__.TestProtocolsBGP.test_bgp_30_import_vrf_routemap) ... ok
test_bgp_99_bmp (__main__.TestProtocolsBGP.test_bgp_99_bmp) ... ok

----------------------------------------------------------------------
Ran 30 tests in 456.902s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
