### PR TITLE
router-advert: T8140: add captive portal support (RFC 8910)

### DIFF
--- a/data/templates/router-advert/radvd.conf.j2
+++ b/data/templates/router-advert/radvd.conf.j2
@@ -4,6 +4,9 @@
 {%     for iface, iface_config in interface.items() %}
 interface {{ iface }} {
     IgnoreIfMissing on;
+{%         if iface_config.captive_portal is vyos_defined %}
+    AdvCaptivePortalAPI "{{ iface_config.captive_portal }}";
+{%         endif %}
 {%         if iface_config.default_preference is vyos_defined %}
     AdvDefaultPreference {{ iface_config.default_preference }};
 {%         endif %}

--- a/interface-definitions/service_router-advert.xml.in
+++ b/interface-definitions/service_router-advert.xml.in
@@ -16,6 +16,7 @@
               </completionHelp>
             </properties>
             <children>
+              #include <include/dhcp/captive-portal.xml.i>
               <leafNode name="hop-limit">
                 <properties>
                   <help>Set Hop Count field of the IP header for outgoing packets</help>

--- a/smoketest/scripts/cli/test_service_router-advert.py
+++ b/smoketest/scripts/cli/test_service_router-advert.py
@@ -224,6 +224,17 @@ class TestServiceRADVD(VyOSUnitTestSHIM.TestCase):
         self.assertIn(tmp, config)
         self.assertIn('AdvValidLifetime 65528;', config) # default
 
+    def test_captive_portal(self):
+        captive_portal = 'https://example.com/api/capport.json'
+
+        self.cli_set(base_path + ['captive-portal', captive_portal])
+        # commit changes
+        self.cli_commit()
+
+        # Verify generated configuration
+        tmp = get_config_value('AdvCaptivePortalAPI')
+        self.assertEqual(tmp, f'"{captive_portal}"')
+
     def test_advsendadvert_advintervalopt(self):
         ra_src = ['fe80::1', 'fe80::2']
 


### PR DESCRIPTION
## Change summary
Add support for captive portal identification in IPv6 router adverts as defined in RFC 8910. The value is a quoted URL pointing to an RFC 8908-compliant API endpoint.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8140

## Related PR(s)
* https://github.com/vyos/vyos-documentation/pull/1732

## How to test / Smoketest result
All smoketests for radvd fail for me in my testing VM, and I haven't been able to figure out why yet. Although I have tested setting the option using
```
set service router-advert interface eth0 captive-portal https://example.com/api/capport.json
```
and then verifying that it shows up in `/run/radvd/radvd.conf`. I have also verified via Wireshark that the captive portal option is being set in router advertisements.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
