### PR TITLE
T7957: filter stderr when deleting container images

### DIFF
--- a/src/op_mode/container.py
+++ b/src/op_mode/container.py
@@ -120,11 +120,11 @@ def delete_image(name: str, force: typing.Optional[bool] = False):
 
     for image in name:
         # convert the truncated image ID to a full image ID
-        rc, ancestor = rc_cmd(f'podman inspect {image} --format "{{{{.Id}}}}"')
+        rc, ancestor = rc_cmd(f'podman inspect {image} --format "{{{{.Id}}}}"', stderr=None)
         if rc != 0:
             raise vyos.opmode.InternalError(ancestor)
         # check if the image ID is an ancestor of any running container
-        rc, in_use = rc_cmd(f'podman ps --filter ancestor={ancestor} -q')
+        rc, in_use = rc_cmd(f'podman ps --filter ancestor={ancestor} -q', stderr=None)
         if rc != 0:
             raise vyos.opmode.InternalError(in_use)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The call to `rc_cmd('podman inspect ...')` determines whether a container image scheduled for deletion has any ancestor containers still using it. Previously, if the podman command wrote output to stderr, `rc_cmd()` would return that error message alongside or instead of the ancestor container ID.

This caused subsequent podman calls to fail, as the error string was incorrectly treated as a valid command argument. This change ensures only valid ancestor IDs are returned.

This is a fix for commit a99ca6d11b5 ("op-mode: T7403: add option for forcefully remove a container image")

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7957

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4590

## How to test / Smoketest result

```
vyos@vyos:~$ delete container image cd91c0f1d8b3
Cannot delete image "cd91c0f1d8b3" because it is currently being used by container "3b42e5405dec"!
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

