### PR TITLE
T8012: Add user vpp to user groups

### DIFF
--- a/debian/vyos-1x.postinst
+++ b/debian/vyos-1x.postinst
@@ -81,6 +81,7 @@ if ! grep -q '^tacacs' /etc/passwd; then
             adduser --quiet tacacs${level} disk
             adduser --quiet tacacs${level} frr
             adduser --quiet tacacs${level} _kea
+            adduser --quiet tacacs${level} vpp
         fi
         level=$(( level+1 ))
     done 2>&1 | grep -v "User tacacs${level} already exists"
@@ -113,6 +114,7 @@ if ! grep -q '^radius_priv_user' /etc/passwd; then
     adduser --quiet radius_priv_user users
     adduser --quiet radius_priv_user frr
     adduser --quiet radius_priv_user _kea
+    adduser --quiet radius_priv_user vpp
 fi
 
 # add hostsd group for vyos-hostsd

--- a/src/conf_mode/system_login.py
+++ b/src/conf_mode/system_login.py
@@ -376,7 +376,7 @@ def apply(login):
             command += f" --home '{home_directory}'"
 
             if 'operator' not in user_config:
-                command += f' --groups frr,frrvty,vyattacfg,sudo,adm,dip,disk,_kea'
+                command += f' --groups frr,frrvty,vyattacfg,sudo,adm,dip,disk,_kea,vpp'
 
             command += f' {user}'
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
To allow call VPP api without sudo

 - Get op-mode commands without sudo
 - Use API call in smoke-tests

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Add user `vpp` to user groups

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T8012

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
vyos@r1:~$ cat interface_address.py 
#!/usr/bin/env python3
from vyos.vpp import VPPControl


def get_all_addresses():
    vpp = VPPControl()
    addresses = []

    for iface in vpp.api.sw_interface_dump():
        sw_if_index = iface.sw_if_index

        # IPv4
        for a in vpp.api.ip_address_dump(sw_if_index=sw_if_index, is_ipv6=False):
            addresses.append(str(a.prefix))

        # IPv6
        for a in vpp.api.ip_address_dump(sw_if_index=sw_if_index, is_ipv6=True):
            addresses.append(str(a.prefix))

    return addresses


if __name__ == "__main__":
    for addr in get_all_addresses():
        print(addr)
vyos@r1:~$ 
vyos@r1:~$ 
vyos@r1:~$ ./interface_address.py
192.0.2.123/24
vyos@r1:~$ 
```

Before we got:
```
vyos@r14:~$ ./interface_address.py
Traceback (most recent call last):
  File "/home/vyos/./interface_address.py", line 24, in <module>
    for addr in get_all_addresses():
                ^^^^^^^^^^^^^^^^^^^
  File "/home/vyos/./interface_address.py", line 6, in get_all_addresses
    vpp = VPPControl()
          ^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/vpp/control_vpp.py", line 101, in __init__
    self.__vpp_api_client.connect('vpp-vyos')
  File "/usr/lib/python3/dist-packages/vpp_papi/vpp_papi.py", line 655, in connect
    return self.connect_internal(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vpp_papi/vpp_papi.py", line 620, in connect_internal
    rv = self.transport.connect(name, pfx, msg_handler, rx_qlen, do_async)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vpp_papi/vpp_transport_socket.py", line 93, in connect
    raise msg
  File "/usr/lib/python3/dist-packages/vpp_papi/vpp_transport_socket.py", line 90, in connect
    self.socket.connect(self.server_address)
PermissionError: [Errno 13] Permission denied
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
