### PR TITLE
T8003: Add early kernel panic reboot support

### DIFF
--- a/src/conf_mode/system_option.py
+++ b/src/conf_mode/system_option.py
@@ -196,6 +196,11 @@ def generate(options):
         if 'quiet' in options['kernel']:
             cmdline_options.append('quiet')
 
+    # Early reboot on kernel panic via kernel cmdline
+    # Keep this in sync with image_installer.py:get_cli_kernel_options()
+    if 'reboot_on_panic' in options:
+        cmdline_options.append('panic=60')
+
     if 'disable_hpet' in kernel_opts:
         cmdline_options.append('hpet=disable')
 

--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -521,6 +521,10 @@ def get_cli_kernel_options(config_file: str) -> list:
     if 'quiet' in kernel_options:
         cmdline_options.append('quiet')
 
+    # Early reboot on kernel panic via kernel cmdline (must match system_option.py)
+    if dict_search('system.option.reboot-on-panic', config_dict) is not None:
+        cmdline_options.append('panic=60')
+
     if 'disable-hpet' in kernel_options:
         cmdline_options.append('hpet=disable')
 


### PR DESCRIPTION
## Change summary
Enable kernel command line parameter to enable early boot panic reboot.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T8003

## Related PR(s)
N/A

## How to test / Smoketest result

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
