### PR TITLE
dhcp: T6068: Fix Kea HA duplicate peer names

### DIFF
--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -881,8 +881,24 @@ def kea_high_availability_json(config):
         peer1_role = 'standby' if ha_mode == 'hot-standby' else 'secondary'
         peer2_role = 'primary'
 
+    # FIX: Use config['name'] for this server instead of hostname
+    this_server_name = config['name']
+
+    # FIX: Derive remote peer name to avoid duplicates
+    if this_server_name == 'backup':
+        remote_peer_name = 'main'
+    elif this_server_name == 'main':
+        remote_peer_name = 'backup'
+    elif this_server_name == 'secondary':
+        remote_peer_name = 'primary'
+    elif this_server_name == 'primary':
+        remote_peer_name = 'secondary'
+    else:
+        # Fallback: append suffix to differentiate
+        remote_peer_name = f"{this_server_name}-peer"
+
     data = {
-        'this-server-name': os.uname()[1],
+        'this-server-name': this_server_name,
         'mode': ha_mode,
         'heartbeat-delay': 10000,
         'max-response-delay': 10000,
@@ -890,13 +906,13 @@ def kea_high_availability_json(config):
         'max-unacked-clients': 0,
         'peers': [
         {
-            'name': os.uname()[1],
+            'name': this_server_name,
             'url': f'http://{source_addr}:647/',
             'role': peer1_role,
             'auto-failover': True
         },
         {
-            'name': config['name'],
+            'name': remote_peer_name,
             'url': f'http://{remote_addr}:647/',
             'role': peer2_role,
             'auto-failover': True

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -883,19 +883,7 @@ def kea_high_availability_json(config):
 
     # FIX: Use config['name'] for this server instead of hostname
     this_server_name = config['name']
-
-    # FIX: Derive remote peer name to avoid duplicates
-    if this_server_name == 'backup':
-        remote_peer_name = 'main'
-    elif this_server_name == 'main':
-        remote_peer_name = 'backup'
-    elif this_server_name == 'secondary':
-        remote_peer_name = 'primary'
-    elif this_server_name == 'primary':
-        remote_peer_name = 'secondary'
-    else:
-        # Fallback: append suffix to differentiate
-        remote_peer_name = f"{this_server_name}-peer"
+    remote_peer_name = f'{this_server_name}-peer'
 
     data = {
         'this-server-name': this_server_name,

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -14,7 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import re
 import unittest
 
@@ -1067,7 +1066,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
                 'peers',
             ],
             {
-                'name': os.uname()[1],
+                'name': failover_name,
                 'url': f'http://{failover_local}:647/',
                 'role': 'primary',
                 'auto-failover': True,
@@ -1086,7 +1085,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
                 'peers',
             ],
             {
-                'name': failover_name,
+                'name': f'{failover_name}-peer',
                 'url': f'http://{failover_remote}:647/',
                 'role': 'secondary',
                 'auto-failover': True,
@@ -1166,7 +1165,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
                 'peers',
             ],
             {
-                'name': os.uname()[1],
+                'name': failover_name,
                 'url': f'http://{failover_local}:647/',
                 'role': 'standby',
                 'auto-failover': True,
@@ -1185,7 +1184,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
                 'peers',
             ],
             {
-                'name': failover_name,
+                'name': f'{failover_name}-peer',
                 'url': f'http://{failover_remote}:647/',
                 'role': 'primary',
                 'auto-failover': True,


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Implements https://github.com/vyos/vyos-1x/pull/4563

Simplifies peer naming, Include smoketest fix

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4563

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
DEBUG - Running Testcase: /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py
DEBUG - test_dhcp_client_class (__main__.TestServiceDHCPServer.test_dhcp_client_class) ... ok
DEBUG - test_dhcp_dynamic_dns_update (__main__.TestServiceDHCPServer.test_dhcp_dynamic_dns_update) ... ok
DEBUG - test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
DEBUG - test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
DEBUG - test_dhcp_high_availability (__main__.TestServiceDHCPServer.test_dhcp_high_availability) ... ok
DEBUG - test_dhcp_high_availability_standby (__main__.TestServiceDHCPServer.test_dhcp_high_availability_standby) ... ok
DEBUG - test_dhcp_hostsd_lease_sync (__main__.TestServiceDHCPServer.test_dhcp_hostsd_lease_sync) ... ok
DEBUG - test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
DEBUG - test_dhcp_on_interface_with_vrf (__main__.TestServiceDHCPServer.test_dhcp_on_interface_with_vrf) ... ok
DEBUG - test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
DEBUG - test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... ok
DEBUG - test_dhcp_single_pool_options_scoped (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options_scoped) ... ok
DEBUG - test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... ok
DEBUG - test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... ok
DEBUG - 
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 14 tests in 70.983s
DEBUG - 
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
