### PR TITLE
frr: T7664: properly set log configuration during daemon startup

### DIFF
--- a/src/etc/systemd/system/frr.service.d/override.conf
+++ b/src/etc/systemd/system/frr.service.d/override.conf
@@ -5,8 +5,9 @@ After=vyos-router.service
 LimitNOFILE=4096
 ExecStartPre=/bin/bash -c 'if [ ! -f /run/frr/config/frr.conf ]; then \
              mkdir -p /run/frr/config; \
-             echo "log syslog" > /run/frr/config/frr.conf; \
-             echo "log facility local7" >> /run/frr/config/frr.conf; \
+             echo "log facility daemon" > /run/frr/config/frr.conf; \
+             echo "log timestamp precision 3" >> /run/frr/config/frr.conf; \
+             echo "log syslog notifications" >> /run/frr/config/frr.conf; \
              chown frr:frr /run/frr/config/frr.conf; \
              chmod 664 /run/frr/config/frr.conf; \
              mount --bind /run/frr/config/frr.conf /etc/frr/frr.conf; \


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Properly set log configuration during daemon startup

Related to commits:
* fca49413f - frrender: T7664: do not log unique-id in syslog messages
* c4c339fb5 - frrender: T7664: reduce log level to notifications during normal operation
* 7ff824f44 - frrender: T7664: add "log timestamp precision 3" global option

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7764

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4791
* https://github.com/vyos/vyos-1x/pull/4794

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
