### PR TITLE
T8031: file comparison in boolean check unsaved_commits should ignore blank lines

### DIFF
--- a/python/vyos/config_mgmt.py
+++ b/python/vyos/config_mgmt.py
@@ -48,6 +48,7 @@ from vyos.utils.process import is_systemd_service_active
 from vyos.utils.process import rc_cmd
 from vyos.defaults import DEFAULT_COMMIT_CONFIRM_MINUTES
 from vyos.component_version import append_system_version
+from vyos.utils.file import file_compare
 
 SAVE_CONFIG = '/usr/libexec/vyos/vyos-save-config.py'
 config_json = '/run/vyatta/config/config.json'
@@ -97,7 +98,7 @@ def unsaved_commits(allow_missing_config=False) -> bool:
         return True
     tmp_save = '/tmp/config.running'
     save_config(tmp_save)
-    ret = not cmp(tmp_save, config_file, shallow=False)
+    ret = not file_compare(tmp_save, config_file)
     os.unlink(tmp_save)
     return ret
 

--- a/python/vyos/utils/file.py
+++ b/python/vyos/utils/file.py
@@ -312,3 +312,30 @@ def move_recursive(src: str, dst: str, overwrite=False):
 
     copy_recursive(src, dst, overwrite=overwrite)
     shutil.rmtree(src)
+
+
+def file_compare(file1: str, file2: str) -> bool:
+    """
+    Compare two files modulo blank lines, leading/trailing whitespace, final
+    newline.
+
+    Returns:
+        bool: True if files are equivalent in the sense above.
+
+    """
+
+    def non_empty(line):
+        return bool(line.strip())
+
+    with open(file1) as f1, open(file2) as f2:
+        it1 = filter(non_empty, f1)
+        it2 = filter(non_empty, f2)
+
+        try:
+            for l1, l2 in zip(it1, it2, strict=True):
+                if l1.strip() != l2.strip():
+                    return False
+        except ValueError:
+            return False
+
+        return True


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Discrepancies in blank lines, whitespace, or missing final newline can lead to false positives in the boolean check unsaved_commits, which is used to provide warning messages on reboot/poweroff and commit-confirm.

The discrepancies can arise due to automated formatting at boot from migration/activation scripts or intialization on first install; such discrepancies trigger a false positive due to the use of Python's filecmp module.

Irrespective of consistent formatting, use a smarter file comparison utility.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
