### PR TITLE
vpp: T8036: Commit fails removing nat44 static rule

### DIFF
--- a/src/conf_mode/vpp_nat.py
+++ b/src/conf_mode/vpp_nat.py
@@ -240,7 +240,7 @@ def verify(config):
         addresses_without_ports = set()
         local_addresses = set()
 
-        for rule, rule_config in config['static']['rule'].items():
+        for rule, rule_config in config['static'].get('rule', {}).items():
             error_msg = f'Configuration error in static rule {rule}:'
 
             if not rule_config.get('local', {}).get('address'):
@@ -327,7 +327,7 @@ def verify(config):
                     )
 
     if 'exclude' in config:
-        for rule, rule_config in config['exclude']['rule'].items():
+        for rule, rule_config in config['exclude'].get('rule', {}).items():
             keys = {'local_address', 'external_interface'}
             if not any(key in rule_config for key in keys):
                 raise ConfigError(


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8036
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set vpp nat44 address-pool translation interface 'eth1'
set vpp nat44 interface inside 'eth0'
set vpp nat44 interface outside 'eth1'
set vpp nat44 static rule 100 external address '192.0.0.2'
set vpp nat44 static rule 100 local address '192.168.102.1'
set vpp settings interface eth1 driver 'dpdk'
set vpp settings interface eth0 driver 'dpdk'
commit
```
Beforethe fix:
```
vyos@vyos# del vpp nat44 static rule 100
[edit]

vyos@vyos# commit
[ vpp nat44 ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 146, in run_script
    script.verify(c)
  File "/usr/libexec/vyos/conf_mode/vpp_nat.py", line 243, in verify
    for rule, rule_config in config['static']['rule'].items():
                             ~~~~~~~~~~~~~~~~^^^^^^^^
KeyError: 'rule'

[[vpp nat44]] failed
Commit failed
```
After:
```
vyos@vyos# del vpp nat44 static rule 100
[edit]
vyos@vyos# commit
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
