### PR TITLE
T8027: vpn: adding config for swanctl "send-cert always"

### DIFF
--- a/data/templates/ipsec/swanctl/remote_access.j2
+++ b/data/templates/ipsec/swanctl/remote_access.j2
@@ -8,6 +8,9 @@
         proposals = {{ ike_group[rw_conf.ike_group] | get_esp_ike_cipher | join(',') }}
         version = {{ ike.key_exchange[4:] if ike.key_exchange is vyos_defined else "0" }}
         send_certreq = no
+{% if rw_conf.authentication.always_send_cert is vyos_defined %}
+        send_cert = always
+{% endif %}
 {% if ike.dead_peer_detection is vyos_defined %}
         dpd_timeout = {{ ike.dead_peer_detection.timeout }}
         dpd_delay = {{ ike.dead_peer_detection.interval }}

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -870,6 +870,12 @@
                         <defaultValue>eap-mschapv2</defaultValue>
                       </leafNode>
                       #include <include/auth-local-users.xml.i>
+                      <leafNode name="always-send-cert">
+                        <properties>
+                          <help>Always send local certificate for this connection</help>
+                          <valueless/>
+                        </properties>
+                      </leafNode>
                       <leafNode name="server-mode">
                         <properties>
                           <help>Server authentication mode</help>

--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -1151,10 +1151,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         for line in swanctl_lines:
             self.assertIn(line, swanctl_conf)
 
-        swanctl_unexpected_lines = [
-            f'auth = eap-',
-            f'eap_id'
-        ]
+        swanctl_unexpected_lines = [f'auth = eap-', f'eap_id', f'send_cert =']
         for unexpected_line in swanctl_unexpected_lines:
             self.assertNotIn(unexpected_line, swanctl_conf)
 
@@ -1170,6 +1167,22 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         self.assertTrue(os.path.exists(os.path.join(CA_PATH, f'{ca_name}.pem')))
         self.assertTrue(os.path.exists(os.path.join(CA_PATH, f'{int_ca_name}.pem')))
         self.assertTrue(os.path.exists(os.path.join(CERT_PATH, f'{peer_name}.pem')))
+
+        # Add the always-send-cert config and observe the change
+        self.cli_set(
+            base_path
+            + [
+                'remote-access',
+                'connection',
+                conn_name,
+                'authentication',
+                'always-send-cert',
+            ]
+        )
+        self.cli_commit()
+
+        swanctl_conf = read_file(swanctl_file)
+        self.assertIn(f'send_cert = always', swanctl_conf)
 
         self.tearDownPKI()
 


### PR DESCRIPTION
This setting seems to be required for various Apple clients to connect to the IKEv2 IPSec VPN.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
Setting this configuration flag for a remote-access connection will cause the swanctl config file to render with "send_cert always". This causes the server to voluntarily send its certificate, even if it wasn't requested. This appears to be needed to appease certain Apple client devices.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8027

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-documentation/pull/1712

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
I built an install image with my change and booted a vm with it. I built a remote-access VPN connection and verified that the desired configuration is emitted when the option is set. I've been forcing this configuration into my swanctl.conf on a 1.5-stream-2025-Q2 build using a post-commit hook, so the generated config works as intended.

```
generate pki ca install VPN-ROOT
generate pki certificate sign VPN-ROOT install my-router-vpn

configure
set vpn ipsec esp-group RW-ESP lifetime '3600'
set vpn ipsec esp-group RW-ESP pfs 'enable'
set vpn ipsec esp-group RW-ESP proposal 10 encryption 'aes256'
set vpn ipsec esp-group RW-ESP proposal 10 hash 'sha256'
set vpn ipsec esp-group RW-ESP proposal 20 encryption 'aes256gcm128'
set vpn ipsec ike-group RW-IKE key-exchange 'ikev2'
set vpn ipsec ike-group RW-IKE lifetime '3600'
set vpn ipsec ike-group RW-IKE proposal 10 dh-group '19'
set vpn ipsec ike-group RW-IKE proposal 10 encryption 'aes256'
set vpn ipsec ike-group RW-IKE proposal 10 hash 'sha256'
set vpn ipsec remote-access connection RWv4 authentication client-mode 'eap-tls'
set vpn ipsec remote-access connection RWv4 authentication local-id 'my-router.example.com'
set vpn ipsec remote-access connection RWv4 authentication x509 ca-certificate 'VPN-ROOT'
set vpn ipsec remote-access connection RWv4 authentication x509 certificate 'my-router-vpn'
set vpn ipsec remote-access connection RWv4 dhcp-interface 'eth0'
set vpn ipsec remote-access connection RWv4 esp-group 'RW-ESP'
set vpn ipsec remote-access connection RWv4 ike-group 'RW-IKE'
set vpn ipsec remote-access connection RWv4 pool 'RWv4'
set vpn ipsec remote-access pool RWv4 prefix '10.1.10.0/24'
commit

less /etc/swanctl/swanctl.conf  # should not see send_cert

configure
set vpn ipsec remote-access connection RWv4 authentication send-cert-always
commit

less /etc/swanctl/swanctl.conf  # should see send_cert 

# CLI completions & hints
vyos@vyos# set vpn ipsec remote-access connection RWv4 authentication 
Possible completions:
   client-mode          Client authentication mode (default: eap-mschapv2)
   eap-id               Remote EAP ID for client authentication (default: any)
   local-id             Local ID for peer authentication
 > local-users          Local user authentication
   pre-shared-secret    Pre-shared secret key
   send-cert-always     Always send local certificate for this connection
   server-mode          Server authentication mode (default: x509)
 > x509                 X.509 certificate

      
[edit]

# connection is properly loaded
vyos@vyos:~$ sudo swanctl --list-conns 
ra-RWv4: IKEv2, no reauthentication, rekeying every 3600s
  local:  10.1.1.1
  remote: %any
  local public key authentication:
    id: my-router.example.com
    certs: C=GB, ST=Some-State, L=Some-City, O=VyOS, CN=my-router.example.com
  remote EAP_TLS authentication:
    eap_id: %any
    cacerts: C=GB, ST=Some-State, L=Some-City, O=VyOS, CN=vyos.io
  RWv4-client: TUNNEL, rekeying every 3272s
    local:  0.0.0.0/0 ::/0
    remote: dynamic
vyos@vyos:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly