### PR TITLE
T7929: VPP: nat44: validate that only self-twice-nat external address is in translation pool

### DIFF
--- a/src/conf_mode/vpp_nat.py
+++ b/src/conf_mode/vpp_nat.py
@@ -279,10 +279,6 @@ def verify(config):
                         f'{error_msg} external address/port is already in use!'
                     )
                 addresses_with_ports.add(pair)
-                if ext_address not in addresses_translation:
-                    raise ConfigError(
-                        f'{error_msg} external address {ext_address} is not in "address-pool translation"'
-                    )
 
             else:
                 if ext_address in addresses_without_ports or any(
@@ -300,6 +296,13 @@ def verify(config):
                 local_addresses.add(local_address)
 
             options = rule_config.get('options', {})
+
+            if 'self_twice_nat' in options and ext_address not in addresses_translation:
+                raise ConfigError(
+                    f'{error_msg} external address {ext_address} must be part of '
+                    '"address-pool translation" when using self-twice-nat'
+                )
+
             if all(key in options for key in ('twice_nat', 'self_twice_nat')):
                 raise ConfigError(
                     f'{error_msg} cannot set both options "twice-nat" and "self-twice-nat"'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7929
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-documentation/pull/1695
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set vpp settings interface eth1 driver 'dpdk'
set vpp settings interface eth0 driver 'dpdk'
set vpp nat44 address-pool twice-nat address '203.0.113.6'
set vpp nat44 interface inside 'eth1'
set vpp nat44 interface outside 'eth0'
set vpp nat44 static rule 100 description 'RDP server - external access only'
set vpp nat44 static rule 100 external address '203.0.113.5'
set vpp nat44 static rule 100 external port '3389'
set vpp nat44 static rule 100 local address '10.10.10.30'
set vpp nat44 static rule 100 local port '3389'
set vpp nat44 static rule 100 options out-to-in-only
set vpp nat44 static rule 100 protocol 'tcp'
set vpp nat44 static rule 200 description 'Web server alt port with twice-NAT'
set vpp nat44 static rule 200 external address '203.0.113.3'
set vpp nat44 static rule 200 external port '8080'
set vpp nat44 static rule 200 local address '10.10.10.10'
set vpp nat44 static rule 200 local port '8080'
set vpp nat44 static rule 200 options self-twice-nat
set vpp nat44 static rule 200 protocol 'tcp'


vyos@vyos# commit
[ vpp ]

WARNING: NOTE: Current dataplane capacity (estimated): 2.1 M IPv4
routes. Exceeding these values will lead to a dataplane out-of-memory
condition and a crash. Extensive use of features like ACLs, NAT and
others may reduce the numbers above. Please read the documentation for
details: https://docs.vyos.io/


[ vpp nat44 ]
Configuration error in static rule 200: external address 203.0.113.3 is
not in "address-pool translation"
[[vpp nat44]] failed
Commit failed
[edit]
vyos@vyos# set vpp nat44 address-pool translation address 203.0.113.3
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# sudo vppctl show nat44 static mappings
NAT44 static mappings:
 TCP local 10.10.10.30:3389 external 203.0.113.5:3389 vrf 0  out2in-only
 TCP local 10.10.10.10:8080 external 203.0.113.3:8080 vrf 0 self-twice-nat
[edit]
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
