### PR TITLE
syslog: T4251: Rename "permitted-peers" to "permitted-peer" and improve TLS checks

### DIFF
--- a/data/templates/rsyslog/rsyslog.conf.j2
+++ b/data/templates/rsyslog/rsyslog.conf.j2
@@ -120,9 +120,12 @@ if prifilt("{{ tmp | join(',') }}") then {
         StreamDriverMode="1"
         # Select the authentication mode
         StreamDriverAuthMode="{{ auth_mode if auth_mode == 'anon' else 'x509/' + auth_mode }}"
-{%                 if tls.permitted_peers is vyos_defined and auth_mode in ('fingerprint', 'name') %}
+{%                 if tls.permitted_peer is vyos_defined and auth_mode in ('fingerprint', 'name') %}
+{%                     set permitted_peers = tls.permitted_peer | map('trim') | select | join(',') %}
+{%                     if permitted_peers %}
         # Only include permitted peers (list of allowed fingerprints or names)
-        StreamDriverPermittedPeers="{{ tls.permitted_peers }}"
+        StreamDriverPermittedPeers="{{ permitted_peers }}"
+{%                     endif %}
 {%                 endif %}
 {%                 if tls.ca_certificate_path is vyos_defined %}
         # Include the path to the CA certificate file

--- a/interface-definitions/include/version/system-version.xml.i
+++ b/interface-definitions/include/version/system-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/system-version.xml.i -->
-<syntaxVersion component='system' version='29'></syntaxVersion>
+<syntaxVersion component='system' version='30'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/system_syslog.xml.in
+++ b/interface-definitions/system_syslog.xml.in
@@ -86,7 +86,7 @@
                       </valueHelp>
                       <valueHelp>
                         <format>fingerprint</format>
-                        <description>Authenticate peer by matching its certificate fingerprint to a configured, permitted list (`permitted-peers` option)</description>
+                        <description>Authenticate peer by matching its certificate fingerprint to a configured, permitted list (`permitted-peer` option)</description>
                       </valueHelp>
                       <valueHelp>
                         <format>certvalid</format>
@@ -94,7 +94,7 @@
                       </valueHelp>
                       <valueHelp>
                         <format>name</format>
-                        <description>Authenticate peer by verifying its certificate subject name against a configured value (`permitted-peers` option)</description>
+                        <description>Authenticate peer by verifying its certificate subject name against a configured value (`permitted-peer` option)</description>
                       </valueHelp>
                       <constraint>
                         <regex>(anon|fingerprint|certvalid|name)</regex>
@@ -102,13 +102,14 @@
                     </properties>
                     <defaultValue>anon</defaultValue>
                   </leafNode>
-                  <leafNode name="permitted-peers">
+                  <leafNode name="permitted-peer">
                     <properties>
-                      <help>Comma-separated list of allowed peer certificate fingerprints or subject names</help>
+                      <help>Allowed peer certificate fingerprint or subject name</help>
                       <valueHelp>
                         <format>txt</format>
-                        <description>Comma-separated fingerprints or peer names.\nFor example:\n - 'SHA1:DD:23:E3:E7:70:F5:B4:13:44:16:78:A5:5A:8C:39:48:53:A6:DD:25,SHA256:10:C4:26:1D:CB:3C:AB:12:DB:1A:F0:47:37:AE:6D:D2:DE:66:B5:71:B7:2E:5B:BB:AE:0C:7E:7F:5F:0D:E9:64'\n - 'logs.example.com'</description>
+                        <description>Peer fingerprint - SHA1:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX:XX or subject name - logs.example.com</description>
                       </valueHelp>
+                      <multi/>
                     </properties>
                   </leafNode>
                 </children>

--- a/src/conf_mode/system_syslog.py
+++ b/src/conf_mode/system_syslog.py
@@ -71,15 +71,15 @@ def _verify_tls_remote_options(remote, remote_options, syslog):
     if ca_certificate:
         verify_pki_ca_certificate(syslog, ca_certificate)
 
-    permitted_peers = dict_search('tls.permitted_peers', remote_options)
+    permitted_peers = dict_search('tls.permitted_peer', remote_options)
     if not permitted_peers:
         if auth_mode == "fingerprint":
             raise ConfigError(
-                f'Auth mode "fingerprint" for remote "{remote}" requires "permitted-peers" to be configured!'
+                f'Auth mode "fingerprint" for remote "{remote}" requires "permitted-peer" to be configured!'
             )
         elif auth_mode == "name":
             raise ConfigError(
-                f'Auth mode "name" for remote "{remote}" requires "permitted-peers" to specify allowed subject names!'
+                f'Auth mode "name" for remote "{remote}" requires "permitted-peer" to specify allowed subject names!'
             )
 
 
@@ -181,7 +181,7 @@ def verify(syslog):
                 _verify_tls_remote_options(remote, remote_options, syslog)
 
                 if 'protocol' in remote_options and remote_options['protocol'] == 'udp':
-                    Warning(
+                    raise ConfigError(
                         f'TLS is enabled for remote "{remote}", but protocol is set to UDP. TLS is only supported with protocol TCP!'
                     )
 

--- a/src/migration-scripts/system/29-to-30
+++ b/src/migration-scripts/system/29-to-30
@@ -1,0 +1,52 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# T4251:
+#   - drop "tls enable" node (make "tls" a standalone key)
+#   - split "tls permitted-peers" list by commas into multiple "tls permitted-peer" entries
+
+from vyos.configtree import ConfigTree
+
+base = ['system', 'syslog', 'remote']
+
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(base):
+        return
+
+    # Iterate over all remote syslog server entries (like 172.18.0.5)
+    for remote_addr in config.list_nodes(base):
+        remote_base = base + [remote_addr]
+        tls_base = remote_base + ['tls']
+
+        # (1) Remove "tls enable" -> migrate to simple "tls"
+        enable_path = tls_base + ['enable']
+        if config.exists(enable_path):
+            # Remove obsolete "enable" node
+            config.delete(enable_path)
+
+        # (2) Split "tls permitted-peers" (comma-separated string)
+        permitted_peers_path = tls_base + ['permitted-peers']
+        if config.exists(permitted_peers_path):
+            peers_str = config.return_value(permitted_peers_path)
+            # Split CSV values and normalize whitespace
+            peers = [p.strip() for p in peers_str.split(',') if p.strip()]
+
+            # Create a new "permitted-peer" entry per item
+            for peer in peers:
+                config.set(tls_base + ['permitted-peer'], value=peer, replace=False)
+
+            # Remove the old combined node
+            config.delete(permitted_peers_path)


### PR DESCRIPTION
## Change summary
- Renamed `permitted-peers` to `permitted-peer` across templates, schema, and tests.
- Added support for multiple `permitted-peer` entries and trimmed empty values.
- Replaced TLS/UDP warning with `ConfigError` for strict validation.
- Updated tests to use TCP for TLS and verified new validation logic.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T4251

## Related PR(s)
* https://github.com/vyos/vyos-1x/pull/4734
* https://github.com/vyos/vyos-documentation/pull/1701

## How to test / Smoketest result
```
$ /usr/libexec/vyos/tests/smoke/cli/test_system_syslog.py
test_basic (__main__.TestRSYSLOGService.test_basic) ... ok
test_console (__main__.TestRSYSLOGService.test_console) ... ok
test_remote (__main__.TestRSYSLOGService.test_remote) ... ok
test_remote_tls (__main__.TestRSYSLOGService.test_remote_tls) ... ok
test_remote_tls_protocol_udp (__main__.TestRSYSLOGService.test_remote_tls_protocol_udp) ... ok
test_vrf_source_address (__main__.TestRSYSLOGService.test_vrf_source_address) ... ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly