### PR TITLE
T8103: add root to those allowed to call op-run commands directly

### DIFF
--- a/src/opt/vyatta/share/vyatta-op/functions/interpreter/vyatta-op-run
+++ b/src/opt/vyatta/share/vyatta-op/functions/interpreter/vyatta-op-run
@@ -218,7 +218,7 @@ _vyatta_op_run ()
     run_cmd=$(_vyatta_op_conv_run_cmd "$run_cmd") # convert the positional parameters
     local ret=0
 
-    if groups "$(whoami)" | grep -q -E ' vyattacfg(\s|$)'; then
+    if [[ $EUID -eq 0 ]] || groups "$(whoami)" | grep -q -E ' vyattacfg(\s|$)'; then
       # If the user is an admin,
       # use sudo directly for now
       op_runner="sudo"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

When op-mode commands are called via http-api they do not register as being called by admin in vyatta-op-run; consequently, certain checks fail, breaking, for example, the `install_into_config` functionality of the `/generate` endpoint.

Fix the check for admin to include those having euid == 0, as is the case for the vyos-http-api service.

The related, lower priority, question of appropriate env vars to test `in_session` for non-privileged calls to vyos-op-run will be handled separately. The current fix resolves the regression of T8103.

Note that this is related to, but independent of, https://github.com/vyos/vyos-1x/pull/4899

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Before:

```
└──> curl -k -X POST -d '{"key": "baz", "op": "generate", "path": ["pki", "wireguard", "key-pair", "install", "interface", "wg0"]}' https://192.168.122.31/generate 
{"success": true, "data": "You are not in configure mode, commands to install manually from configure mode:\nset interfaces wireguard wg0 private-key 'UP3TXQCoexDTDnbmuNdjzR/y1HjQUFAnJs9tyVpzh1k='\nCorresponding public-key to use on peer system is: '8ER4u63NkO489Rcm9zY2BOs6bkADFnVjL2G8bdN3LDM='\n", "error": null}
```

After:

```
└──> curl -k -X POST -d '{"key": "baz", "op": "generate", "path": ["pki", "wireguard", "key-pair", "install", "interface", "wg0"]}' https://192.168.122.146/generate
{"success": true, "data": "1 value(s) installed. Use \"compare\" to see the pending changes, and \"commit\" to apply.\nCorresponding public-key to use on peer system is: 'phce83BicbcwVFMWn0xyrNA0X6FADQwj18EkZmMEJV8='\n", "error": null}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
