### PR TITLE
remote: T7940: Add subdirectory support for git commit archiving

### DIFF
--- a/python/vyos/remote.py
+++ b/python/vyos/remote.py
@@ -29,6 +29,7 @@ from pathlib import Path
 
 from ftplib import FTP
 from ftplib import FTP_TLS
+from typing import Optional
 
 from paramiko import SSHClient, SSHException
 from paramiko import MissingHostKeyPolicy
@@ -350,7 +351,7 @@ class GitC:
         raise NotImplementedError("not supported")
 
     @umask(0o077)
-    def upload(self, location: str):
+    def upload(self, location: str, subdirectory: Optional[str] = None):
         scheme = self.url.scheme
         _, _, scheme = scheme.partition("+")
         netloc = self.url.netloc
@@ -395,10 +396,17 @@ class GitC:
 
             # git add
             filename = Path(Path(self.url.path).name).stem
-            dst = path_repository / filename
+            if subdirectory:
+                subdir_path = Path(subdirectory)
+                os.mkdir(path_repository / subdir_path)
+                dst = path_repository / subdirectory / filename
+                dst_file = subdir_path / filename
+            else:
+                dst = path_repository / filename
+                dst_file = filename
             shutil.copy2(location, dst)
             rc, out = rc_cmd(
-                [self.command, "-C", str(path_repository), "add", filename],
+                [self.command, "-C", str(path_repository), "add", dst_file],
                 env=env,
                 shell=False,
             )
@@ -457,11 +465,27 @@ def download(local_path, urlstring, progressbar=False, check_space=False,
         print_error('\nDownload aborted by user.')
         sys.exit(1)
 
-def upload(local_path, urlstring, progressbar=False,
-           source_host='', source_port=0, timeout=10.0):
+
+def upload(
+    local_path,
+    urlstring,
+    progressbar=False,
+    source_host='',
+    source_port=0,
+    timeout=10.0,
+    subdirectory: Optional[str] = None,
+):
     try:
         progressbar = progressbar and is_interactive()
-        urlc(urlstring, progressbar, False, source_host, source_port, timeout).upload(local_path)
+        urlc(
+            urlstring,
+            progressbar,
+            False,
+            source_host,
+            source_port,
+            timeout,
+            subdirectory,
+        ).upload(local_path)
     except Exception as err:
         print_error(f'Unable to upload "{urlstring}": {err}')
         sys.exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
Add the option to allow subdirectories to be used for the git commit-archive location.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7940

## How to test / Smoketest result
Add a git config with an extra subdirectory path after the config object. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
