### PR TITLE
T8154: "monitor traffic" - fix traceback on KeyboardInterrupt (Ctrl+C)

### DIFF
--- a/src/op_mode/tcpdump.py
+++ b/src/op_mode/tcpdump.py
@@ -162,4 +162,7 @@ if __name__ == '__main__':
                 sys.exit(0)
 
     command = convert(tcpdump, args)
-    call(f'{command} -i {ifname}')
+    try:
+       call(f'{command} -i {ifname}')
+    except KeyboardInterrupt:
+       sys.exit(0)


### PR DESCRIPTION
## Change summary
Implemented proper handling of `KeyboardInterrupt` in the `tcpdump.py` operational mode script. This ensures that when a user terminates the `monitor interface traffic | match '*'` command using `Ctrl+C`, the script exits gracefully instead of printing a Python stack trace.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T8154

## Related PR(s)
None.

## How to test / Smoketest result
Verified manually on a VyOS instance.

```before
vyos@vyos:~$ monitor traffic interface eth1 numeric filter 'port 80' | match '1.1.1.1'
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eth1, link-type EN10MB (Ethernet), snapshot length 262144 bytes

^C9 packets captured
19 packets received by filter
0 packets dropped by kernel
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/tcpdump.py", line 169, in <module>
    call(f'{command} -i {ifname}')
  File "/usr/lib/python3/dist-packages/vyos/utils/process.py", line 187, in call
    out, code = popen(
                ^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/utils/process.py", line 82, in popen
    pipe = p.communicate(input, timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 1199, in communicate
    self.wait()
  File "/usr/lib/python3.11/subprocess.py", line 1262, in wait
    return self._wait(timeout=timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 1997, in _wait
    (pid, sts) = self._try_wait(0)
                 ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 1955, in _try_wait
    (pid, sts) = os.waitpid(self.pid, wait_flags)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyboardInterrupt

vyos@vyos:~$
```

```after
vyos@vyos:~$ sudo vi /usr/libexec/vyos/op_mode/tcpdump.py
vyos@vyos:~$ monitor traffic interface eth1 numeric filter 'port 80' | match '1.1.1.1'
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eth1, link-type EN10MB (Ethernet), snapshot length 262144 bytes


^C18 packets captured
18 packets received by filter
0 packets dropped by kernel

vyos@vyos:~$ 

```

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
