### PR TITLE
smoketest: T7996: fix hardcoded "vrf red" search path in FRR config

### DIFF
--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -140,12 +140,14 @@ class VyOSUnitTestSHIM:
                 pprint.pprint(out)
             return out
 
-        def getFRRconfig(self, start_section:str=None, stop_section='^!',
+        def getFRRconfig(self, start_section:str=None, end_marker='$', stop_section='^!',
                          start_subsection:str=None, stop_subsection='^ exit') -> str:
             """
             Retrieve current "running configuration" from FRR
 
             start_section:    search for a specific start string in the configuration
+            end_marker:       override default "line end $" marker to match on an
+                              "open end" string
             stop_section:     end of the configuration
             start_subsection: search section under the result found by string
             stop_subsection:  end of the subsection (usually something with "exit")
@@ -158,7 +160,7 @@ class VyOSUnitTestSHIM:
             in_section = False
             for line in frr_config.splitlines():
                 if not in_section:
-                    if re.match(start_section, line):
+                    if re.match(f'^{start_section}{end_marker}', line):
                         in_section = True
                         extracted.append(line)
                 else:

--- a/smoketest/scripts/cli/test_policy.py
+++ b/smoketest/scripts/cli/test_policy.py
@@ -123,7 +123,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        config = self.getFRRconfig('access-list')
+        config = self.getFRRconfig('access-list', end_marker='')
         for acl, acl_config in acls.items():
             for rule, rule_config in acl_config['rule'].items():
                 tmp = f'access-list {acl} seq {rule}'
@@ -214,7 +214,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        config = self.getFRRconfig('ipv6 access-list')
+        config = self.getFRRconfig('ipv6 access-list', end_marker='')
         for acl, acl_config in acls.items():
             for rule, rule_config in acl_config['rule'].items():
                 tmp = f'ipv6 access-list {acl} seq {rule}'
@@ -312,7 +312,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        config = self.getFRRconfig('bgp as-path access-list')
+        config = self.getFRRconfig('bgp as-path access-list', end_marker='')
         for as_path, as_path_config in test_data.items():
             if 'rule' not in as_path_config:
                 continue
@@ -370,7 +370,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        config = self.getFRRconfig('bgp community-list')
+        config = self.getFRRconfig('bgp community-list', end_marker='')
         for comm_list, comm_list_config in test_data.items():
             if 'rule' not in comm_list_config:
                 continue
@@ -428,7 +428,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        config = self.getFRRconfig('bgp extcommunity-list')
+        config = self.getFRRconfig('bgp extcommunity-list', end_marker='')
         for comm_list, comm_list_config in test_data.items():
             if 'rule' not in comm_list_config:
                 continue
@@ -493,7 +493,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        config = self.getFRRconfig('bgp large-community-list')
+        config = self.getFRRconfig('bgp large-community-list', end_marker='')
         for comm_list, comm_list_config in test_data.items():
             if 'rule' not in comm_list_config:
                 continue
@@ -571,7 +571,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        config = self.getFRRconfig('ip prefix-list')
+        config = self.getFRRconfig('ip prefix-list', end_marker='')
         for prefix_list, prefix_list_config in test_data.items():
             if 'rule' not in prefix_list_config:
                 continue
@@ -654,7 +654,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        config = self.getFRRconfig('ipv6 prefix-list')
+        config = self.getFRRconfig('ipv6 prefix-list', end_marker='')
         for prefix_list, prefix_list_config in test_data.items():
             if 'rule' not in prefix_list_config:
                 continue
@@ -705,7 +705,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
-        config = self.getFRRconfig('ip prefix-list')
+        config = self.getFRRconfig('ip prefix-list', end_marker='')
         for rule in test_range:
             tmp = f'ip prefix-list {prefix_list} seq {rule} permit {prefix} le {rule}'
             self.assertIn(tmp, config)
@@ -842,7 +842,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                 self.assertIn(name, config)
 
                 if 'set' in rule_config:
-                    #Check community
+                    # Check community
                     if 'community' in rule_config['set']:
                         if 'none' in rule_config['set']['community']:
                             tmp = f'set community none'
@@ -855,7 +855,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                             values = ' '.join(rule_config['set']['community']['add'])
                             tmp = f'set community {values} additive'
                             self.assertIn(tmp, config)
-                    #Check large-community
+                    # Check large-community
                     if 'large-community' in rule_config['set']:
                         if 'none' in rule_config['set']['large-community']:
                             tmp = f'set large-community none'
@@ -868,7 +868,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
                             values = ' '.join(rule_config['set']['large-community']['add'])
                             tmp = f'set large-community {values} additive'
                             self.assertIn(tmp, config)
-                    #Check extcommunity
+                    # Check extcommunity
                     if 'extcommunity' in rule_config['set']:
                         if 'none' in rule_config['set']['extcommunity']:
                             tmp = 'set extcommunity none'

--- a/smoketest/scripts/cli/test_protocols_static.py
+++ b/smoketest/scripts/cli/test_protocols_static.py
@@ -254,7 +254,7 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR bgpd configuration
-        frrconfig = self.getFRRconfig('ip route')
+        frrconfig = self.getFRRconfig('ip route', end_marker='')
 
         # Verify routes
         for route, route_config in routes.items():
@@ -368,7 +368,7 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR bgpd configuration
-        frrconfig = self.getFRRconfig('ip route')
+        frrconfig = self.getFRRconfig('ip route', end_marker='')
 
         for table in tables:
             # Verify routes
@@ -558,7 +558,7 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify FRR configuration
-        frrconfig = self.getFRRconfig('ip mroute')
+        frrconfig = self.getFRRconfig('ip mroute', end_marker='')
         for route, route_config in multicast_routes.items():
             if 'next_hop' in route_config:
                 for next_hop, next_hop_config in route_config['next_hop'].items():
@@ -712,15 +712,12 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
         self.assertIsNotNone(router, 'DHCP router should be available')
 
         # Verify FRR configuration contains the static routes with DHCP router
-        frrconfig = self.getFRRconfig('ip route')
+        frrconfig = self.getFRRconfig('ip route', end_marker='')
 
         for route in dhcp_routes.keys():
             expected_route = f'ip route {route} {router} {dhcp_interface}'
-            self.assertIn(
-                expected_route,
-                frrconfig,
-                f'Static route {route} with dhcp-interface should be in FRR config',
-            )
+            self.assertIn(expected_route, frrconfig, f'Static route {route} '\
+                          'with dhcp-interface should be in FRR config')
 
         # Test table-based routes with dhcp-interface
         table_id = '100'
@@ -730,7 +727,7 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify table route in FRR config
-        frrconfig = self.getFRRconfig('ip route')
+        frrconfig = self.getFRRconfig('ip route', end_marker='')
         expected_table_route = (
             f'ip route {table_route} {router} {dhcp_interface} table {table_id}'
         )

--- a/smoketest/scripts/cli/test_system_ip.py
+++ b/smoketest/scripts/cli/test_system_ip.py
@@ -86,14 +86,16 @@ class TestSystemIP(VyOSUnitTestSHIM.TestCase):
         protocols = ['any', 'babel', 'bgp', 'connected', 'eigrp', 'isis',
                      'kernel', 'ospf', 'rip', 'static', 'table']
 
+        rule_num = '10'
+
         for protocol in protocols:
-            self.cli_set(['policy', 'route-map', f'route-map-{protocol}', 'rule', '10', 'action', 'permit'])
+            self.cli_set(['policy', 'route-map', f'route-map-{protocol}', 'rule', rule_num, 'action', 'permit'])
             self.cli_set(base_path + ['protocol', protocol, 'route-map', f'route-map-{protocol}'])
 
         self.cli_commit()
 
         # Verify route-map properly applied to FRR
-        frrconfig = self.getFRRconfig('ip protocol', stop_section='^end')
+        frrconfig = self.getFRRconfig('ip protocol', end_marker='', stop_section='^end')
         for protocol in protocols:
             self.assertIn(f'ip protocol {protocol} route-map route-map-{protocol}', frrconfig)
 

--- a/smoketest/scripts/cli/test_system_ipv6.py
+++ b/smoketest/scripts/cli/test_system_ipv6.py
@@ -109,7 +109,7 @@ class TestSystemIPv6(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify route-map properly applied to FRR
-        frrconfig = self.getFRRconfig('ipv6 protocol', stop_section='^end')
+        frrconfig = self.getFRRconfig('ipv6 protocol', end_marker='', stop_section='^end')
         for protocol in protocols:
             # VyOS and FRR use a different name for OSPFv3 (IPv6)
             if protocol == 'ospfv3':

--- a/smoketest/scripts/cli/test_vrf.py
+++ b/smoketest/scripts/cli/test_vrf.py
@@ -819,7 +819,7 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
         # We need to wait until DHCP client has started and an IP address has been received
         sleep(8)
 
-        frrconfig = self.getFRRconfig('^vrf red', stop_section='^exit-vrf')
+        frrconfig = self.getFRRconfig(f'^vrf {vrf_name}', stop_section='^exit-vrf')
         self.assertIn(f' ip route 0.0.0.0/0 {default_gateway} {dhcp_if_client} '\
                       f'tag 210 {default_distance}', frrconfig)
 
@@ -828,7 +828,7 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['protocols', 'static', 'route', '10.0.0.0/24', 'blackhole'])
         self.cli_commit()
 
-        frrconfig = self.getFRRconfig('^vrf red', stop_section='^exit-vrf')
+        frrconfig = self.getFRRconfig(f'^vrf {vrf_name}', stop_section='^exit-vrf')
         self.assertIn(f' ip route 0.0.0.0/0 {default_gateway} {dhcp_if_client} '\
                       f'tag 210 {default_distance}', frrconfig)
 

--- a/smoketest/scripts/cli/test_vrf.py
+++ b/smoketest/scripts/cli/test_vrf.py
@@ -834,7 +834,6 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
 
         self.cli_delete(['interfaces', 'virtual-ethernet'])
         self.cli_delete(['service', 'dhcp-server'])
-        self.cli_delete(['vrf', 'name', vrf_name])
 
     def test_dhcpv6_single_pool(self):
         # Prepare the vrf and other options


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Commit 186900f7165b2 (`smoketest: T7927: test DHCP route preservation`) which was added to validate a bugfix for DHCP default routes added it's own little regression. Tests defined a VRF named red15, but when reading in the FRR configuration we have had a hardcoded search for `vrf red` instead. 

This has been fixed to re-use the defined VRF variable name we perform our test on.

The original VRF DHCP test case, introduced in commit 186900f7165b2 (`smoketest: T7927: test DHCP route preservation`), used a fixed delay of 8 seconds to wait for the DHCP server and client to initialize. This approach was unreliable and could cause unnecessary test delays.

Since commit 354517677f (`wlb: T7977: Updated smoketest to validate nft vmap weight buckets`), the `vyos.utils.misc.wait_for()` helper provides a more efficient busy-wait loop with an early-exit condition. This test case now uses `wait_for()` to detect when the DHCP-assigned default route becomes available, eliminating the fixed sleep and reducing test runtime.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7996

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

Local smoketests runs of `make testc`, `make test-no-interfaces-no-vpp`  and `make test-interfaces` completed successfully

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
