### PR TITLE
ipsec: T8001: Commit fails removing VTI interface in IPsec config

### DIFF
--- a/python/vyos/utils/vti_updown_db.py
+++ b/python/vyos/utils/vti_updown_db.py
@@ -173,7 +173,7 @@ class VTIUpDownDB:
         self._fileHandle.truncate()
 
         for interface in self._ifsDown:
-            vti_link = get_interface_config(interface)
+            vti_link = get_interface_config(interface) or {}
             vti_link_up = (vti_link['operstate'] != 'DOWN' if 'operstate' in vti_link else False)
             if vti_link_up:
                 call(f'sudo ip link set {interface} down')
@@ -182,7 +182,7 @@ class VTIUpDownDB:
         self._ifsDown.clear()
 
         for interface in self._ifsUp:
-            vti_link = get_interface_config(interface)
+            vti_link = get_interface_config(interface) or {}
             vti_link_up = (vti_link['operstate'] != 'DOWN' if 'operstate' in vti_link else False)
             if not vti_link_up:
                 vti = interface_dict_supplier(interface)

--- a/src/etc/ipsec.d/vti-up-down
+++ b/src/etc/ipsec.d/vti-up-down
@@ -29,7 +29,7 @@ from vyos.configquery import ConfigTreeQuery
 from vyos.configdict import get_interface_dict
 from vyos.utils.commit import wait_for_commit_lock
 from vyos.utils.process import call
-from vyos.utils.vti_updown_db import open_vti_updown_db_for_update
+from vyos.utils.vti_updown_db import open_vti_updown_db_for_create_or_update
 
 def supply_interface_dict(interface):
     # Lazy-load the running config on first invocation
@@ -58,10 +58,10 @@ if __name__ == '__main__':
     wait_for_commit_lock()
 
     if verb in ['up-client', 'up-client-v6', 'up-host', 'up-host-v6']:
-        with open_vti_updown_db_for_update() as db:
+        with open_vti_updown_db_for_create_or_update() as db:
             db.add(interface, connection, protocol)
             db.commit(supply_interface_dict)
     elif verb in ['down-client', 'down-client-v6', 'down-host', 'down-host-v6']:
-        with open_vti_updown_db_for_update() as db:
+        with open_vti_updown_db_for_create_or_update() as db:
             db.remove(interface, connection, protocol)
             db.commit(supply_interface_dict)


### PR DESCRIPTION
## Change summary
Fix cases where commit or IPsec up/down hooks fail if the VTI interface has already been deleted or the `/tmp/ipsec_vti_interfaces` file does not exist.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8001

## How to test / Smoketest result

#### Step 1. To reproduce and verify the issues necessary configure Peer B:
```
conf
set vpn ipsec authentication psk psk1 id 'A'
set vpn ipsec authentication psk psk1 id 'B'
set vpn ipsec authentication psk psk1 secret 'AB'
set vpn ipsec esp-group esp1 mode 'tunnel'
set vpn ipsec esp-group esp1 pfs 'disable'
set vpn ipsec esp-group esp1 proposal 10 encryption 'aes256'
set vpn ipsec esp-group esp1 proposal 10 hash 'sha256'
set vpn ipsec ike-group ike1 close-action 'none'
set vpn ipsec ike-group ike1 dead-peer-detection action 'clear'
set vpn ipsec ike-group ike1 proposal 10 encryption 'camellia256ccm96'
set vpn ipsec ike-group ike1 proposal 10 hash 'sha256'
set vpn ipsec interface 'eth0'
set vpn ipsec site-to-site peer A authentication local-id 'B'
set vpn ipsec site-to-site peer A authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer A authentication remote-id 'A'
set vpn ipsec site-to-site peer A connection-type 'respond'
set vpn ipsec site-to-site peer A default-esp-group 'esp1'
set vpn ipsec site-to-site peer A ike-group 'ike1'
set vpn ipsec site-to-site peer A local-address '172.168.99.3'
set vpn ipsec site-to-site peer A remote-address '172.168.99.2'
set vpn ipsec site-to-site peer A vti bind 'vti1'
set interfaces vti vti1
set protocols static route 172.168.102.0/24 interface vti1
commit
```

#### Step 2. Reproduce Issue 1: Commit failure when deleting VTI (Peer A)
```
conf
set interfaces vti vti1
set protocols static route 172.168.202.0/24 interface vti1
set vpn ipsec site-to-site peer B vti bind 'vti1'
set vpn ipsec authentication psk psk1 id 'A'
set vpn ipsec authentication psk psk1 id 'B'
set vpn ipsec authentication psk psk1 secret 'AB'
set vpn ipsec esp-group esp1 mode 'tunnel'
set vpn ipsec esp-group esp1 pfs 'disable'
set vpn ipsec esp-group esp1 proposal 10 encryption 'aes256'
set vpn ipsec esp-group esp1 proposal 10 hash 'sha256'
set vpn ipsec ike-group ike1 close-action 'none'
set vpn ipsec ike-group ike1 dead-peer-detection action 'clear'
set vpn ipsec ike-group ike1 proposal 10 encryption 'camellia256ccm96'
set vpn ipsec ike-group ike1 proposal 10 hash 'sha256'
set vpn ipsec interface 'eth0'
set vpn ipsec site-to-site peer B authentication local-id 'A'
set vpn ipsec site-to-site peer B authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer B authentication remote-id 'B'
set vpn ipsec site-to-site peer B connection-type 'initiate'
set vpn ipsec site-to-site peer B default-esp-group 'esp1'
set vpn ipsec site-to-site peer B ike-group 'ike1'
set vpn ipsec site-to-site peer B local-address '172.168.99.2'
set vpn ipsec site-to-site peer B remote-address '172.168.99.3'
set vpn ipsec site-to-site peer B vti bind 'vti1'
commit

del interfaces vti vti1
del protocols static route 172.168.202.0/24
del vpn ipsec site-to-site peer B vti
set vpn ipsec site-to-site peer B tunnel 0 local prefix '172.168.102.0/24'
set vpn ipsec site-to-site peer B tunnel 0 remote prefix '172.168.202.0/24'
commit
```

#### Step 3. Reproduce Issue 2: Missing `/tmp/ipsec_vti_interfaces` file (Peer A)
```
conf
set interfaces vti vti1
set protocols static route 172.168.202.0/24 interface vti1
set vpn ipsec site-to-site peer B vti bind 'vti1'
set vpn ipsec authentication psk psk1 id 'A'
set vpn ipsec authentication psk psk1 id 'B'
set vpn ipsec authentication psk psk1 secret 'AB'
set vpn ipsec esp-group esp1 mode 'tunnel'
set vpn ipsec esp-group esp1 pfs 'disable'
set vpn ipsec esp-group esp1 proposal 10 encryption 'aes256'
set vpn ipsec esp-group esp1 proposal 10 hash 'sha256'
set vpn ipsec ike-group ike1 close-action 'none'
set vpn ipsec ike-group ike1 dead-peer-detection action 'clear'
set vpn ipsec ike-group ike1 proposal 10 encryption 'camellia256ccm96'
set vpn ipsec ike-group ike1 proposal 10 hash 'sha256'
set vpn ipsec interface 'eth0'
set vpn ipsec site-to-site peer B authentication local-id 'A'
set vpn ipsec site-to-site peer B authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer B authentication remote-id 'B'
set vpn ipsec site-to-site peer B connection-type 'initiate'
set vpn ipsec site-to-site peer B default-esp-group 'esp1'
set vpn ipsec site-to-site peer B ike-group 'ike1'
set vpn ipsec site-to-site peer B local-address '172.168.99.2'
set vpn ipsec site-to-site peer B remote-address '172.168.99.3'
set vpn ipsec site-to-site peer B vti bind 'vti1'
commit

del vpn ipsec site-to-site peer B vti
set vpn ipsec site-to-site peer B tunnel 0 local prefix '172.168.102.0/24'
set vpn ipsec site-to-site peer B tunnel 0 remote prefix '172.168.202.0/24'
commit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
