### PR TITLE
T7849: ZBF allow to use wildcard interfaces as member

### DIFF
--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -466,7 +466,7 @@
               <help>Interface associated with zone</help>
             </properties>
             <children>
-              #include <include/generic-interface-multi.xml.i>
+              #include <include/generic-interface-multi-wildcard.xml.i>
               <leafNode name="vrf">
                 <properties>
                   <help>VRF associated with zone</help>

--- a/interface-definitions/include/constraint/interface-name-with-wildcard.xml.i
+++ b/interface-definitions/include/constraint/interface-name-with-wildcard.xml.i
@@ -1,4 +1,5 @@
 <!-- include start from constraint/interface-name-with-wildcard.xml.i -->
-<regex>(bond|br|dum|en|ersp|eth|gnv|ifb|lan|l2tp|l2tpeth|macsec|peth|ppp|pppoe|pptp|sstp|tun|veth|vti|vtun|vxlan|wg|wlan|wwan)([0-9]?)(\*?)(.+)?|lo</regex>
+<regex>(bond|br|dum|en|ersp|eth|gnv|ifb|ipoe|lan|l2tp|l2tpeth|macsec|peth|ppp|pppoe|pptp|sstp|sstpc|tun|veth|vpptap|vpptun|vti|vtun|vxlan|wg|wlan|wwan)([0-9]?)(\*?)(.+)?|lo</regex>
+<regex>(pod-[-_a-zA-Z0-9]{1,11})</regex>
 <validator name="file-path --lookup-path /sys/class/net --directory"/>
 <!-- include end -->

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -1086,6 +1086,34 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.verify_nftables(nftables_search, 'ip vyos_filter')
         self.verify_nftables(nftables_search_v6, 'ip6 vyos_filter')
 
+    def test_wildcard_interfaces(self):
+        wc_interfaces = [
+            'eth0',
+            'eth0.*',
+            'eth1',
+            'eth1.23.*',
+            'eth2.5.25',
+            'eth2.5.25.54',
+            'eth3*',
+            'eth4.*',
+            'ipoe*',
+            'peth3',
+            'peth3.',
+            'pod-one',
+            'pppoe*',
+            'pptp*',
+            'l2tp*',
+            'sstp*',
+            'vpptun*',
+        ]
+        for iface in wc_interfaces:
+            self.cli_set(
+                ['firewall', 'zone', 'smoketest-wildcard', 'member', 'interface', iface]
+            )
+        self.cli_commit()
+
+        self.verify_nftables(wc_interfaces, 'ip vyos_filter')
+
     def test_flow_offload(self):
         self.cli_set(['interfaces', 'ethernet', 'eth0', 'vif', '10'])
         self.cli_set(['firewall', 'flowtable', 'smoketest', 'interface', 'eth0.10'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Allow to use dynamic interfaces `ipoe*/pppoe*/l2tp` for zone-based firewal member interface
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/7849

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_firewall.py -k test_wildcard_interfaces
test_wildcard_interfaces (__main__.TestFirewall.test_wildcard_interfaces) ... ok

----------------------------------------------------------------------
Ran 1 test in 3.661s

OK
vyos@r14:~$ 
```

CLI config:
```

set firewall zone foo member interface 'eth0'
set firewall zone foo member interface 'eth0.*'
set firewall zone foo member interface 'eth1'
set firewall zone foo member interface 'eth1.23.*'
set firewall zone foo member interface 'eth2.5.25'
set firewall zone foo member interface 'eth2.5.25.54'
set firewall zone foo member interface 'eth3*'
set firewall zone foo member interface 'eth4.*'
set firewall zone foo member interface 'ipoe*'
set firewall zone foo member interface 'peth3'
set firewall zone foo member interface 'peth3.'
set firewall zone foo member interface 'pod-one'
set firewall zone foo member interface 'pppoe*'
set firewall zone foo member interface 'pptp*'
set firewall zone foo member interface 'l2tp*'
set firewall zone foo member interface 'sstp*'
set firewall zone foo member interface 'vpptun*'
```
nftables:
```
vyos@r14:~$ sudo nft list chain ip vyos_filter VYOS_ZONE_FORWARD
table ip vyos_filter {
	chain VYOS_ZONE_FORWARD {
		type filter hook forward priority filter + 1; policy accept;
		oifname { "eth0", "eth0.*", "eth1", "eth2.5.25", "eth2.5.25.54", "eth3*", "eth4.*", "ipoe*", "l2tp*", "peth3", "peth3.", "pod-one", "pppoe*", "pptp*", "sstp*", "vpptun*" } counter packets 0 bytes 0 jump VZONE_foo
	}
}
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
