### PR TITLE
T7941: fix DHCP client running in VRF with non-word characters

### DIFF
--- a/src/etc/dhcp/dhclient-enter-hooks.d/03-vyos-ipwrapper
+++ b/src/etc/dhcp/dhclient-enter-hooks.d/03-vyos-ipwrapper
@@ -4,7 +4,7 @@
 IF_METRIC=${IF_METRIC:-210}
 
 # Check if interface is inside a VRF
-VRF_OPTION=$(/usr/sbin/ip -j -d link show ${interface} | awk '{if(match($0, /.*"master":"(\w+)".*"info_slave_kind":"vrf"/, IFACE_DETAILS)) printf("vrf %s", IFACE_DETAILS[1])}')
+VRF_OPTION=$(/usr/sbin/ip --json --detail link show ${interface} | jq -r '.[0] | select(.linkinfo.info_slave_kind == "vrf") | "vrf \(.master)"')
 
 # get status of FRR
 function frr_alive () {


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The previous implementation used awk with a regex to extract the VRF name from JSON data, relying on `(\w+)` to match the value. This broke for valid VRF names containing hyphens or other non-word characters.

This update replaces the regex-based extraction with a jq query that reliably parses the JSON structure, ensuring correct behavior regardless of VRF name format. This also reduces parsing fragility by using a tool purpose-built for JSON processing.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7941

## How to test / Smoketest result

```
set vrf name red-15 table 1000
set interfaces ethernet eth1 vif 10 vrf red-15
commit
```

```
vyos@vyos# run show int
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address                             MAC                VRF        MTU  S/L    Description
-----------  -------------------------------------  -----------------  -------  -----  -----  -------------
eth0         -                                      00:50:56:bf:c5:6d  default   1500  u/u
eth1         -                                      00:50:56:b3:38:c5  default   1500  u/u
eth1.10      -                                      00:50:56:b3:38:c5  red-15    1500  u/u
eth2         -                                      00:50:56:b3:9c:1d  default   1500  u/u
eth3         -                                      00:50:56:b3:9d:8e  default   1500  u/u
```

The **OLD** implementation did not get the VRF name

```
vyos@vyos# ip -j -d link show eth1.10 | awk '{if(match($0, /.*"master":"(\w+)".*"info_slave_kind":"vrf"/, IFACE_DETAILS)) printf("vrf %s", IFACE_DETAILS[1])}'
```

The **NEW** one does

```
vyos@vyos# ip --json --detail link show eth1.10 | jq -r '.[0] | select(.linkinfo.info_slave_kind == "vrf") | "vrf \(.master)"'
vrf red-15
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
