### PR TITLE
T7949: VPP add the ability to configure bond subinterfaces for NAT

### DIFF
--- a/data/config-mode-dependencies/vyos-vpp.json
+++ b/data/config-mode-dependencies/vyos-vpp.json
@@ -67,7 +67,8 @@
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
     },
     "vpp_kernel_interfaces": {
-        "vpp_nat_cgnat": ["vpp_nat_cgnat"]
+        "vpp_nat_cgnat": ["vpp_nat_cgnat"],
+        "vpp_nat": ["vpp_nat"]
     }
 }
 

--- a/python/vyos/vpp/utils.py
+++ b/python/vyos/vpp/utils.py
@@ -48,6 +48,22 @@ def iftunnel_transform(iface: str) -> str:
     return f'{iface_type}_tunnel{iface_num}'
 
 
+def vpp_iface_name_transform(iface: str) -> str:
+    """Convert a CLI interface name to its corresponding VPP interface name format
+
+    Args:
+        iface (str): Interface name as used in VyOS configuration (e.g., "bond0").
+
+    Returns:
+        str: Interface name formatted as recognized by VPP (e.g., "BondEthernet0").
+    """
+    vpp_iface_name = iface
+    if vpp_iface_name.startswith('bond'):
+        # interface name in VPP is BondEthernetX
+        vpp_iface_name = vpp_iface_name.replace('bond', 'BondEthernet')
+    return vpp_iface_name
+
+
 def cli_ifaces_list(config_instance, mode: str = 'candidate') -> list[str]:
     """List of all VPP interfaces (CLI names)
 

--- a/src/conf_mode/vpp_kernel-interfaces.py
+++ b/src/conf_mode/vpp_kernel-interfaces.py
@@ -82,6 +82,8 @@ def get_config(config=None) -> dict:
 
     if conf.exists(['vpp', 'nat', 'cgnat']):
         set_dependents('vpp_nat_cgnat', conf)
+    if conf.exists(['vpp', 'nat44']):
+        set_dependents('vpp_nat', conf)
 
     config['ifname'] = ifname
 

--- a/src/conf_mode/vpp_nat_cgnat.py
+++ b/src/conf_mode/vpp_nat_cgnat.py
@@ -21,17 +21,10 @@ from vyos.config import Config, config_dict_merge
 from vyos.configdict import node_changed
 from vyos.configdiff import Diff
 from vyos.vpp.utils import cli_ifaces_list
+from vyos.vpp.utils import vpp_iface_name_transform
 
 from vyos.vpp.nat.det44 import Det44
 from vyos.vpp.control_vpp import VPPControl
-
-
-def _vpp_iface_name_transform(iface_name):
-    vpp_iface_name = iface_name
-    if vpp_iface_name.startswith('bond'):
-        # interface name in VPP is BondEthernetX
-        vpp_iface_name = vpp_iface_name.replace('bond', 'BondEthernet')
-    return vpp_iface_name
 
 
 def get_config(config=None) -> dict:
@@ -132,7 +125,7 @@ def verify(config):
     vpp = VPPControl()
     for direction in ['inside', 'outside']:
         for interface in config['interface'][direction]:
-            vpp_iface_name = _vpp_iface_name_transform(interface)
+            vpp_iface_name = vpp_iface_name_transform(interface)
             if vpp.get_sw_if_index(vpp_iface_name) is None:
                 raise ConfigError(
                     f'{interface} must be a VPP interface for {direction} CGNAT interface'
@@ -187,11 +180,11 @@ def apply(config):
     cgnat.enable_det44_plugin()
     # Add inside interfaces
     for interface in config['interface']['inside']:
-        vpp_iface_name = _vpp_iface_name_transform(interface)
+        vpp_iface_name = vpp_iface_name_transform(interface)
         cgnat.add_det44_interface_inside(vpp_iface_name)
     # Add outside interfaces
     for interface in config['interface']['outside']:
-        vpp_iface_name = _vpp_iface_name_transform(interface)
+        vpp_iface_name = vpp_iface_name_transform(interface)
         cgnat.add_det44_interface_outside(vpp_iface_name)
     # Add CGNAT rules
     for rule in config['changed_rules']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7949
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set vpp settings interface eth1 driver 'dpdk'
set vpp interfaces bonding bond0 kernel-interface 'vpptun0'
set vpp interfaces bonding bond0 member interface 'eth1'
set vpp kernel-interfaces vpptun0 vif 10 address '192.0.2.23/32'
set vpp kernel-interfaces vpptun0 vif 20 address '100.64.23.1/24'

set vpp nat44 address-pool translation address '203.0.113.6'
set vpp nat44 interface inside 'bond0.10'
set vpp nat44 interface outside 'bond0.20'

vyos@vyos# commit
[ vpp ]

WARNING: NOTE: Current dataplane capacity (estimated): 2.1 M IPv4
routes. Exceeding these values will lead to a dataplane out-of-memory
condition and a crash. Extensive use of features like ACLs, NAT and
others may reduce the numbers above. Please read the documentation for
details: https://docs.vyos.io/


[edit]
vyos@vyos# run show vpp na
nat    nat44
[edit]
vyos@vyos# run show vpp nat44 interfaces
NAT44 interfaces:
  BondEthernet0.10 in
  BondEthernet0.20 out
[edit]
```

```
vyos@vyos#  /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... ok
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... ok
test_14_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_14_vpp_ipsec_xfrm_nl) ... ok
test_15_1_vpp_cgnat (__main__.TestVPP.test_15_1_vpp_cgnat) ... ok
test_15_2_vpp_cgnat_bond_with_vifs (__main__.TestVPP.test_15_2_vpp_cgnat_bond_with_vifs) ... ok
test_16_vpp_nat (__main__.TestVPP.test_16_vpp_nat) ... ok
test_17_vpp_sflow (__main__.TestVPP.test_17_vpp_sflow) ... ok
test_18_resource_limits (__main__.TestVPP.test_18_resource_limits) ... ok
test_19_vpp_pppoe_mapping (__main__.TestVPP.test_19_vpp_pppoe_mapping) ... ok
test_20_kernel_options_hugepages (__main__.TestVPP.test_20_kernel_options_hugepages) ... ok

----------------------------------------------------------------------
Ran 23 tests in 758.268s

OK (skipped=1)
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
