### PR TITLE
wlb: T7966: Restore default route when interface disconnects/reconnects

### DIFF
--- a/src/helpers/vyos-load-balancer.py
+++ b/src/helpers/vyos-load-balancer.py
@@ -103,15 +103,36 @@ def get_ipv4_address(ifname):
                     return addr_json['addr_info'][0]['local']
     return None
 
+def get_dynamic_nexthop(ifname: str) -> str | None | bool:
+    '''
+    Resolve the dynamic next-hop for a WAN interface.
+
+    Determines the current default gateway learned dynamically on the interface:
+    - PPPoE interfaces (`pppoe*`): uses `parse_ppp_nexthop`.
+    - Other interfaces (e.g. DHCP): uses `parse_dhcp_nexthop`.
+
+    Return values:
+    - str: IPv4 next-hop address
+    - None: when DHCP lease has no router value
+    - False: when PPPoE nexthop state file is missing
+
+    Args:
+        ifname: Interface name (e.g. 'pppoe0', 'eth0').
+
+    Returns:
+        See above for possible values.
+    '''
+    if ifname.startswith('pppoe'):
+        return parse_ppp_nexthop(ifname)
+    else:
+        return parse_dhcp_nexthop(ifname)
+
 def dynamic_nexthop_update(lb, ifname):
     # Update on DHCP/PPP address/nexthop changes
     # Return True if nftables needs to be updated - IP change
 
     if 'dhcp_nexthop' in lb['health_state'][ifname]:
-        if ifname[:5] == 'pppoe':
-            dhcp_nexthop_addr = parse_ppp_nexthop(ifname)
-        else:
-            dhcp_nexthop_addr = parse_dhcp_nexthop(ifname)
+        dhcp_nexthop_addr = get_dynamic_nexthop(ifname)
 
         table_num = lb['health_state'][ifname]['table_number']
 
@@ -151,10 +172,7 @@ def restore_default_route(lb: dict, ifname: str) -> None:
             return
         else:
             if 'dhcp_nexthop' in lb['health_state'][ifname]:
-                if ifname[:5] == 'pppoe':
-                    nexthop_addr = parse_ppp_nexthop(ifname)
-                else:
-                    nexthop_addr = parse_dhcp_nexthop(ifname)
+                nexthop_addr = get_dynamic_nexthop(ifname)
             else:
                 nexthop_addr = dict_search_args(lb, 'interface_health', ifname, 'nexthop')
 
@@ -334,7 +352,6 @@ if __name__ == '__main__':
                         ip_change = True
 
                     restore_default_route(lb, ifname)
-
 
             if any(state['state_changed'] for ifname, state in lb['health_state'].items()):
                 if not nftables_update(lb):

--- a/src/helpers/vyos-load-balancer.py
+++ b/src/helpers/vyos-load-balancer.py
@@ -24,6 +24,7 @@ import time
 from vyos.config import Config
 from vyos.template import render
 from vyos.utils.commit import commit_in_progress
+from vyos.utils.dict import dict_search_args
 from vyos.utils.network import get_interface_address
 from vyos.utils.process import rc_cmd
 from vyos.utils.process import run
@@ -124,6 +125,43 @@ def dynamic_nexthop_update(lb, ifname):
         return True
 
     return False
+
+def restore_default_route(lb: dict, ifname: str) -> None:
+    """
+    Restores a missing default route for a WAN interface in its policy routing table.
+
+    When a link flap or DHCP/PPP renegotiation removes the per-interface default route,
+    this function checks the interface’s assigned table for an existing default entry.
+    If none is found, it determines the proper next-hop (from DHCP, PPP, or static config)
+    and reinstalls the route using:
+      ip route replace table <table_num> default dev <ifname> via <nexthop>
+
+    @param lb       Load-balancer state/config dictionary.
+    @param ifname   Interface name whose default route should be verified and restored.
+    @returns        None — exits quietly if the table number or next-hop cannot be found.
+    """
+    table_num = dict_search_args(lb, 'health_state', ifname, 'table_number')
+    if not table_num:
+        return
+
+    rc, out = rc_cmd(f'ip -j route show default table {table_num}')
+    if rc == 0:
+        rt_table = json.loads(out)
+        if len(rt_table) > 0:
+            return
+        else:
+            if 'dhcp_nexthop' in lb['health_state'][ifname]:
+                if ifname[:5] == 'pppoe':
+                    nexthop_addr = parse_ppp_nexthop(ifname)
+                else:
+                    nexthop_addr = parse_dhcp_nexthop(ifname)
+            else:
+                nexthop_addr = dict_search_args(lb, 'interface_health', ifname, 'nexthop')
+
+            if nexthop_addr:
+                run(f'ip route replace table {table_num} default dev {ifname} via {nexthop_addr}')
+    else:
+        return
 
 def nftables_update(lb):
     # Atomically reload nftables table from template
@@ -294,6 +332,9 @@ if __name__ == '__main__':
 
                     if dynamic_nexthop_update(lb, ifname):
                         ip_change = True
+
+                    restore_default_route(lb, ifname)
+
 
             if any(state['state_changed'] for ifname, state in lb['health_state'].items()):
                 if not nftables_update(lb):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
When an interface disconnects, like if a user needs to unplug interfaces, the default routes within the tables used for `ip rule` policy routing are removed. When the interface returns to an operational state, the default routes are not repopulated since the nexthop hasn't changed.

This change adds a check to ensure when the default route is dropped, it can be restored.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7966
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
### Before Change:
#### Configure WAN Load Balancing:
```
set interfaces ethernet eth0 vif 20 address 'dhcp'
set interfaces ethernet eth0 vif 101 address 'dhcp'
set interfaces ethernet eth1 address '10.5.5.1/24'

set load-balancing wan enable-local-traffic
set load-balancing wan interface-health eth0.20 nexthop 'dhcp'
set load-balancing wan interface-health eth0.101 nexthop 'dhcp'
set load-balancing wan rule 10 inbound-interface 'eth1'
set load-balancing wan rule 10 interface eth0.20
set load-balancing wan rule 10 interface eth0.101
```
#### Check the `ip rule` and routing tables:
```
vyos@vyos# sudo ip rule show
0:      from all lookup local
32764:  from all fwmark 0xca lookup 202
32765:  from all fwmark 0xc9 lookup 201
32766:  from all lookup main
32767:  from all lookup default

vyos@vyos# sudo ip route show default table 201
default via 192.168.2.1 dev eth0.20 

vyos@vyos# sudo ip route show default table 202
default via 10.0.101.1 dev eth0.101 
```
#### Disconnect the interface, and then reconnect the interface. After, check the default routes in the tables again, they will not be present. This will lead to traffic failures as traffic leaves incorrect interfaces, and is not source NAT-ed:
```
vyos@vyos# sudo ip route show default table 201

vyos@vyos# sudo ip route show default table 202

```
### After Change:
#### Disconnect the interface, and then reconnect the interface. After, check the default routes in the tables again, they will now be repopulated:
```
vyos@vyos# sudo ip route show default table 201
default via 192.168.2.1 dev eth0.20 

vyos@vyos# sudo ip route show default table 202
default via 10.0.101.1 dev eth0.101 
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
