### PR TITLE
interfaces: T7730: Add interrupt coalescing settings for Ethernet interfaces

### DIFF
--- a/interface-definitions/interfaces_ethernet.xml.in
+++ b/interface-definitions/interfaces_ethernet.xml.in
@@ -221,6 +221,313 @@
               </leafNode>
             </children>
           </node>
+          <node name="interrupt-coalescing">
+            <properties>
+              <help>Interrupt coalescing options for the interface</help>
+            </properties>
+            <children>
+              <leafNode name="adaptive-rx">
+                <properties>
+                  <help>Enable adaptive receive interrupt coalescing</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="adaptive-tx">
+                <properties>
+                  <help>Enable adaptive transmit interrupt coalescing</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="rx-usecs">
+                <properties>
+                  <help>Delay in microseconds before generating RX interrupt</help>
+                  <valueHelp>
+                    <format>u32:0-16384</format>
+                    <description>RX interrupt coalescing delay</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-16384"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="rx-frames">
+                <properties>
+                  <help>Number of RX frames before generating interrupt</help>
+                  <valueHelp>
+                    <format>u32:0-4294967295</format>
+                    <description>RX interrupt coalescing frames threshold</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967295"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="rx-usecs-irq">
+                <properties>
+                  <help>Delay in microseconds before generating RX interrupt while servicing IRQ</help>
+                  <valueHelp>
+                    <format>u32:0-16384</format>
+                    <description>RX IRQ interrupt coalescing delay</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-16384"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="rx-frames-irq">
+                <properties>
+                  <help>Number of RX frames before generating interrupt while servicing IRQ</help>
+                  <valueHelp>
+                    <format>u32:0-4294967295</format>
+                    <description>RX IRQ interrupt coalescing frames threshold</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967295"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="tx-usecs">
+                <properties>
+                  <help>Delay in microseconds before generating TX interrupt</help>
+                  <valueHelp>
+                    <format>u32:0-16384</format>
+                    <description>TX interrupt coalescing delay</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-16384"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="tx-frames">
+                <properties>
+                  <help>Number of TX frames before generating interrupt</help>
+                  <valueHelp>
+                    <format>u32:0-4294967295</format>
+                    <description>TX interrupt coalescing frames threshold</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967295"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="tx-usecs-irq">
+                <properties>
+                  <help>Delay in microseconds before generating TX interrupt while servicing IRQ</help>
+                  <valueHelp>
+                    <format>u32:0-16384</format>
+                    <description>TX IRQ interrupt coalescing delay</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-16384"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="tx-frames-irq">
+                <properties>
+                  <help>Number of TX frames before generating interrupt while servicing IRQ</help>
+                  <valueHelp>
+                    <format>u32:0-4294967295</format>
+                    <description>TX IRQ interrupt coalescing frames threshold</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967295"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="stats-block-usecs">
+                <properties>
+                  <help>Time in microseconds between updating coalescing statistics</help>
+                  <valueHelp>
+                    <format>u32:0-4294967295</format>
+                    <description>Statistics block interval</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967295"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="pkt-rate-low">
+                <properties>
+                  <help>Lower packet rate threshold for adaptive coalescing</help>
+                  <valueHelp>
+                    <format>u32:0-4294967295</format>
+                    <description>Low packet rate threshold</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967295"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="rx-usecs-low">
+                <properties>
+                  <help>RX coalescing delay (usecs) for low packet rate</help>
+                  <valueHelp>
+                    <format>u32:0-16384</format>
+                    <description>Low-rate RX coalescing delay</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-16384"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="rx-frame-low">
+                <properties>
+                  <help>RX coalescing frames threshold for low packet rate</help>
+                  <valueHelp>
+                    <format>u32:0-4294967295</format>
+                    <description>Low-rate RX coalescing frames threshold</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967295"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="tx-usecs-low">
+                <properties>
+                  <help>TX coalescing delay (usecs) for low packet rate</help>
+                  <valueHelp>
+                    <format>u32:0-16384</format>
+                    <description>Low-rate TX coalescing delay</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-16384"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="tx-frame-low">
+                <properties>
+                  <help>TX coalescing frames threshold for low packet rate</help>
+                  <valueHelp>
+                    <format>u32:0-4294967295</format>
+                    <description>Low-rate TX coalescing frames threshold</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967295"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="pkt-rate-high">
+                <properties>
+                  <help>Upper packet rate threshold for adaptive coalescing</help>
+                  <valueHelp>
+                    <format>u32:0-4294967295</format>
+                    <description>High packet rate threshold</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967295"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="rx-usecs-high">
+                <properties>
+                  <help>RX coalescing delay (usecs) for high packet rate</help>
+                  <valueHelp>
+                    <format>u32:0-16384</format>
+                    <description>High-rate RX coalescing delay</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-16384"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="rx-frame-high">
+                <properties>
+                  <help>RX coalescing frames threshold for high packet rate</help>
+                  <valueHelp>
+                    <format>u32:0-4294967295</format>
+                    <description>High-rate RX coalescing frames threshold</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967295"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="tx-usecs-high">
+                <properties>
+                  <help>TX coalescing delay (usecs) for high packet rate</help>
+                  <valueHelp>
+                    <format>u32:0-16384</format>
+                    <description>High-rate TX coalescing delay</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-16384"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="tx-frame-high">
+                <properties>
+                  <help>TX coalescing frames threshold for high packet rate</help>
+                  <valueHelp>
+                    <format>u32:0-4294967295</format>
+                    <description>High-rate TX coalescing frames threshold</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967295"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="sample-interval">
+                <properties>
+                  <help>Sampling interval for adaptive coalescing (in seconds)</help>
+                  <valueHelp>
+                    <format>u32:0-4294967295</format>
+                    <description>Adaptive sampling interval</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967295"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="cqe-mode-rx">
+                <properties>
+                  <help>Enable RX CQE (Completion Queue Entry) mode</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="cqe-mode-tx">
+                <properties>
+                  <help>Enable TX CQE (Completion Queue Entry) mode</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="tx-aggr-max-bytes">
+                <properties>
+                  <help>Maximum number of bytes to aggregate before transmitting</help>
+                  <valueHelp>
+                    <format>u32:0-4294967295</format>
+                    <description>TX aggregation maximum bytes</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967295"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="tx-aggr-max-frames">
+                <properties>
+                  <help>Maximum number of frames to aggregate before transmitting</help>
+                  <valueHelp>
+                    <format>u32:0-4294967295</format>
+                    <description>TX aggregation maximum frames</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-4294967295"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="tx-aggr-time-usecs">
+                <properties>
+                  <help>Maximum time in microseconds to wait before transmitting aggregated frames</help>
+                  <valueHelp>
+                    <format>u32:0-16384</format>
+                    <description>TX aggregation timeout</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-16384"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+            </children>
+          </node>
           #include <include/interface/redirect.xml.i>
           #include <include/interface/vif-s.xml.i>
           #include <include/interface/vif.xml.i>

--- a/python/vyos/netlink/__init__.py
+++ b/python/vyos/netlink/__init__.py
@@ -1,0 +1,14 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.

--- a/python/vyos/netlink/coalesce.py
+++ b/python/vyos/netlink/coalesce.py
@@ -1,0 +1,363 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from pyroute2.netlink import genlmsg
+from pyroute2.netlink import NLM_F_ACK
+from pyroute2.netlink import NLM_F_REQUEST
+from pyroute2.netlink.exceptions import NetlinkError
+from pyroute2.netlink.generic import GenericNetlinkSocket
+from pyroute2.netlink.generic.ethtool import ETHTOOL_GENL_NAME
+from pyroute2.netlink.generic.ethtool import ETHTOOL_GENL_VERSION
+from pyroute2.netlink.generic.ethtool import ethtoolheader
+
+# Netlink message types for coalesce (from Linux kernel)
+ETHTOOL_MSG_COALESCE_GET = 0x13
+ETHTOOL_MSG_COALESCE_SET = 0x14
+
+# Error codes from the kernel
+EINVAL = 0x16  # Invalid argument
+EOPNOTSUPP = 0x5F  # Operation not supported
+
+# Mapping between Python attribute names and netlink attribute names, types
+# https://docs.kernel.org/networking/ethtool-netlink.html#coalesce-get
+# https://git.kernel.org/pub/scm/network/ethtool/ethtool.git/tree/netlink/coalesce.c
+COALESCE_NL_ATTRS = {
+    'adaptive_rx': 'ETHTOOL_A_COALESCE_USE_ADAPTIVE_RX',
+    'adaptive_tx': 'ETHTOOL_A_COALESCE_USE_ADAPTIVE_TX',
+    'cqe_mode_rx': 'ETHTOOL_A_COALESCE_USE_CQE_MODE_RX',
+    'cqe_mode_tx': 'ETHTOOL_A_COALESCE_USE_CQE_MODE_TX',
+    'pkt_rate_high': 'ETHTOOL_A_COALESCE_PKT_RATE_HIGH',
+    'pkt_rate_low': 'ETHTOOL_A_COALESCE_PKT_RATE_LOW',
+    'rx_frame_high': 'ETHTOOL_A_COALESCE_RX_MAX_FRAMES_HIGH',
+    'rx_frame_low': 'ETHTOOL_A_COALESCE_RX_MAX_FRAMES_LOW',
+    'rx_frames': 'ETHTOOL_A_COALESCE_RX_MAX_FRAMES',
+    'rx_frames_irq': 'ETHTOOL_A_COALESCE_RX_MAX_FRAMES_IRQ',
+    'rx_usecs': 'ETHTOOL_A_COALESCE_RX_USECS',
+    'rx_usecs_high': 'ETHTOOL_A_COALESCE_RX_USECS_HIGH',
+    'rx_usecs_irq': 'ETHTOOL_A_COALESCE_RX_USECS_IRQ',
+    'rx_usecs_low': 'ETHTOOL_A_COALESCE_RX_USECS_LOW',
+    'sample_interval': 'ETHTOOL_A_COALESCE_RATE_SAMPLE_INTERVAL',
+    'stats_block_usecs': 'ETHTOOL_A_COALESCE_STATS_BLOCK_USECS',
+    'tx_aggr_max_bytes': 'ETHTOOL_A_COALESCE_TX_AGGR_MAX_BYTES',
+    'tx_aggr_max_frames': 'ETHTOOL_A_COALESCE_TX_AGGR_MAX_FRAMES',
+    'tx_aggr_time_usecs': 'ETHTOOL_A_COALESCE_TX_AGGR_TIME_USECS',
+    'tx_frame_high': 'ETHTOOL_A_COALESCE_TX_MAX_FRAMES_HIGH',
+    'tx_frame_low': 'ETHTOOL_A_COALESCE_TX_MAX_FRAMES_LOW',
+    'tx_frames': 'ETHTOOL_A_COALESCE_TX_MAX_FRAMES',
+    'tx_frames_irq': 'ETHTOOL_A_COALESCE_TX_MAX_FRAMES_IRQ',
+    'tx_usecs': 'ETHTOOL_A_COALESCE_TX_USECS',
+    'tx_usecs_high': 'ETHTOOL_A_COALESCE_TX_USECS_HIGH',
+    'tx_usecs_irq': 'ETHTOOL_A_COALESCE_TX_USECS_IRQ',
+    'tx_usecs_low': 'ETHTOOL_A_COALESCE_TX_USECS_LOW',
+}
+
+
+class ethtool_coalesce_msg(genlmsg):
+    """Netlink message structure for coalesce parameters."""
+
+    ethtoolheader = ethtoolheader
+
+    # https://docs.kernel.org/networking/ethtool-netlink.html#coalesce-get
+    nla_map = (
+        ('ETHTOOL_A_COALESCE_UNSPEC', 'none'),
+        ('ETHTOOL_A_COALESCE_HEADER', 'ethtoolheader'),
+        ('ETHTOOL_A_COALESCE_RX_USECS', 'uint32'),
+        ('ETHTOOL_A_COALESCE_RX_MAX_FRAMES', 'uint32'),
+        ('ETHTOOL_A_COALESCE_RX_USECS_IRQ', 'uint32'),
+        ('ETHTOOL_A_COALESCE_RX_MAX_FRAMES_IRQ', 'uint32'),
+        ('ETHTOOL_A_COALESCE_TX_USECS', 'uint32'),
+        ('ETHTOOL_A_COALESCE_TX_MAX_FRAMES', 'uint32'),
+        ('ETHTOOL_A_COALESCE_TX_USECS_IRQ', 'uint32'),
+        ('ETHTOOL_A_COALESCE_TX_MAX_FRAMES_IRQ', 'uint32'),
+        ('ETHTOOL_A_COALESCE_STATS_BLOCK_USECS', 'uint32'),
+        ('ETHTOOL_A_COALESCE_USE_ADAPTIVE_RX', 'uint8'),
+        ('ETHTOOL_A_COALESCE_USE_ADAPTIVE_TX', 'uint8'),
+        ('ETHTOOL_A_COALESCE_PKT_RATE_LOW', 'uint32'),
+        ('ETHTOOL_A_COALESCE_RX_USECS_LOW', 'uint32'),
+        ('ETHTOOL_A_COALESCE_RX_MAX_FRAMES_LOW', 'uint32'),
+        ('ETHTOOL_A_COALESCE_TX_USECS_LOW', 'uint32'),
+        ('ETHTOOL_A_COALESCE_TX_MAX_FRAMES_LOW', 'uint32'),
+        ('ETHTOOL_A_COALESCE_PKT_RATE_HIGH', 'uint32'),
+        ('ETHTOOL_A_COALESCE_RX_USECS_HIGH', 'uint32'),
+        ('ETHTOOL_A_COALESCE_RX_MAX_FRAMES_HIGH', 'uint32'),
+        ('ETHTOOL_A_COALESCE_TX_USECS_HIGH', 'uint32'),
+        ('ETHTOOL_A_COALESCE_TX_MAX_FRAMES_HIGH', 'uint32'),
+        ('ETHTOOL_A_COALESCE_RATE_SAMPLE_INTERVAL', 'uint32'),
+        ('ETHTOOL_A_COALESCE_USE_CQE_MODE_TX', 'uint8'),
+        ('ETHTOOL_A_COALESCE_USE_CQE_MODE_RX', 'uint8'),
+        ('ETHTOOL_A_COALESCE_TX_AGGR_MAX_BYTES', 'uint32'),
+        ('ETHTOOL_A_COALESCE_TX_AGGR_MAX_FRAMES', 'uint32'),
+        ('ETHTOOL_A_COALESCE_TX_AGGR_TIME_USECS', 'uint32'),
+    )
+
+    @classmethod
+    def get_nl_attr_type(cls, nl_attr: str) -> str:
+        """Returns type of attribute using declared 'nla_map' field"""
+
+        for nla_name, nla_type in cls.nla_map:
+            if nla_name == nl_attr:
+                return nla_type
+
+        raise ValueError(f'Unknown netlink attribute name: {nl_attr}')
+
+
+GeneralNetlinkError = NetlinkError
+
+
+class CoalesceError(Exception):
+    """Base exception for coalesce operations"""
+
+    pass
+
+
+class CoalesceNotSupportedParam(CoalesceError):
+    """Raised when a coalesce parameter is not supported for modification"""
+
+    pass
+
+
+class CoalesceNotSupportedOperation(CoalesceError):
+    """Raised when a coalesce operation is not supported by NIC driver"""
+
+    pass
+
+
+class CoalesceInvalidValue(CoalesceError):
+    """Raised when a coalesce parameter value is invalid"""
+
+    pass
+
+
+class CoalesceNetlink(GenericNetlinkSocket):
+    """
+    Interface coalesce management using `pyroute2` with netlink support.
+
+    This class provides functions to read and set interface coalesce parameters
+    using the ethtool netlink interface, which properly handles "unsupported" values
+    (shown as `n/a` in `ethtool --show-coalesce` output).
+
+    IMPORTANT: The kernel's ethtool netlink interface returns coalesce parameters
+    that have non-zero values, but this does NOT mean they are modifiable. The
+    driver may impose additional constraints:
+
+     1. Some parameters are read-only (e.g., `rx_usecs` may be reported but not settable)
+     2. Some parameters only accept specific values (e.g., `rx_frames` may only accept 1)
+     3. The `supported_coalesce_params` bitmask in the driver determines what's truly
+        supported, but this is not directly queryable via netlink.
+
+    When setting parameters fails with EOPNOTSUPP (0x5F) or EINVAL (0x16), it typically
+    means the parameter is not modifiable or the value is not accepted by the driver.
+    """
+
+    def __init__(self, ifname: str):
+        super().__init__()
+        self._bound = False
+        self._ifname = ifname
+
+    def _ensure_bound(self):
+        """Ensure the socket is bound to the ethtool generic netlink family"""
+
+        if not self._bound:
+            self.bind(ETHTOOL_GENL_NAME, ethtool_coalesce_msg)
+            self._bound = True
+
+    def _get_dev_header(self):
+        """Create device header for netlink message"""
+
+        return {'attrs': [['ETHTOOL_A_HEADER_DEV_NAME', self._ifname]]}
+
+    def get_coalesce(self):
+        """
+        Get coalesce parameters for an interface using netlink.
+
+        Example:
+            >>> cn = CoalesceNetlink('eth0')
+            >>> coalesce = cn.get_coalesce()
+            >>> print(coalesce)
+            {'rx_usecs': 3, 'rx_frames': None, 'tx_usecs': None, ... }
+        """
+        self._ensure_bound()
+
+        msg = ethtool_coalesce_msg()
+        msg['cmd'] = ETHTOOL_MSG_COALESCE_GET
+        msg['version'] = ETHTOOL_GENL_VERSION
+        msg['attrs'].append(('ETHTOOL_A_COALESCE_HEADER', self._get_dev_header()))
+
+        try:
+            response = self.nlm_request(
+                msg, msg_type=self.prid, msg_flags=NLM_F_REQUEST
+            )
+        except NetlinkError as e:
+            if e.code == EOPNOTSUPP:
+                raise CoalesceNotSupportedOperation(
+                    f'Coalesce operation for {self._ifname} not supported by driver'
+                ) from e
+            raise
+
+        if not response:
+            raise CoalesceError(f'No response for coalesce get on {self._ifname}')
+
+        nl_msg = response[0]
+
+        # Parse response - only include attributes that were returned
+        # (unsupported attributes won't be in the response)
+        result = {}
+        for py_attr, nl_attr in COALESCE_NL_ATTRS.items():
+            value = nl_msg.get_attr(nl_attr)  # Will be None if not present/supported
+
+            if value is not None:
+                nl_type = ethtool_coalesce_msg.get_nl_attr_type(nl_attr)
+
+                # Convert to boolean value if it is 'uint8' type
+                if nl_type == 'uint8':
+                    value = bool(value)
+
+            result[py_attr] = value
+
+        return result
+
+    def set_coalesce(self, **kwargs):
+        """
+        Set coalesce parameters for an interface using netlink.
+
+        Only the parameters that are explicitly passed will be set.
+        Unsupported parameters will raise an error from the kernel.
+
+        Args:
+            **kwargs: Coalesce parameters to set.  Valid keys are:
+                - rx_usecs, rx_frames, rx_usecs_irq, rx_frames_irq
+                - tx_usecs, tx_frames, tx_usecs_irq, tx_frames_irq
+                - stats_block_usecs
+                - adaptive_rx, adaptive_tx
+                - pkt_rate_low, pkt_rate_high
+                - rx_usecs_low, rx_frame_low, tx_usecs_low, tx_frame_low
+                - rx_usecs_high, rx_frame_high, tx_usecs_high, tx_frame_high
+                - sample_interval
+                - cqe_mode_tx, cqe_mode_rx
+                - tx_aggr_max_bytes, tx_aggr_max_frames, tx_aggr_time_usecs
+
+        Example:
+            >>> cn = CoalesceNetlink('eth0')
+            >>> cn.set_coalesce(rx_usecs=10, tx_usecs=10)
+        """
+        self._ensure_bound()
+
+        msg = ethtool_coalesce_msg()
+        msg['cmd'] = ETHTOOL_MSG_COALESCE_SET
+        msg['version'] = ETHTOOL_GENL_VERSION
+        msg['attrs'].append(('ETHTOOL_A_COALESCE_HEADER', self._get_dev_header()))
+
+        # Add only the parameters that were explicitly provided
+        for py_attr, value in kwargs.items():
+            if py_attr not in COALESCE_NL_ATTRS:
+                raise CoalesceInvalidValue(f'Unknown coalesce parameter: {py_attr}')
+
+            if value is not None:
+                nl_attr = COALESCE_NL_ATTRS[py_attr]
+                nl_type = ethtool_coalesce_msg.get_nl_attr_type(nl_attr)
+
+                # Convert values to 'uint' type
+                if nl_type.startswith('uint'):
+                    value = int(value)
+
+                msg['attrs'].append((nl_attr, value))
+
+        try:
+            self.nlm_request(
+                msg, msg_type=self.prid, msg_flags=NLM_F_REQUEST | NLM_F_ACK
+            )
+        except NetlinkError as e:
+            params_str = ', '.join(
+                '='.join([k.replace('_', '-'), str(v)]) for k, v in kwargs.items()
+            )
+
+            if e.code == EOPNOTSUPP:
+                raise CoalesceNotSupportedParam(
+                    f'Parameter(s) not supported for modification on '
+                    f'{self._ifname}: {params_str}'
+                ) from e
+            elif e.code == EINVAL:
+                raise CoalesceInvalidValue(
+                    f'Invalid value for coalesce parameter(s) on '
+                    f'{self._ifname}: {params_str}'
+                ) from e
+            raise
+
+
+def get_coalesce(ifname) -> dict:
+    """
+    Get coalesce parameters for an interface.
+
+    This is a convenience function that creates a CoalesceNetlink instance,
+    gets the coalesce parameters, and closes the socket.
+
+    Args:
+        ifname: Interface name (e.g., 'eth0')
+
+    Returns:
+        dict: Coalesce parameters with None for unsupported values.
+    """
+    with CoalesceNetlink(ifname) as cn:
+        return cn.get_coalesce()
+
+
+def set_coalesce(ifname, **kwargs):
+    """
+    Set coalesce parameters for an interface.
+
+    This is a convenience function that creates a CoalesceNetlink instance,
+    sets the coalesce parameters, and closes the socket.
+
+    Args:
+        ifname: Interface name (e.g., 'eth0')
+        **kwargs: Coalesce parameters to set.
+    """
+    with CoalesceNetlink(ifname) as cn:
+        cn.set_coalesce(**kwargs)
+
+
+def get_all_params(boolean: bool = None) -> tuple:
+    """
+    Get all available parameters by the Linux kernel.
+
+    This is a function that gets the coalesce parameters
+    which are available by implementation and the Linux kernel.
+
+    Args:
+        boolean: Filter parameters and return only/without boolean types.
+
+    Returns:
+        tuple: All coalesce parameters
+    """
+
+    params = list(COALESCE_NL_ATTRS.keys())
+
+    def _param_is_bool(p):
+        nl_type = ethtool_coalesce_msg.get_nl_attr_type(COALESCE_NL_ATTRS[p])
+        return nl_type == 'uint8'
+
+    if boolean is not None:
+        boolean_params = list(filter(_param_is_bool, params))
+
+        if boolean:
+            # Use only boolean parameters
+            params = boolean_params
+        else:
+            # Use other parameters except booleans
+            for boolean_param in boolean_params:
+                params.remove(boolean_param)
+
+    return tuple(params)


### PR DESCRIPTION
## Change summary

This change introduces CLI support for configuring network interface interrupt coalescing parameters (`ethtool --coalesce`).

> **Note:** Not all NIC drivers support interrupt coalescing.
> ```
> vyos@vyos:~$ ethtool --coalesce eth0 adaptive-rx on
> netlink error: cannot modify an unsupported parameter (offset 36)
> netlink error: Invalid argument
> ```
> Before you run the tests, make sure your device supports all of these features.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T7730

## Related PR(s)
* https://github.com/vyos/vyos-documentation/pull/1728

## How to test / Smoketest result
#### Manual test:

1. Manual interrupt moderation
```
conf
set interfaces ethernet eth2 interrupt-coalescing rx-usecs 64
set interfaces ethernet eth2 interrupt-coalescing tx-usecs 64
commit
```

```
vyos@he-r650-01:~$ ethtool --show-coalesce eth2
Coalesce parameters for eth2:
Adaptive RX: off  TX: off
stats-block-usecs:      n/a
sample-interval:        n/a
pkt-rate-low:           n/a
pkt-rate-high:          n/a

rx-usecs:       64
rx-frames:      32
rx-usecs-irq:   n/a
rx-frames-irq:  n/a

tx-usecs:       64
tx-frames:      32
tx-usecs-irq:   n/a
tx-frames-irq:  n/a
...
```

2. Adaptive interrupt coalescing
```
conf
set interfaces ethernet eth2 interrupt-coalescing adaptive-rx
set interfaces ethernet eth2 interrupt-coalescing adaptive-tx
commit
```

```
vyos@he-r650-01# ethtool --show-coalesce eth2
Coalesce parameters for eth2:
Adaptive RX: on  TX: on
stats-block-usecs:      n/a
sample-interval:        n/a
pkt-rate-low:           n/a
pkt-rate-high:          n/a
...
```

3. Unsupported NIC driver
```
conf
set interfaces ethernet eth1 interrupt-coalescing adaptive-rx
set interfaces ethernet eth1 interrupt-coalescing adaptive-tx
commit
```

```
vyos@vyos# commit
[ interfaces ethernet eth1 ]
Driver does not support "adaptive-rx" coalesce setting!
[[interfaces ethernet eth1]] failed
Commit failed
```

#### Smoketest:

```
vyos@he-r650-01:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_ethernet.py -k ethtool_coalesce
test_ethtool_coalesce (__main__.EthernetInterfaceTest.test_ethtool_coalesce)
 Verify that coalesce configuration is correctly applied to the interface using ethtool ... ok
...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly