### PR TITLE
bond: T8084: disallow bond members that do not support MAC changes

### DIFF
--- a/python/vyos/ethtool.py
+++ b/python/vyos/ethtool.py
@@ -28,6 +28,7 @@ _drivers_without_speed_duplex_flow = ['vmxnet3', 'virtio_net', 'xen_netfront',
 _drivers_without_mac_change = ['ena']
 # enable interface bonding will change the interface MAC address, thus all drivers
 # not supporting MAC address change, also do not support bonding
+_drivers_without_bonding_support = _drivers_without_mac_change + []
 
 class Ethtool:
     """
@@ -230,3 +231,7 @@ class Ethtool:
     def check_mac_change(self) -> bool:
         """ Check if ethernet drivers supports changing MAC address """
         return bool(self.get_driver_name() not in _drivers_without_mac_change)
+
+    def check_bonding(self) -> bool:
+        """ Check if ethernet drivers supports bonding """
+        return bool(self.get_driver_name() not in _drivers_without_bonding_support)

--- a/python/vyos/ethtool.py
+++ b/python/vyos/ethtool.py
@@ -25,6 +25,10 @@ _drivers_without_speed_duplex_flow = ['vmxnet3', 'virtio_net', 'xen_netfront',
                                       'iavf', 'ice', 'i40e', 'hv_netvsc', 'veth', 'ixgbevf',
                                       'tun', 'vif']
 
+_drivers_without_mac_change = ['ena']
+# enable interface bonding will change the interface MAC address, thus all drivers
+# not supporting MAC address change, also do not support bonding
+
 class Ethtool:
     """
     Class is used to retrive and cache information about an ethernet adapter
@@ -222,3 +226,7 @@ class Ethtool:
         matches = re.findall(rf'{rx_tx_comb}:\s+(\d+)', self._channels)
 
         return [int(value) for value in matches]
+
+    def check_mac_change(self) -> bool:
+        """ Check if ethernet drivers supports changing MAC address """
+        return bool(self.get_driver_name() not in _drivers_without_mac_change)

--- a/src/conf_mode/interfaces_bonding.py
+++ b/src/conf_mode/interfaces_bonding.py
@@ -34,7 +34,6 @@ from vyos.frrender import FRRender
 from vyos.frrender import get_frrender_dict
 from vyos.ifconfig import BondIf
 from vyos.ifconfig.ethernet import EthernetIf
-from vyos.ifconfig import Section
 from vyos.utils.assertion import assert_mac
 from vyos.utils.dict import dict_search
 from vyos.utils.dict import dict_to_paths_values
@@ -114,8 +113,7 @@ def get_config(config=None):
             # ethernet commit again in apply function
             # to apply options under ethernet section
             set_dependents('ethernet', conf, interface)
-            section = Section.section(interface) # this will be 'ethernet' for 'eth0'
-            if conf.exists([section, interface, 'disable']):
+            if conf.exists(['ethernet', interface, 'disable']):
                 tmp[interface] = {'disable': ''}
             else:
                 tmp[interface] = {}
@@ -144,14 +142,8 @@ def get_config(config=None):
                 bond['shutdown_required'] = {}
                 bond['member']['interface'][interface].update({'new_added' : {}})
 
-            # Check if member interface is disabled
-            conf.set_level(['interfaces'])
-
-            section = Section.section(interface) # this will be 'ethernet' for 'eth0'
-            if conf.exists([section, interface, 'disable']):
-                if tmp: bond['member']['interface'][interface].update({'disable': ''})
-
-            conf.set_level(old_level)
+            if 'disable' in interface_ethernet_config:
+                bond['member']['interface'][interface].update({'disable': ''})
 
             # Check if member interface is already member of another bridge
             tmp = is_member(conf, interface, 'bridge')

--- a/src/conf_mode/interfaces_bonding.py
+++ b/src/conf_mode/interfaces_bonding.py
@@ -30,6 +30,7 @@ from vyos.configverify import verify_mirror_redirect
 from vyos.configverify import verify_mtu_ipv6
 from vyos.configverify import verify_vlan_config
 from vyos.configverify import verify_vrf
+from vyos.ethtool import Ethtool
 from vyos.frrender import FRRender
 from vyos.frrender import get_frrender_dict
 from vyos.ifconfig import BondIf
@@ -250,6 +251,10 @@ def verify(bond):
                 if mtu < min_mtu:
                     raise ConfigError('Configured MTU is less then member '\
                                       f'interface "{interface}" minimum of {min_mtu}!')
+
+            # not all ethernet drivers support interface bonding
+            if not Ethtool(interface).check_bonding():
+                raise ConfigError(error_msg + 'driver is not supported!')
 
     if 'primary' in bond:
         if bond['primary'] not in bond['member']['interface']:

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -371,51 +371,44 @@ def verify(ethernet):
 
     if 'deleted' in ethernet:
         return None
+
+    ethtool = Ethtool(ethernet['ifname'])
+    verify_interface_exists(ethernet, ethernet['ifname'])
+    verify_eapol(ethernet)
+    verify_mirror_redirect(ethernet)
+    # No need to check speed and duplex keys as both have default values
+    verify_speed_duplex(ethernet, ethtool)
+    verify_flow_control(ethernet, ethtool)
+    verify_ring_buffer(ethernet, ethtool)
+    verify_offload(ethernet, ethtool)
+
     if 'is_bond_member' in ethernet:
-        verify_bond_member(ethernet)
+        verify_bond_member(ethernet, ethtool)
     else:
-        verify_ethernet(ethernet)
+        verify_ethernet(ethernet, ethtool)
 
 
-def verify_bond_member(ethernet):
+def verify_bond_member(ethernet: dict, ethtool: Ethtool) -> None:
     """
      Verification function for ethernet interface which is in bonding
     :param ethernet: dictionary which is received from get_interface_dict
     :type ethernet: dict
     """
-    ifname = ethernet['ifname']
-    verify_interface_exists(ethernet, ifname)
-    verify_eapol(ethernet)
-    verify_mirror_redirect(ethernet)
-    ethtool = Ethtool(ifname)
-    verify_speed_duplex(ethernet, ethtool)
-    verify_flow_control(ethernet, ethtool)
-    verify_ring_buffer(ethernet, ethtool)
-    verify_offload(ethernet, ethtool)
     verify_allowedbond_changes(ethernet)
+    return None
 
-def verify_ethernet(ethernet):
+def verify_ethernet(ethernet: dict, ethtool: Ethtool) -> None:
     """
      Verification function for simple ethernet interface
     :param ethernet: dictionary which is received from get_interface_dict
     :type ethernet: dict
     """
-    ifname = ethernet['ifname']
-    verify_interface_exists(ethernet, ifname)
     verify_mtu(ethernet)
     verify_mtu_ipv6(ethernet)
     verify_dhcpv6(ethernet)
     verify_address(ethernet)
     verify_vrf(ethernet)
     verify_bond_bridge_member(ethernet)
-    verify_eapol(ethernet)
-    verify_mirror_redirect(ethernet)
-    ethtool = Ethtool(ifname)
-    # No need to check speed and duplex keys as both have default values.
-    verify_speed_duplex(ethernet, ethtool)
-    verify_flow_control(ethernet, ethtool)
-    verify_ring_buffer(ethernet, ethtool)
-    verify_offload(ethernet, ethtool)
     # use common function to verify VLAN configuration
     verify_vlan_config(ethernet)
     return None

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -273,6 +273,20 @@ def verify_offload(ethernet: dict, ethtool: Ethtool):
             raise ConfigError('Xen netback drivers requires scatter-gatter offloading '\
                               'for MTU size larger then 1500 bytes')
 
+def verify_mac_change(ethernet: dict, ethtool: Ethtool):
+    """
+     Verify if ethernet card driver supports changing the interface MAC address.
+     AWS ENA driver has no support for MAC address changes.
+
+    :param ethernet: dictionary which is received from get_interface_dict
+    :type ethernet: dict
+    :param ethtool: Ethernet object
+    :type ethtool: Ethtool
+    """
+    if 'mac' not in ethernet:
+        return None
+    if not ethtool.check_mac_change():
+        raise ConfigError(f'Driver does not suport changing MAC address!')
 
 def verify_allowedbond_changes(ethernet: dict):
     """
@@ -381,6 +395,7 @@ def verify(ethernet):
     verify_flow_control(ethernet, ethtool)
     verify_ring_buffer(ethernet, ethtool)
     verify_offload(ethernet, ethtool)
+    verify_mac_change(ethernet, ethtool)
 
     if 'is_bond_member' in ethernet:
         verify_bond_member(ethernet, ethtool)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

This commit series hardens bonding support and simplifies related code.

It prevents interfaces from joining a bond if they cannot change MAC addresses, including explicit handling for ENA interfaces on AWS EC2 with clear error messages instead of generic failures. It also refactors bond verification to remove duplicated logic and drops dynamic interface type detection, simplifying the code by assuming Ethernet-only bond underlays.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8084

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

* Embedded Smoketests
* I placed `virtio_net` driver to the list of disallwoed drivers and errors got emitted.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
