### PR TITLE
T8030: VPP: Check support for changed driver too

### DIFF
--- a/python/vyos/vpp/config_verify.py
+++ b/python/vyos/vpp/config_verify.py
@@ -22,7 +22,6 @@ from vyos import ConfigError
 from vyos.base import Warning
 from vyos.utils.cpu import get_core_count as total_core_count, get_cpus
 
-from vyos.vpp.control_host import get_eth_driver
 from vyos.vpp.config_resource_checks import cpu as cpu_checks, memory as mem_checks
 from vyos.vpp.config_resource_checks.resource_defaults import default_resource_map
 from vyos.vpp.utils import human_memory_to_bytes, bytes_to_human_memory
@@ -122,7 +121,7 @@ def verify_vpp_tunnel_source_address(config: dict):
     )
 
 
-def verify_dev_driver(iface_name: str, driver_type: str) -> bool:
+def verify_dev_driver(driver_type: str, driver: str) -> bool:
     # Lists of drivers compatible with DPDK and XDP
     drivers_dpdk: list[str] = [
         'atlantic',
@@ -166,8 +165,6 @@ def verify_dev_driver(iface_name: str, driver_type: str) -> bool:
         'virtio_net',
         'vmxnet3',
     ]
-
-    driver: str = get_eth_driver(iface_name)
 
     if driver_type == 'dpdk':
         if driver in drivers_dpdk:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8030
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
NIC e1000
```
set vpp settings interface eth1 driver dpdk
commit
```
Before the fix, when we changed driver type there was an error and VPP reloaded to previous configuration because original NIC does not support XDP:
```
vyos@vyos# set vpp settings interface eth1 driver xdp
[edit]
vyos@vyos# commit
[ vpp ]
WARNING: offload option in eth1 settings is not supported by VPP interfaces. It will be ignored.

WARNING: NOTE: Current dataplane capacity (estimated): 2.1 M IPv4
routes. Exceeding these values will lead to a dataplane out-of-memory
condition and a crash. Extensive use of features like ACLs, NAT and
others may reduce the numbers above. Please read the documentation for
details: https://docs.vyos.io/

An error occurred: VPP API call failed: -12. VPP service will be
restarted with the previous configuration
[[vpp]] failed
Commit failed
[ vpp ]
WARNING: offload option in eth1 settings is not supported by VPP interfaces. It will be ignored.

WARNING: NOTE: Current dataplane capacity (estimated): 2.1 M IPv4
routes. Exceeding these values will lead to a dataplane out-of-memory
condition and a crash. Extensive use of features like ACLs, NAT and
others may reduce the numbers above. Please read the documentation for
details: https://docs.vyos.io/



[edit]
```
After the fix:
```
vyos@vyos# set vpp settings interface eth1 driver xdp
[edit]
vyos@vyos# commit
[ vpp ]
WARNING: offload option in eth1 settings is not supported by VPP interfaces. It will be ignored.
Driver xdp is not compatible with interface eth1!
[[vpp]] failed
Commit failed
[edit]
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
