### PR TITLE
bridge: T6775: The isolation option disappears after reboot

### DIFF
--- a/interface-definitions/interfaces_bridge.xml.in
+++ b/interface-definitions/interfaces_bridge.xml.in
@@ -5,7 +5,7 @@
       <tagNode name="bridge" owner="${vyos_conf_scripts_dir}/interfaces_bridge.py">
         <properties>
           <help>Bridge Interface</help>
-          <priority>310</priority>
+          <priority>319</priority>
           <constraint>
             <regex>br[0-9]+</regex>
           </constraint>


### PR DESCRIPTION
## Change summary
Previously, the bridge definition had priority **310** while ethernet interfaces used **318**. This caused bridges to be built before their member interfaces were ready, resulting in missing or incomplete bridge configuration at boot.

Increase bridge priority from 310 to 319 to ensure bridges are processed after base ethernet/VLAN interfaces and before higher‑level subsystems.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6775

## How to test / Smoketest result

#### Manual test

Configure instance and save the configuration:
```
conf
set interfaces ethernet eth1 address dhcp
set interfaces ethernet eth1 vif 21
set interfaces ethernet eth1 vif 22
set interfaces bridge br1 member interface eth1.21 isolated
set interfaces bridge br1 member interface eth1.22 isolated
commit
save
```

Check info about bridge before reboot:
```
vyos@2f680cac950c:~$ bridge --json -d link | jq '.[] | {ifname, isolated}'
{
  "ifname": "eth1.21",
  "isolated": true
}
{
  "ifname": "eth1.22",
  "isolated": true
}
```

Reboot the instance:
```
vyos@2f680cac950c:~$ sudo reboot now
```

Check info about bridge after reboot:
```
vyos@2f680cac950c:~$ bridge --json -d link | jq '.[] | {ifname, isolated}'
{
  "ifname": "eth1.21",
  "isolated": true
}
{
  "ifname": "eth1.22",
  "isolated": true
}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
