### PR TITLE
T7832: Add support for assigning ACLs on subinterfaces

### DIFF
--- a/src/conf_mode/vpp_acl.py
+++ b/src/conf_mode/vpp_acl.py
@@ -214,9 +214,17 @@ def verify(config):
 
             for iface, iface_config in acl.get('interface', {}).items():
                 if iface not in config.get('vpp_ifaces'):
-                    raise ConfigError(
-                        f'{iface} must be a VPP interface for ACL interface'
-                    )
+                    # Check if it is a sub-interface
+                    if '.' in iface:
+                        parent = iface.split('.')[0]
+                        if parent not in config.get('vpp_ifaces'):
+                            raise ConfigError(
+                                f'{iface} must be a VPP interface for ACL interface'
+                            )
+                    else:
+                        raise ConfigError(
+                            f'{iface} must be a VPP interface for ACL interface'
+                        )
 
     if 'ip' in config:
         acl = config.get('ip')


### PR DESCRIPTION
## Change summary
Support assigning ACLs to subinterfaces (e.g., eth0.100, eth5.200)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

- https://vyos.dev/T7832

## Related PR(s)


## How to test / Smoketest result
```
set interfaces ethernet eth2 vif 1000 address '172.16.0.251/24'
set vpp settings interface eth2 driver 'dpdk'
set vpp settings interface eth2 rx-mode 'polling'
set vpp acl ip tag-name drop-all rule 1000 action 'deny'
set vpp acl ip interface eth2.1000 input acl-tag 100 tag-name 'drop-all'

vyos# commit

vyos@vyos# run show vpp acl ip interface 
Interface    Input ACLs    Output ACLs
-----------  ------------  -------------
eth2.1000     drop-all 
[edit]
vyos@vyos#
```

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
