### PR TITLE
veth: T7990: fix stale DHCP clients when removing virtual Ethernet pairs

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_virtual-ethernet.py
+++ b/smoketest/scripts/cli/test_interfaces_virtual-ethernet.py
@@ -15,13 +15,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-from netifaces import interfaces # pylint: disable = no-name-in-module
 
 from base_interfaces_test import BasicInterfaceTest
 from base_vyostest_shim import VyOSUnitTestSHIM
-
-from vyos.frrender import mgmt_daemon
-from vyos.utils.process import process_named_running
 
 class VEthInterfaceTest(BasicInterfaceTest.TestCase):
     @classmethod
@@ -35,29 +31,6 @@ class VEthInterfaceTest(BasicInterfaceTest.TestCase):
         cls._interfaces = list(cls._options)
         # call base-classes classmethod
         super(VEthInterfaceTest, cls).setUpClass()
-
-    # As we always need a pair of veth interfaces, we can not rely on the base
-    # class check to determine if there is a dhcp6c or dhclient instance
-    # running. This test will always fail as there is an instance still running
-    # on the peer interface.
-    def tearDown(self):
-        self.cli_delete(self._base_path)
-        self.cli_commit()
-
-        # Verify that no previously interface remained on the system
-        for intf in self._interfaces:
-            self.assertNotIn(intf, interfaces())
-
-        # check process health and continuity
-        self.assertEqual(self.mgmt_daemon_pid, process_named_running(mgmt_daemon))
-
-    @classmethod
-    def tearDownClass(cls):
-        # No daemon started during tests should remain running
-        for daemon in ['dhcp6c', 'dhclient']:
-            cls.assertFalse(cls, process_named_running(daemon))
-
-        super(VEthInterfaceTest, cls).tearDownClass()
 
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())


### PR DESCRIPTION
## Change summary
<!--- Provide a general summary of your changes in the Title above -->

When removing a veth interface, the kernel automatically deletes its peer interface, since veth devices always exist in pairs. However, this automatic removal does not trigger the remove() helper in vyos.ifconfig.interfaces, which can leave associated DHCP(v6) clients running indefinitely.

For example:
```
ip link add veth0 type veth peer name veth1
ip link del dev veth1
```

Removing veth1 will also delete veth0 in the kernel, but the VyOS cleanup routines are never called for veth0. This patch ensures that peer removal correctly purges both interfaces and their associated state.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7990

## How to test / Smoketest result

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_virtual-ethernet.py
test_add_multiple_ip_addresses (__main__.VEthInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.VEthInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.VEthInterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.VEthInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.VEthInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.VEthInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.VEthInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.VEthInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.VEthInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.VEthInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol (__main__.VEthInterfaceTest.test_eapol) ... skipped 'unsupported on interface family'
test_interface_description (__main__.VEthInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.VEthInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.VEthInterfaceTest.test_interface_ip_options) ... skipped 'unsupported on interface family'
test_interface_ipv6_options (__main__.VEthInterfaceTest.test_interface_ipv6_options) ... skipped 'unsupported on interface family'
test_interface_mtu (__main__.VEthInterfaceTest.test_interface_mtu) ... ok
test_ipv6_link_local_address (__main__.VEthInterfaceTest.test_ipv6_link_local_address) ... skipped 'unsupported on interface family'
test_move_interface_between_vrf_instances (__main__.VEthInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.VEthInterfaceTest.test_mtu_1200_no_ipv6_interface) ... skipped 'unsupported on interface family'
test_span_mirror (__main__.VEthInterfaceTest.test_span_mirror) ... skipped 'unsupported on interface family'
test_vif_8021q_interfaces (__main__.VEthInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.VEthInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.VEthInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.VEthInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.VEthInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.VEthInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 26 tests in 87.140s
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
