### PR TITLE
dhcp6: T7882: Restart dhcp6c if PD is defined

### DIFF
--- a/src/etc/netplug/vyos-netplug-dhcp-client
+++ b/src/etc/netplug/vyos-netplug-dhcp-client
@@ -56,6 +56,8 @@ if in_out == 'out':
     if is_systemd_service_active(systemdV6_service):
         cmd(f'systemctl stop {systemdV6_service}')
 elif in_out == 'in':
+    v6_restart = False
+
     if config.exists_effective(interface_path + ['address']):
         tmp = config.return_effective_values(interface_path + ['address'])
         # Always (re-)start the DHCP(v6) client service. If the DHCP(v6) client
@@ -68,4 +70,10 @@ elif in_out == 'in':
         if 'dhcp' in tmp:
             cmd(f'systemctl restart {systemdV4_service}')
         if 'dhcpv6' in tmp:
-            cmd(f'systemctl restart {systemdV6_service}')
+            v6_restart = True
+
+    if config.exists_effective(interface_path + ['dhcpv6-options', 'pd']):
+        v6_restart = True
+
+    if v6_restart:
+        cmd(f'systemctl restart {systemdV6_service}')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Restart dhcp6c client if PD is defined on interface

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7882

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Confirmed on link flap that `dhcp6c` process is started

```
vyos@vyos# ps aux | grep dhcp
vyos        3118  0.0  0.1   6340  2132 ttyS0    S+   13:31   0:00 grep dhcp
[edit]
vyos@vyos# ps aux | grep dhcp
root        3141  0.0  0.0   2620  1340 ?        Ss   13:31   0:00 /usr/sbin/dhcp6c -D -k /run/dhcp6c/dhcp6c.eth0.sock -c /run/dhcp6c/dhcp6c.eth0.conf -p /run/dhcp6c/dhcp6c.eth0.pid eth0
vyos        3164  0.0  0.1   6340  2152 ttyS0    S+   13:31   0:00 grep dhcp
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
