### PR TITLE
pki: T7976: calls to node_changed_presence() must use unmangled config paths

### DIFF
--- a/src/conf_mode/pki.py
+++ b/src/conf_mode/pki.py
@@ -83,6 +83,7 @@ sync_search = [
     {
         'keys': ['certificate', 'ca_certificate'],
         'path': ['load_balancing', 'haproxy'],
+        'orig_path': ['load-balancing', 'haproxy'],
     },
     {
         'keys': ['key'],
@@ -276,11 +277,12 @@ def get_config(config=None):
                         if isinstance(found_name, str) and found_name != item_name:
                             continue
 
-                        path = search['path']
+                        # prefer orig_path over path when unmangling is needed
+                        path = search.get('orig_path', search.get('path'))
                         # Only enable this for debug purposes - otherwise we will always
                         # print this message for ACME certificates during renew tests -
                         # even if they are not due for renew!
-                        # path_str = ' '.join(path + found_path).replace('_','-')
+                        # path_str = ' '.join(path + found_path)
                         # print(f'Updating configuration: "{path_str} {item_name}"')
 
                         if path[0] == 'interfaces':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

We do use mangled config paths where `pki = conf.get_config_dict(base, key_mangling=('-', '_'), ...`
returns a config dict where "-" is replaced by "_" when assembling the config dict keys.

This does not work when we throw the retrieved path into `ConfigDiff().node_changed_presence()`

https://github.com/vyos/vyos-1x/blob/07936657062c/src/conf_mode/pki.py#L259-L265

Add `orig_path` key which is preferred over `path`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7976

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
