### PR TITLE
T7556: VPP add IPFIX collector configuration

### DIFF
--- a/data/config-mode-dependencies/vyos-vpp.json
+++ b/data/config-mode-dependencies/vyos-vpp.json
@@ -11,6 +11,7 @@
         "vpp_interfaces_vxlan": ["vpp_interfaces_vxlan"],
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],
         "vpp_acl": ["vpp_acl"],
+        "vpp_ipfix": ["vpp_ipfix"],
         "vpp_nat": ["vpp_nat"],
         "vpp_nat_cgnat": ["vpp_nat_cgnat"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"],

--- a/data/op-mode-standardized.json
+++ b/data/op-mode-standardized.json
@@ -32,5 +32,6 @@
 "system.py",
 "uptime.py",
 "version.py",
+"vpp.py",
 "vrf.py"
 ]

--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -91,6 +91,8 @@ plugins {
     plugin linux_cp_plugin.so { enable }
     plugin linux_nl_plugin.so { enable }
     plugin pppoe_plugin.so { enable }
+    # Flow
+    plugin flowprobe_plugin.so { enable }
     plugin sflow_plugin.so { enable }
     # NAT uncomment if needed
     # plugin cnat_plugin.so { enable }

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -346,6 +346,182 @@
           </tagNode>
         </children>
       </node>
+      <node name="ipfix" owner="${vyos_conf_scripts_dir}/vpp_ipfix.py">
+        <properties>
+          <help>IP Flow Information Export (IPFIX) configuration</help>
+          <priority>322</priority>
+        </properties>
+        <children>
+          <tagNode name="collector">
+            <properties>
+              <help>Collector IP address</help>
+              <valueHelp>
+                <format>ipv4</format>
+                <description>IPv4 server to export IPFIX</description>
+              </valueHelp>
+              <valueHelp>
+                <format>ipv6</format>
+                <description>IPv6 server to export IPFIX</description>
+              </valueHelp>
+              <constraint>
+                <validator name="ip-address"/>
+              </constraint>
+            </properties>
+            <children>
+              #include <include/port-number.xml.i>
+              <leafNode name="port">
+                <defaultValue>4739</defaultValue>
+              </leafNode>
+              <leafNode name="path-mtu">
+                <properties>
+                  <help>Path MTU</help>
+                  <valueHelp>
+                    <format>u32:68-1450</format>
+                    <description>Bytes</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 68-1450"/>
+                  </constraint>
+                </properties>
+                <defaultValue>512</defaultValue>
+              </leafNode>
+              #include <include/source-address-ipv4-ipv6.xml.i>
+              <leafNode name="template-interval">
+                <properties>
+                  <help>Interval in seconds</help>
+                  <valueHelp>
+                    <format>u32:1-300</format>
+                    <description>Seconds</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 1-300"/>
+                  </constraint>
+                </properties>
+                <defaultValue>20</defaultValue>
+              </leafNode>
+              <leafNode name="udp-checksum">
+                <properties>
+                  <help>Allow UDP checksum</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+            </children>
+          </tagNode>
+          <tagNode name="interface">
+            <properties>
+              <help>Interface</help>
+              <completionHelp>
+                <script>${vyos_completion_dir}/list_interfaces</script>
+              </completionHelp>
+              <valueHelp>
+                <format>txt</format>
+                <description>Interface name</description>
+              </valueHelp>
+            </properties>
+            <children>
+              <leafNode name="direction">
+                <properties>
+                  <help>Flow direction</help>
+                  <completionHelp>
+                    <list>rx tx both</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>rx</format>
+                    <description>Rx direction</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>tx</format>
+                    <description>Tx direction</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>both</format>
+                    <description>Rx and Tx direction</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(rx|tx|both)</regex>
+                  </constraint>
+                </properties>
+                <defaultValue>both</defaultValue>
+              </leafNode>
+              <leafNode name="flow-variant">
+                <properties>
+                  <help>Flow variant</help>
+                  <completionHelp>
+                    <list>l2 ipv4 ipv6</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>l2</format>
+                    <description>L2</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>_ipv4</format>
+                    <description>IPv4</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>_ipv6</format>
+                    <description>IPv6</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(l2|ipv4|ipv6)</regex>
+                  </constraint>
+                </properties>
+                <defaultValue>ipv4</defaultValue>
+              </leafNode>
+            </children>
+          </tagNode>
+          <leafNode name="active-timeout">
+            <properties>
+              <help>Flow activity timeout</help>
+              <valueHelp>
+                <format>u32:0-2147483647</format>
+                <description>Active flow export timeout (seconds)</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 0-2147483647"/>
+              </constraint>
+            </properties>
+            <defaultValue>15</defaultValue>
+          </leafNode>
+          <leafNode name="inactive-timeout">
+            <properties>
+              <help>Flow inactivity timeout</help>
+              <valueHelp>
+                <format>u32:0-2147483647</format>
+                <description>Inactive flow export timeout (seconds)</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 0-2147483647"/>
+              </constraint>
+            </properties>
+            <defaultValue>120</defaultValue>
+          </leafNode>
+          <leafNode name="flowprobe-record">
+            <properties>
+              <help>Flow record layers</help>
+              <completionHelp>
+                <list>l2 l3 l4</list>
+              </completionHelp>
+              <valueHelp>
+                <format>l2</format>
+                <description>Include level 2 information</description>
+              </valueHelp>
+              <valueHelp>
+                <format>l3</format>
+                <description>Include level 3 information</description>
+              </valueHelp>
+              <valueHelp>
+                <format>l4</format>
+                <description>Include level 4 information</description>
+              </valueHelp>
+              <constraint>
+                <regex>(l2|l3|l4)</regex>
+              </constraint>
+              <multi/>
+            </properties>
+            <defaultValue>l3</defaultValue>
+          </leafNode>
+        </children>
+      </node>
       <node name="settings">
         <properties>
           <help>VPP settings</help>

--- a/op-mode-definitions/vpp_ipfix.xml.in
+++ b/op-mode-definitions/vpp_ipfix.xml.in
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="show">
+    <children>
+      <node name="vpp">
+        <children>
+          <node name="ipfix">
+            <properties>
+              <help>Show VPP IPFIX information</help>
+            </properties>
+            <children>
+              <node name="collectors">
+                <properties>
+                  <help>Show IPFIX collectors</help>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/vpp.py show_ipfix_collectors</command>
+              </node>
+              <node name="interfaces">
+                <properties>
+                  <help>Show IPFIX interfaces</help>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/vpp.py show_ipfix_interfaces</command>
+              </node>
+              <node name="table">
+                <properties>
+                  <help>Show IPFIX table</help>
+                </properties>
+                <command>sudo ${vyos_op_scripts_dir}/vpp.py show_ipfix_table</command>
+              </node>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/python/vyos/vpp/ipfix/__init__.py
+++ b/python/vyos/vpp/ipfix/__init__.py
@@ -1,0 +1,3 @@
+from .ipfix import IPFIX
+
+__all__ = ['IPFIX']

--- a/python/vyos/vpp/ipfix/ipfix.py
+++ b/python/vyos/vpp/ipfix/ipfix.py
@@ -1,0 +1,181 @@
+#
+# Copyright (C) VyOS Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+from vpp_papi import VppEnum
+from vyos.vpp import VPPControl
+
+
+class IPFIX:
+    def __init__(
+        self,
+        collector_address: str = '0.0.0.0',
+        collector_port: int = 4739,
+        src_address: str = '0.0.0.0',
+        path_mtu: int = 0,
+        template_interval: int = 20,
+        udp_checksum: bool = False,
+        vrf_id: int = 0,
+    ):
+        self.vpp = VPPControl()
+        self.collector_address = collector_address
+        self.collector_port = collector_port
+        self.src_address = src_address
+        self.path_mtu = path_mtu
+        self.template_interval = template_interval
+        self.udp_checksum = udp_checksum
+        self.vrf_id = vrf_id
+
+        # enums mapping
+        self.RECORD_FLAGS_MAP = {
+            'l2': VppEnum.vl_api_flowprobe_record_flags_t.FLOWPROBE_RECORD_FLAG_L2,
+            'l3': VppEnum.vl_api_flowprobe_record_flags_t.FLOWPROBE_RECORD_FLAG_L3,
+            'l4': VppEnum.vl_api_flowprobe_record_flags_t.FLOWPROBE_RECORD_FLAG_L4,
+        }
+
+        self.WHICH_FLAGS_MAP = {
+            'ipv4': VppEnum.vl_api_flowprobe_which_t.FLOWPROBE_WHICH_IP4,
+            'ipv6': VppEnum.vl_api_flowprobe_which_t.FLOWPROBE_WHICH_IP6,
+            'l2': VppEnum.vl_api_flowprobe_which_t.FLOWPROBE_WHICH_L2,
+        }
+
+        self.DIRECTION_MAP = {
+            'rx': VppEnum.vl_api_flowprobe_direction_t.FLOWPROBE_DIRECTION_RX,
+            'tx': VppEnum.vl_api_flowprobe_direction_t.FLOWPROBE_DIRECTION_TX,
+            'both': VppEnum.vl_api_flowprobe_direction_t.FLOWPROBE_DIRECTION_BOTH,
+        }
+
+    def ipfix_exporter_delete(self):
+        """Delete IPFIX exporter
+        https://github.com/FDio/vpp/blob/stable/2506/src/vnet/ipfix-export/ipfix_export.api
+        Example:
+            from vyos.vpp import ipfix
+            i = ipfix.IPFIX()
+            i.ipfix_exporter_delete()
+        """
+        self.vpp.api.set_ipfix_exporter(
+            collector_port=0,
+            collector_address='0.0.0.0',
+            src_address='0.0.0.0',
+            path_mtu=0xFFFFFFFF,
+            template_interval=0,
+            udp_checksum=False,
+            vrf_id=4294967295,
+        )
+
+    def set_ipfix_exporter(self):
+        """Set IPFIX exporter parameters
+        Example:
+            from vyos.vpp import ipfix
+            i = ipfix.IPFIX(collector_address='192.0.2.2', src_address='192.0.2.1', collector_port=2055, template_interval=20, path_mtu=1450)
+            i.set_ipfix_exporter()
+        """
+        self.vpp.api.set_ipfix_exporter(
+            collector_port=self.collector_port,
+            collector_address=self.collector_address,
+            src_address=self.src_address,
+            path_mtu=self.path_mtu,
+            template_interval=self.template_interval,
+            udp_checksum=self.udp_checksum,
+            vrf_id=self.vrf_id,
+        )
+
+    def flowprobe_interface_add(
+        self,
+        interface: str,
+        direction: str = 'both',
+        which: str = 'ipv4',
+    ):
+        """Add IPFIX flowprobe to interface
+        https://github.com/FDio/vpp/blob/stable/2506/src/plugins/flowprobe/flowprobe.api
+        Args:
+            interface (str): Interface name
+            direction (str): Direction of flowprobe ('rx', 'tx', 'both')
+            which (str): Which packets to probe ('ipv4', 'ipv6', 'l2')
+        Example:
+            from vyos.vpp import ipfix
+            i = ipfix.IPFIX(collector_address='192.0.2.2', src_address='192.0.2.1', collector_port=2055, template_interval=20, path_mtu=1450)
+            i.flowprobe_set_params(record_flags=['l2', 'l3'], active_timer=2, passive_timer=20)
+            i.flowprobe_interface_add('eth0')
+        """
+        sw_if_index = self.vpp.get_sw_if_index(interface)
+        direction_flag = self.DIRECTION_MAP.get(direction, self.DIRECTION_MAP['both'])
+        which_flag = self.WHICH_FLAGS_MAP.get(which, self.WHICH_FLAGS_MAP['ipv4'])
+
+        self.vpp.api.flowprobe_interface_add_del(
+            is_add=True,
+            sw_if_index=sw_if_index,
+            direction=direction_flag,
+            which=which_flag,
+        )
+
+    def flowprobe_interface_delete(
+        self,
+        interface: str,
+        direction: str = 'both',
+        which: str = 'ipv4',
+    ):
+        """Delete IPFIX flowprobe from interface
+        https://github.com/FDio/vpp/blob/stable/2506/src/plugins/flowprobe/flowprobe.api
+        Args:
+            interface (str): Interface name
+        Example:
+            from vyos.vpp import ipfix
+            i = ipfix.IPFIX(collector_address='192.0.2.2', src_address='192.0.2.1', collector_port=2055, template_interval=20, path_mtu=1450)
+            i.flowprobe_interface_delete('eth0')
+        """
+        sw_if_index = self.vpp.get_sw_if_index(interface)
+        direction_flag = self.DIRECTION_MAP.get(direction, self.DIRECTION_MAP['both'])
+        which_flag = self.WHICH_FLAGS_MAP.get(which, self.WHICH_FLAGS_MAP['ipv4'])
+
+        self.vpp.api.flowprobe_interface_add_del(
+            is_add=False,
+            sw_if_index=sw_if_index,
+            direction=direction_flag,
+            which=which_flag,
+        )
+
+    def flowprobe_set_params(
+        self,
+        active_timer: int = 15,
+        passive_timer: int = 120,
+        record_flags: list = None,
+    ):
+        """Set IPFIX flowprobe parameters
+
+        Args:
+            active_timer (int): Active timer in seconds
+            passive_timer (int): Passive timer in seconds
+            record_flags: Record flags as list of 'l2', 'l3', 'l4'
+                Examples: ['l2'], ['l2', 'l3'], ['l2', 'l3', 'l4']
+        Example:
+            from vyos.vpp import ipfix
+            i = ipfix.IPFIX(collector_address='192.0.2.2', src_address='192.0.2.1', collector_port=2055, template_interval=20, path_mtu=1450)
+            i.flowprobe_set_params(record_flags=['l2', 'l3'], active_timer=10, passive_timer=30)
+            i.flowprobe_interface_add('eth0')
+        """
+        if record_flags is None:
+            record_flags = ['l2', 'l3', 'l4']
+        # Calculate combined flags
+        record_flag = 0
+        for flag in record_flags:
+            record_flag |= self.RECORD_FLAGS_MAP[flag]
+
+        self.vpp.api.flowprobe_set_params(
+            active_timer=active_timer,
+            passive_timer=passive_timer,
+            record_flags=record_flag,
+        )

--- a/src/conf_mode/vpp_ipfix.py
+++ b/src/conf_mode/vpp_ipfix.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+#
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from vyos import ConfigError
+from vyos.config import Config
+from vyos.vpp.ipfix import IPFIX
+from vyos.vpp.utils import cli_ifaces_list
+
+
+def get_config(config=None) -> dict:
+    if config:
+        conf = config
+    else:
+        conf = Config()
+
+    base = ['vpp', 'ipfix']
+
+    # Get config_dict with default values
+    config = conf.get_config_dict(
+        base,
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+        with_defaults=True,
+        with_recursive_defaults=True,
+    )
+
+    # Get effective config as we need full dictionary for deletion
+    effective_config = conf.get_config_dict(
+        base,
+        key_mangling=('-', '_'),
+        effective=True,
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+    )
+
+    if effective_config:
+        config.update({'effective': effective_config})
+
+    if not conf.exists(base):
+        config['remove'] = True
+        return config
+
+    # Add list of VPP interfaces to the config
+    config.update({'vpp_ifaces': cli_ifaces_list(conf)})
+
+    return config
+
+
+def verify(config):
+    if 'remove' in config:
+        return None
+
+    # Verify that at least one interface is configured
+    if 'interface' not in config or not config['interface']:
+        raise ConfigError(
+            'At least one interface must be configured for IPFIX monitoring'
+        )
+
+    # Verify that all interfaces specified exist in VPP
+    for interface in config['interface']:
+        if interface not in config['vpp_ifaces']:
+            raise ConfigError(
+                f'{interface} must be a VPP interface for IPFIX monitoring'
+            )
+
+    # Verify that at least one collector is configured
+    if 'collector' not in config:
+        raise ConfigError('At least one IPFIX collector must be configured')
+
+    # Enforce that only one collector is configured (VPP limitation)
+    if len(config['collector']) > 1:
+        raise ConfigError('Only one IPFIX collector can be configured')
+
+    # Verify that source_address is specified
+    for c, c_conf in config.get('collector', {}).items():
+        if 'source_address' not in c_conf:
+            raise ConfigError(f'Source address must be specified for collector {c}')
+
+    # Verify active timeout is not greater than inactive timeout
+    if 'active_timeout' in config and 'inactive_timeout' in config:
+        active_timeout = int(config['active_timeout'])
+        inactive_timeout = int(config['inactive_timeout'])
+
+        if active_timeout > inactive_timeout:
+            raise ConfigError(
+                f'Active timeout ({active_timeout}) cannot be greater than inactive timeout ({inactive_timeout})'
+            )
+
+
+def generate(config):
+    # No templates to render for IPFIX
+    pass
+
+
+def apply(config):
+    i = IPFIX()
+
+    # Remove collectors
+    for c, c_conf in config.get('effective', {}).get('collector', {}).items():
+        i.ipfix_exporter_delete()
+
+    # Remove interfaces
+    for iface, iface_conf in config.get('effective', {}).get('interface', {}).items():
+        direction = iface_conf.get('direction')
+        which = iface_conf.get('flow_variant')
+        i.flowprobe_interface_delete(iface, direction=direction, which=which)
+
+    if 'remove' in config:
+        return None
+
+    active_timeout = config.get('active_timeout')
+    inactive_timeout = config.get('inactive_timeout')
+    flowprobe_record = config.get('flowprobe_record')
+
+    # Flowprobe params
+    i.flowprobe_set_params(
+        active_timer=int(active_timeout),
+        passive_timer=int(inactive_timeout),
+        record_flags=list(flowprobe_record),
+    )
+
+    # Collectors
+    for c, c_conf in config.get('collector', {}).items():
+        collector_address = c
+        collector_port = c_conf.get('port')
+        src_address = c_conf.get('source_address')
+        template_interval = c_conf.get('template_interval')
+        path_mtu = c_conf.get('path_mtu')
+        udp_checksum = 'udp_checksum' in c_conf
+
+        i.collector_address = collector_address
+        i.src_address = src_address
+        i.collector_port = int(collector_port)
+        i.template_interval = int(template_interval)
+        i.path_mtu = int(path_mtu)
+        i.udp_checksum = udp_checksum
+        # VRF support is not currently implemented; exporter is always configured in the default VRF (0).
+        # Consider adding VRF support in the future if needed.
+        i.vrf_id = 0
+
+        i.set_ipfix_exporter()
+
+    # Interfaces
+    if 'interface' in config:
+        for iface, iface_config in config.get('interface', {}).items():
+            direction = iface_config.get('direction')
+            which = iface_config.get('flow_variant')
+
+            i.flowprobe_interface_add(iface, direction=direction, which=which)
+
+
+if __name__ == '__main__':
+    try:
+        c = get_config()
+        verify(c)
+        generate(c)
+        apply(c)
+    except ConfigError as e:
+        print(e)
+        exit(1)

--- a/src/op_mode/vpp.py
+++ b/src/op_mode/vpp.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+#
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import sys
+import typing
+
+from tabulate import tabulate
+from vyos.vpp import VPPControl
+from vyos.configquery import ConfigTreeQuery
+import vyos.opmode
+
+
+class VPPShow:
+    def __init__(self):
+        self.config = ConfigTreeQuery()
+        self.vpp = VPPControl()
+
+    # -----------------------------
+    # IPFIX Interfaces
+    # -----------------------------
+    def _get_ipfix_interfaces_raw(self) -> typing.List[dict]:
+        interfaces = self.vpp.api.flowprobe_interface_dump()
+        index_map = {
+            i.sw_if_index: i.interface_name for i in self.vpp.api.sw_interface_dump()
+        }
+
+        return [
+            {
+                'interface': index_map.get(e.sw_if_index, f'if{e.sw_if_index}'),
+                'sw_if_index': e.sw_if_index,
+                'which': e.which.name.replace('FLOWPROBE_WHICH_', '').lower(),
+                'direction': e.direction.name.replace(
+                    'FLOWPROBE_DIRECTION_', ''
+                ).lower(),
+            }
+            for e in interfaces
+        ]
+
+    def _show_ipfix_interfaces_formatted(self, data: typing.List[dict]) -> str:
+        if not data:
+            return 'No flowprobe interfaces configured.'
+        table_data = [
+            {
+                'Interface': d['interface'],
+                'VppIfIndex': d['sw_if_index'],
+                'Flow-variant': d['which'],
+                'Direction': d['direction'],
+            }
+            for d in data
+        ]
+        return tabulate(table_data, headers='keys', tablefmt='simple')
+
+    def ipfix_interfaces(self, raw: bool):
+        base = ['vpp', 'ipfix', 'interface']
+        if not self.config.exists(base):
+            raise vyos.opmode.UnconfiguredSubsystem(
+                'vpp ipfix interface is not configured'
+            )
+
+        data = self._get_ipfix_interfaces_raw()
+        return data if raw else self._show_ipfix_interfaces_formatted(data)
+
+    # -----------------------------
+    # IPFIX Collectors
+    # -----------------------------
+    def _get_ipfix_collectors_raw(self) -> typing.List[dict]:
+        _, collectors = self.vpp.api.ipfix_all_exporter_get()
+        return [
+            {
+                'collector_address': str(c.collector_address),
+                'collector_port': c.collector_port,
+                'src_address': str(c.src_address),
+                'vrf_id': c.vrf_id,
+                'path_mtu': c.path_mtu,
+                'template_interval': c.template_interval,
+                'udp_checksum': bool(c.udp_checksum),
+            }
+            for c in collectors
+        ]
+
+    def _show_ipfix_collectors_formatted(self, data: typing.List[dict]) -> str:
+        if not data:
+            return 'No IPFIX collectors configured.'
+        table_data = [
+            {
+                'Collector': f"{d['collector_address']}:{d['collector_port']}",
+                'Source': d['src_address'],
+                'VRF': d['vrf_id'],
+                'MTU': d['path_mtu'],
+                'Template Intvl': d['template_interval'],
+                'UDP Cksum': 'on' if d['udp_checksum'] else 'off',
+            }
+            for d in data
+        ]
+        return tabulate(table_data, headers='keys', tablefmt='simple')
+
+    def ipfix_collectors(self, raw: bool):
+        base = ['vpp', 'ipfix', 'collector']
+        if not self.config.exists(base):
+            raise vyos.opmode.UnconfiguredSubsystem(
+                'vpp ipfix collector is not configured'
+            )
+
+        data = self._get_ipfix_collectors_raw()
+        return data if raw else self._show_ipfix_collectors_formatted(data)
+
+    # -----------------------------
+    # IPFIX table
+    # -----------------------------
+    def _get_ipfix_table_raw(self):
+        # VPP does not have API call to get this data
+        data = self.vpp.cli_cmd('show flowprobe table')
+        return [data.reply]
+
+    def _show_ipfix_table_formatted(self) -> str:
+        data = self.vpp.cli_cmd('show flowprobe table')
+        return data.reply
+
+    def ipfix_table(self, raw: bool):
+        base = ['vpp', 'ipfix', 'collector']
+        if not self.config.exists(base):
+            raise vyos.opmode.UnconfiguredSubsystem(
+                'vpp ipfix collector is not configured'
+            )
+
+        data = self._get_ipfix_table_raw()
+        return data if raw else self._show_ipfix_table_formatted()
+
+
+# -----------------------------
+# VyOS IPFIX op-mode entries
+# -----------------------------
+def show_ipfix_interfaces(raw: bool):
+    return VPPShow().ipfix_interfaces(raw)
+
+
+def show_ipfix_collectors(raw: bool):
+    return VPPShow().ipfix_collectors(raw)
+
+
+def show_ipfix_table(raw: bool):
+    return VPPShow().ipfix_table(raw)
+
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except (ValueError, vyos.opmode.Error) as e:
+        print(e)
+        sys.exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add VPP IPFIX configuration and operational mode commands
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7556

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
set vpp ipfix active-timeout '8'
set vpp ipfix collector 10.0.0.2 port '2055'
set vpp ipfix collector 10.0.0.2 source-address '10.0.0.1'
set vpp ipfix flowprobe-record 'l2'
set vpp ipfix flowprobe-record 'l3'
set vpp ipfix flowprobe-record 'l4'
set vpp ipfix inactive-timeout '32'
set vpp ipfix interface eth0
set vpp ipfix interface eth1 direction 'both'
set vpp ipfix interface eth1 flow-variant 'ipv4'
set vpp settings interface eth0 driver 'dpdk'
set vpp settings interface eth1 driver 'dpdk'
set vpp settings unix poll-sleep-usec '2222'

```
Check VPP collector, interfaces and table:
```
vyos@r14:~$ 
vyos@r14:~$ show vpp ipfix collectors 
Collector      Source      VRF    MTU    Template Intvl  UDP Cksum
-------------  --------  -----  -----  ----------------  -----------
10.0.0.2:2055  10.0.0.1      0    512                20  off
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ show vpp ipfix interfaces 
Interface      VppIfIndex  Flow-variant    Direction
-----------  ------------  --------------  -----------
eth0                    1  ip4             both
eth1                    2  ip4             both
vyos@r14:~$ 
vyos@r14:~$ 
vyos@r14:~$ show vpp ipfix table 
Dumping IPFIX table
 tx 3/1 52:54:00:8d:67:6e 52:54:00:d4:d9:a1 192.168.122.14 -> 192.168.122.1 6 22 60866
 rx 1/-1 52:54:00:d4:d9:a1 52:54:00:8d:67:6e 192.168.122.1 -> 192.168.122.14 6 60866 22

vyos@r14:~$ 


```
Check collector:
```
>>> from vyos.vpp import VPPControl
>>> 
>>> vpp = VPPControl()
>>> vpp.api.ipfix_all_exporter_get()
(ipfix_all_exporter_get_reply(_0=912, context=1, retval=0, cursor=4294967295), [ipfix_all_exporter_details(_0=913, context=1, collector_address=IPv4Address('10.0.0.2'), collector_port=2055, src_address=IPv4Address('10.0.0.1'), vrf_id=0, path_mtu=512, template_interval=20, udp_checksum=False)])
>>> 

```

Smoketest:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpp.py -k test_21_vpp_ipfix
test_21_vpp_ipfix (__main__.TestVPP.test_21_vpp_ipfix) ... ok

----------------------------------------------------------------------
Ran 1 test in 10.595s

OK
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
