### PR TITLE
syslog: T8059: migrate host:port node names to the new syntax with a dedicated port option

### DIFF
--- a/smoketest/config-tests/basic-syslog
+++ b/smoketest/config-tests/basic-syslog
@@ -22,4 +22,7 @@ set system syslog remote syslog02.vyos.net format octet-counted
 set system syslog remote syslog02.vyos.net port '8001'
 set system syslog remote syslog02.vyos.net protocol 'tcp'
 set system syslog remote syslog02.vyos.net vrf 'red'
+set system syslog remote syslog03.vyos.net facility local7 level 'notice'
+set system syslog remote syslog03.vyos.net port '9000'
+set system syslog remote syslog03.vyos.net vrf 'red'
 set vrf name red table '12321'

--- a/smoketest/configs/basic-syslog
+++ b/smoketest/configs/basic-syslog
@@ -56,6 +56,11 @@ system {
             protocol tcp
             port 8001
         }
+        host syslog03.vyos.net:9000 {
+            facility local7 {
+                level notice
+            }
+        }
         vrf red
     }
 }
@@ -67,4 +72,4 @@ vrf {
 
 // Warning: Do not remove the following line.
 // vyos-config-version: "bgp@5:broadcast-relay@1:cluster@2:config-management@1:conntrack@5:conntrack-sync@2:container@2:dhcp-relay@2:dhcp-server@8:dhcpv6-server@1:dns-dynamic@4:dns-forwarding@4:firewall@15:flow-accounting@1:https@6:ids@1:interfaces@32:ipoe-server@3:ipsec@13:isis@3:l2tp@9:lldp@2:mdns@1:monitoring@1:nat@8:nat66@3:ntp@3:openconnect@3:ospf@2:pim@1:policy@8:pppoe-server@10:pptp@5:qos@2:quagga@11:reverse-proxy@1:rip@1:rpki@2:salt@1:snmp@3:ssh@2:sstp@6:system@27:vrf@3:vrrp@4:vyos-accel-ppp@2:wanloadbalance@3:webproxy@2"
-// Release version: 1.4.0
+// Release version: 1.3.8

--- a/src/migration-scripts/system/28-to-29
+++ b/src/migration-scripts/system/28-to-29
@@ -18,6 +18,16 @@
 #   - remove syslog user console logging
 #   - move "global preserve-fqdn" one CLI level up
 #   - rename "host" to "remote"
+#
+# T8059:
+#   - if a syslog remote contains a port (like 192.0.2.1:9000),
+#     migrate the port part to the new dedicated "port" option
+#
+# XXX: this script leads to data loss when a config
+# has multiple remotes with the same host address but different ports.
+# That issue needs to be addressed separately (T8058)
+
+import re
 
 from vyos.configtree import ConfigTree
 
@@ -64,8 +74,35 @@ def migrate(config: ConfigTree) -> None:
         config.set(base + ['remote'])
         config.set_tag(base + ['remote'])
         for remote in config.list_nodes(base + ['host']):
-            config.copy(base + ['host', remote], base + ['remote', remote])
-            config.set_tag(base + ['remote'])
-            if vrf:
-                config.set(base + ['remote', remote, 'vrf'], value=vrf)
+            # Check if the host address has a port
+            # to migrate the port part to the new dedicated "port" option
+            res = re.match(r'(?P<host>[^:]+):(?P<port>.*)', remote)
+            if res:
+                remote_host = res.group('host')
+                remote_port = res.group('port')
+            else:
+                remote_host = remote
+                remote_port = None
+
+            # XXX: the fact that it was possible to use node names like "192.0.2.1:9000"
+            # made it possible to create configurations that would send different messages
+            # to different ports on the same server.
+            # At the moment, such configurations are unsupported
+            # so the script only keeps one of such remotes.
+            if config.exists(base + ['remote', remote_host]):
+                # Skip the remote if it already exists
+                # XXX: This tacitly implies that if multiple remotes
+                # with the same address but different ports are used,
+                # only the first one of those makes it into the migrated config.
+                continue
+            else:
+                config.copy(base + ['host', remote], base + ['remote', remote_host])
+
+                if remote_port:
+                    config.set(base + ['remote', remote_host, 'port'], value=remote_port)
+
+                config.set_tag(base + ['remote'])
+                if vrf:
+                    config.set(base + ['remote', remote_host, 'vrf'], value=vrf)
+
         config.delete(base + ['host'])


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Migrate `set system syslog host 192.0.2.1:9000 ...` to `set system syslog remote 192.0.2.1 port 9000`. 

Caveat: this fix de facto admits that it's impossible to configure VyOS to send different log messages to different ports of the same server at the moment. There's a separate task for that (https://vyos.dev/T8058) and we need to agree upon a design for allowing that again.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

* https://vyos.dev/T8058
* https://vyos.dev/T8059

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos# cat test.conf 
interfaces {
}

system {
 syslog {
     global {
         facility all {
             level "info"
         }
         facility local7 {
             level "debug"
         }
     }
     host 10.29.113.213:8000 {
         facility all {
             level "info"
         }
     }
     host 10.29.113.213:9000 {
         facility auth {
             level "info"
         }
     }
     host 10.29.113.214 {
         facility kern {
             level "info"
         }
     }
     host example.com:8888 {
         facility all {
             level "info"
         }
     }
  }
 }
// Warning: Do not remove the following line.
// vyos-config-version: "bgp@6:broadcast-relay@1:cluster@2:config-management@1:conntrack@6:conntrack-sync@2:container@3:dhcp-relay@2:dhcp-server@11:dhcpv6-server@6:dns-dynamic@4:dns-forwarding@4:firewall@20:flow-accounting@3:https@7:ids@2:interfaces@34:ipoe-server@4:ipsec@13:isis@3:l2tp@9:lldp@3:mdns@1:monitoring@2:nat@3:nat66@3:nhrp@1:ntp@3:openconnect@3:openvpn@4:ospf@2:pim@1:policy@8:pppoe-server@11:pptp@5:qos@2:quagga@12:reverse-proxy@3:rip@1:rpki@2:salt@1:snmp@3:ssh@2:sstp@6:system@20:vpp@3:vrf@3:vrrp@4:vyos-accel-ppp@2:wanloadbalance@4:webproxy@2"
// Release version: 1.3.8
[edit]

vyos@vyos# /usr/libexec/vyos/run-config-migration.py --output-file new.conf ./test.conf 
[edit]

vyos@vyos# cat new.conf 
interfaces {
}
system {
    syslog {
        local {
            facility all {
                level "info"
            }
            facility local7 {
                level "debug"
            }
        }
        remote 10.29.113.213 {
            facility all {
                level "info"
            }
            port "8000"
        }
        remote 10.29.113.214 {
            facility kern {
                level "info"
            }
        }
        remote example.com {
            facility all {
                level "info"
            }
            port "8888"
        }
    }
}


// Warning: Do not remove the following line.
// vyos-config-version: "bgp@6:broadcast-relay@1:cluster@2:config-management@1:conntrack@6:conntrack-sync@2:container@3:dhcp-relay@2:dhcp-server@11:dhcpv6-server@6:dns-dynamic@4:dns-forwarding@4:firewall@20:flow-accounting@3:https@7:ids@2:interfaces@34:ipoe-server@4:ipsec@13:isis@3:l2tp@9:lldp@3:mdns@1:monitoring@2:nat@8:nat66@3:nhrp@1:ntp@3:openconnect@3:openvpn@4:ospf@2:pim@1:policy@8:pppoe-server@11:pptp@5:qos@2:quagga@12:reverse-proxy@3:rip@1:rpki@2:salt@1:snmp@3:ssh@2:sstp@6:system@29:vpp@3:vrf@3:vrrp@4:vyos-accel-ppp@2:wanloadbalance@4:webproxy@2"
// Release version: 2025.11
[edit]

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
