### PR TITLE
interfaces: T8054: use --is-valid-intf-address for validating interface addresses

### DIFF
--- a/interface-definitions/include/interface/address-ipv4-ipv6-dhcp.xml.i
+++ b/interface-definitions/include/interface/address-ipv4-ipv6-dhcp.xml.i
@@ -22,7 +22,7 @@
       <description>Dynamic Host Configuration Protocol for IPv6</description>
     </valueHelp>
     <constraint>
-      <validator name="ip-host"/>
+      <validator name="interface-address"/>
       <regex>(dhcp|dhcpv6)</regex>
     </constraint>
     <multi/>

--- a/interface-definitions/include/interface/address-ipv4-ipv6.xml.i
+++ b/interface-definitions/include/interface/address-ipv4-ipv6.xml.i
@@ -11,7 +11,7 @@
       <description>IPv6 address and prefix length</description>
     </valueHelp>
     <constraint>
-      <validator name="ip-host"/>
+      <validator name="interface-address"/>
     </constraint>
     <multi/>
   </properties>

--- a/src/validators/interface-address
+++ b/src/validators/interface-address
@@ -1,3 +1,10 @@
 #!/bin/sh
 
-ipaddrcheck --is-any-host "$1"
+ipaddrcheck --allow-loopback --is-valid-intf-address "$1"
+
+if [ $? -gt 0 ]; then
+    echo "Error: $1 is not a valid network interface address"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Currently interface address command templates use the `ip-host` validator. The problem with that is that not every valid _host address_ is a valid _network interface address_.

For example, 224.0.0.1/24 is a "host address" in the sense that it's not a network address, but it's the multicast group address of all routers and should never be assigned to an interface manually — it must be joined correctly via IGMP to actually work as expected.

The curious part is that we in fact have had `interface-address` validator since the introduction of ipaddrcheck-based validators in  2018, but for some reason never used it. Now it refers to `--is-any-host` but ipaddrcheck already had an option specially for this purpose: `--is-valid-intf-address`.

The function behind it (https://github.com/vyos/ipaddrcheck/blob/current/src/ipaddrcheck_functions.c#L416-L442) excludes all special-purpose addresses.

It disallows IPv4 loopback addresses by default — ideally we should only allow them on `lo`, but we don't have a mechanism to pass parent node names to validators yet, so here it's allowed unconditionally.

If this PR is merged, we can then deal with https://vyos.dev/T7973 (the question about all-zero host part IPv6 addresses) in that function, if we decide to allow them.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8054

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
