### PR TITLE
op-mode: T7810: fix broken 'reset connection' command

### DIFF
--- a/op-mode-definitions/reset-connection.xml.in
+++ b/op-mode-definitions/reset-connection.xml.in
@@ -11,7 +11,7 @@
             <path>interfaces wwan</path>
           </completionHelp>
         </properties>
-        <command>${vyos_op_scripts_dir}/connect_disconnect.py --connect --disconnect --interface "$3"</command>
+        <command>${vyos_op_scripts_dir}/connect_disconnect.py --reconnect --interface "$3"</command>
       </tagNode>
     </children>
   </node>

--- a/src/op_mode/connect_disconnect.py
+++ b/src/op_mode/connect_disconnect.py
@@ -98,19 +98,23 @@ def main():
     group = parser.add_mutually_exclusive_group()
     group.add_argument("--connect", help="Bring up a connection-oriented network interface", action="store_true")
     group.add_argument("--disconnect", help="Take down connection-oriented network interface", action="store_true")
+    group.add_argument("--reconnect", help="Reconnect connection-oriented network interface", action="store_true")
     parser.add_argument("--interface", help="Interface name", action="store", required=True)
     args = parser.parse_args()
 
-    if args.connect or args.disconnect:
-        if args.disconnect:
-            disconnect(args.interface)
+    # Disallow connecting interfaces while their configuration might be changing
+    if args.connect or args.reconnect:
+        if commit_in_progress():
+            print('Cannot connect while a commit is in progress')
+            exit(1)
 
-        if args.connect:
-            if commit_in_progress():
-                print('Cannot connect while a commit is in progress')
-                exit(1)
-            connect(args.interface)
-
+    if args.connect:
+        connect(args.interface)
+    elif args.disconnect:
+        disconnect(args.interface)
+    elif args.reconnect:
+        disconnect(args.interface)
+        connect(args.interface)
     else:
         parser.print_help()
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Fix the command that fails with an argument parsing error. The cause is that `--connect` and `--disconnect` were made members of a mutually exclusive group in https://github.com/vyos/vyos-1x/commit/72a704d2e2b06bfedc4f1ee841814f983fc34baa , without consideration for the strange-looking `--connect --disconnect` usage in the `reset` command script.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
