### PR TITLE
T7988: adjust function name to distinguish compare from show config

### DIFF
--- a/libvyosconfig/Makefile
+++ b/libvyosconfig/Makefile
@@ -42,8 +42,8 @@ all: sharedlib
 PHONY: depends
 depends:
 	sudo sh -c 'eval $$(opam env --root=/opt/opam --set-root) ;\
-		opam pin add vyos1x-config https://github.com/vyos/vyos1x-config.git#6e2a6efc5de6c2e395df377fcd273231ad8ed683 -y ; \
-		opam pin add vyconf https://github.com/vyos/vyconf.git#591dd5ee3dc353655a3c9b17eababaf0864c5514 -y'
+		opam pin add vyos1x-config https://github.com/vyos/vyos1x-config.git#5f1d834561ce9463ce1900fef7a2614418a412bc -y ; \
+		opam pin add vyconf https://github.com/vyos/vyconf.git#b5a3d62714bc47f5187a10c8ad0773c9e655e9e4 -y'
 
 sharedlib: depends $(BUILDDIR)/libvyosconfig$(EXTDLL)
 

--- a/libvyosconfig/lib/bindings.ml
+++ b/libvyosconfig/lib/bindings.ml
@@ -378,7 +378,7 @@ let diff_tree path c_ptr_l c_ptr_r =
         | CD.Incommensurable -> error_message := "Incommensurable"; Ctypes.null
         | CD.Empty_comparison -> error_message := "Empty comparison"; Ctypes.null
 
-let show_diff cmds path c_ptr_l c_ptr_r =
+let diff_compare cmds path c_ptr_l c_ptr_r =
     (* alert exn CD.show_diff:
         [Config_diff.Incommensurable] caught
         [Config_diff.Empty_comparison] caught
@@ -387,7 +387,7 @@ let show_diff cmds path c_ptr_l c_ptr_r =
     let ct_l = Root.get c_ptr_l in
     let ct_r = Root.get c_ptr_r in
     try
-        (CD.show_diff[@alert "-exn"]) ~cmds:cmds path ct_l ct_r
+        (CD.diff_compare[@alert "-exn"]) ~cmds:cmds path ct_l ct_r
     with
         | CD.Incommensurable -> error_message := "Incommensurable"; "#1@"
         | CD.Empty_comparison -> error_message := "Empty comparison"; "#1@"
@@ -499,7 +499,7 @@ struct
   let () = I.internal "return_value" ((ptr void) @-> string @-> returning string) return_value
   let () = I.internal "return_values" ((ptr void) @-> string @-> returning string) return_values
   let () = I.internal "diff_tree" (string @-> (ptr void) @-> (ptr void) @-> returning (ptr void)) diff_tree
-  let () = I.internal "show_diff" (bool @-> string @-> (ptr void) @-> (ptr void) @-> returning string) show_diff
+  let () = I.internal "diff_compare" (bool @-> string @-> (ptr void) @-> (ptr void) @-> returning string) diff_compare
   let () = I.internal "tree_union" ((ptr void) @-> (ptr void) @-> returning (ptr void)) tree_union
   let () = I.internal "tree_merge" (bool @-> (ptr void) @-> (ptr void) @-> returning (ptr void)) tree_merge
   let () = I.internal "reference_tree_to_json" (string @-> string @-> string @-> returning int) reference_tree_to_json

--- a/python/vyos/config_mgmt.py
+++ b/python/vyos/config_mgmt.py
@@ -37,7 +37,7 @@ from vyos.configtree import ConfigTree
 from vyos.configtree import ConfigTreeError
 from vyos.configsession import ConfigSession
 from vyos.configsession import ConfigSessionError
-from vyos.configtree import show_diff
+from vyos.configtree import diff_compare
 from vyos.load_config import load
 from vyos.load_config import LoadConfigError
 from vyos.defaults import directories
@@ -413,9 +413,9 @@ Proceed ?"""
         path = [] if commands else self.edit_path
         try:
             if commands:
-                out = show_diff(ct1, ct2, path=path, commands=True)
+                out = diff_compare(ct1, ct2, path=path, commands=True)
             else:
-                out = show_diff(ct1, ct2, path=path)
+                out = diff_compare(ct1, ct2, path=path)
         except ConfigTreeError as e:
             return e, 1
 

--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -473,7 +473,7 @@ class ConfigTree(object):
         return subt
 
 
-def show_diff(left, right, path=[], commands=False, libpath=LIBPATH):
+def diff_compare(left, right, path=[], commands=False, libpath=LIBPATH):
     if left is None:
         left = ConfigTree(config_string='\n')
     if right is None:
@@ -488,14 +488,14 @@ def show_diff(left, right, path=[], commands=False, libpath=LIBPATH):
     path_str = ' '.join(map(str, path)).encode()
 
     __lib = cdll.LoadLibrary(libpath)
-    __show_diff = __lib.show_diff
-    __show_diff.argtypes = [c_bool, c_char_p, c_void_p, c_void_p]
-    __show_diff.restype = c_char_p
+    __diff_compare = __lib.diff_compare
+    __diff_compare.argtypes = [c_bool, c_char_p, c_void_p, c_void_p]
+    __diff_compare.restype = c_char_p
     __get_error = __lib.get_error
     __get_error.argtypes = []
     __get_error.restype = c_char_p
 
-    res = __show_diff(commands, path_str, left._get_config(), right._get_config())
+    res = __diff_compare(commands, path_str, left._get_config(), right._get_config())
     res = res.decode()
     if res == '#1@':
         msg = __get_error().decode()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

NOTE: this PR will be updated with revised commit hashes, following the merge of
https://github.com/vyos/vyos1x-config/pull/56
https://github.com/vyos/vyconf/pull/35

In addition, it adjusts some internal function names to distinguish between the existing `compare` command (which is already vyconf aware) and the `show` command.
Given the function name changes, package integration will fail until the above PRs are merged and commit refs updated.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): internal update

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/vyos1x-config/pull/56
https://github.com/vyos/vyconf/pull/35

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
