### PR TITLE
vpp: T7819: do not override driver if it is already done

### DIFF
--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -90,7 +90,6 @@ dependency_interface_type_map = {
 # dict of drivers that needs to be overrided
 override_drivers: dict[str, str] = {
     'hv_netvsc': 'uio_hv_generic',
-    'ena': 'vfio-pci',
 }
 
 # drivers that does not use PCIe addresses


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Do not override already overridden drivers 

The upstream VPP code already writes the ena device ID to new_id
So we can remove `ena` from `override_driver()`

The kernel does not provide a reliable way to check whether an ID has already been
registered, so we simply attempt the write and ignore the FileExistsError.
Any other failure is treated as a warning.

Fixes this case:
```
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 156, in run_script
    script.apply(c)
  File "/usr/libexec/vyos/conf_mode/vpp.py", line 613, in apply
    control_host.override_driver(
  File "/usr/lib/python3/dist-packages/vyos/vpp/control_host.py", line 138, in override_driver
    Path('/sys/module/vfio_pci/drivers/pci:vfio-pci/new_id').write_text(
  File "/usr/lib/python3.11/pathlib.py", line 1079, in write_text
    with self.open(mode='w', encoding=encoding, errors=errors, newline=newline) as f:
FileExistsError: [Errno 17] File exists
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7819

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
after fix:
```
vyos@VyOS-for-Smoke-Tests# set vpp settings unix poll-sleep-usec 234
[edit]
vyos@VyOS-for-Smoke-Tests# set vpp settings interface eth1 driver dpdk 
[edit]
vyos@VyOS-for-Smoke-Tests# commit
[ vpp ]

WARNING: NOTE: Current dataplane capacity (estimated): 2.1 M IPv4
routes. Exceeding these values will lead to a dataplane out-of-memory
condition and a crash. Extensive use of features like ACLs, NAT and
others may reduce the numbers above. Please read the documentation for
details: https://docs.vyos.io/


[edit]
vyos@VyOS-for-Smoke-Tests# set vpp settings interface eth2 driver dpdk 
[edit]
vyos@VyOS-for-Smoke-Tests# commit
[ vpp ]

WARNING: NOTE: Current dataplane capacity (estimated): 2.1 M IPv4
routes. Exceeding these values will lead to a dataplane out-of-memory
condition and a crash. Extensive use of features like ACLs, NAT and
others may reduce the numbers above. Please read the documentation for
details: https://docs.vyos.io/


[edit]
vyos@VyOS-for-Smoke-Tests# run show vpp int
Kernel    Dataplane    Type    IP Address       MAC                  MTU  State
--------  -----------  ------  ---------------  -----------------  -----  -------
          eth1         dpdk    172.16.21.76/24  06:70:6a:f1:dc:73   1500  up
          eth2         dpdk                     06:bb:96:13:74:41   1500  up
          local0       local                    00:00:00:00:00:00      0  down
eth1      tap4096      virtio                   02:fe:83:93:f9:35   9000  up
eth2      tap4097      virtio                   02:fe:3d:07:7e:b7   9000  up
[edit]
vyos@VyOS-for-Smoke-Tests# 
[edit]
vyos@VyOS-for-Smoke-Tests# run show ver
Version:          VyOS 1.5-rolling-202512100605
Release train:    current
Release flavor:   aws

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
