### PR TITLE
wlb: T7977: Fix weight calculation for multiple interfaces

### DIFF
--- a/python/vyos/utils/misc.py
+++ b/python/vyos/utils/misc.py
@@ -12,6 +12,9 @@
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+import time
+
+from typing import Callable, Any
 
 def begin(*args):
     """
@@ -64,3 +67,23 @@ def install_into_config(conf, config_paths, override_prompt=True):
 
     if count > 0:
         print(f'{count} value(s) installed. Use "compare" to see the pending changes, and "commit" to apply.')
+
+def wait_for(func: Callable[[], Any], interval: float = 1.0, timeout: float = 5.0) -> bool:
+    """
+    Repeatedly calls `func()` until it returns True or the timeout expires.
+
+    Args:
+        func: A function with no arguments that returns a truthy value when ready.
+        interval: Seconds to wait between calls (default: 1.0).
+        timeout: Maximum time to wait in seconds (default: 5.0).
+
+    Returns:
+        True if the function returned True within the timeout, otherwise False.
+    """
+    start = time.monotonic()
+    while True:
+        if func():
+            return True
+        if (time.monotonic() - start) >= timeout:
+            return False
+        time.sleep(interval)

--- a/python/vyos/utils/misc.py
+++ b/python/vyos/utils/misc.py
@@ -68,7 +68,13 @@ def install_into_config(conf, config_paths, override_prompt=True):
     if count > 0:
         print(f'{count} value(s) installed. Use "compare" to see the pending changes, and "commit" to apply.')
 
-def wait_for(func: Callable[[], Any], interval: float = 1.0, timeout: float = 5.0) -> bool:
+def wait_for(
+    func: Callable[..., Any],
+    *args,
+    interval: float = 1.0,
+    timeout: float = 5.0,
+    **kwargs
+) -> bool:
     """
     Repeatedly calls `func()` until it returns True or the timeout expires.
 
@@ -82,7 +88,7 @@ def wait_for(func: Callable[[], Any], interval: float = 1.0, timeout: float = 5.
     """
     start = time.monotonic()
     while True:
-        if func():
+        if func(*args, **kwargs):
             return True
         if (time.monotonic() - start) >= timeout:
             return False

--- a/python/vyos/wanloadbalance.py
+++ b/python/vyos/wanloadbalance.py
@@ -154,7 +154,7 @@ def wlb_weight_interfaces(rule_conf, health_state):
     for ifname, weight in sorted(interfaces, key=lambda i: i[1]): # build weight ranges
         end = start + weight - 1
         out.append((ifname, f'{start}-{end}' if end > start else start))
-        start = weight
+        start += weight
 
     return out, total_weight
 

--- a/smoketest/scripts/cli/test_load-balancing_wan.py
+++ b/smoketest/scripts/cli/test_load-balancing_wan.py
@@ -21,8 +21,10 @@ import time
 from base_vyostest_shim import VyOSUnitTestSHIM
 from vyos.utils.file import chmod_755
 from vyos.utils.file import write_file
+from vyos.utils.misc import wait_for
 from vyos.utils.process import call
 from vyos.utils.process import cmd
+from vyos.utils.process import rc_cmd
 
 base_path = ['load-balancing']
 
@@ -428,6 +430,80 @@ echo "$ifname - $state" > {hook_output_path}
 
         self.verify_nftables_chain(nftables_search, 'ip vyos_wanloadbalance', 'wlb_mangle_prerouting')
 
+    def test_3_or_more_interfaces_in_rule(self):
+        lan_iface = 'eth1'
+
+        # Interfaces for equal weight test
+        self.cli_set(['interfaces', 'ethernet', 'eth0', 'vif', '101', 'address', '203.0.113.2/30'])
+        self.cli_set(['interfaces', 'ethernet', 'eth0', 'vif', '102', 'address', '203.0.113.6/30'])
+        self.cli_set(['interfaces', 'ethernet', 'eth0', 'vif', '103', 'address', '203.0.113.10/30'])
+
+        # Interfaces for unequal weight test
+        self.cli_set(['interfaces', 'ethernet', 'eth0', 'vif', '201', 'address', '203.0.113.14/30'])
+        self.cli_set(['interfaces', 'ethernet', 'eth0', 'vif', '202', 'address', '203.0.113.18/30'])
+        self.cli_set(['interfaces', 'ethernet', 'eth0', 'vif', '203', 'address', '203.0.113.22/30'])
+
+        self.cli_set(['interfaces', 'ethernet', lan_iface, 'vif', '100', 'address', '198.51.100.2/30'])
+        self.cli_set(['interfaces', 'ethernet', lan_iface, 'vif', '200', 'address', '198.51.100.6/30'])
+
+        # Health checks for equal weight test
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.101', 'nexthop', '203.0.113.2'])
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.101', 'success-count', '1'])
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.101', 'failure-count', '1'])
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.102', 'nexthop', '203.0.113.6'])
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.102', 'success-count', '1'])
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.102', 'failure-count', '1'])
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.103', 'nexthop', '203.0.113.10'])
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.103', 'success-count', '1'])
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.103', 'failure-count', '1'])
+        self.cli_set(base_path + ['wan', 'rule', '10', 'inbound-interface', f'{lan_iface}.100'])
+        self.cli_set(base_path + ['wan', 'rule', '10', 'interface', 'eth0.101'])
+        self.cli_set(base_path + ['wan', 'rule', '10', 'interface', 'eth0.102'])
+        self.cli_set(base_path + ['wan', 'rule', '10', 'interface', 'eth0.103'])
+
+        # Health checks for unequal weight test
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.201', 'nexthop', '203.0.113.14'])
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.201', 'success-count', '1'])
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.201', 'failure-count', '1'])
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.202', 'nexthop', '203.0.113.18'])
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.202', 'success-count', '1'])
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.202', 'failure-count', '1'])
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.203', 'nexthop', '203.0.113.22'])
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.203', 'success-count', '1'])
+        self.cli_set(base_path + ['wan', 'interface-health', 'eth0.203', 'failure-count', '1'])
+        self.cli_set(base_path + ['wan', 'rule', '20', 'inbound-interface', f'{lan_iface}.200'])
+        self.cli_set(base_path + ['wan', 'rule', '20', 'interface', 'eth0.201'])
+        self.cli_set(base_path + ['wan', 'rule', '20', 'interface', 'eth0.202', 'weight', '2'])
+        self.cli_set(base_path + ['wan', 'rule', '20', 'interface', 'eth0.203', 'weight', '3'])
+
+        # commit changes
+        self.cli_commit()
+
+        def check_wlb_status():
+            rc, wlb_status = rc_cmd('nft list chain ip vyos_wanloadbalance wlb_mangle_prerouting')
+            if rc != 0:
+                return False
+
+            # get all lines containing 'jump'
+            lines = [l for l in wlb_status.splitlines() if 'jump' in l]
+
+            # check total count of 'jump' across all matching lines
+            total_jumps = sum(l.count('jump') for l in lines)
+
+            return total_jumps == 6
+
+        wait_for(check_wlb_status)
+
+        nftables_search = [
+            ['jump wlb_mangle_isp_eth0.101'],
+            ['jump wlb_mangle_isp_eth0.102'],
+            ['jump wlb_mangle_isp_eth0.103'],
+            ['jump wlb_mangle_isp_eth0.201'],
+            ['jump wlb_mangle_isp_eth0.202'],
+            ['jump wlb_mangle_isp_eth0.203'],
+        ]
+
+        self.verify_nftables_chain(nftables_search, 'ip vyos_wanloadbalance', 'wlb_mangle_prerouting')
 
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
When more than 2 interfaces were configured in a WLB rule, nftables would fail to load the config since there were duplicate keys in the vmap. This corrects that issue.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7977
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
#### Configure 3 or more interfaces in a WLB rule:
```
set load-balancing wan rule 10 interface eth0.20
set load-balancing wan rule 10 interface eth0.101
set load-balancing wan rule 10 interface eth0.102
```
### Before:
#### Check for presence of nft chain:
```
sudo nft list table vyos_wanloadbalance
Error: No such file or directory
list table vyos_wanloadbalance
           ^^^^^^^^^^^^^^^^^^^
```
#### Errors can be viewed in the log. You'll see errors like this:
```
/run/nftables_wlb.conf:15:139-139: Error: Could not process rule: File exists
        iifname "eth1" ct state new counter numgen random mod 3 vmap { 0 : jump wlb_mangle_isp_eth0.20, 1 : jump wlb_mangle_isp_eth0.101, 1 : jump wlb_mangle_isp_eth0.102 }
                                                                                                                                          ^
```
### After:
#### Check the nft chain. vmap keys are now correct:
```
sudo nft list table vyos_wanloadbalance
table ip vyos_wanloadbalance {
        chain wlb_nat_postrouting {
                type nat hook postrouting priority srcnat - 1; policy accept;
                ct mark 0x000000c9 oifname "eth0.20" counter packets 0 bytes 0 snat to 192.168.2.186
                ct mark 0x000000ca oifname "eth0.101" counter packets 0 bytes 0 snat to 10.0.101.207
                ct mark 0x000000cb oifname "eth2" counter packets 0 bytes 0 snat to 10.0.101.208
        }

        chain wlb_mangle_prerouting {
                type filter hook prerouting priority mangle; policy accept;
                iifname "eth1" ct state new counter packets 0 bytes 0 numgen random mod 12 vmap { 0 : jump wlb_mangle_isp_eth0.20, 1 : jump wlb_mangle_isp_eth2, 2-11 : jump wlb_mangle_isp_eth0.101 }
                iifname "eth1" counter packets 0 bytes 0 meta mark set ct mark
        }

        chain wlb_mangle_output {
                type filter hook output priority mangle; policy accept;
                meta mark != 0x00000000 counter packets 0 bytes 0 return
                meta l4proto icmp counter packets 198 bytes 16632 return
                ip saddr 127.0.0.0/8 ip daddr 127.0.0.0/8 counter packets 24 bytes 1440 return
                oifname != "eth1" ct state new counter packets 0 bytes 0 numgen random mod 12 vmap { 0 : jump wlb_mangle_isp_eth0.20, 1 : jump wlb_mangle_isp_eth2, 2-11 : jump wlb_mangle_isp_eth0.101 }
                oifname != "eth1" counter packets 0 bytes 0 meta mark set ct mark
        }

        chain wlb_mangle_isp_eth0.20 {
                meta mark set 0x000000c9 ct mark set 0x000000c9 counter packets 0 bytes 0 accept
        }

        chain wlb_mangle_isp_eth0.101 {
                meta mark set 0x000000ca ct mark set 0x000000ca counter packets 0 bytes 0 accept
        }

        chain wlb_mangle_isp_eth2 {
                meta mark set 0x000000cb ct mark set 0x000000cb counter packets 0 bytes 0 accept
        }
}
```
### Smoketest results:
```
test_3_or_more_interfaces_in_rule (__main__.TestLoadBalancingWan.test_3_or_more_interfaces_in_rule) ... ok
test_check_chains (__main__.TestLoadBalancingWan.test_check_chains) ... ok
test_criteria_failover_hook (__main__.TestLoadBalancingWan.test_criteria_failover_hook) ... ok
test_firewall_groups (__main__.TestLoadBalancingWan.test_firewall_groups) ... ok
test_table_routes (__main__.TestLoadBalancingWan.test_table_routes) ... ok

----------------------------------------------------------------------
Ran 5 tests in 142.330s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
