### PR TITLE
vpp: T7954: Add op-mode commands to show LACP

### DIFF
--- a/op-mode-definitions/vpp_lacp.xml.in
+++ b/op-mode-definitions/vpp_lacp.xml.in
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="show">
+    <children>
+      <node name="vpp">
+        <children>
+          <node name="lacp">
+            <properties>
+              <help>Show VPP LACP information</help>
+            </properties>
+            <command>${vyos_op_scripts_dir}/vpp.py show_lacp</command>
+            <children>
+              <virtualTagNode>
+                <properties>
+                  <help>Show specific interface LACP information</help>
+                  <completionHelp>
+                    <script>${vyos_completion_dir}/list_interfaces --bondable</script>
+                  </completionHelp>
+                </properties>
+                <command>${vyos_op_scripts_dir}/vpp.py show_lacp --ifname=$4</command>
+                <children>
+                  <leafNode name="detail">
+                    <properties>
+                      <help>Show interface LACP details</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/vpp.py show_lacp_details --ifname=$4</command>
+                  </leafNode>
+                </children>
+              </virtualTagNode>
+              <leafNode name="detail">
+                <properties>
+                  <help>Show LACP detailed information</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/vpp.py show_lacp_details</command>
+              </leafNode>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
```
vyos@vyos:~$ show vpp lacp
Possible completions:
  <Enter>               Execute the current command
  detail                Show LACP detailed information
  eth0                  Show specific interface LACP information
  eth1
  eth2
  eth3


vyos@vyos:~$ show vpp lacp eth1
Possible completions:
  <Enter>               Execute the current command
  detail                Show interface LACP details

```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7954
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ show vpp lacp
                                                        actor state                      partner state
interface name            sw_if_index  bond interface   exp/def/dis/col/syn/agg/tim/act  exp/def/dis/col/syn/agg/tim/act
eth1                                 2 BondEthernet1      1   1   0   0   0   1   1   1    0   0   0   0   0   0   1   0
  LAG ID: [(ffff,0c-58-8e-4c-00-01,0005,00ff,0001), (ffff,00-00-00-00-00-00,0005,00ff,0001)]
  RX-state: EXPIRED, TX-state: TRANSMIT, MUX-state: DETACHED, PTX-state: NO_PERIODIC
eth0                                 1 BondEthernet2      1   1   0   0   0   1   1   1    0   0   0   0   0   0   1   0
  LAG ID: [(ffff,0c-58-8e-4c-00-00,0007,00ff,0001), (ffff,00-00-00-00-00-00,0007,00ff,0001)]
  RX-state: EXPIRED, TX-state: TRANSMIT, MUX-state: DETACHED, PTX-state: NO_PERIODIC
vyos@vyos:~$
vyos@vyos:~$ show vpp lacp eth1 detail
Number of interfaces: 2
  eth1
    Good LACP PDUs received: 0
    Bad LACP PDUs received: 0
    LACP PDUs sent: 0
    Good Marker PDUs received: 0
    Bad Marker PDUs received: 0
    debug: 0
    loopback port: 0
    port_enabled: 0
    port moved: 0
    ready_n: 0
    ready: 0
    Actor
      system: 0c:58:8e:4c:00:01
      system priority: 65535
      key: 5
      port priority: 255
      port number: 1
      state: 0xc7
        LACP_STATE_LACP_ACTIVITY (0)
        LACP_STATE_LACP_TIMEOUT (1)
        LACP_STATE_AGGREGATION (2)
        LACP_STATE_DEFAULTED (6)
        LACP_STATE_EXPIRED (7)
    Partner
      system: 00:00:00:00:00:00
      system priority: 65535
      key: 5
      port priority: 255
      port number: 1
      state: 0x2
        LACP_STATE_LACP_TIMEOUT (1)
      wait while timer: not running
      current while timer:   -2800.83 seconds
      periodic timer:   -2803.83 seconds
    RX-state: EXPIRED
    TX-state: TRANSMIT
    MUX-state: DETACHED
    PTX-state: NO_PERIODIC

vyos@vyos:~$

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
