### PR TITLE
firewall: T7112: Default action drop fails

### DIFF
--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -1086,6 +1086,15 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.verify_nftables(nftables_search, 'ip vyos_filter')
         self.verify_nftables(nftables_search_v6, 'ip6 vyos_filter')
 
+    def test_zone_without_member(self):
+        self.cli_set(['firewall', 'zone', 'wan', 'default-action', 'drop'])
+        error_message = 'Zone "wan" has no interfaces and is not the local zone'
+        with self.assertRaisesRegex(ConfigSessionError, error_message):
+            self.cli_commit()
+
+        self.cli_set(['firewall', 'zone', 'wan', 'member', 'interface', 'eth1'])
+        self.cli_commit()
+
     def test_wildcard_interfaces(self):
         wc_interfaces = [
             'eth0',

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -146,9 +146,10 @@ def get_config(config=None):
         for local_zone, local_zone_conf in firewall['zone'].items():
             if 'local_zone' not in local_zone_conf:
                 # Get physical interfaces assigned to the zone if vrf is used:
-                if 'vrf' in local_zone_conf['member']:
+                local_zone_member = local_zone_conf.get('member', {})
+                if 'vrf' in local_zone_member:
                     local_zone_conf['vrf_interfaces'] = {}
-                    for vrf_name in local_zone_conf['member']['vrf']:
+                    for vrf_name in local_zone_member['vrf']:
                         local_zone_conf['vrf_interfaces'][vrf_name] = ','.join(get_vrf_members(vrf_name))
                 continue
 


### PR DESCRIPTION
## Change summary
Prevent `KeyError` by safely handling missing 'member' dict in zone config.
Add smoketest to verify commit fails gracefully when zone has no interfaces.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7112

#### Manual test
```
vyos@vyos:~$ conf
vyos@vyos# set firewall zone wan default-action drop
vyos@vyos# commit
[ firewall ]
Zone "wan" has no interfaces and is not the local zone
[[firewall]] failed
Commit failed
```

#### Smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_firewall.py
...
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... ok
test_zone_with_vrf (__main__.TestFirewall.test_zone_with_vrf) ... ok
test_zone_without_member (__main__.TestFirewall.test_zone_without_member) ... ok
...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
