### PR TITLE
T8011: VPP fix log duplication in systemd journal

### DIFF
--- a/data/templates/vpp/override.conf.j2
+++ b/data/templates/vpp/override.conf.j2
@@ -13,3 +13,6 @@ WorkingDirectory=
 WorkingDirectory=/run/vpp
 Restart=no
 Type=notify
+# T8011 avoid duplicating logs
+StandardOutput=null
+StandardError=null


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Set the standard output/error to `null` to avoid log duplication.
Starting the service as "nodaemon" seems cause of this behavior.
Fixes VPP log duplication
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T8011

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
set vpp settings interface eth1 driver 'dpdk'
set vpp settings unix poll-sleep-usec '2222'
```
Before the fix, we see duplicate log entries:
```
vyos@vyos# sudo journalctl -b --unit vpp | tee
Nov 19 14:46:07 vyos systemd[1]: Starting vector packet processing engine...
Nov 19 14:46:07 vyos systemd[1]: Started vector packet processing engine.
Nov 19 14:46:09 vyos vpp[4295]: vpp[4295]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'det44-out2in', arc 'ip4-unicast')
Nov 19 14:46:09 vyos vpp[4295]: vpp[4295]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'nat44-ei-out2in', arc 'ip4-unicast')
Nov 19 14:46:09 vyos vpp[4295]: vpp[4295]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'nat44-ei-out2in-worker-handoff', arc 'ip4-unicast')
Nov 19 14:46:09 vyos vpp[4295]: vpp[4295]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'nat-pre-out2in', arc 'ip4-unicast')
Nov 19 14:46:09 vyos vpp[4295]: vpp[4295]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'nat44-out2in-worker-handoff', arc 'ip4-unicast')
Nov 19 14:46:09 vyos vpp[4295]: vpp[4295]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'nat44-ed-out2in', arc 'ip4-unicast')
Nov 19 14:46:09 vyos vpp[4295]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'det44-out2in', arc 'ip4-unicast')
Nov 19 14:46:09 vyos vpp[4295]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'nat44-ei-out2in', arc 'ip4-unicast')
Nov 19 14:46:09 vyos vpp[4295]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'nat44-ei-out2in-worker-handoff', arc 'ip4-unicast')
Nov 19 14:46:09 vyos vpp[4295]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'nat-pre-out2in', arc 'ip4-unicast')
Nov 19 14:46:09 vyos vpp[4295]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'nat44-out2in-worker-handoff', arc 'ip4-unicast')
Nov 19 14:46:09 vyos vpp[4295]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'nat44-ed-out2in', arc 'ip4-unicast')
Nov 19 14:46:10 vyos vpp[4295]: vpp[4295]: vat-plug/load: vat_plugin_register: adl plugin not loaded...
Nov 19 14:46:10 vyos vpp[4295]: vat-plug/load: vat_plugin_register: adl plugin not loaded...
Nov 19 14:46:10 vyos vpp[4295]: vpp[4295]: vat-plug/load: vat_plugin_register: arping plugin not loaded...
Nov 19 14:46:10 vyos vpp[4295]: vat-plug/load: vat_plugin_register: arping plugin not loaded...
Nov 19 14:46:10 vyos vpp[4295]: vpp[4295]: vat-plug/load: vat_plugin_register: cdp plugin not loaded...
Nov 19 14:46:10 vyos vpp[4295]: vat-plug/load: vat_plugin_register: cdp plugin not loaded...
Nov 19 14:46:10 vyos vpp[4295]: vpp[4295]: vat-plug/load: vat_plugin_register: ct6 plugin not loaded...
Nov 19 14:46:10 vyos vpp[4295]: vat-plug/load: vat_plugin_register: ct6 plugin not loaded...
Nov 19 14:46:10 vyos vpp[4295]: vpp[4295]: vat-plug/load: vat_plugin_register: dhcp plugin not loaded...
Nov 19 14:46:10 vyos vpp[4295]: vat-plug/load: vat_plugin_register: dhcp plugin not loaded...
Nov 19 14:46:10 vyos vpp[4295]: vpp[4295]: vat-plug/load: vat_plugin_register: dns plugin not loaded...
Nov 19 14:46:10 vyos vpp[4295]: vat-plug/load: vat_plugin_register: dns plugin not loaded...
...
```
After the fix we do not see log duplication:
```
Dec 01 15:30:50 r14 systemd[1]: Starting vector packet processing engine...
Dec 01 15:30:50 r14 vpp[31824]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'det44-out2in', arc 'ip4-unicast')
Dec 01 15:30:50 r14 vpp[31824]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'nat44-ei-out2in', arc 'ip4-unicast')
Dec 01 15:30:50 r14 vpp[31824]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'nat44-ei-out2in-worker-handoff', arc 'ip4-unicast')
Dec 01 15:30:50 r14 vpp[31824]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'nat-pre-out2in', arc 'ip4-unicast')
Dec 01 15:30:50 r14 vpp[31824]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'nat44-out2in-worker-handoff', arc 'ip4-unicast')
Dec 01 15:30:50 r14 vpp[31824]: vnet_feature_arc_init:272: feature node 'ip4-dhcp-client-detect' not found (before 'nat44-ed-out2in', arc 'ip4-unicast')
Dec 01 15:30:50 r14 vpp[31824]: vat-plug/load: vat_plugin_register: adl plugin not loaded...
Dec 01 15:30:50 r14 vpp[31824]: vat-plug/load: vat_plugin_register: arping plugin not loaded...
Dec 01 15:30:50 r14 vpp[31824]: vat-plug/load: vat_plugin_register: cdp plugin not loaded...
Dec 01 15:30:50 r14 vpp[31824]: vat-plug/load: vat_plugin_register: ct6 plugin not loaded...
Dec 01 15:30:50 r14 vpp[31824]: vat-plug/load: vat_plugin_register: dhcp plugin not loaded...
Dec 01 15:30:50 r14 vpp[31824]: vat-plug/load: vat_plugin_register: dns plugin not loaded...
...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
