### PR TITLE
T8133: BGP add local-rib feature for BMP

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -510,11 +510,17 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
 {%                 if bmp_config.monitor.ipv4_unicast.post_policy is vyos_defined %}
   bmp monitor ipv4 unicast post-policy
 {%                 endif %}
+{%                 if bmp_config.monitor.ipv4_unicast.local_rib is vyos_defined %}
+  bmp monitor ipv4 unicast loc-rib
+{%                 endif %}
 {%                 if bmp_config.monitor.ipv6_unicast.pre_policy is vyos_defined %}
   bmp monitor ipv6 unicast pre-policy
 {%                 endif %}
 {%                 if bmp_config.monitor.ipv6_unicast.post_policy is vyos_defined %}
   bmp monitor ipv6 unicast post-policy
+{%                 endif %}
+{%                 if bmp_config.monitor.ipv6_unicast.local_rib is vyos_defined %}
+  bmp monitor ipv6 unicast loc-rib
 {%                 endif %}
 {%             endif %}
 {%             if bmp_config.address is vyos_defined %}

--- a/interface-definitions/include/bgp/bmp-monitor-afi-policy.xml.i
+++ b/interface-definitions/include/bgp/bmp-monitor-afi-policy.xml.i
@@ -1,4 +1,10 @@
 <!-- include start from bgp/bmp-monitor-afi-policy.xml.i -->
+<leafNode name="local-rib">
+  <properties>
+    <help>Enable BMP monitoring of local RIB</help>
+    <valueless/>
+  </properties>
+</leafNode>
 <leafNode name="pre-policy">
   <properties>
     <help>Send state before policy and filter processing</help>

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -1674,7 +1674,9 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_set(target_path + ['max-retry', max_retry])
         self.cli_set(target_path + ['mirror'])
         self.cli_set(target_path + ['monitor', 'ipv4-unicast', monitor_ipv4])
+        self.cli_set(target_path + ['monitor', 'ipv4-unicast', 'local-rib'])
         self.cli_set(target_path + ['monitor', 'ipv6-unicast', monitor_ipv6])
+        self.cli_set(target_path + ['monitor', 'ipv6-unicast', 'local-rib'])
         self.cli_commit()
 
         # Verify bgpd bmp configuration
@@ -1684,6 +1686,8 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'bmp mirror', frrconfig)
         self.assertIn(f'bmp monitor ipv4 unicast {monitor_ipv4}', frrconfig)
         self.assertIn(f'bmp monitor ipv6 unicast {monitor_ipv6}', frrconfig)
+        self.assertIn(f'bmp monitor ipv4 unicast loc-rib', frrconfig)
+        self.assertIn(f'bmp monitor ipv6 unicast loc-rib', frrconfig)
         self.assertIn(f'bmp connect {target_address} port {target_port} min-retry {min_retry} max-retry {max_retry}', frrconfig)
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
BGP add local-rib feature for BMP
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8133

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
vyos@r14# run show conf com | match "bgp|bmp"
set protocols bgp bmp target FIRST address '192.0.2.1'
set protocols bgp bmp target FIRST monitor ipv4-unicast local-rib
set protocols bgp bmp target FIRST monitor ipv6-unicast local-rib
set protocols bgp system-as '65001'
set system frr bmp
[edit]
vyos@r14# 
[edit]
vyos@r14# vtysh -c "show run bgpd"
Building configuration...

Current configuration:
!
frr version 10.2.4
frr defaults traditional
hostname r14
log syslog notifications
log timestamp precision 3
no log unique-id
service integrated-vtysh-config
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp default ipv4-unicast
 no bgp network import-check
 !
 bmp targets FIRST
  bmp monitor ipv4 unicast loc-rib
  bmp monitor ipv6 unicast loc-rib
  bmp connect 192.0.2.1 port 5000 min-retry 1000 max-retry 2000
 exit
exit
!
end
[edit]
vyos@r14# 

```
Smoketest:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py -k test_bgp_99_bmp
test_bgp_99_bmp (__main__.TestProtocolsBGP.test_bgp_99_bmp) ... ok

----------------------------------------------------------------------
Ran 1 test in 17.194s

OK
vyos@r14:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
