### PR TITLE
T7930: VPP: Changing NAT44 settings resets `forwarding_enabled` to False

### DIFF
--- a/python/vyos/vpp/control_vpp.py
+++ b/python/vyos/vpp/control_vpp.py
@@ -440,15 +440,6 @@ class VPPControl:
         return None
 
     @_Decorators.api_call
-    def enable_disable_nat44_forwarding(self, enable: bool) -> None:
-        """Enable/disable NAT44 forwarding
-
-        Args:
-            enable (bool): True if enable, False if disable
-        """
-        self.__vpp_api_client.api.nat44_forwarding_enable_disable(enable=enable)
-
-    @_Decorators.api_call
     def set_nat44_session_limit(self, session_limit: int) -> None:
         """Set NAT44 session limit
 

--- a/python/vyos/vpp/nat/nat44.py
+++ b/python/vyos/vpp/nat/nat44.py
@@ -224,6 +224,10 @@ class Nat44:
             tcp_transitory=tcp_transitory,
         )
 
+    def enable_disable_nat44_forwarding(self, enable):
+        """Enable/disable NAT44 forwarding"""
+        self.vpp.api.nat44_forwarding_enable_disable(enable=enable)
+
     def enable_ipfix(self):
         """Enable NAT44 IPFIX logging"""
         self.vpp.api.nat44_ei_ipfix_enable_disable(enable=True)

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -749,11 +749,6 @@ def apply(config):
             # NAT44 settings
             nat44_settings = config['settings'].get('nat44', {})
 
-            enable_forwarding = True
-            if 'no_forwarding' in nat44_settings:
-                enable_forwarding = False
-            vpp_control.enable_disable_nat44_forwarding(enable_forwarding)
-
             vpp_control.set_nat44_session_limit(
                 int(nat44_settings.get('session_limit'))
             )

--- a/src/conf_mode/vpp_nat.py
+++ b/src/conf_mode/vpp_nat.py
@@ -108,13 +108,12 @@ def get_config(config=None) -> dict:
         }
     )
 
-    if conf.exists(['vpp', 'settings', 'nat44', 'timeout']):
-        timeouts = conf.get_config_dict(
-            ['vpp', 'settings', 'nat44', 'timeout'],
-            key_mangling=('-', '_'),
-            with_defaults=True,
-        )
-        config.update(timeouts)
+    settings = conf.get_config_dict(
+        ['vpp', 'settings', 'nat44'],
+        key_mangling=('-', '_'),
+        with_recursive_defaults=True,
+    )
+    config.update(settings.get('nat44'))
 
     if effective_config:
         config.update({'effective': effective_config})
@@ -434,6 +433,13 @@ def apply(config):
 
     # Add NAT44
     n.enable_nat44_ed()
+
+    # Enable/disable forwarding
+    enable_forwarding = True
+    if 'no_forwarding' in config:
+        enable_forwarding = False
+    n.enable_disable_nat44_forwarding(enable_forwarding)
+
     # Add inside interfaces
     for interface in config['interface']['inside']:
         n.add_nat44_interface_inside(interface)


### PR DESCRIPTION
Enable/disable NAT forwarding in vpp_nat.py script to prevent it's reset

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7930
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set vpp nat44 address-pool translation address '192.0.2.1'
set vpp nat44 interface inside 'eth0'
set vpp nat44 interface outside 'eth0'

vyos@vyos# commit
[edit]
vyos@vyos# sudo python3
Python 3.11.2 (main, Apr 28 2025, 14:11:48) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from vyos.vpp import VPPControl
>>> vpp = VPPControl()
>>> vpp.api.nat44_show_running_config().forwarding_enabled
True
```
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... ok
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... ok
test_14_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_14_vpp_ipsec_xfrm_nl) ... ok
test_15_1_vpp_cgnat (__main__.TestVPP.test_15_1_vpp_cgnat) ... ok
test_15_2_vpp_cgnat_bond_with_vifs (__main__.TestVPP.test_15_2_vpp_cgnat_bond_with_vifs) ... ok
test_16_vpp_nat (__main__.TestVPP.test_16_vpp_nat) ... ok
test_17_vpp_sflow (__main__.TestVPP.test_17_vpp_sflow) ... ok
test_18_resource_limits (__main__.TestVPP.test_18_resource_limits) ... ok
test_19_vpp_pppoe_mapping (__main__.TestVPP.test_19_vpp_pppoe_mapping) ... ok
test_20_kernel_options_hugepages (__main__.TestVPP.test_20_kernel_options_hugepages) ... ok

----------------------------------------------------------------------
Ran 23 tests in 628.258s

OK (skipped=1)

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
