### PR TITLE
pki: T7953: implement certbot_renew() function to have everything at one place

### DIFF
--- a/src/etc/systemd/system/certbot.service.d/10-override.conf
+++ b/src/etc/systemd/system/certbot.service.d/10-override.conf
@@ -1,3 +1,6 @@
 [Service]
 Group=vyattacfg
+ExecStart=
 ExecStart=/usr/libexec/vyos/op_mode/pki.py renew_certbot
+# Required for properly loading VyOS config
+PrivateTmp=false

--- a/src/helpers/vyos-certbot-renew-pki.sh
+++ b/src/helpers/vyos-certbot-renew-pki.sh
@@ -1,3 +1,0 @@
-#!/bin/vbash
-source /opt/vyatta/etc/functions/script-template
-/usr/libexec/vyos/conf_mode/pki.py certbot_renew

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -1378,7 +1378,7 @@ def renew_certbot(raw: bool, force: typing.Optional[bool] = False):
     from vyos.defaults import directories
 
     certbot_config = directories['certbot']
-    hook_dir = directories['base']
+    vyos_conf_scripts_dir = directories['conf_mode']
 
     if force and not os.path.isdir(f'{certbot_config}'):
         # Assume someone deleted the certbot_config folder, renew alone will not
@@ -1388,18 +1388,13 @@ def renew_certbot(raw: bool, force: typing.Optional[bool] = False):
         # a bad time
         Warning(f'Directory "{certbot_config}" missing. Reinitializing PKI ' \
                 'subsystem...\n\n')
-        vyos_conf_scripts_dir = directories['conf_mode']
-        cmd(f'sudo sg vyattacfg -c {vyos_conf_scripts_dir}/pki.py')
+        out = cmd(f'sudo sg vyattacfg -c "{vyos_conf_scripts_dir}/pki.py"')
+    elif force:
+        out = cmd(f'sudo sg vyattacfg -c "{vyos_conf_scripts_dir}/pki.py certbot_renew_force"')
+    else:
+        out = cmd(f'sudo sg vyattacfg -c "{vyos_conf_scripts_dir}/pki.py certbot_renew"')
 
-    tmp = f'/usr/bin/certbot renew --no-random-sleep-on-renew ' \
-          f'--config-dir "{certbot_config}" ' \
-          f'--post-hook "{hook_dir}/vyos-certbot-renew-pki.sh"'
-    if force:
-        tmp += ' --force-renewal'
-
-    out = cmd(tmp)
-    if not raw:
-        print(out)
+    print(out)
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Consolidate all logic related to certbot under `pki.py` conf_mode script.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7953

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4812

## How to Test

### CLI config

```
set pki certificate LE_LR5 acme domain-name 'LR5.wue4.vyos.net'
set pki certificate LE_LR5 acme email 'ca@vyos.net'
set pki certificate LE_LR5 acme rsa-key-size '2048'
set pki certificate LE_LR5 acme url 'https://acme-staging-v02.api.letsencrypt.org/directory'

set load-balancing haproxy backend cloud server helix address '188.0.151.3'
set load-balancing haproxy backend cloud server helix port '443'
set load-balancing haproxy global-parameters tls-version-min '1.2'
set load-balancing haproxy service cloud backend 'cloud'
set load-balancing haproxy service cloud port '443'
set load-balancing haproxy service cloud redirect-http-to-https
set load-balancing haproxy service cloud rule 10 set redirect-location '/remote.php/dav/'
set load-balancing haproxy service cloud rule 10 url-path exact '/.well-known/caldav'
set load-balancing haproxy service cloud ssl certificate 'LE_LR5'

set vpn openconnect authentication local-users username HIDDEN password 'HIDDEN'
set vpn openconnect authentication mode local 'password'
set vpn openconnect listen-ports tcp '8443'
set vpn openconnect network-settings client-ip-settings subnet '172.20.20.0/24'
set vpn openconnect network-settings name-server '10.1.1.1'
set vpn openconnect network-settings name-server '10.1.1.2'
set vpn openconnect ssl certificate 'LE_LR5'

set vpn ipsec esp-group ESP-RW lifetime '3600'
set vpn ipsec esp-group ESP-RW pfs 'disable'
set vpn ipsec esp-group ESP-RW proposal 1 encryption 'aes256'
set vpn ipsec esp-group ESP-RW proposal 1 hash 'sha512'
set vpn ipsec esp-group ESP-RW proposal 2 encryption 'aes256'
set vpn ipsec esp-group ESP-RW proposal 2 hash 'sha384'
set vpn ipsec esp-group ESP-RW proposal 3 encryption 'aes256'
set vpn ipsec esp-group ESP-RW proposal 3 hash 'sha256'
set vpn ipsec esp-group ESP-RW proposal 4 encryption 'aes256'
set vpn ipsec esp-group ESP-RW proposal 4 hash 'sha1'
set vpn ipsec esp-group ESP-RW proposal 10 encryption 'aes128gcm128'
set vpn ipsec esp-group ESP-RW proposal 10 hash 'sha256'
set vpn ipsec ike-group IKE-RW key-exchange 'ikev2'
set vpn ipsec ike-group IKE-RW lifetime '7200'
set vpn ipsec ike-group IKE-RW proposal 1 dh-group '14'
set vpn ipsec ike-group IKE-RW proposal 1 encryption 'aes256'
set vpn ipsec ike-group IKE-RW proposal 1 hash 'sha512'
set vpn ipsec ike-group IKE-RW proposal 2 dh-group '14'
set vpn ipsec ike-group IKE-RW proposal 2 encryption 'aes256'
set vpn ipsec ike-group IKE-RW proposal 2 hash 'sha256'
set vpn ipsec ike-group IKE-RW proposal 3 dh-group '2'
set vpn ipsec ike-group IKE-RW proposal 3 encryption 'aes256'
set vpn ipsec ike-group IKE-RW proposal 3 hash 'sha256'
set vpn ipsec ike-group IKE-RW proposal 10 dh-group '14'
set vpn ipsec ike-group IKE-RW proposal 10 encryption 'aes128gcm128'
set vpn ipsec ike-group IKE-RW proposal 10 hash 'sha256'
set vpn ipsec remote-access connection rw authentication local-id 'ipsec.vyos.net'
set vpn ipsec remote-access connection rw authentication local-users username HIDDEN password 'HIDDEN'
set vpn ipsec remote-access connection rw authentication server-mode 'x509'
set vpn ipsec remote-access connection rw authentication x509 ca-certificate 'ISRG-Root-X1'
set vpn ipsec remote-access connection rw authentication x509 ca-certificate 'R12'
set vpn ipsec remote-access connection rw authentication x509 ca-certificate 'R13'
set vpn ipsec remote-access connection rw authentication x509 certificate 'LE_LR5'
set vpn ipsec remote-access connection rw esp-group 'ESP-RW'
set vpn ipsec remote-access connection rw ike-group 'IKE-RW'
set vpn ipsec remote-access connection rw local-address '188.0.151.213'
set vpn ipsec remote-access connection rw pool 'ra-rw-ipv4'
set vpn ipsec remote-access pool ra-rw-ipv4 name-server '172.16.254.100'
set vpn ipsec remote-access pool ra-rw-ipv4 prefix '172.16.250.0/28'
```

### Running Processes and current in-use certificates

```
cpo@LR5.wue4:~$ ps faux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root       27035  0.0  0.3  95572 13096 ?        Ss   03:29   0:00 /usr/sbin/haproxy -Ws -f /run/haproxy/haproxy.cfg -p /run/haproxy.pid -S /run/haproxy-master.sock
haproxy    32053  0.0  0.9 187928 39108 ?        Sl   08:38   0:00  \_ /usr/sbin/haproxy -sf 27037 -x sockpair@3 -Ws -f /run/haproxy/haproxy.cfg -p /run/haproxy.pid -S /run/haproxy-master.sock
root       27052  0.0  0.1  12024  6760 ?        Ss   03:29   0:00 ocserv-main
root       27054  0.0  0.1  11964  5116 ?        S    03:29   0:00  \_ ocserv-sm
root       27055  0.0  0.1  11964  5116 ?        S    03:29   0:00  \_ ocserv-sm
```

```
cpo@LR5.wue4:~$ show pki certificate
Certificates:
Name    Type    Subject CN             Issuer CN                          Issued               Expiry               Revoked    Private Key    CA Present
------  ------  ---------------------  ---------------------------------  -------------------  -------------------  ---------  -------------  ----------------------
LE_LR5  Server  CN=lr5.wue4.vyos.net  CN=(STAGING) Riddling Rhubarb R12  2025-11-01 06:40:10  2026-01-30 06:40:09  No         Yes            Yes (AUTOCHAIN_LE_LR5)
```

### Forcefully renew certificates

```
cpo@LR5.wue4:~$ renew certbot force
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Processing /config/auth/letsencrypt/renewal/LE_LR5.conf
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Renewing an existing certificate for lr5.wue4.vyos.net

- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
Congratulations, all renewals succeeded:
  /config/auth/letsencrypt/live/LE_LR5/fullchain.pem (success)
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
```

Processes restarted using the new Certificates

```
(08:38) cpo lnx01:~ # openssl s_client -connect LR5.wue4.vyos.net:443 | grep NotBefore
depth=1 C = US, O = (STAGING) Let's Encrypt, CN = (STAGING) Riddling Rhubarb R12
verify error:num=20:unable to get local issuer certificate
verify return:1
depth=0 CN = lr5.wue4.vyos.net
verify return:1
   v:NotBefore: Nov  1 06:41:11 2025 GMT; NotAfter: Jan 30 06:41:10 2026 GMT
   v:NotBefore: Mar 13 00:00:00 2024 GMT; NotAfter: Mar 12 23:59:59 2027 GMT
```

```
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root       33316  0.0  0.3  95568 12896 ?        Ss   08:39   0:00 /usr/sbin/haproxy -Ws -f /run/haproxy/haproxy.cfg -p /run/haproxy.pid -S /run/haproxy-master.sock
haproxy    33318  0.0  1.0 187944 43196 ?        Sl   08:39   0:00  \_ /usr/sbin/haproxy -Ws -f /run/haproxy/haproxy.cfg -p /run/haproxy.pid -S /run/haproxy-master.sock
root       33335  0.0  0.1  12156  6704 ?        Ss   08:39   0:00 ocserv-main
root       33337  0.0  0.1  11992  4776 ?        S    08:39   0:00  \_ ocserv-sm
root       33338  0.0  0.1  11992  4776 ?        S    08:39   0:00  \_ ocserv-sm
```

```
cpo@LR5.wue4:~$ show pki certificate
Certificates:
Name    Type    Subject CN             Issuer CN                          Issued               Expiry               Revoked    Private Key    CA Present
------  ------  ---------------------  ---------------------------------  -------------------  -------------------  ---------  -------------  ----------------------
LE_LR5  Server  CN=lr5.wue4.vyos.net  CN=(STAGING) Riddling Rhubarb R12  2025-11-01 06:41:11  2026-01-30 06:41:10  No         Yes            Yes (AUTOCHAIN_LE_LR5)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
