### PR TITLE
ssh: T7483: Add fido2 PubkeyAuthOptions

### DIFF
--- a/data/templates/ssh/sshd_config.j2
+++ b/data/templates/ssh/sshd_config.j2
@@ -72,6 +72,20 @@ HostKeyAlgorithms {{ hostkey_algorithm | join(',') }}
 PubkeyAcceptedAlgorithms {{ pubkey_accepted_algorithm | join(',') }}
 {% endif %}
 
+{% if fido is vyos_defined %}
+{%     set configured_pubkey_options = [] %}
+{%     if fido.pin_required is vyos_defined %}
+{%         do configured_pubkey_options.append('verify-required') %}
+{%     endif %}
+{%     if fido.touch_required is vyos_defined %}
+{%         do configured_pubkey_options.append('touch-required') %}
+{%     endif %}
+{%     if configured_pubkey_options | length > 0 %}
+# Sets one or more public key authentication options.
+PubkeyAuthOptions {{ configured_pubkey_options | join(' ') }}
+{%     endif %}
+{% endif %}
+
 {% if mac is vyos_defined %}
 # Specifies the available MAC (message authentication code) algorithms
 MACs {{ mac | join(',') }}

--- a/interface-definitions/service_ssh.xml.in
+++ b/interface-definitions/service_ssh.xml.in
@@ -61,6 +61,25 @@
               <valueless/>
             </properties>
           </leafNode>
+          <node name="fido">
+            <properties>
+              <help>FIDO2 SSH options</help>
+            </properties>
+            <children>
+              <leafNode name="pin-required">
+                <properties>
+                  <help>Require FIDO2 keys to attest that a user has been verified (e.g. via a PIN)</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="touch-required">
+                <properties>
+                  <help>Require FIDO2 keys to attest that a user is physically present</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+            </children>
+          </node>
           <node name="dynamic-protection">
             <properties>
               <help>Allow dynamic protection</help>

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -55,7 +55,7 @@ def _get_environment(location=None):
         loader=loc_loader,
         trim_blocks=True,
         undefined=ChainableUndefined,
-        extensions=['jinja2.ext.loopcontrols']
+        extensions=['jinja2.ext.loopcontrols', 'jinja2.ext.do']
     )
     env.filters.update(_FILTERS)
     env.tests.update(_TESTS)

--- a/smoketest/scripts/cli/test_service_ssh.py
+++ b/smoketest/scripts/cli/test_service_ssh.py
@@ -494,5 +494,22 @@ class TestServiceSSH(VyOSUnitTestSHIM.TestCase):
         self.assertNotIn('none', authorize_principals_file_config)
         self.assertFalse(os.path.exists(f'/home/{test_user}/.ssh/authorized_principals'))
 
+    def test_ssh_fido(self):
+        # Order does matter for this test because of how the template
+        # collects and maps the options.
+        opt_map = {
+            'pin-required': 'verify-required',
+            'touch-required': 'touch-required',
+        }
+        expected = 'PubkeyAuthOptions '
+        for k, v in opt_map.items():
+            self.cli_set(base_path + ['fido', k])
+            expected = f'{expected}{v} '
+        expected = expected[:-1]
+        self.cli_commit()
+        tmp_sshd_conf = read_file(SSHD_CONF)
+        self.assertIn(expected, tmp_sshd_conf)
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())


### PR DESCRIPTION
## Change summary
Add `PubkeyAuthOptions` to allow requiring touch and user verification.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related PRs
* https://github.com/vyos/vyos-documentation/pull/1708

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7483

## How to test / Smoketest result
Run ssh with these options enabled and verify that it requires touch and pin verification.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
