### PR TITLE
nat: T8038: remove duplicate XML definitions for <properties>

### DIFF
--- a/interface-definitions/nat.xml.in
+++ b/interface-definitions/nat.xml.in
@@ -65,17 +65,6 @@
         <children>
           #include <include/nat-rule.xml.i>
           <tagNode name="rule">
-            <properties>
-              <help>Rule number for NAT</help>
-              <valueHelp>
-                <format>u32:1-999999</format>
-                <description>Number of NAT rule</description>
-              </valueHelp>
-              <constraint>
-                <validator name="numeric" argument="--range 1-999999"/>
-              </constraint>
-              <constraintErrorMessage>NAT rule number must be between 1 and 999999</constraintErrorMessage>
-            </properties>
             <children>
               #include <include/firewall/outbound-interface.xml.i>
               <node name="translation">


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

We can remove the XML `<properties>` because it's the same as already defined in `#include <include/nat-rule.xml.i>`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8038

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
