### PR TITLE
vpp: T8080: Fix handling of configuration system lock after vpp commit failure

### DIFF
--- a/python/vyos/vpp/__init__.py
+++ b/python/vyos/vpp/__init__.py
@@ -18,3 +18,7 @@
 from .control_vpp import VPPControl
 
 __all__ = ['VPPControl']
+
+
+class VppNotRunningError(Exception):
+    pass

--- a/src/helpers/reset_section.py
+++ b/src/helpers/reset_section.py
@@ -26,6 +26,7 @@ from vyos.configsession import ConfigSession
 from vyos.config import Config
 from vyos.configdiff import get_config_diff
 from vyos.xml_ref import is_leaf
+from vyos.utils.commit import wait_for_commit_lock
 
 
 CFG_GROUP = 'vyattacfg'
@@ -99,6 +100,8 @@ if in_session:
 cfg_group = grp.getgrnam(CFG_GROUP)
 os.setgid(cfg_group.gr_gid)
 os.umask(0o002)
+
+wait_for_commit_lock()
 
 shared = not bool(reload)
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
- Bail out early  if the VPP service is not running, to prevent running configuration steps when VPP is unavailable.
- Call wait_for_commit_lock() in the reset section to make sure reset actions are properly synchronized with other commit operations.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8080
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyatta-cfg/pull/120
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set vpp settings interface eth1 driver 'dpdk'
commit

set vpp settings buffers page-size 1G

vyos@vyos# commit
[ vpp ]

WARNING: NOTE: Current dataplane capacity (estimated): 2.1 M IPv4
routes. Exceeding these values will lead to a dataplane out-of-memory
condition and a crash. Extensive use of features like ACLs, NAT and
others may reduce the numbers above. Please read the documentation for
details: https://docs.vyos.io/

An error occurred: VPP service failed to start. VPP service will be
restarted with the previous configuration
[[vpp]] failed
Commit failed
[edit]
vyos@vyos# show vpp
+settings {
+    buffers {
+        page-size 1G
+    }
+}
```
VPP service restarts correctly after error in commit:
```
vyos@vyos# run show interfaces
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address        MAC                VRF        MTU  S/L    Description
-----------  ----------------  -----------------  -------  -----  -----  -------------
eth0         -                 0c:58:8e:4c:00:00  default   1500  u/D
eth1         -                 0c:58:8e:4c:00:01  default   1500  u/D
eth2         10.20.40.141/24   0c:58:8e:4c:00:02  default   1500  u/u
eth3         10.217.32.131/24  0c:58:8e:4c:00:03  default   1500  u/u
lo           127.0.0.1/8       00:00:00:00:00:00  default  65536  u/u
             ::1/128
[edit]
vyos@vyos# run show vpp interfaces
Kernel    Dataplane    Type    IP Address    MAC                  MTU  State
--------  -----------  ------  ------------  -----------------  -----  -------
          eth1         dpdk                  0c:58:8e:4c:00:01   1500  down
          local0       local                 00:00:00:00:00:00      0  down
eth1      tap4096      virtio                02:fe:9f:5c:65:75   9000  up
[edit]
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
