### PR TITLE
dhcpv6: T7967: fix migration script for automatic SLAAC selection

### DIFF
--- a/smoketest/config-tests/basic-ipv6
+++ b/smoketest/config-tests/basic-ipv6
@@ -6,9 +6,11 @@ set interfaces ethernet eth0 vif-s 10 vif-c 20 address 'dhcpv6'
 set interfaces ethernet eth0 vif-s 10 vif-c 20 ipv6 address autoconf
 set interfaces ethernet eth1 duplex 'auto'
 set interfaces ethernet eth1 speed 'auto'
-set interfaces ethernet eth1 vif 50
-set interfaces ethernet eth1 vif-s 60 vif-c 70
+set interfaces ethernet eth1 vif 50 address '1.2.3.4/31'
+set interfaces ethernet eth1 vif-s 60 vif-c 70 address '2.3.4.5/31'
+set interfaces ethernet eth2 address 'dhcpv6'
 set interfaces ethernet eth2 duplex 'auto'
+set interfaces ethernet eth2 ipv6 address autoconf
 set interfaces ethernet eth2 speed 'auto'
 set interfaces loopback lo
 set interfaces pppoe pppoe0 authentication password 'vyos'

--- a/smoketest/configs/basic-ipv6
+++ b/smoketest/configs/basic-ipv6
@@ -22,13 +22,16 @@ interfaces {
         duplex auto
         speed auto
         vif 50 {
+            address 1.2.3.4/31
         }
         vif-s 60 {
             vif-c 70 {
+                address 2.3.4.5/31
             }
         }
     }
     ethernet eth2 {
+        address dhcpv6
         duplex auto
         speed auto
     }

--- a/src/migration-scripts/interfaces/32-to-33
+++ b/src/migration-scripts/interfaces/32-to-33
@@ -23,31 +23,36 @@ def migrate(config: ConfigTree) -> None:
     for type in config.list_nodes(['interfaces']):
         for interface in config.list_nodes(['interfaces', type]):
             iface_base_path = ['interfaces', type, interface]
-            dhcpv6_addr_path = iface_base_path + ['address', 'dhcpv6']
-            autoconf_path = iface_base_path + ['ipv6', 'address', 'autoconf']
-            if config.exists(dhcpv6_addr_path) and not config.exists(autoconf_path):
-                config.set(autoconf_path)
+            dhcpv6_addr_path = iface_base_path + ['address']
+
+            if config.exists(dhcpv6_addr_path) and 'dhcpv6' in config.return_values(dhcpv6_addr_path):
+                autoconf_path = iface_base_path + ['ipv6', 'address', 'autoconf']
+                if not config.exists(autoconf_path):
+                    config.set(autoconf_path)
 
             vif_path = iface_base_path + ['vif']
             if config.exists(vif_path):
                 for vif in config.list_nodes(vif_path):
                     vif_dhcpv6_addr_path = vif_path + [vif, 'address']
-                    vif_autoconf_path = vif_path + [vif, 'ipv6', 'address', 'autoconf']
-                    if config.exists(vif_dhcpv6_addr_path) and not config.exists(vif_autoconf_path):
-                        config.set(vif_autoconf_path)
+                    if config.exists(vif_dhcpv6_addr_path) and 'dhcpv6' in config.return_values(vif_dhcpv6_addr_path):
+                        vif_autoconf_path = vif_path + [vif, 'ipv6', 'address', 'autoconf']
+                        if not config.exists(vif_autoconf_path):
+                            config.set(vif_autoconf_path)
 
             vif_s_path = iface_base_path + ['vif-s']
             if config.exists(vif_s_path):
                 for vif_s in config.list_nodes(vif_s_path):
                     vif_s_dhcpv6_addr_path = vif_s_path + [vif_s, 'address']
-                    vif_s_autoconf_path = vif_s_path + [vif_s, 'ipv6', 'address', 'autoconf']
-                    if config.exists(vif_s_dhcpv6_addr_path) and not config.exists(vif_s_autoconf_path):
-                        config.set(vif_s_autoconf_path)
+                    if config.exists(vif_s_dhcpv6_addr_path) and 'dhcpv6' in config.return_values(vif_s_dhcpv6_addr_path):
+                        vif_s_autoconf_path = vif_s_path + [vif_s, 'ipv6', 'address', 'autoconf']
+                        if not config.exists(vif_s_autoconf_path):
+                            config.set(vif_s_autoconf_path)
 
                     vif_c_path = iface_base_path + ['vif-s', vif_s, 'vif-c']
                     if config.exists(vif_c_path):
                         for vif_c in config.list_nodes(vif_c_path):
                             vif_c_dhcpv6_addr_path = vif_c_path + [vif_c, 'address']
-                            vif_c_autoconf_path = vif_c_path + [vif_c, 'ipv6', 'address', 'autoconf']
-                            if config.exists(vif_c_dhcpv6_addr_path) and not config.exists(vif_c_autoconf_path):
-                                config.set(vif_c_autoconf_path)
+                            if config.exists(vif_c_dhcpv6_addr_path) and 'dhcpv6' in config.return_values(vif_c_dhcpv6_addr_path):
+                                vif_c_autoconf_path = vif_c_path + [vif_c, 'ipv6', 'address', 'autoconf']
+                                if not config.exists(vif_c_autoconf_path):
+                                    config.set(vif_c_autoconf_path)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Commit f08a5700e7 (`dhcpv6: T7646: restore missing default route after upgrade`) introduced a regression affecting both non-VIF and VIF interfaces.

The addressing mode check in the migration logic was incorrect for both cases. For non-VIF interfaces, the migration was skipped entirely due to a missing configuration test. For VIF (VLAN) interfaces, the existing test always evaluated to true, since it incorrectly assumed that DHCPv6 was configured even when a static address was present.

Smoketests have been extended to cover for these cases.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7967

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4717

## How to test / Smoketest result

Manual tests:

```
vyos@vyos# load /usr/libexec/vyos/tests/config/basic-ipv6
Load complete. Use 'commit' to make changes effective.
```
```
vyos@vyos# compare commands | match "set interfaces ethernet"
set interfaces ethernet eth0 vif 5 address 'dhcpv6'
set interfaces ethernet eth0 vif 5 ipv6 address autoconf
set interfaces ethernet eth0 vif-s 10 address 'dhcpv6'
set interfaces ethernet eth0 vif-s 10 ipv6 address autoconf
set interfaces ethernet eth0 vif-s 10 vif-c 20 address 'dhcpv6'
set interfaces ethernet eth0 vif-s 10 vif-c 20 ipv6 address autoconf
set interfaces ethernet eth1 vif 50 address '1.2.3.4/31'
set interfaces ethernet eth1 vif-s 60 vif-c 70 address '2.3.4.5/31'
set interfaces ethernet eth2 address 'dhcpv6'
set interfaces ethernet eth2 ipv6 address autoconf
```

Automatic tests from CI with extended smoketests:

```
DEBUG - test_basic_ipv6 (__main__.TestConfigBasicIpv6.test_basic_ipv6) ...  time: 27.780
DEBUG - ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
