### PR TITLE
T7965:  reapply the QoS policy when the interface reconnect

### DIFF
--- a/src/etc/ppp/ip-up.d/99-vyos-pppoe-qos
+++ b/src/etc/ppp/ip-up.d/99-vyos-pppoe-qos
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+# Dynamic interfaces may lose QoS config on reconnect.
+# This script reapplies the QoS policy when the interface comes up.
+
+from sys import argv
+from sys import exit
+from vyos.utils.process import call
+from vyos.configquery import ConfigTreeQuery
+
+# When the ppp link comes up, this script is called with the following
+# parameters
+#       $1      the interface name used by pppd (e.g., pppoe0, l2tpc0, sstpc0)
+#       $2      the tty device name
+#       $3      the tty device speed
+#       $4      the local IP address for the interface
+#       $5      the remote IP address
+#       $6      the parameter specified by the 'ipparam' option to pppd
+
+if len(argv) < 7:
+    exit(1)
+
+interface = argv[6]
+
+conf = ConfigTreeQuery()
+
+try:
+    # Check if QoS is configured for the interface
+    qos_path = ['qos', 'interface', interface]
+    if conf.exists(qos_path):
+        call('/usr/libexec/vyos/conf_mode/qos.py')
+except Exception:
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
pppoe interfaces may lose QoS config on reconnect. This PR reapplies the QoS policy when the interface comes up.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T7965

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
After the server-side disconnection，and when the pppoe0 link is up:

```
vyos@vyos:/etc/ppp/ip-up.d$ show qos cake interface pppoe0
qdisc cake 1: root refcnt 2 bandwidth 60Mbit diffserv3 flows nat nowash no-ack-filter split-gso rtt 100ms raw overhead 0
 Sent 666822251 bytes 3329477 pkt (dropped 16, overlimits 396425 requeues 0)
 backlog 0b 0p requeues 0
 memory used: 474624b of 4Mb
 capacity estimate: 60Mbit
 min/max network layer size:           29 /    1480
 min/max overhead-adjusted size:       29 /    1480
 average network hdr offset:            0

                   Bulk  Best Effort        Voice
  thresh       3750Kbit       60Mbit       15Mbit
  target            5ms          5ms          5ms
  interval        100ms        100ms        100ms
  pk_delay          0us        162us         10us
  av_delay          0us         15us          3us
  sp_delay          0us          1us          2us
  backlog            0b           0b           0b
  pkts                0      3326153         3340
  bytes               0    666668856       173760
  way_inds            0       247740            0
  way_miss            0       179041            7
  way_cols            0            0            0
  drops               0           16            0
  marks               0            0            0
  ack_drop            0            0            0
  sp_flows            0            3            0
  bk_flows            0            1            0
  un_flows            0            0            0
  max_len             0        21600           60
  quantum           300         1514          457

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
