### PR TITLE
T7980: Load active config on vyconfd restart

### DIFF
--- a/src/init/vyconfd.sh
+++ b/src/init/vyconfd.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Check if state file exists to determine if restart
+if [ -f /var/run/vyconfd.state ]; then
+    echo "Restarting vyconfd from active config"
+    /usr/libexec/vyos/vyconf/vyconfd --log-file /var/run/log/vyconfd.log --reload-active-config --legacy-config-path
+else
+    echo "Starting vyconfd from saved config"
+    touch /var/run/vyconfd.state
+    /usr/libexec/vyos/vyconf/vyconfd --log-file /var/run/log/vyconfd.log --legacy-config-path
+fi

--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -594,8 +594,6 @@ start ()
 
     disabled system_config || system_config || overall_status=1
 
-    systemctl start vyconfd.service
-
     for s in ${subinit[@]} ; do
         if ! disabled $s; then
             log_progress_msg $s

--- a/src/systemd/vyconfd.service
+++ b/src/systemd/vyconfd.service
@@ -8,7 +8,7 @@ DefaultDependencies=no
 After=systemd-remount-fs.service
 
 [Service]
-ExecStart=/usr/libexec/vyos/vyconf/vyconfd --log-file /var/run/log/vyconfd.log --legacy-config-path
+ExecStart=/usr/libexec/vyos/init/vyconfd.sh
 Type=exec
 SyslogIdentifier=vyconfd
 SyslogFacility=daemon


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

NOTE: requires
https://github.com/vyos/vyos1x-config/pull/55
https://github.com/vyos/vyconf/pull/34

Distinguish vyconfd initialization from subsequent restart and reload active config in the latter case.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): add missing internal feature

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos1x-config/pull/55
https://github.com/vyos/vyconf/pull/34

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
