### PR TITLE
veth: T8017: bugfix KeyError: 'peer_name'

### DIFF
--- a/src/conf_mode/interfaces_virtual-ethernet.py
+++ b/src/conf_mode/interfaces_virtual-ethernet.py
@@ -27,6 +27,7 @@ from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_vrf
 from vyos.configverify import verify_mtu_ipv6
 from vyos.ifconfig import VethIf
+from vyos.utils.dict import dict_search
 from vyos.utils.network import interface_exists
 airbag.enable()
 
@@ -82,7 +83,7 @@ def verify(veth):
         raise ConfigError(f'Used peer-name "{peer_name}" on interface "{ifname}" ' \
                           'is not configured!')
 
-    if veth['other_interfaces'][peer_name]['peer_name'] != ifname:
+    if dict_search(f'other_interfaces.{peer_name}.peer_name', veth) != ifname:
         raise ConfigError(
             f'Configuration mismatch between "{ifname}" and "{peer_name}"!')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Use safe `dict_search()` function to locate veth peer interface name. If no peer is defined an error will be displayed.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8017

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_virtual-ethernet.py
test_add_multiple_ip_addresses (__main__.VEthInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.VEthInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.VEthInterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.VEthInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.VEthInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.VEthInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.VEthInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.VEthInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.VEthInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.VEthInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol (__main__.VEthInterfaceTest.test_eapol) ... skipped 'unsupported on interface family'
test_interface_description (__main__.VEthInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.VEthInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.VEthInterfaceTest.test_interface_ip_options) ... skipped 'unsupported on interface family'
test_interface_ipv6_options (__main__.VEthInterfaceTest.test_interface_ipv6_options) ... skipped 'unsupported on interface family'
test_interface_mtu (__main__.VEthInterfaceTest.test_interface_mtu) ... ok
test_invalid_peers (__main__.VEthInterfaceTest.test_invalid_peers) ... ok
test_ipv6_link_local_address (__main__.VEthInterfaceTest.test_ipv6_link_local_address) ... skipped 'unsupported on interface family'
test_move_interface_between_vrf_instances (__main__.VEthInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.VEthInterfaceTest.test_mtu_1200_no_ipv6_interface) ... skipped 'unsupported on interface family'
test_span_mirror (__main__.VEthInterfaceTest.test_span_mirror) ... skipped 'unsupported on interface family'
test_vif_8021q_interfaces (__main__.VEthInterfaceTest.test_vif_8021q_interfaces) ... ok
test_vif_8021q_lower_up_down (__main__.VEthInterfaceTest.test_vif_8021q_lower_up_down) ... ok
test_vif_8021q_mtu_limits (__main__.VEthInterfaceTest.test_vif_8021q_mtu_limits) ... ok
test_vif_8021q_qos_change (__main__.VEthInterfaceTest.test_vif_8021q_qos_change) ... ok
test_vif_s_8021ad_vlan_interfaces (__main__.VEthInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... ok
test_vif_s_protocol_change (__main__.VEthInterfaceTest.test_vif_s_protocol_change) ... ok

----------------------------------------------------------------------
Ran 27 tests in 92.147s

OK (skipped=6)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
