### PR TITLE
container: T7305: fix VRF loss when restarting pods

### DIFF
--- a/python/vyos/container.py
+++ b/python/vyos/container.py
@@ -1,0 +1,41 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from vyos.config import Config
+from vyos.ifconfig import Interface
+from vyos.utils.dict import dict_search
+from vyos.utils.network import interface_exists
+
+def restart_network(config: Config) -> None:
+    """
+    Start network and assign it to given VRF if requested.
+
+    This can only be done after the containers got started as the podman network
+    interface will only be enabled by the first container and yet I do not know
+    how to enable the network interface in advance.
+    """
+    if 'network' in config:
+        for network, network_config in config['network'].items():
+            type_config = dict_search('type', network_config)
+            if not dict_search('macvlan', type_config):
+                network_name = f'pod-{network}'
+                # T5147: Networks are started only as soon as there is a consumer.
+                # If only a network is created in the first place, no need to assign
+                # it to a VRF as there's no consumer, yet.
+                if interface_exists(network_name):
+                    tmp = Interface(network_name)
+                    tmp.set_vrf(network_config.get('vrf', ''))
+                    tmp.add_ipv6_eui64_address('fe80::/64')
+
+    return None

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -619,7 +619,7 @@ class Interface(Control):
         if 'netns' in self.config:
             return False
 
-        tmp = self.get_interface('vrf')
+        tmp = self.get_vrf()
         if tmp == vrf:
             return False
 

--- a/src/op_mode/container.py
+++ b/src/op_mode/container.py
@@ -166,6 +166,8 @@ def show_network(raw: bool):
 
 def restart(name: str):
     from vyos.utils.process import rc_cmd
+    from vyos.config import Config
+    from vyos.container import restart_network
 
     rc, output = rc_cmd(f'systemctl restart vyos-container-{name}.service')
     if rc != 0:
@@ -173,6 +175,13 @@ def restart(name: str):
         if rc2 != 0:
             print(output)
             return None
+    if rc == 0:
+        conf = Config()
+        container = conf.get_config_dict(['container'], key_mangling=('-', '_'),
+                                    no_tag_node_value_mangle=True,
+                                    get_first_key=True,
+                                    with_recursive_defaults=True)
+        restart_network(container)
     print(f'Container "{name}" restarted!')
     return output
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Container networks are only started when there is at least one active consumer. If a network is created without any attached containers, it does not need to be assigned to a VRF yet.

When the last container in a pod is stopped, its associated container network is removed. Upon container restart, the kernel recreates the network, but the VRF assignment may be lost in the process.

This change ensures that all container networks are correctly reattached to their designated VRFs when a pod restarts.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7305

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

**BEFORE**

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_container.py -k test_network_vrf
test_network_vrf (__main__.TestContainer.test_network_vrf) ... FAIL

======================================================================
FAIL: test_network_vrf (__main__.TestContainer.test_network_vrf)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/libexec/vyos/tests/smoke/cli/test_container.py", line 522, in test_network_vrf
    self.assertEqual(tmp, vrf_name)
AssertionError: 'default' != 'red-15'
- default
+ red-15
```

**AFTER**

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_container.py -k test_network_vrf
test_network_vrf (__main__.TestContainer.test_network_vrf) ... ok

----------------------------------------------------------------------
Ran 1 test in 15.381s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly


** BEFORE **