### PR TITLE
login: T8086: replace getpwall() based user enumeration to avoid NSS/TACACS timeouts

### DIFF
--- a/python/vyos/utils/auth.py
+++ b/python/vyos/utils/auth.py
@@ -20,7 +20,6 @@ import string
 
 from dataclasses import dataclass
 from decimal import Decimal
-from pwd import getpwnam
 from enum import StrEnum
 from typing import List
 from typing import Optional
@@ -215,7 +214,9 @@ def get_local_users(min_uid=MIN_USER_UID, max_uid=MAX_USER_UID) -> list:
 
     return local_users
 
-
 def get_user_home_dir(user: str) -> str:
     """Return user's home directory"""
-    return getpwnam(user).pw_dir
+    for u in get_local_passwd_entries():
+        if u.pw_name == user:
+            return u.pw_dir
+    raise KeyError(f"User '{user}' not found in /etc/passwd")

--- a/smoketest/scripts/cli/test_service_ssh.py
+++ b/smoketest/scripts/cli/test_service_ssh.py
@@ -19,12 +19,11 @@ import paramiko
 import re
 import unittest
 
-from pwd import getpwall
-
 from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.configsession import ConfigSessionError
 from vyos.defaults import config_files
+from vyos.utils.auth import get_local_passwd_entries
 from vyos.utils.process import cmd
 from vyos.utils.process import is_systemd_service_running
 from vyos.utils.process import process_named_running
@@ -311,7 +310,7 @@ class TestServiceSSH(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # After deletion the test user is not allowed to remain in /etc/passwd
-        usernames = [x[0] for x in getpwall()]
+        usernames = [x.pw_name for x in get_local_passwd_entries()]
         self.assertNotIn(test_user, usernames)
 
     def test_ssh_dynamic_protection(self):

--- a/smoketest/scripts/cli/test_system_login.py
+++ b/smoketest/scripts/cli/test_system_login.py
@@ -28,11 +28,11 @@ from base_vyostest_shim import VyOSUnitTestSHIM
 from gzip import GzipFile
 from subprocess import Popen
 from subprocess import PIPE
-from pwd import getpwall
 
 from vyos.configsession import ConfigSessionError
 from vyos.configquery import ConfigTreeQuery
 from vyos.utils.auth import get_current_user
+from vyos.utils.auth import get_local_passwd_entries
 from vyos.utils.process import cmd
 from vyos.utils.file import read_file
 from vyos.utils.file import write_file
@@ -175,7 +175,7 @@ class TestSystemLogin(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # After deletion, a user is not allowed to remain in /etc/passwd
-        usernames = [x[0] for x in getpwall()]
+        usernames = [x.pw_name for x in get_local_passwd_entries()]
         for user in users:
             self.assertNotIn(user, usernames)
         # always forward to base class

--- a/src/conf_mode/system_login.py
+++ b/src/conf_mode/system_login.py
@@ -21,7 +21,6 @@ import json
 from copy import deepcopy
 from passlib.hosts import linux_context
 from psutil import users
-from pwd import getpwall
 from pwd import getpwuid
 from sys import exit
 from time import sleep
@@ -38,6 +37,7 @@ from vyos.template import is_ipv4
 from vyos.utils.auth import EPasswdStrength
 from vyos.utils.auth import evaluate_strength
 from vyos.utils.auth import get_current_user
+from vyos.utils.auth import get_local_passwd_entries
 from vyos.utils.auth import get_local_users
 from vyos.utils.auth import get_user_home_dir
 from vyos.utils.auth import MIN_USER_UID
@@ -136,7 +136,7 @@ def verify(login):
             raise ConfigError(f'Attempting to delete current user: {tmp}')
 
     if 'user' in login:
-        system_users = getpwall()
+        system_users = get_local_passwd_entries()
         for user, user_config in login['user'].items():
             # Linux system users range up until UID 1000, we can not create a
             # VyOS CLI user which already exists as system user

--- a/src/conf_mode/system_login.py
+++ b/src/conf_mode/system_login.py
@@ -21,7 +21,6 @@ import json
 from copy import deepcopy
 from passlib.hosts import linux_context
 from psutil import users
-from pwd import getpwuid
 from sys import exit
 from time import sleep
 
@@ -432,7 +431,7 @@ def apply(login):
             # retrieve current owner of home directory and adjust on demand
             dir_owner = None
             try:
-                dir_owner = getpwuid(os.stat(home_dir).st_uid).pw_name
+                dir_owner = get_local_passwd_entries(os.stat(home_dir).st_uid).pw_name
             except:
                 pass
 

--- a/src/op_mode/show_users.py
+++ b/src/op_mode/show_users.py
@@ -13,15 +13,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import argparse
-import pwd
 import struct
 import sys
 from time import ctime
 
 from tabulate import tabulate
 from vyos.config import Config
-
+from vyos.utils.auth import get_local_passwd_entries
 
 class UserInfo:
     def __init__(self, uid, name, user_type, is_locked, login_time, tty, host):

--- a/src/op_mode/show_users.py
+++ b/src/op_mode/show_users.py
@@ -79,7 +79,9 @@ def list_users():
     vyos_users = cfg.list_effective_nodes('system login user')
     users = []
     with open('/var/log/lastlog', 'rb') as lastlog_file:
-        for (name, _, uid, _, _, _, _) in pwd.getpwall():
+        for entry in get_local_passwd_entries():
+            name = entry.pw_name
+            uid = entry.pw_uid
             lastlog_info = decode_lastlog(lastlog_file, uid)
             if lastlog_info is None:
                 continue

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -12,11 +12,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import pwd
 from unittest import TestCase
-
-from vyos.utils import auth
-
 
 class TestVyOSUtils(TestCase):
     def test_key_mangling(self):
@@ -41,44 +37,3 @@ class TestVyOSUtils(TestCase):
         self.assertEqual(list_strip(lst, rsb, right=True), ['a', 'b', 'c'])
         self.assertEqual(list_strip(lst, non), [])
         self.assertEqual(list_strip(sub, lst), [])
-
-class TestVyOSUtilsAuth(TestCase):
-
-    def test_get_local_users_returns_existing_usernames(self):
-        # Returned users exist, skip list is excluded, and UIDs are in range
-
-        all_users = set(s_user.pw_name for s_user in pwd.getpwall())
-        local_users = auth.get_local_users()
-
-        # All returned users must really exist
-        for user in local_users:
-            self.assertIn(user, all_users)
-
-        # Nobody in the skip list
-        for skipped in auth.SYSTEM_USER_SKIP_LIST:
-            self.assertNotIn(skipped, local_users)
-
-        # All are within UID range
-        for s_user in pwd.getpwall():
-            if s_user.pw_name in local_users:
-                self.assertGreaterEqual(s_user.pw_uid, auth.MIN_USER_UID)
-                self.assertLessEqual(s_user.pw_uid, auth.MAX_USER_UID)
-
-    def test_get_user_home_dir_for_real_user(self):
-        # User's homedir is a non-empty string for a valid user
-
-        local_users = auth.get_local_users()
-        if local_users:
-            for user in local_users:
-                home_dir = auth.get_user_home_dir(user)
-                self.assertIsInstance(home_dir, str)
-                self.assertTrue(bool(home_dir))  # Should not be empty
-        else:
-            self.skipTest("No suitable non-system users found on this system")
-
-    def test_get_user_home_dir_invalid_user(self):
-        # Raises KeyError for nonexistent username
-
-        user = "__this_user_does_not_exist__"  # Test using unlikely username
-        with self.assertRaises(KeyError):
-            auth.get_user_home_dir(user)

--- a/src/tests/test_utils_auth.py
+++ b/src/tests/test_utils_auth.py
@@ -1,0 +1,75 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pwd
+import unittest
+
+from vyos.utils import auth
+
+class TestVyOSUtilsAuth(unittest.TestCase):
+    def test_uid_root(self):
+        self.assertEqual(auth.get_local_passwd_entries(0).pw_name, 'root')
+        self.assertEqual(auth.get_local_passwd_entries(0).pw_uid, 0)
+
+    def test_uid_daemon(self):
+        uid = None
+        for user in auth.get_local_passwd_entries():
+            if user.pw_name == 'daemon':
+                uid = user.pw_uid
+                break
+
+        self.assertEqual(auth.get_local_passwd_entries(uid).pw_name, 'daemon')
+        self.assertEqual(auth.get_local_passwd_entries(uid).pw_uid, uid)
+
+    def test_uid_not_found(self):
+        self.assertEqual(auth.get_local_passwd_entries(5465487635), None)
+
+    def test_get_local_users_returns_existing_usernames(self):
+        # Returned users exist, skip list is excluded, and UIDs are in range
+
+        all_users = set(s_user.pw_name for s_user in pwd.getpwall())
+        local_users = auth.get_local_users()
+
+        # All returned users must really exist
+        for user in local_users:
+            self.assertIn(user, all_users)
+
+        # Nobody in the skip list
+        for skipped in auth.SYSTEM_USER_SKIP_LIST:
+            self.assertNotIn(skipped, local_users)
+
+        # All are within UID range
+        for s_user in pwd.getpwall():
+            if s_user.pw_name in local_users:
+                self.assertGreaterEqual(s_user.pw_uid, auth.MIN_USER_UID)
+                self.assertLessEqual(s_user.pw_uid, auth.MAX_USER_UID)
+
+    def test_get_user_home_dir_for_real_user(self):
+        # User's homedir is a non-empty string for a valid user
+
+        local_users = auth.get_local_users()
+        if local_users:
+            for user in local_users:
+                home_dir = auth.get_user_home_dir(user)
+                self.assertIsInstance(home_dir, str)
+                self.assertTrue(bool(home_dir))  # Should not be empty
+        else:
+            self.skipTest("No suitable non-system users found on this system")
+
+    def test_get_user_home_dir_invalid_user(self):
+        # Raises KeyError for nonexistent username
+
+        user = "__this_user_does_not_exist__"  # Test using unlikely username
+        with self.assertRaises(KeyError):
+            auth.get_user_home_dir(user)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The previous implementation of `system login` relied on Python's `pwd.getpwall()` to enumerate user accounts. This forces a full walk through the NSS stack, which is acceptable in general but problematic for our use-case. VyOS only needs information about locally created accounts and not remote accounts provided via AAA backends such as TACACS or RADIUS.

When TACACS servers are unreachable, NSS lookups become extremely slow due to repeated timeouts. As a result, any operation triggering `pwd.getpwall()` (including configuration commits) can stall for several minutes.

This change introduces a dedicated helper, `get_local_passwd_entries()`, which reads `/etc/passwd` directly and avoids NSS entirely. Since only local UIDs are relevant, this provides all required data with no external dependencies.

Performance improvement on VyOS 1.4.3 with two unreachable TACACS servers:

```
set system login tacacs server 192.168.1.50 key test123
set system login tacacs server 192.168.1.51 key test123
time commit
```

### Before

```
real    3m29.825s
user    0m0.329s
sys     0m0.246s
```

### After

```
real    0m1.464s
user    0m0.337s
sys     0m0.195s
```

This significantly improves commit performance and removes sensitivity to AAA server outages.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8086

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

All smoketests passed:

* `make test-interfaces`
* `make test-no-interfaces-no-vpp`
* `make testc`


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
