### PR TITLE
bond: T2416: support hot-add/remove of bond member interfaces

### DIFF
--- a/python/vyos/ifconfig/bond.py
+++ b/python/vyos/ifconfig/bond.py
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
-
 from vyos.ifconfig.interface import Interface
 from vyos.utils.dict import dict_search
 from vyos.utils.assertion import assert_list
@@ -89,6 +87,9 @@ class BondIf(Interface):
     _sysfs_get = {**Interface._sysfs_get, **{
         'bond_arp_ip_target': {
             'location': '/sys/class/net/{ifname}/bonding/arp_ip_target',
+        },
+        'bond_members': {
+            'location': '/sys/class/net/{ifname}/bonding/slaves',
         },
         'bond_mode': {
             'location': '/sys/class/net/{ifname}/bonding/mode',
@@ -335,15 +336,7 @@ class BondIf(Interface):
         >>> BondIf('bond0').get_slaves()
         ['eth1', 'eth2']
         """
-        enslaved_ifs = []
-        # retrieve real enslaved interfaces from OS kernel
-        sysfs_bond = '/sys/class/net/{}'.format(self.config['ifname'])
-        if os.path.isdir(sysfs_bond):
-            for directory in os.listdir(sysfs_bond):
-                if 'lower_' in directory:
-                    enslaved_ifs.append(directory.replace('lower_', ''))
-
-        return enslaved_ifs
+        return self.get_interface('bond_members').split()
 
     def get_mode(self):
         """

--- a/src/conf_mode/interfaces_bonding.py
+++ b/src/conf_mode/interfaces_bonding.py
@@ -104,7 +104,6 @@ def get_config(config=None):
     conf.set_level(['interfaces'])
 
     if interfaces_removed:
-        bond['shutdown_required'] = {}
         if 'member' not in bond:
             bond['member'] = {}
 
@@ -141,7 +140,6 @@ def get_config(config=None):
 
             # Check if member interface is a new member
             if not conf.exists_effective(base + [ifname, 'member', 'interface', interface]):
-                bond['shutdown_required'] = {}
                 bond['member']['interface'][interface].update({'new_added' : {}})
 
             # Check if member interface is disabled

--- a/src/op_mode/show-bond.py
+++ b/src/op_mode/show-bond.py
@@ -60,7 +60,7 @@ elif args.slaves:
         cfg_dict['mode'] = tmp.get_mode()
         cfg_dict['admin_state'] = tmp.get_admin_state()
         cfg_dict['oper_state'] = tmp.operational.get_state()
-        cfg_dict['members'] = tmp.get_slaves()
+        cfg_dict['members'] = tmp.get_members()
         data.append(cfg_dict)
 
 elif args.interface:
@@ -74,7 +74,7 @@ elif args.interface:
 
     # each bond member interface has its own statistics
     data['members'] = []
-    for member in BondIf(args.interface).get_slaves():
+    for member in BondIf(args.interface).get_members():
         tmp = {}
         tmp['ifname'] = member
         tmp['rx_bytes'] = read_file(f'/sys/class/net/{member}/statistics/rx_bytes')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Previously, adding or removing a bond member interface would force the entire bond into an admin-down state, removing and re-adding all member interfaces. This caused unnecessary link up/down events and excessive log noise on partner
devices.

This change refactors the code to allow hot-adding and removal of bond member interfaces without disrupting existing members, minimizing link state changes and log entries.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T2416

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<img width="1674" height="270" alt="image" src="https://github.com/user-attachments/assets/140d4010-b113-41f6-af2d-d3bef0b222eb" />

### Manual Testing

Remove member for `bond10` - logs are from remote switch partner

#### Before:
```
2025-12-26T13:11:36.732734+01:00 SWITCH Lag:  208739: %LAG-5-MEMBER_REMOVED: Interface Ethernet37 has left Port-Channel35 due to: partner not in sync
2025-12-26T13:11:36.797687+01:00 SWITCH Lag:  208740: %LAG-5-MEMBER_REMOVED: Interface Ethernet35 has left Port-Channel35 due to: waiting for LACP response
2025-12-26T13:11:36.897181+01:00 SWITCH Lag:  208741: %LAG-5-MEMBER_REMOVED: Interface Ethernet38 has left Port-Channel35 due to: partner not in sync
2025-12-26T13:11:36.964368+01:00 SWITCH Lag:  208742: %LAG-5-MEMBER_REMOVED: Interface Ethernet36 has left Port-Channel35 due to: partner not in sync
2025-12-26T13:11:36.972646+01:00 SWITCH Ebra: 208743: %LINEPROTO-5-UPDOWN: Line protocol on Interface Port-Channel35, changed state to down
2025-12-26T13:11:37.005894+01:00 SWITCH Stp:  208744: %SPANTREE-6-INTERFACE_DEL: Interface Port-Channel35 has been removed from instance MST0
2025-12-26T13:11:37.642633+01:00 SWITCH Ebra: 208745: %LINEPROTO-5-UPDOWN: Line protocol on Interface Ethernet37, changed state to down
2025-12-26T13:11:37.642792+01:00 SWITCH Ebra: 208746: %LINEPROTO-5-UPDOWN: Line protocol on Interface Ethernet35, changed state to down
2025-12-26T13:11:37.693362+01:00 SWITCH Ebra: 208747: %LINEPROTO-5-UPDOWN: Line protocol on Interface Ethernet38, changed state to down
2025-12-26T13:11:37.794042+01:00 SWITCH Ebra: 208748: %LINEPROTO-5-UPDOWN: Line protocol on Interface Ethernet36, changed state to down
2025-12-26T13:11:40.845856+01:00 SWITCH Ebra: 208749: %LINEPROTO-5-UPDOWN: Line protocol on Interface Ethernet35, changed state to up
2025-12-26T13:11:41.099035+01:00 SWITCH Ebra: 208750: %LINEPROTO-5-UPDOWN: Line protocol on Interface Ethernet36, changed state to up
2025-12-26T13:11:41.100636+01:00 SWITCH Ebra: 208751: %LINEPROTO-5-UPDOWN: Line protocol on Interface Ethernet37, changed state to up
2025-12-26T13:11:41.245575+01:00 SWITCH Ebra: 208752: %LINEPROTO-5-UPDOWN: Line protocol on Interface Ethernet38, changed state to up
2025-12-26T13:11:41.608722+01:00 SWITCH Lldp: 208753: %LLDP-5-NEIGHBOR_NEW: LLDP neighbor with chassisId 0050.abcd.ba99 and portId 0050.abcd.ba99 added on interface Ethernet35
2025-12-26T13:11:41.610055+01:00 SWITCH Lldp: 208754: %LLDP-5-NEIGHBOR_NEW: LLDP neighbor with chassisId 0050.abcd.ba99 and portId 0050.abcd.ba9c added on interface Ethernet38
2025-12-26T13:11:41.612560+01:00 SWITCH Lldp: 208755: %LLDP-5-NEIGHBOR_NEW: LLDP neighbor with chassisId 0050.abcd.ba99 and portId 0050.abcd.ba9a added on interface Ethernet36
2025-12-26T13:11:41.613946+01:00 SWITCH Lldp: 208756: %LLDP-5-NEIGHBOR_NEW: LLDP neighbor with chassisId 0050.abcd.ba99 and portId 0050.abcd.ba9b added on interface Ethernet37
2025-12-26T13:11:43.152622+01:00 SWITCH Stp:  208757: %SPANTREE-6-INTERFACE_ADD: Interface Port-Channel35 has been added to instance MST0
2025-12-26T13:11:43.317359+01:00 SWITCH Lag:  208758: %LAG-5-MEMBER_ADDED: Interface Ethernet36 has joined Port-Channel35
2025-12-26T13:11:43.319472+01:00 SWITCH Lag:  208759: %LAG-5-MEMBER_ADDED: Interface Ethernet35 has joined Port-Channel35
2025-12-26T13:11:43.321031+01:00 SWITCH Lag:  208760: %LAG-5-MEMBER_ADDED: Interface Ethernet37 has joined Port-Channel35
2025-12-26T13:11:43.324502+01:00 SWITCH Ebra: 208761: %LINEPROTO-5-UPDOWN: Line protocol on Interface Port-Channel35, changed state to up
```

#### After:
```
2025-12-26T13:15:12.391711+01:00 SWITCH Lag:  208847: %LAG-5-MEMBER_REMOVED: Interface Ethernet38 has left Port-Channel35 due to: partner not in sync
2025-12-26T13:15:13.274740+01:00 SWITCH Ebra: 208848: %LINEPROTO-5-UPDOWN: Line protocol on Interface Ethernet38, changed state to down
2025-12-26T13:15:16.745105+01:00 SWITCH Ebra: 208849: %LINEPROTO-5-UPDOWN: Line protocol on Interface Ethernet38, changed state to up
2025-12-26T13:15:17.101123+01:00 SWITCH Lldp: 208850: %LLDP-5-NEIGHBOR_NEW: LLDP neighbor with chassisId 0050.abcd.ba9b and portId 0050.abcd.ba9c added on interface Ethernet38
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
