### PR TITLE
T7731: Static ARP entries are missing after an interface status change

### DIFF
--- a/data/config-mode-dependencies/vyos-1x.json
+++ b/data/config-mode-dependencies/vyos-1x.json
@@ -8,11 +8,40 @@
         "group_resync": ["system_conntrack", "nat", "policy_route", "load-balancing_wan"]
     },
     "interfaces_bonding": {
-        "ethernet": ["interfaces_ethernet"]
+        "ethernet": ["interfaces_ethernet"],
+        "static_arp": ["protocols_static_arp"]
     },
     "interfaces_bridge": {
         "vxlan": ["interfaces_vxlan"],
-        "wlan": ["interfaces_wireless"]
+        "wlan": ["interfaces_wireless"],
+        "static_arp": ["protocols_static_arp"]
+    },
+    "interfaces_ethernet": {
+        "static_arp": ["protocols_static_arp"]
+    },
+    "interfaces_geneve": {
+        "static_arp": ["protocols_static_arp"]
+    },
+    "interfaces_l2tpv3": {
+        "static_arp": ["protocols_static_arp"]
+    },
+    "interfaces_macsec": {
+        "static_arp": ["protocols_static_arp"]
+    },
+    "interfaces_pseudo_ethernet": {
+        "static_arp": ["protocols_static_arp"]
+    },
+    "interfaces_virtual_ethernet": {
+        "static_arp": ["protocols_static_arp"]
+    },
+    "interfaces_vxlan": {
+        "static_arp": ["protocols_static_arp"]
+    },
+    "interfaces_wireless": {
+        "static_arp": ["protocols_static_arp"]
+    },
+    "interfaces_wwan": {
+        "static_arp": ["protocols_static_arp"]
     },
     "interfaces_wireguard": {
         "vxlan": ["interfaces_vxlan"]

--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -613,6 +613,16 @@ def get_interface_dict(config, base, ifname='', recursive_defaults=True, with_pk
 
     # Check vif, vif-s/vif-c VLAN interfaces for removal
     dict = get_removed_vlans(config, base + [ifname], dict)
+
+    # Checks for the presence of static ARP entries on a given interface or VLAN
+    static_arp = config.get_config_dict(
+        ['protocols', 'static', 'arp', 'interface'],
+        key_mangling=('-', '_'),
+        get_first_key=True,
+    )
+    if any(key == ifname or key.startswith(f'{ifname}.') for key in static_arp.keys()):
+        dict.update({'static_arp': {}})
+
     return ifname, dict
 
 def get_vlan_ids(interface):

--- a/src/conf_mode/interfaces_bonding.py
+++ b/src/conf_mode/interfaces_bonding.py
@@ -175,6 +175,10 @@ def get_config(config=None):
             tmp = has_vrf_configured(conf, interface)
             if tmp: bond['member']['interface'][interface].update({'has_vrf' : ''})
 
+    # Protocols static arp dependency
+    if 'static_arp' in bond:
+        set_dependents('static_arp', conf)
+
     return bond
 
 
@@ -279,7 +283,7 @@ def apply(bond):
     else:
         b.update(bond)
 
-    if dict_search('member.interface_remove', bond):
+    if dict_search('member.interface_remove', bond) or 'static_arp' in bond:
         try:
             call_dependents()
         except ConfigError:

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -20,6 +20,8 @@ from sys import exit
 
 from vyos.base import Warning
 from vyos.config import Config
+from vyos.configdep import set_dependents
+from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
 from vyos.configdict import get_flowtable_interfaces
@@ -170,6 +172,10 @@ def get_config(config=None):
     if tmp: ethernet.update({'frr_dict' : get_frrender_dict(conf)})
 
     ethernet['flowtable_interfaces'] = get_flowtable_interfaces(conf)
+
+    # Protocols static arp dependency
+    if 'static_arp' in ethernet:
+        set_dependents('static_arp', conf)
 
     return ethernet
 
@@ -368,6 +374,8 @@ def apply(ethernet):
         e.remove()
     else:
         e.update(ethernet)
+    if 'static_arp' in ethernet:
+        call_dependents()
     return None
 
 if __name__ == '__main__':

--- a/src/conf_mode/interfaces_geneve.py
+++ b/src/conf_mode/interfaces_geneve.py
@@ -17,6 +17,8 @@
 from sys import exit
 
 from vyos.config import Config
+from vyos.configdep import set_dependents
+from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
 from vyos.configverify import verify_address
@@ -50,6 +52,10 @@ def get_config(config=None):
     for cli_option in ['remote', 'vni', 'parameters', 'port']:
         if is_node_changed(conf, base + [ifname, cli_option]):
             geneve.update({'rebuild_required': {}})
+
+    # Protocols static arp dependency
+    if 'static_arp' in geneve:
+        set_dependents('static_arp', conf)
 
     return geneve
 
@@ -89,6 +95,9 @@ def apply(geneve):
         # Finally create the new interface
         g = GeneveIf(**geneve)
         g.update(geneve)
+
+    if 'static_arp' in geneve:
+        call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_l2tpv3.py
+++ b/src/conf_mode/interfaces_l2tpv3.py
@@ -17,6 +17,8 @@
 from sys import exit
 
 from vyos.config import Config
+from vyos.configdep import set_dependents
+from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
 from vyos.configdict import leaf_node_changed
 from vyos.configverify import verify_address
@@ -55,6 +57,10 @@ def get_config(config=None):
 
         tmp = leaf_node_changed(conf, base + [ifname, 'session-id'])
         l2tpv3.update({'session_id': tmp[0]})
+
+    # Protocols static arp dependency
+    if 'static_arp' in l2tpv3:
+        set_dependents('static_arp', conf)
 
     return l2tpv3
 
@@ -99,6 +105,9 @@ def apply(l2tpv3):
         # Finally create the new interface
         l = L2TPv3If(**l2tpv3)
         l.update(l2tpv3)
+
+    if 'static_arp' in l2tpv3:
+        call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_pseudo-ethernet.py
+++ b/src/conf_mode/interfaces_pseudo-ethernet.py
@@ -17,8 +17,9 @@
 from sys import exit
 
 from vyos.config import Config
+from vyos.configdep import set_dependents
+from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
-from vyos.configdict import is_node_changed
 from vyos.configdict import is_source_interface
 from vyos.configdict import is_node_changed
 from vyos.configverify import verify_vrf
@@ -61,6 +62,10 @@ def get_config(config=None):
         tmp = is_source_interface(conf, peth['source_interface'], ['macsec'])
         if tmp and tmp != ifname: peth.update({'is_source_interface' : tmp})
 
+    # Protocols static arp dependency
+    if 'static_arp' in peth:
+        set_dependents('static_arp', conf)
+
     return peth
 
 def verify(peth):
@@ -94,6 +99,9 @@ def apply(peth):
     if 'deleted' not in peth:
         p = MACVLANIf(**peth)
         p.update(peth)
+
+    if 'static_arp' in peth:
+        call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_virtual-ethernet.py
+++ b/src/conf_mode/interfaces_virtual-ethernet.py
@@ -19,6 +19,8 @@ from sys import exit
 from vyos import ConfigError
 from vyos import airbag
 from vyos.config import Config
+from vyos.configdep import set_dependents
+from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
 from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
@@ -46,6 +48,10 @@ def get_config(config=None):
     # interfaces configrued on the CLI so we can assign proper IP addresses etc.
     veth['other_interfaces'] = conf.get_config_dict(base, key_mangling=('-', '_'),
                                      get_first_key=True, no_tag_node_value_mangle=True)
+
+    # Protocols static arp dependency
+    if 'static_arp' in veth:
+        set_dependents('static_arp', conf)
 
     return veth
 
@@ -100,6 +106,9 @@ def apply(veth):
     if 'deleted' not in veth:
         p = VethIf(**veth)
         p.update(veth)
+
+    if 'static_arp' in veth:
+        call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_vxlan.py
+++ b/src/conf_mode/interfaces_vxlan.py
@@ -18,6 +18,8 @@ from sys import exit
 
 from vyos.base import Warning
 from vyos.config import Config
+from vyos.configdep import set_dependents
+from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
 from vyos.configdict import leaf_node_changed
 from vyos.configdict import is_node_changed
@@ -82,6 +84,10 @@ def get_config(config=None):
         del vxlan['other_tunnels'][ifname]
     if len(vxlan['other_tunnels']) == 0:
         del vxlan['other_tunnels']
+
+    # Protocols static arp dependency
+    if 'static_arp' in vxlan:
+        set_dependents('static_arp', conf)
 
     return vxlan
 
@@ -248,6 +254,9 @@ def apply(vxlan):
         # Finally create the new interface
         v = VXLANIf(**vxlan)
         v.update(vxlan)
+
+    if 'static_arp' in vxlan:
+        call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_wireless.py
+++ b/src/conf_mode/interfaces_wireless.py
@@ -22,6 +22,8 @@ from netaddr import EUI, mac_unix_expanded
 from time import sleep
 
 from vyos.config import Config
+from vyos.configdep import set_dependents
+from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
 from vyos.configdict import dict_merge
 from vyos.configverify import verify_address
@@ -132,6 +134,10 @@ def get_config(config=None):
     # used in hostapd.conf.j2
     wifi['hostapd_accept_station_conf'] = hostapd_accept_station_conf.format(**wifi)
     wifi['hostapd_deny_station_conf'] = hostapd_deny_station_conf.format(**wifi)
+
+    # Protocols static arp dependency
+    if 'static_arp' in wifi:
+        set_dependents('static_arp', conf)
 
     return wifi
 
@@ -330,6 +336,9 @@ def apply(wifi):
 
         elif wifi['type'] == 'station':
             call(f'systemctl start wpa_supplicant@{interface}.service')
+
+    if 'static_arp' in wifi:
+        call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_wwan.py
+++ b/src/conf_mode/interfaces_wwan.py
@@ -20,6 +20,8 @@ from sys import exit
 from time import sleep
 
 from vyos.config import Config
+from vyos.configdep import set_dependents
+from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
 from vyos.configverify import verify_authentication
@@ -86,6 +88,10 @@ def get_config(config=None):
         del wwan['other_interfaces'][ifname]
     if len(wwan['other_interfaces']) == 0:
         del wwan['other_interfaces']
+
+    # Protocols static arp dependency
+    if 'static_arp' in wwan:
+        set_dependents('static_arp', conf)
 
     return wwan
 
@@ -179,6 +185,10 @@ def apply(wwan):
         call(command, stdout=DEVNULL)
 
     w.update(wwan)
+
+    if 'static_arp' in wwan:
+        call_dependents()
+
     return None
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7731
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set interfaces ethernet eth1 address 10.0.0.1/24
set protocols static arp interface eth1 address 10.0.0.2 mac 00:11:22:33:44:55
commit

vyos@vyos# sudo ip neighbor
10.0.0.2 dev eth1 lladdr 00:11:22:33:44:55 PERMANENT
10.20.40.1 dev eth2 lladdr 52:54:00:96:c3:5d STALE
```
Change interface status (VPP configuration requires interface reinitialization)
```
set vpp settings interface eth1 driver dpdk
commit
```
Before the fix ARP entry was missing
```
vyos@vyos# sudo ip neighbor
10.20.40.1 dev eth2 lladdr 52:54:00:96:c3:5d STALE
```
After the fix it's in place
```
vyos@vyos# sudo ip neighbor
10.0.0.2 dev eth1 lladdr 00:11:22:33:44:55 PERMANENT
10.20.40.1 dev eth2 lladdr 52:54:00:96:c3:5d STALE
```

```
vyos@vyos# /usr/libexec/vyos/tests/smoke/cli/test_vpp.py -k test_21_static_arp
test_21_static_arp (__main__.TestVPP.test_21_static_arp) ... ok

----------------------------------------------------------------------
Ran 1 test in 34.444s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
