### PR TITLE
frr: T8034: use dict_search() for routing protocols to check if VRF is used

### DIFF
--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -184,7 +184,8 @@ def verify(config_dict):
         vrf = config_dict['vrf_context']
 
     # eqivalent of the C foo ? 'a' : 'b' statement
-    bgp = vrf and config_dict['vrf']['name'][vrf]['protocols']['bgp'] or config_dict['bgp']
+    bgp = vrf and dict_search(f'vrf.name.{vrf}.protocols.bgp',
+                              config_dict) or config_dict['bgp']
     bgp['policy'] = config_dict['policy']
 
     if 'deleted' in bgp:
@@ -331,7 +332,7 @@ def verify(config_dict):
                             peer_group = peer_config['interface']['v6only']['peer_group']
                             if 'remote_as' in peer_config['interface']['v6only'] and 'remote_as' in bgp['peer_group'][peer_group]:
                                 raise ConfigError(f'Peer-group member "{peer}" cannot override remote-as of peer-group "{peer_group}"!')
-                            
+
                 for afi in ['ipv4_unicast', 'ipv4_multicast', 'ipv4_labeled_unicast', 'ipv4_flowspec',
                             'ipv6_unicast', 'ipv6_multicast', 'ipv6_labeled_unicast', 'ipv6_flowspec',
                             'l2vpn_evpn']:

--- a/src/conf_mode/protocols_eigrp.py
+++ b/src/conf_mode/protocols_eigrp.py
@@ -20,6 +20,7 @@ from sys import argv
 from vyos.config import Config
 from vyos.configverify import has_frr_protocol_in_dict
 from vyos.configverify import verify_vrf
+from vyos.utils.dict import dict_search
 from vyos.utils.process import is_systemd_service_running
 from vyos.frrender import FRRender
 from vyos.frrender import get_frrender_dict
@@ -44,7 +45,8 @@ def verify(config_dict):
         vrf = config_dict['vrf_context']
 
     # eqivalent of the C foo ? 'a' : 'b' statement
-    eigrp = vrf and config_dict['vrf']['name'][vrf]['protocols']['eigrp'] or config_dict['eigrp']
+    eigrp = vrf and dict_search(f'vrf.name.{vrf}.protocols.eigrp',
+                                 config_dict) or config_dict['eigrp']
     eigrp['policy'] = config_dict['policy']
 
     if 'system_as' not in eigrp:

--- a/src/conf_mode/protocols_isis.py
+++ b/src/conf_mode/protocols_isis.py
@@ -48,7 +48,8 @@ def verify(config_dict):
         vrf = config_dict['vrf_context']
 
     # eqivalent of the C foo ? 'a' : 'b' statement
-    isis = vrf and config_dict['vrf']['name'][vrf]['protocols']['isis'] or config_dict['isis']
+    isis = vrf and dict_search(f'vrf.name.{vrf}.protocols.isis',
+                                 config_dict) or config_dict['isis']
     isis['policy'] = config_dict['policy']
 
     if 'deleted' in isis:

--- a/src/conf_mode/protocols_ospf.py
+++ b/src/conf_mode/protocols_ospf.py
@@ -50,7 +50,8 @@ def verify(config_dict):
         vrf = config_dict['vrf_context']
 
     # eqivalent of the C foo ? 'a' : 'b' statement
-    ospf = vrf and config_dict['vrf']['name'][vrf]['protocols']['ospf'] or config_dict['ospf']
+    ospf = vrf and dict_search(f'vrf.name.{vrf}.protocols.ospf',
+                                 config_dict) or config_dict['ospf']
     ospf['policy'] = config_dict['policy']
 
     verify_common_route_maps(ospf)

--- a/src/conf_mode/protocols_ospfv3.py
+++ b/src/conf_mode/protocols_ospfv3.py
@@ -49,7 +49,8 @@ def verify(config_dict):
         vrf = config_dict['vrf_context']
 
     # eqivalent of the C foo ? 'a' : 'b' statement
-    ospfv3 = vrf and config_dict['vrf']['name'][vrf]['protocols']['ospfv3'] or config_dict['ospfv3']
+    ospfv3 = vrf and dict_search(f'vrf.name.{vrf}.protocols.ospfv3',
+                                 config_dict) or config_dict['ospfv3']
     ospfv3['policy'] = config_dict['policy']
 
     verify_common_route_maps(ospfv3)

--- a/src/conf_mode/protocols_rpki.py
+++ b/src/conf_mode/protocols_rpki.py
@@ -26,6 +26,7 @@ from vyos.frrender import FRRender
 from vyos.frrender import get_frrender_dict
 from vyos.pki import wrap_openssh_public_key
 from vyos.pki import wrap_openssh_private_key
+from vyos.utils.dict import dict_search
 from vyos.utils.dict import dict_search_args
 from vyos.utils.file import write_file
 from vyos.utils.process import is_systemd_service_running
@@ -51,7 +52,8 @@ def verify(config_dict):
         vrf = config_dict['vrf_context']
 
     # eqivalent of the C foo ? 'a' : 'b' statement
-    rpki = vrf and config_dict['vrf']['name'][vrf]['protocols']['rpki'] or config_dict['rpki']
+    rpki = vrf and dict_search(f'vrf.name.{vrf}.protocols.rpki',
+                                 config_dict) or config_dict['rpki']
 
     if 'cache' in rpki:
         preferences = []
@@ -90,7 +92,8 @@ def generate(config_dict):
         vrf = config_dict['vrf_context']
 
     # eqivalent of the C foo ? 'a' : 'b' statement
-    rpki = vrf and config_dict['vrf']['name'][vrf]['protocols']['rpki'] or config_dict['rpki']
+    rpki = vrf and dict_search(f'vrf.name.{vrf}.protocols.rpki',
+                                config_dict) or config_dict['rpki']
 
     if 'cache' in rpki:
         for cache, cache_config in rpki['cache'].items():

--- a/src/conf_mode/protocols_static.py
+++ b/src/conf_mode/protocols_static.py
@@ -25,8 +25,9 @@ from vyos.configverify import verify_common_route_maps
 from vyos.configverify import verify_vrf
 from vyos.frrender import FRRender
 from vyos.frrender import get_frrender_dict
-from vyos.utils.process import is_systemd_service_running
+from vyos.utils.dict import dict_search
 from vyos.utils.file import write_file
+from vyos.utils.process import is_systemd_service_running
 from vyos.template import render
 from vyos import ConfigError
 from vyos import airbag
@@ -53,7 +54,8 @@ def verify(config_dict):
         vrf = config_dict['vrf_context']
 
     # eqivalent of the C foo ? 'a' : 'b' statement
-    static = vrf and config_dict['vrf']['name'][vrf]['protocols']['static'] or config_dict['static']
+    static = vrf and dict_search(f'vrf.name.{vrf}.protocols.static',
+                                 config_dict) or config_dict['static']
     static['policy'] = config_dict['policy']
 
     verify_common_route_maps(static)
@@ -94,7 +96,8 @@ def generate(config_dict):
         vrf = config_dict['vrf_context']
 
     # eqivalent of the C foo ? 'a' : 'b' statement
-    static = vrf and config_dict['vrf']['name'][vrf]['protocols']['static'] or config_dict['static']
+    static = vrf and dict_search(f'vrf.name.{vrf}.protocols.static',
+                                 config_dict) or config_dict['static']
 
     # Collect interfaces that have DHCP configuration for DHCP hooks
     dhcp_interfaces = set()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

`dict_search()` is save when passing in keys that do not exist in the dict we are working on.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8034

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
 All smoketests passed (`make test` and `make testc`)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
