### PR TITLE
T8026: Fixed session commit for the generate router

### DIFF
--- a/src/services/api/rest/routers.py
+++ b/src/services/api/rest/routers.py
@@ -711,6 +711,7 @@ def generate_op(data: GenerateModel):
     try:
         if op == 'generate':
             res = session.generate(path)
+            session.commit()
         else:
             return error(400, f"'{op}' is not a valid operation")
     except ConfigSessionError as e:


### PR DESCRIPTION
## Change summary

Fix session commit in `/generate` route and ensuring generated router data is applied as expected.

## Types of changes

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Code style update (formatting, renaming)
* [ ] Refactoring (no functional changes)
* [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
* [ ] Other (please describe):

## Related Task(s)

https://vyos.dev/T8026

## Related PR(s)

N/A

## How to test / Smoketest result

### Test environment

* VyOS current
* Local development environment

### Testing performed

1. Triggered the `/generate` route before the change and observed that generated router data was not persisted.
2. Added `session.commit()` in `routers.py` under the `/generate` route.
3. Triggered the `/generate` route again and verified that the generated router data is now correctly committed and persists as expected.

No regressions observed.

## Checklist:

* [x] I have read the [**[CONTRIBUTING](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md)**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
* [x] I have linked this PR to one or more Phabricator Task(s)
* [x] I have run the components [**[SMOKETESTS](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli)**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
* [x] My commit headlines contain a valid Task id
* [ ] My change requires a change to the documentation
* [ ] I have updated the documentation accordingly