### PR TITLE
frrender: T7927: de-nest DHCP and PPPoE interface section for VRFs

### DIFF
--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -14,7 +14,11 @@
 # along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Library used to interface with FRRs mgmtd introduced in version 10.0
+Helper class attached to vyos-configd to interfact between our CLI configuration
+and FRR. Class will render one full FRR configuration and apply this via
+frr-reload.py, if the configuration has no errors.
+
+Will fail early if the rendered configuration has any errors.
 """
 
 import os

--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -23,10 +23,16 @@ Will fail early if the rendered configuration has any errors.
 
 import os
 
+from copy import deepcopy
 from time import sleep
 
+from vyos.config import Config
+from vyos.config import config_dict_merge
+from vyos.configdict import get_dhcp_interfaces
+from vyos.configdict import get_pppoe_interfaces
 from vyos.defaults import frr_debug_enable
 from vyos.utils.dict import dict_search
+from vyos.utils.dict import dict_set_nested
 from vyos.utils.file import write_file
 from vyos.utils.process import cmd
 from vyos.utils.process import rc_cmd
@@ -62,12 +68,7 @@ ripng_daemon = 'ripngd'
 zebra_daemon = 'zebra'
 nhrp_daemon = 'nhrpd'
 
-def get_frrender_dict(conf, argv=None) -> dict:
-    from copy import deepcopy
-    from vyos.config import config_dict_merge
-    from vyos.configdict import get_dhcp_interfaces
-    from vyos.configdict import get_pppoe_interfaces
-
+def get_frrender_dict(conf: Config, argv=None) -> dict:
     # We need to re-set the CLI path to the root level, as this function uses
     # conf.exists() with an absolute path form the CLI root
     conf.set_level([])
@@ -439,17 +440,10 @@ def get_frrender_dict(conf, argv=None) -> dict:
 
     # T3680 - get a list of all interfaces currently configured to use DHCP
     tmp = get_dhcp_interfaces(conf)
-    if tmp:
-        if 'static' in dict:
-            dict['static'].update({'dhcp' : tmp})
-        else:
-            dict.update({'static' : {'dhcp' : tmp}})
+    if tmp: dict_set_nested('static.dhcp', tmp, dict)
+
     tmp = get_pppoe_interfaces(conf)
-    if tmp:
-        if 'static' in dict:
-            dict['static'].update({'pppoe' : tmp})
-        else:
-            dict.update({'static' : {'pppoe' : tmp}})
+    if tmp: dict_set_nested('static.pppoe', tmp, dict)
 
     # keep a re-usable list of dependent VRFs
     dependent_vrfs_default = {}
@@ -577,15 +571,16 @@ def get_frrender_dict(conf, argv=None) -> dict:
                 static = conf.get_config_dict(static_vrf_path, key_mangling=('-', '_'),
                                               get_first_key=True,
                                               no_tag_node_value_mangle=True)
-                # T3680 - get a list of all interfaces currently configured to use DHCP
-                tmp = get_dhcp_interfaces(conf, vrf_name)
-                if tmp: static.update({'dhcp' : tmp})
-                tmp = get_pppoe_interfaces(conf, vrf_name)
-                if tmp: static.update({'pppoe' : tmp})
-
                 vrf['name'][vrf_name]['protocols'].update({'static': static})
             elif conf.exists_effective(static_vrf_path):
                 vrf['name'][vrf_name]['protocols'].update({'static': {'deleted' : ''}})
+
+            # T3680 - get a list of all interfaces currently configured to use DHCP
+            tmp = get_dhcp_interfaces(conf, vrf_name)
+            if tmp: dict_set_nested(f'name.{vrf_name}.protocols.static.dhcp', tmp, vrf)
+
+            tmp = get_pppoe_interfaces(conf, vrf_name)
+            if tmp: dict_set_nested(f'name.{vrf_name}.protocols.static.pppoe', tmp, vrf)
 
             vrf_vni_path = ['vrf', 'name', vrf_name, 'vni']
             if conf.exists(vrf_vni_path):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

This update refactors the code path to eliminate unnecessary nesting when processing interfaces using PPPoE or DHCP that are bound to a VRF.

Previously, the configuration dictionary was only populated if a static route was defined under the corresponding VRF node. This behavior was incorrect, as interfaces tied to a VRF can receive dynamic routes - such as a default route via DHCP - without having any static routing configuration. A typical use case is a VRF dedicated to out-of-band management.

While debugging and resolving the underlying VRF assignment issue in T7929, this code path was refactored for clarity. Previously, the `check_dhcp()` helper function relied on the parent scope’s vrf variable. Although this worked correctly, it was not clean or explicit. The function now takes and uses its own vrf argument, improving readability and maintainability.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7927

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

`make test-interfaces`, `make test-no-interfaces` and `make testc` all reported no errors.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
