### PR TITLE
T7938: VPP: Rewrite sFlow implementation

### DIFF
--- a/data/config-mode-dependencies/vyos-1x.json
+++ b/data/config-mode-dependencies/vyos-1x.json
@@ -80,5 +80,8 @@
     "system_option": {
         "ip_ipv6": ["system_ip", "system_ipv6"],
         "sysctl": ["system_sysctl"]
+    },
+    "system_sflow": {
+        "vpp_sflow": ["vpp_sflow"]
     }
 }

--- a/interface-definitions/include/version/vpp-version.xml.i
+++ b/interface-definitions/include/version/vpp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/vpp-version.xml.i -->
-<syntaxVersion component='vpp' version='2'></syntaxVersion>
+<syntaxVersion component='vpp' version='3'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -952,14 +952,45 @@
             <multi/>
           </properties>
         </leafNode>
-        <leafNode name="sample-rate">
+        <leafNode name="header-bytes">
           <properties>
-            <help>sFlow sample rate</help>
+            <help>sFlow maximum packet-header length</help>
+            <completionHelp>
+              <list>64 96 128 160 192 224 256</list>
+            </completionHelp>
             <valueHelp>
-              <format>u32</format>
-              <description>sFlow sample rate</description>
+              <format>64</format>
+              <description>64 bytes</description>
             </valueHelp>
+            <valueHelp>
+              <format>96</format>
+              <description>96 bytes</description>
+            </valueHelp>
+            <valueHelp>
+              <format>128</format>
+              <description>128 bytes</description>
+            </valueHelp>
+            <valueHelp>
+              <format>160</format>
+              <description>160 bytes</description>
+            </valueHelp>
+            <valueHelp>
+              <format>192</format>
+              <description>192 bytes</description>
+            </valueHelp>
+            <valueHelp>
+              <format>224</format>
+              <description>224 bytes</description>
+            </valueHelp>
+            <valueHelp>
+              <format>256</format>
+              <description>256 bytes</description>
+            </valueHelp>
+            <constraint>
+              <regex>(64|96|128|160|192|224|256)</regex>
+            </constraint>
           </properties>
+          <defaultValue>128</defaultValue>
         </leafNode>
       </children>
     </node>

--- a/op-mode-definitions/vpp_sflow.xml.in
+++ b/op-mode-definitions/vpp_sflow.xml.in
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="show">
+    <children>
+      <node name="vpp">
+        <children>
+          <node name="sflow">
+            <properties>
+              <help>Show VPP sFlow information</help>
+            </properties>
+            <command>bash -c 'if cli-shell-api existsActive vpp sflow; then sudo vppctl show sflow; else echo "vpp sflow is not configured"; fi'</command>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/python/vyos/vpp/sflow/__init__.py
+++ b/python/vyos/vpp/sflow/__init__.py
@@ -1,0 +1,3 @@
+from .sflow import SFlow
+
+__all__ = ['SFlow']

--- a/python/vyos/vpp/sflow/sflow.py
+++ b/python/vyos/vpp/sflow/sflow.py
@@ -1,0 +1,49 @@
+#
+# Copyright (C) VyOS Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from vyos.vpp import VPPControl
+
+
+class SFlow:
+    def __init__(self):
+        self.vpp = VPPControl()
+
+    def enable_sflow(self, interface):
+        """Enable sFlow on interface"""
+        self.vpp.api.sflow_enable_disable(
+            enable_disable=True,
+            sw_if_index=self.vpp.get_sw_if_index(interface),
+        )
+
+    def disable_sflow(self, interface):
+        """Disable sFlow on interface"""
+        self.vpp.api.sflow_enable_disable(
+            enable_disable=False,
+            sw_if_index=self.vpp.get_sw_if_index(interface),
+        )
+
+    def set_sampling_rate(self, sample_rate):
+        """Set sFlow sampling-rate"""
+        self.vpp.api.sflow_sampling_rate(sampling_N=sample_rate)
+
+    def set_polling_interval(self, interval):
+        """Set sFlow polling interval"""
+        self.vpp.api.sflow_polling_interval(polling_S=interval)
+
+    def set_header_bytes(self, header_bytes):
+        """Set sFlow maximum header length in bytes"""
+        self.vpp.api.sflow_header_bytes(header_B=header_bytes)

--- a/src/migration-scripts/vpp/2-to-3
+++ b/src/migration-scripts/vpp/2-to-3
@@ -1,0 +1,30 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# Remove "vpp sflow sample-rate" since it should be automatically inherited
+# from "system sflow" to prevent conflicts
+
+from vyos.configtree import ConfigTree
+
+base = ['vpp', 'sflow']
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(base):
+        # Nothing to do
+        return
+
+    if config.exists(base + ['sample-rate']):
+        # Delete sample-rate option from sFlow configuration
+        config.delete(base + ['sample-rate'])


### PR DESCRIPTION
Execute commands for vpp sflow with API calls. Use values for polling and sampling rate from 'system sflow'.
Add op mode command `show vpp sflow`

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): rewrite feature implementation

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7938
* https://vyos.dev/T7690
* https://vyos.dev/T7691
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-documentation/pull/1694
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set interfaces ethernet eth1 address '192.0.2.1/30'
set interfaces ethernet eth1 description 'LAN'
set system sflow interface 'eth1'
set system sflow server 127.0.0.1
set system sflow vpp

set vpp settings interface eth1 driver 'dpdk'
set vpp settings interface eth0 driver 'dpdk'
set vpp settings unix poll-sleep-usec '222'
set vpp sflow interface 'eth1'
commit

vyos@vyos# run show vpp sflow
sflow sampling-rate 1000
sflow sampling-direction ingress
sflow polling-interval 30
sflow header-bytes 128
sflow enable eth1
Status
  interfaces enabled: 1
  packet samples sent: 0
  packet samples dropped: 0
  counter samples sent: 1
  counter samples dropped: 0
[edit]


vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... ok
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... ok
test_14_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_14_vpp_ipsec_xfrm_nl) ... ok
test_15_1_vpp_cgnat (__main__.TestVPP.test_15_1_vpp_cgnat) ... ok
test_15_2_vpp_cgnat_bond_with_vifs (__main__.TestVPP.test_15_2_vpp_cgnat_bond_with_vifs) ... ok
test_16_vpp_nat (__main__.TestVPP.test_16_vpp_nat) ... ok
test_17_vpp_sflow (__main__.TestVPP.test_17_vpp_sflow) ... ok
test_18_resource_limits (__main__.TestVPP.test_18_resource_limits) ... ok
test_19_vpp_pppoe_mapping (__main__.TestVPP.test_19_vpp_pppoe_mapping) ... ok
test_20_kernel_options_hugepages (__main__.TestVPP.test_20_kernel_options_hugepages) ... ok

----------------------------------------------------------------------
Ran 23 tests in 576.071s

OK (skipped=1)

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
