### PR TITLE
T7872: VPP XDP with rx-queue-size stuck

### DIFF
--- a/interface-definitions/include/vpp/queue_size.xml.i
+++ b/interface-definitions/include/vpp/queue_size.xml.i
@@ -1,0 +1,44 @@
+<!-- include start from vpp/queue_size.xml.i -->
+<completionHelp>
+  <list>0 256 512 1024 2048 4096 8192 16384 32468</list>
+</completionHelp>
+<valueHelp>
+  <format>0</format>
+  <description>Use default VPP queue size</description>
+</valueHelp>
+<valueHelp>
+  <format>256</format>
+  <description>256 descriptors</description>
+</valueHelp>
+<valueHelp>
+  <format>512</format>
+  <description>512 descriptors</description>
+</valueHelp>
+<valueHelp>
+  <format>1024</format>
+  <description>1024 descriptors</description>
+</valueHelp>
+<valueHelp>
+  <format>2048</format>
+  <description>2048 descriptors</description>
+</valueHelp>
+<valueHelp>
+  <format>4096</format>
+  <description>4096 descriptors</description>
+</valueHelp>
+<valueHelp>
+  <format>8192</format>
+  <description>8192 descriptors</description>
+</valueHelp>
+<valueHelp>
+  <format>16384</format>
+  <description>16384 descriptors</description>
+</valueHelp>
+<valueHelp>
+  <format>32468</format>
+  <description>32468 descriptors</description>
+</valueHelp>
+<constraint>
+  <regex>(0|256|512|1024|2048|4096|8192|16384|32468)</regex>
+</constraint>
+<!-- include end -->

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -588,26 +588,14 @@
                   <leafNode name="rx-queue-size">
                     <properties>
                       <help>Receive queue size</help>
-                      <valueHelp>
-                        <format>u32:0-65535</format>
-                        <description>Size of receive queue</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 0-65535"/>
-                      </constraint>
+                      #include <include/vpp/queue_size.xml.i>
                     </properties>
                     <defaultValue>0</defaultValue>
                   </leafNode>
                   <leafNode name="tx-queue-size">
                     <properties>
                       <help>Tranceive queue size</help>
-                      <valueHelp>
-                        <format>u32:0-65535</format>
-                        <description>Size of tranceive queue</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 0-65535"/>
-                      </constraint>
+                      #include <include/vpp/queue_size.xml.i>
                     </properties>
                     <defaultValue>0</defaultValue>
                   </leafNode>


### PR DESCRIPTION
Queue sizes must be a power of two and between VLIB_FRAME_SIZE=256 and 65535
https://github.com/FDio/vpp/blob/d39cc2bd9374f9df7e42ad39bb9fb8e2531d3da8/src/plugins/af_xdp/device.c#L588-L608

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7872
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# set vpp settings interface eth1 driver xdp
[edit]
vyos@vyos# set vpp settings interface eth1 xdp-options rx-queue-size
Possible completions:
   0                    Use default VPP queue size (default)
   256                  256 descriptors
   512                  512 descriptors
   1024                 1024 descriptors
   2048                 2048 descriptors
   4096                 4096 descriptors
   8192                 8192 descriptors
   16384                16384 descriptors
   32468                32468 descriptors



[edit]
vyos@vyos# set vpp settings interface eth1 xdp-options rx-queue-size 1024
[edit]
vyos@vyos# commit
[ vpp ]

WARNING: NOTE: Current dataplane capacity (estimated): 2.1 M IPv4
routes. Exceeding these values will lead to a dataplane out-of-memory
condition and a crash. Extensive use of features like ACLs, NAT and
others may reduce the numbers above. Please read the documentation for
details: https://docs.vyos.io/


[edit]
vyos@vyos# 
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
