### PR TITLE
T8138: add nat66 as dependent of firewall groups

### DIFF
--- a/data/config-mode-dependencies/vyos-1x.json
+++ b/data/config-mode-dependencies/vyos-1x.json
@@ -5,7 +5,7 @@
     },
     "firewall": {
         "conntrack": ["system_conntrack"],
-        "group_resync": ["system_conntrack", "nat", "policy_route", "load-balancing_wan"]
+        "group_resync": ["system_conntrack", "nat", "nat66", "policy_route", "load-balancing_wan"]
     },
     "interfaces_bonding": {
         "ethernet": ["interfaces_ethernet"],


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
Add nat66 as a dependency of firewall groups, because nat66 may reference firewall groups via `source-destination-group-ipv6.xml.i`. The dependency is necessary to ensure a fresh nft ruleset is built when dependent groups are updated, so that the changes actually take effect in nat66 on commit.

Also adds a smoketest to cover nft rulesets failing to update as a result of changes to dependent firewall groups.

Original commit adding support for groups in nat66 is commit f96733dd.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T8138
* https://vyos.dev/T6679

## How to test / Smoketest result
```
$ /usr/libexec/vyos/tests/smoke/cli/test_nat66.py
[...]
test_firewall_group_dependence (__main__.TestNAT66.test_firewall_group_dependence) ... ok
[...]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
