### PR TITLE
config: T8124: make get_config_dict() pki={} node purely optional

### DIFF
--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -363,7 +363,7 @@ class Config(object):
                         pki_dict['certificate'][certificate] = config_dict_mangle_acme(
                             certificate, pki_dict['certificate'][certificate])
 
-            conf_dict['pki'] = pki_dict
+                conf_dict['pki'] = pki_dict
 
         interfaces_root = root_dict.get('interfaces', {})
         setattr(conf_dict, 'interfaces_root', interfaces_root)

--- a/src/conf_mode/load-balancing_haproxy.py
+++ b/src/conf_mode/load-balancing_haproxy.py
@@ -127,7 +127,7 @@ def verify(lb):
 
 def generate(lb):
     if not lb:
-        # Delete /run/haproxy/haproxy.cfg
+        # Delete generated config files
         config_files = [load_balancing_conf_file, systemd_override]
         for file in config_files:
             if os.path.isfile(file):
@@ -142,8 +142,8 @@ def generate(lb):
     if not os.path.isdir(load_balancing_dir):
         os.mkdir(load_balancing_dir)
 
-    loaded_ca_certs = {load_certificate(c['certificate'])
-        for c in lb['pki']['ca'].values()} if 'ca' in lb['pki'] else {}
+    loaded_ca_certs = {load_certificate(cert_data['certificate'])
+        for _, cert_data in dict_search('pki.ca', lb, default={}).items()}
 
     # SSL Certificates for frontend
     for front, front_config in lb['service'].items():


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Automatic parsing and integration of the PKI subsystem into the resulting config dict is now enabled by passing `with_pki=True` to `get_config_dict()`.

However, when no PKI configuration is present, the resulting dictionary still includes an empty PKI key. This is undesirable; we should only include keys in the dictionary when they contain relevant data.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8124

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<img width="1674" height="270" alt="image" src="https://github.com/user-attachments/assets/e06d2d68-da7d-4f97-8ea3-8c80dd3e6d5e" />

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
