### PR TITLE
T8120: Add support AMA console for ARM devices

### DIFF
--- a/data/templates/grub/grub_common.j2
+++ b/data/templates/grub/grub_common.j2
@@ -7,7 +7,7 @@ fi
 # create and activate serial console
 function setup_serial {
     # initialize the first serial port by default
-    if [ "${console_type}" == "ttyS" ]; then
+    if [ "${console_type}" = "ttyS" -o "${console_type}" = "ttyAMA" ]; then
         if [ "${console_num}" == "0" ]; then
           serial --unit=0 --speed=${console_speed}
         else

--- a/data/templates/grub/grub_compat.j2
+++ b/data/templates/grub/grub_compat.j2
@@ -12,7 +12,7 @@
 {% macro console_name(type) -%}
 {% if type == 'tty' -%}
     KVM
-{%- elif type == 'ttyS' -%}
+{%- elif type == 'ttyS' or type == 'ttyAMA' -%}
     Serial
 {%- else -%}
     Unknown
@@ -23,6 +23,8 @@
     console=ttyS0,{{ console_speed }} console=tty0
 {%- elif type == 'ttyS' -%}
     console=tty0 console=ttyS0,{{ console_speed }}
+{%- elif type == 'ttyAMA' -%}
+    console=tty0 console=ttyAMA0,{{ console_speed }}
 {%- else -%}
     console=tty0 console=ttyS0,{{ console_speed }}
 {%- endif %}

--- a/data/templates/grub/grub_options.j2
+++ b/data/templates/grub/grub_options.j2
@@ -28,7 +28,12 @@ submenu "Boot options" {
             configfile ${prefix}/grub.cfg.d/*vyos-menu*.cfg
         }
         menuentry "ttyS (serial)" {
-            set console_type="ttyS"
+            if [ "${grub_cpu}" = "arm64" ]; then
+                set serial_console="ttyAMA"
+            else
+                set serial_console="ttyS"
+            fi
+            set console_type="$serial_console"
             export console_type
             setup_serial
             configfile ${prefix}/grub.cfg.d/*vyos-menu*.cfg

--- a/data/templates/grub/grub_vyos_version.j2
+++ b/data/templates/grub/grub_vyos_version.j2
@@ -11,7 +11,7 @@
 {% endif %}
 menuentry "{{ version_name }}" --id {{ version_uuid }} {
     set boot_opts="{{ boot_opts_rendered }}"
-    if [ "${console_type}" = "ttyS" -o "${console_type}" = "ttyAMA" ]; then
+    if [ "${console_type}" == "ttyS" -o "${console_type}" == "ttyAMA" ]; then
         set console_opts="console=${console_type}${console_num},${console_speed}"
     else
         set console_opts="console=${console_type}${console_num}"

--- a/data/templates/grub/grub_vyos_version.j2
+++ b/data/templates/grub/grub_vyos_version.j2
@@ -11,7 +11,7 @@
 {% endif %}
 menuentry "{{ version_name }}" --id {{ version_uuid }} {
     set boot_opts="{{ boot_opts_rendered }}"
-    if [ "${console_type}" == "ttyS" ]; then
+    if [ "${console_type}" = "ttyS" -o "${console_type}" = "ttyAMA" ]; then
         set console_opts="console=${console_type}${console_num},${console_speed}"
     else
         set console_opts="console=${console_type}${console_num}"

--- a/interface-definitions/system_console.xml.in
+++ b/interface-definitions/system_console.xml.in
@@ -28,7 +28,7 @@
                 <description>Xen console</description>
               </valueHelp>
               <constraint>
-                  <regex>(ttyS[0-9]+|hvc[0-9]+|usb[0-9]+b.*)</regex>
+                  <regex>(ttyS[0-9]+|ttyAMA[0-9]+|hvc[0-9]+|usb[0-9]+b.*)</regex>
               </constraint>
             </properties>
             <children>

--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -761,7 +761,7 @@ def console_hint() -> str:
         path = '/dev/tty'
 
     name = Path(path).name
-    if name in ('ttyS0', 'ttyAMA0'):
+    if name in ['ttyS0', 'ttyAMA0']:
         return 'S'
     else:
         return 'K'

--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -761,7 +761,7 @@ def console_hint() -> str:
         path = '/dev/tty'
 
     name = Path(path).name
-    if name == 'ttyS0':
+    if name in ('ttyS0', 'ttyAMA0'):
         return 'S'
     else:
         return 'K'

--- a/src/op_mode/image_manager.py
+++ b/src/op_mode/image_manager.py
@@ -33,7 +33,7 @@ DELETE_IMAGE_PROMPT_MSG: str = 'Select an image to delete:'
 MSG_DELETE_IMAGE_RUNNING: str = 'Currently running image cannot be deleted; reboot into another image first'
 MSG_DELETE_IMAGE_DEFAULT: str = 'Default image cannot be deleted; set another image as default first'
 
-ConsoleType: TypeAlias = Literal['tty', 'ttyS']
+ConsoleType: TypeAlias = Literal['tty', 'ttyS', 'ttyAMA']
 
 def annotate_list(images_list: list[str]) -> list[str]:
     """Annotate list of images with additional info


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add support AMA console for ARM devices
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T8120

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
DEBUG - Welcome to VyOS - vyos ttyAMA0
DEBUG - 
DEBUG - vyos login: vyos
DEBUG - vyos
DEBUG - Password: vyos
DEBUG - 
DEBUG - Welcome to VyOS!
DEBUG - 
DEBUG -    ┌── ┐
DEBUG -    . VyOS 999.202512241417
DEBUG -    └ ──┘  current
DEBUG - 
DEBUG -  * Documentation:  https://docs.vyos.io/en/latest
DEBUG -  * Project news:   https://blog.vyos.io/
DEBUG -  * Bug reports:    https://vyos.dev/
DEBUG - 
DEBUG - You can change this banner using "set system login banner post-login" command.
DEBUG - 
DEBUG - VyOS is a free software distribution that includes multiple components,
DEBUG - you can check individual component licenses under /usr/share/doc/*/copyright
DEBUG - 
DEBUG - ---
DEBUG - WARNING: This VyOS system is not a stable long-term support version and
DEBUG -          is not intended for production use.
DEBUG - 
 INFO - Logged in!
DEBUG - vyos@vyos:~$ sudo modprobe mac80211_hwsim
DEBUG - sudo modprobe mac80211_hwsim
DEBUG - vyos@vyos:~$ touch /tmp/vyos.smoketests.hint
DEBUG - touch /tmp/vyos.smoketests.hint
DEBUG - vyos@vyos:~$ sudo systemctl restart vyos-configd.service &> /dev/null
DEBUG - sudo systemctl restart vyos-configd.service &> /dev/null
 INFO - Basic CLI configuration mode test
DEBUG - vyos@vyos:~$ configure
DEBUG - configure
DEBUG - [edit]
DEBUG - vyos@vyos# exit
DEBUG - exit
DEBUG - exit
DEBUG - vyos@vyos:~$ show version
DEBUG - show version
DEBUG - 
Version:          VyOS 999.202512241417
DEBUG - Release train:    current
DEBUG - Release flavor:   generic-arm64
DEBUG - 
DEBUG - Built by:         root@0bc660be4ca6
DEBUG - qemu
ERROR - Timeout waiting for VyOS system
ERROR - Traceback (most recent call last):
  File "/__w/vyos-build-arm64/vyos-build-arm64/vyos-build/scripts/check-qemu-install", line 626, in <module>
    c.expect('kvm')
  File "/usr/lib/python3/dist-packages/pexpect/spawnbase.py", line 343, in expect
    return self.expect_list(compiled_pattern_list,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/pexpect/spawnbase.py", line 372, in expect_list
    return exp.expect_loop(timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/pexpect/expect.py", line 181, in expect_loop
    return self.timeout(e)
           ^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/pexpect/expect.py", line 144, in timeout
    raise exc
pexpect.exceptions.TIMEOUT: Timeout exceeded.
<pexpect.pty_spawn.spawn object at 0xff4ed322e1d0>
command: /usr/bin/qemu-system-aarch64
args: ['/usr/bin/qemu-system-aarch64', '-name', 'VyOS-QEMU-UEFI', '-smp', '2,sockets=1,cores=2,threads=1', '-cpu', 'cortex-a53', '-machine', 'virt', '-bios', '/usr/share/qemu-efi-aarch64/QEMU_EFI.fd', '-m', '2G', '-vga', 'none', '-nographic', '-vga', 'none', '-uuid', 'f48b60b2-e6ad-49ef-9d09-4245d0585e52', '-monitor', 'unix:/tmp/qemu-monitor-socket-testinstall-20251224-142546-74cc.img,server,nowait', '-netdev', 'user,id=n0,net=192.0.2.0/24,dhcpstart=192.0.2.101,dns=192.0.2.10', '-device', 'virtio-net-pci,netdev=n0,mac=00:00:5E:00:53:00,romfile=,host_mtu=1500', '-netdev', 'user,id=n1', '-device', 'virtio-net-pci,netdev=n1,mac=00:00:5E:00:53:01,romfile=,host_mtu=1500', '-netdev', 'user,id=n2', '-device', 'virtio-net-pci,netdev=n2,mac=00:00:5E:00:53:02,romfile=,host_mtu=1500', '-netdev', 'user,id=n3', '-device', 'virtio-net-pci,netdev=n3,mac=00:00:5E:00:53:03,romfile=,host_mtu=1500', '-netdev', 'user,id=n4', '-device', 'virtio-net-pci,netdev=n4,mac=00:00:5E:00:53:04,romfile=', '-netdev', 'user,id=n5', '-device',
buffer (last 100 chars): b' systemd-detect-virt\r\r\nqemu\r\r\nvyos@vyos:~$ '
before (last 100 chars): b' systemd-detect-virt\r\r\nqemu\r\r\nvyos@vyos:~$ '
after: <class 'pexpect.exceptions.TIMEOUT'>
match: None
match_index: None
exitstatus: None
flag_eof: False
pid: 105249
child_fd: 5
closed: False
timeout: 60
delimiter: <class 'pexpect.exceptions.EOF'>
logfile: <__main__.StreamToLogger object at 0xff4ed32496d0>
logfile_read: None
logfile_send: None
maxread: 2000
ignorecase: False
searchwindowsize: None
delaybeforesend: 0.05
delayafterclose: 0.1
delayafterterminate: 0.1
searcher: searcher_re:
    0: re.compile(b'kvm')
 INFO - Cleaning up
 INFO - Removing disk file: testinstall-20251224-142546-74cc.img
ERROR - Hmm... system got an exception while processing.
ERROR - The ISO image is not considered usable!
Error: Process completed with exit code 1.
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
