### PR TITLE
vrf: T6097: Fix for veth pair in different VRFS

### DIFF
--- a/smoketest/scripts/cli/test_vrf.py
+++ b/smoketest/scripts/cli/test_vrf.py
@@ -651,8 +651,8 @@ class VRFTest(VyOSUnitTestSHIM.TestCase):
     def test_vrf_conntrack(self):
         table = '8710'
         nftables_rules = {
-            'vrf_zones_ct_in': ['ct original zone set iifname map @ct_iface_map'],
-            'vrf_zones_ct_out': ['ct original zone set oifname map @ct_iface_map']
+            'vrf_zones_ct_in': ['ct zone set iifname map @ct_iface_map'],
+            'vrf_zones_ct_out': ['ct zone set oifname map @ct_iface_map'],
         }
 
         self.cli_set(base_path + ['name', 'randomVRF', 'table', '1000'])

--- a/src/conf_mode/vrf.py
+++ b/src/conf_mode/vrf.py
@@ -46,8 +46,8 @@ k_mod = ['vrf']
 
 nftables_table = 'inet vrf_zones'
 nftables_rules = {
-    'vrf_zones_ct_in': 'counter ct original zone set iifname map @ct_iface_map',
-    'vrf_zones_ct_out': 'counter ct original zone set oifname map @ct_iface_map'
+    'vrf_zones_ct_in': 'counter ct zone set iifname map @ct_iface_map',
+    'vrf_zones_ct_out': 'counter ct zone set oifname map @ct_iface_map',
 }
 
 def has_rule(af : str, priority : int, table : str=None):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary

When veth interface pair is in different VRFS and there is a firewall rule, `ct original zone` is set for a VRF, which blocks packets somewhy.

Changing to `ct zone` (for both directions) fixes this.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue) (hopefully non-breaking)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T6097

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

```
configure
set firewall ipv6 input filter default-action accept
set interfaces virtual-ethernet veth0 address 2001:db8::/127
set interfaces virtual-ethernet veth0 peer-name veth1
set interfaces virtual-ethernet veth1 address 2001:db8::1/127
set interfaces virtual-ethernet veth1 peer-name veth0
set interfaces virtual-ethernet veth1 vrf red
set vrf name red table 1000
commit

# Works:
run ping 2001:db8::1 source-address 2001:db8::

set firewall ipv6 input filter rule 10 action accept 
set firewall ipv6 input filter rule 10 state established 
commit

# Doesn't work:
run ping 2001:db8::1 source-address 2001:db8::
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
