### PR TITLE
nat66: T8139: add support for NAT66 source groups

### DIFF
--- a/interface-definitions/nat66.xml.in
+++ b/interface-definitions/nat66.xml.in
@@ -79,6 +79,7 @@
                     </properties>
                   </leafNode>
                   #include <include/nat-port.xml.i>
+                  #include <include/firewall/source-destination-group-ipv6.xml.i>
                 </children>
               </node>
               <node name="translation">
@@ -216,6 +217,7 @@
                     </properties>
                   </leafNode>
                 #include <include/nat-port.xml.i>
+                #include <include/firewall/source-destination-group-ipv6.xml.i>
                 </children>
               </node>
               <node name="translation">

--- a/smoketest/scripts/cli/test_nat66.py
+++ b/smoketest/scripts/cli/test_nat66.py
@@ -148,16 +148,22 @@ class TestNAT66(VyOSUnitTestSHIM.TestCase):
         address_group_member = 'fc00::1'
         network_group = 'smoketest_net'
         network_group_member = 'fc00::/64'
+        mac_group = 'smoketest_mac'
+        mac_group_member = '00:01:02:03:04:05'
         translation_prefix = 'fc01::/64'
 
         self.cli_set(['firewall', 'group', 'ipv6-address-group', address_group, 'address', address_group_member])
         self.cli_set(['firewall', 'group', 'ipv6-network-group', network_group, 'network', network_group_member])
+        self.cli_set(['firewall', 'group', 'mac-group', mac_group, 'mac-address', mac_group_member])
 
         self.cli_set(dst_path + ['rule', '1', 'destination', 'group', 'address-group', address_group])
         self.cli_set(dst_path + ['rule', '1', 'translation', 'address', translation_prefix])
 
         self.cli_set(dst_path + ['rule', '2', 'destination', 'group', 'network-group', network_group])
         self.cli_set(dst_path + ['rule', '2', 'translation', 'address', translation_prefix])
+
+        self.cli_set(dst_path + ['rule', '3', 'source', 'group', 'mac-group', mac_group])
+        self.cli_set(dst_path + ['rule', '3', 'translation', 'address', translation_prefix])
 
         self.cli_commit()
 
@@ -167,7 +173,8 @@ class TestNAT66(VyOSUnitTestSHIM.TestCase):
             [f'set N6_{network_group}'],
             [f'elements = {{ {network_group_member} }}'],
             ['ip6 daddr', f'@A6_{address_group}', 'dnat prefix to fc01::/64'],
-            ['ip6 daddr', f'@N6_{network_group}', 'dnat prefix to fc01::/64']
+            ['ip6 daddr', f'@N6_{network_group}', 'dnat prefix to fc01::/64'],
+            ['ether saddr', f'@M_{mac_group}', 'dnat prefix to fc01::/64'],
         ]
 
         self.verify_nftables(nftables_search, 'ip6 vyos_nat')
@@ -234,16 +241,22 @@ class TestNAT66(VyOSUnitTestSHIM.TestCase):
         address_group_member = 'fc00::1'
         network_group = 'smoketest_net'
         network_group_member = 'fc00::/64'
+        mac_group = 'smoketest_mac'
+        mac_group_member = '00:01:02:03:04:05'
         translation_prefix = 'fc01::/64'
 
         self.cli_set(['firewall', 'group', 'ipv6-address-group', address_group, 'address', address_group_member])
         self.cli_set(['firewall', 'group', 'ipv6-network-group', network_group, 'network', network_group_member])
+        self.cli_set(['firewall', 'group', 'mac-group', mac_group, 'mac-address', mac_group_member])
 
         self.cli_set(src_path + ['rule', '1', 'destination', 'group', 'address-group', address_group])
         self.cli_set(src_path + ['rule', '1', 'translation', 'address', translation_prefix])
 
         self.cli_set(src_path + ['rule', '2', 'destination', 'group', 'network-group', network_group])
         self.cli_set(src_path + ['rule', '2', 'translation', 'address', translation_prefix])
+
+        self.cli_set(src_path + ['rule', '3', 'source', 'group', 'mac-group', mac_group])
+        self.cli_set(src_path + ['rule', '3', 'translation', 'address', translation_prefix])
 
         self.cli_commit()
 
@@ -253,7 +266,8 @@ class TestNAT66(VyOSUnitTestSHIM.TestCase):
             [f'set N6_{network_group}'],
             [f'elements = {{ {network_group_member} }}'],
             ['ip6 daddr', f'@A6_{address_group}', 'snat prefix to fc01::/64'],
-            ['ip6 daddr', f'@N6_{network_group}', 'snat prefix to fc01::/64']
+            ['ip6 daddr', f'@N6_{network_group}', 'snat prefix to fc01::/64'],
+            ['ether saddr', f'@M_{mac_group}', 'snat prefix to fc01::/64'],
         ]
 
         self.verify_nftables(nftables_search, 'ip6 vyos_nat')

--- a/src/conf_mode/nat66.py
+++ b/src/conf_mode/nat66.py
@@ -92,10 +92,14 @@ def verify(nat):
             if prefix != None:
                 if not is_ipv6(prefix):
                     raise ConfigError(f'{err_msg} source-prefix not specified')
-                
+
+            if 'source' in config and 'group' in config['source']:
+                if len({'address_group', 'network_group', 'domain_group'} & set(config['source']['group'])) > 1:
+                    raise ConfigError('Only one source address-group, network-group or domain-group can be specified')
+
             if 'destination' in config and 'group' in config['destination']:
                 if len({'address_group', 'network_group', 'domain_group'} & set(config['destination']['group'])) > 1:
-                    raise ConfigError('Only one address-group, network-group or domain-group can be specified')
+                    raise ConfigError('Only one destination address-group, network-group or domain-group can be specified')
 
     if dict_search('destination.rule', nat):
         for rule, config in dict_search('destination.rule', nat).items():
@@ -112,9 +116,13 @@ def verify(nat):
                         if not interface_exists(interface_name):
                             Warning(f'Interface "{interface_name}" for destination NAT66 rule "{rule}" does not exist!')
 
+            if 'source' in config and 'group' in config['source']:
+                if len({'address_group', 'network_group', 'domain_group'} & set(config['source']['group'])) > 1:
+                    raise ConfigError('Only one source address-group, network-group or domain-group can be specified')
+
             if 'destination' in config and 'group' in config['destination']:
                 if len({'address_group', 'network_group', 'domain_group'} & set(config['destination']['group'])) > 1:
-                    raise ConfigError('Only one address-group, network-group or domain-group can be specified')
+                    raise ConfigError('Only one destination address-group, network-group or domain-group can be specified')
 
     return None
 


### PR DESCRIPTION
## Change summary
Copy the support for NAT66 destination groups (commit f96733dd and commit 43554efc) over to NAT66 source groups as well.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8139
* https://vyos.dev/T7051
* https://vyos.dev/T6679

## Related PR(s)
* https://github.com/vyos/vyos-1x/pull/4927

## How to test / Smoketest result
```
$ /usr/libexec/vyos/tests/smoke/cli/test_nat66.py
[...]
test_destination_nat66_network_group (__main__.TestNAT66.test_destination_nat66_network_group) ... ok
[...]
test_source_nat66_network_group (__main__.TestNAT66.test_source_nat66_network_group) ... ok
[...]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
