### PR TITLE
haproxy: T7906: Probing of a port other than the one to which normal traffic is sent

### DIFF
--- a/data/templates/load-balancing/haproxy.cfg.j2
+++ b/data/templates/load-balancing/haproxy.cfg.j2
@@ -250,7 +250,30 @@ backend {{ back }}
 {%         if back_config.server is vyos_defined %}
 {%             set ssl_back =  'ssl ca-file /run/haproxy/' ~ back_config.ssl.ca_certificate ~ '.pem' if back_config.ssl.ca_certificate is vyos_defined else ('ssl verify none' if back_config.ssl.no_verify is vyos_defined else '') %}
 {%             for server, server_config in back_config.server.items() %}
-    server {{ server }} {{ server_config.address }}:{{ server_config.port }}{{ ' check' if server_config.check is vyos_defined }}{{ ' backup' if server_config.backup is vyos_defined }}{{ ' send-proxy' if server_config.send_proxy is vyos_defined }}{{ ' send-proxy-v2' if server_config.send_proxy_v2 is vyos_defined }} {{ ssl_back }}
+{%                 set address = server_config.address %}
+{%                 set port = server_config.port %}
+{#                 Build optional flags #}
+{%                 set flags = [] %}
+{%                 if server_config.check is vyos_defined %}
+{%                     set _ = flags.append('check') %}
+{#                     Build nested 'check port' flag like this: '... check port 8080' #}
+{%                     if server_config.check.port is vyos_defined %}
+{%                         set _ = flags.extend(['port', server_config.check.port]) %}
+{%                     endif %}
+{%                 endif %}
+{%                 if server_config.backup is vyos_defined %}
+{%                     set _ = flags.append('backup') %}
+{%                 endif %}
+{%                 if server_config.send_proxy is vyos_defined %}
+{%                     set _ = flags.append('send-proxy') %}
+{%                 endif %}
+{%                 if server_config.send_proxy_v2 is vyos_defined %}
+{%                     set _ = flags.append('send-proxy-v2') %}
+{%                 endif %}
+{%                 if ssl_back %}
+{%                     set _ = flags.append(ssl_back) %}
+{%                 endif %}
+    server {{ server }} {{ address }}:{{ port }} {{ flags | select | join(' ') }}
 {%             endfor %}
 {%         endif %}
 {%         if back_config.timeout.check is vyos_defined %}

--- a/interface-definitions/load-balancing_haproxy.xml.in
+++ b/interface-definitions/load-balancing_haproxy.xml.in
@@ -253,12 +253,14 @@
                       <valueless/>
                     </properties>
                   </leafNode>
-                  <leafNode name="check">
+                  <node name="check">
                     <properties>
                       <help>Active health check backend server</help>
-                      <valueless/>
                     </properties>
-                  </leafNode>
+                    <children>
+                      #include <include/port-number.xml.i>
+                    </children>
+                  </node>
                   #include <include/port-number.xml.i>
                   <leafNode name="send-proxy">
                     <properties>

--- a/smoketest/scripts/cli/test_load-balancing_haproxy.py
+++ b/smoketest/scripts/cli/test_load-balancing_haproxy.py
@@ -485,6 +485,66 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
         config = read_file(HAPROXY_CONF)
         self.assertIn(f'option smtpchk', config)
 
+    def test_reverse_proxy_tcp_health_checks_custom_port(self):
+        # Define variables
+        service = 'my-tcp-api'
+        mode = 'tcp'
+        front_port = '9000'
+        backend = 'bk-01'
+        balance = 'round-robin'
+        servers = [
+            ('srv01', '192.0.2.11', '9001', '9011'),
+            ('srv02', '192.0.2.12', '9002', None),
+            ('srv03', '192.0.2.13', '9003', '9013'),
+        ]
+
+        # Configure frontend
+        self.cli_set(base_path + ['service', service, 'backend', backend])
+        self.cli_set(base_path + ['service', service, 'mode', mode])
+        self.cli_set(base_path + ['service', service, 'port', front_port])
+
+        # Configure backend
+        self.cli_set(base_path + ['backend', backend, 'balance', balance])
+        self.cli_set(base_path + ['backend', backend, 'mode', mode])
+
+        # Configure backend servers
+        for name, addr, port, check_port in servers:
+            base_server_path = base_path + ['backend', backend, 'server', name]
+            self.cli_set(base_server_path + ['address', addr])
+            self.cli_set(base_server_path + ['port', port])
+
+            if check_port:
+                self.cli_set(base_server_path + ['check', 'port', check_port])
+            else:
+                self.cli_set(base_server_path + ['check'])
+
+        # Commit and read config
+        self.cli_commit()
+        config = read_file(HAPROXY_CONF)
+        config_lines = [line.strip() for line in config.splitlines()]
+
+        # Validate Frontend
+        self.assertIn(f'frontend {service}', config)
+        self.assertIn(f'bind [::]:{front_port} v4v6', config)
+        self.assertIn(f'mode {mode}', config)
+        self.assertIn(f'default_backend {backend}', config)
+
+        # Validate Backend
+        self.assertIn(f'backend {backend}', config)
+        self.assertIn('balance roundrobin', config)
+        self.assertIn(f'mode {mode}', config)
+
+        # Validate backend servers
+        for name, addr, port, check_port in servers:
+            with self.subTest(name=name):
+                expected_line = f'server {name} {addr}:{port}'
+                if check_port:
+                    expected_line += f' check port {check_port}'
+                else:
+                    expected_line += f' check'
+
+                self.assertIn(expected_line, config_lines)
+
     def test_reverse_proxy_logging(self):
         # Setup base
         self.base_config()


### PR DESCRIPTION
## Change summary
Add support for specifying a [custom health check port](https://www.haproxy.com/documentation/haproxy-configuration-tutorials/reliability/health-checks/#tcp-health-checks) for HAProxy backend servers.

This allows health probes to target a dedicated endpoint - such as port 8080 - separate from normal traffic ports (e.g., 80 or 443).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7906

## Related PR(s)
* https://github.com/vyos/vyos-documentation/pull/1697

## How to test / Smoketest result

#### Manual test
```
set load-balancing haproxy service my-tcp-api backend 'bk-01'
set load-balancing haproxy service my-tcp-api mode 'tcp'
set load-balancing haproxy service my-tcp-api port '8888'

set load-balancing haproxy backend bk-01 balance 'round-robin'
set load-balancing haproxy backend bk-01 mode 'tcp'

set load-balancing haproxy backend bk-01 server srv01 address '192.0.2.11'
set load-balancing haproxy backend bk-01 server srv01 port '8881'
set load-balancing haproxy backend bk-01 server srv01 check
set load-balancing haproxy backend bk-01 server srv02 address '192.0.2.12'
set load-balancing haproxy backend bk-01 server srv02 port '8882'
set load-balancing haproxy backend bk-01 server srv02 check port '8892'


vyos@vyos:~$ cat /run/haproxy/haproxy.cfg | tail -n 15
# Frontend

frontend my-tcp-api
    bind [::]:8888 v4v6
    mode tcp
    default_backend bk-01

# Backend
backend bk-01
    balance roundrobin
    mode tcp
    server srv01 192.0.2.11:8881 check
    server srv02 192.0.2.12:8882 check port 8892
```

#### Smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_load-balancing_haproxy.py
test_reverse_proxy_backend_http_check (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_backend_http_check) ... ok
test_reverse_proxy_backend_ssl_no_verify (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_backend_ssl_no_verify) ... ok
test_reverse_proxy_ca_not_exists (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_ca_not_exists) ... ok
test_reverse_proxy_cert_not_exists (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_cert_not_exists) ... ok
test_reverse_proxy_domain (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_domain) ... ok
test_reverse_proxy_http_compression (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_http_compression) ... ok
test_reverse_proxy_http_redirect (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_http_redirect) ... ok
test_reverse_proxy_http_response_headers (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_http_response_headers) ... ok
test_reverse_proxy_logging (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_logging) ... ok
test_reverse_proxy_tcp_health_checks (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_tcp_health_checks) ... ok
test_reverse_proxy_tcp_health_checks_custom_port (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_tcp_health_checks_custom_port) ... ok
test_reverse_proxy_tcp_mode (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_tcp_mode) ... ok
test_reverse_proxy_timeout (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_timeout) ... ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
