### PR TITLE
T7098: Fix VPP MTU misconfiguration

### DIFF
--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -118,6 +118,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
     def test_01_vpp_basic(self):
         main_core = '0'
         poll_sleep = '0'
+        mtu = '2500'
 
         # Main core must be verified
         # expect raise ConfigError
@@ -160,6 +161,19 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         _, out = rc_cmd('sudo vppctl show lcp')
         required_str = 'lcp route-no-paths off'
         self.assertIn(required_str, out)
+
+        # set interface MTU
+        self.cli_set(['interfaces', 'ethernet', interface, 'mtu', mtu])
+        self.cli_commit()
+
+        # check MTU for the LCP interface pair
+        _, out = rc_cmd('sudo vppctl show interface')
+        normalized_out = re.sub(r'\s+', ' ', out)
+        self.assertIn(f'tap4096 2 up {mtu}/0/0/0', normalized_out)
+
+        # delete mtu settings
+        self.cli_delete(['interfaces', 'ethernet', interface, 'mtu'])
+        self.cli_commit()
 
     def test_02_vpp_vxlan(self):
         vni = '23'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7098
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set vpp settings interface eth1 driver dpdk
commit
```
Before the fix
```
vyos@vyos# sudo vppctl show interface
              Name               Idx    State  MTU (L3/IP4/IP6/MPLS)     Counter          Count
eth1                              1      up          1500/0/0/0     tx-error                       2
local0                            0     down          0/0/0/0       drops                          1
tap4096                           2      up          9000/0/0/0     rx packets                     1
                                                                    rx bytes                      90
                                                                    drops                          1
                                                                    ip6                            1
```
After the fix
```
vyos@vyos# sudo vppctl show interface
              Name               Idx    State  MTU (L3/IP4/IP6/MPLS)     Counter          Count
eth1                              1      up          1500/0/0/0     tx-error                       2
local0                            0     down          0/0/0/0       drops                          1
tap4096                           2      up          1500/0/0/0     rx packets                     1
                                                                    rx bytes                      90
                                                                    drops                          1
                                                                    ip6                            1
```

```
vyos@vyos# /usr/libexec/vyos/tests/smoke/cli/test_vpp.py -k test_01_vpp_basic
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok

----------------------------------------------------------------------
Ran 1 test in 41.221s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
