### PR TITLE
tech-support: T7134: add topology snapshot generation using `hwloc` package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -109,6 +109,7 @@ Depends:
   file,
   iproute2 (>= 6.0.0),
   linux-cpupower,
+  hwloc,
 # ipaddrcheck is widely used in IP value validators
   ipaddrcheck,
   ethtool (>= 6.10),

--- a/src/op_mode/generate_tech-support_archive.py
+++ b/src/op_mode/generate_tech-support_archive.py
@@ -23,6 +23,7 @@ from shutil import rmtree
 from socket import gethostname
 from sys import exit
 from tarfile import open as tar_open
+from vyos.utils.process import call
 from vyos.utils.process import rc_cmd
 from vyos.remote import upload
 
@@ -91,6 +92,22 @@ def __generate_main_archive_file(archive_file: str, tmp_dir_path: str) -> None:
     with tar_open(name=archive_file, mode='x:gz') as tar_file:
         tar_file.add(tmp_dir_path, arcname=os.path.basename(tmp_dir_path))
 
+def __generate_topology_snapshots(output_dir: Path) -> None:
+    """
+    Generates physical and logical topology PNG files using `lstopo`
+
+    :param output_dir: directory where topology PNGs will be stored
+    """
+
+    physical_topo = output_dir / 'topology.png'
+    logical_topo = output_dir / 'topology-logical.png'
+
+    # Capture physical topology
+    call(['lstopo', '--output-format', 'png', str(physical_topo)])
+
+    # Capture logical topology
+    call(['lstopo', '--logical', '--output-format', 'png', str(logical_topo)])
+
 
 if __name__ == '__main__':
     defualt_tmp_dir = '/tmp'
@@ -124,6 +141,10 @@ if __name__ == '__main__':
 
     report_file: Path = Path(f'{tmp_dir_path}/show_tech-support_report.txt')
     report_file.touch()
+
+    # Call the topology snapshot function here
+    __generate_topology_snapshots(tmp_dir)
+
     try:
 
         save_stdout(op('show tech-support report'), report_file)


### PR DESCRIPTION
## Change summary
Get CPU topology in .png format, useful for debug issues related incorrect connection of the NIC to the remote NUMA node.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7134

## How to test / Smoketest result

#### Manual test
```
vyos@4e3247e0ba22:~$ generate tech-support archive
Debug file is generated and located in /tmp/4e3247e0ba22_tech-support-archive_2025-12-08T15-38-15.tar.gz
vyos@4e3247e0ba22:~$
vyos@4e3247e0ba22:~$ tar -tzf /tmp/4e3247e0ba22_tech-support-archive_2025-12-08T15-38-15.tar.gz | grep topology
drops-debug_2025-12-08T15-38-15/topology-logical.png
drops-debug_2025-12-08T15-38-15/topology.png
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly