### PR TITLE
kea: T7821: Fix subnet-id accepted range

### DIFF
--- a/interface-definitions/include/dhcp/dhcp-server-common-config.xml.i
+++ b/interface-definitions/include/dhcp/dhcp-server-common-config.xml.i
@@ -323,18 +323,7 @@
             #include <include/interface/duid.xml.i>
           </children>
         </tagNode>
-        <leafNode name="subnet-id">
-          <properties>
-            <help>Unique ID mapped to leases in the lease file</help>
-            <valueHelp>
-              <format>u32:1-4294967294</format>
-              <description>Unique subnet ID</description>
-            </valueHelp>
-            <constraint>
-              <validator name="numeric" argument="--range 1-4294967294"/>
-            </constraint>
-          </properties>
-        </leafNode>
+        #include <include/dhcp/subnet-id.xml.i>
       </children>
     </tagNode>
   </children>

--- a/interface-definitions/include/dhcp/dhcp-server-common-config.xml.i
+++ b/interface-definitions/include/dhcp/dhcp-server-common-config.xml.i
@@ -327,11 +327,11 @@
           <properties>
             <help>Unique ID mapped to leases in the lease file</help>
             <valueHelp>
-              <format>u32</format>
+              <format>u32:1-4294967294</format>
               <description>Unique subnet ID</description>
             </valueHelp>
             <constraint>
-              <validator name="numeric" argument="--range 1-4294967295"/>
+              <validator name="numeric" argument="--range 1-4294967294"/>
             </constraint>
           </properties>
         </leafNode>

--- a/interface-definitions/include/dhcp/dhcpv6-server-common-config.xml.i
+++ b/interface-definitions/include/dhcp/dhcpv6-server-common-config.xml.i
@@ -261,11 +261,11 @@
           <properties>
             <help>Unique ID mapped to leases in the lease file</help>
             <valueHelp>
-              <format>u32</format>
+              <format>u32:1-4294967294</format>
               <description>Unique subnet ID</description>
             </valueHelp>
             <constraint>
-              <validator name="numeric" argument="--range 1-4294967295"/>
+              <validator name="numeric" argument="--range 1-4294967294"/>
             </constraint>
           </properties>
         </leafNode>

--- a/interface-definitions/include/dhcp/dhcpv6-server-common-config.xml.i
+++ b/interface-definitions/include/dhcp/dhcpv6-server-common-config.xml.i
@@ -257,18 +257,7 @@
             </leafNode>
           </children>
         </tagNode>
-        <leafNode name="subnet-id">
-          <properties>
-            <help>Unique ID mapped to leases in the lease file</help>
-            <valueHelp>
-              <format>u32:1-4294967294</format>
-              <description>Unique subnet ID</description>
-            </valueHelp>
-            <constraint>
-              <validator name="numeric" argument="--range 1-4294967294"/>
-            </constraint>
-          </properties>
-        </leafNode>
+        #include <include/dhcp/subnet-id.xml.i>
       </children>
     </tagNode>
   </children>

--- a/interface-definitions/include/dhcp/subnet-id.xml.i
+++ b/interface-definitions/include/dhcp/subnet-id.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from dhcp/subnet-id.xml.i -->
+<leafNode name="subnet-id">
+    <properties>
+    <help>Unique ID mapped to leases in the lease file</help>
+    <valueHelp>
+        <format>u32:1-4294967294</format>
+        <description>Unique subnet ID</description>
+    </valueHelp>
+    <constraint>
+        <validator name="numeric" argument="--range 1-4294967294"/>
+    </constraint>
+    </properties>
+</leafNode>
+<!-- include end -->


### PR DESCRIPTION
'Subnet IDs must be greater than zero and less than 4294967295.'

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
`subnet-id` auto-complete adjusted to accepted range

Lowered constraint by one as per Kea documentation.

Ref: [Subnet IDs must be greater than zero and less than 4294967295.](https://kea.readthedocs.io/en/latest/arm/dhcp4-srv.html#ipv4-subnet-identifier)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
