### PR TITLE
pppoe: kick RS for IPv6 autoconf; run PPPoE callback on ipv6-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# MacOS .DS_Store File
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/python/vyos/ifconfig/pppoe.py
+++ b/python/vyos/ifconfig/pppoe.py
@@ -139,3 +139,7 @@ class PPPoEIf(Interface):
             self._cmd(f'vtysh -c "conf t" {vrf} -c "ip route 0.0.0.0/0 {self.ifname} tag 210 {distance}"')
             if 'ipv6' in config:
                 self._cmd(f'vtysh -c "conf t" {vrf} -c "ipv6 route ::/0 {self.ifname} tag 210 {distance}"')
+
+        # kick RS when IPv6 is up.
+        if 'ipv6' in config and 'address' in config['ipv6'] and 'autoconf' in config['ipv6']['address']:
+            self._cmd(f'rdisc6 -1 -q -r 3 -w 1000 {self.ifname}')

--- a/src/etc/ppp/ipv6-up.d/96-vyos-sstpc-callback
+++ b/src/etc/ppp/ipv6-up.d/96-vyos-sstpc-callback
@@ -1,0 +1,1 @@
+../ip-up.d/96-vyos-sstpc-callback

--- a/src/etc/ppp/ipv6-up.d/99-vyos-pppoe-callback
+++ b/src/etc/ppp/ipv6-up.d/99-vyos-pppoe-callback
@@ -1,0 +1,1 @@
+../ip-up.d/99-vyos-pppoe-callback


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
When IPv6 autoconf is configured on a PPPoE interface, enabling RA acceptance does not always trigger a new Router Solicitation on an already-up session. This can delay or prevent SLAAC/RA convergence until the user manually runs router discovery or reconnects PPPoE.

Trigger a best-effort router discovery via rdisc6 when "interfaces pppoe <if> ipv6 address autoconf" is present.

Additionally, on IPv6-only PPPoE sessions pppd may execute ipv6-up but not ip-up, so ip-up.d callbacks are not invoked. Install a symlink for the existing PPPoE callback under ipv6-up.d to ensure interface re-apply logic runs when IPv6CP becomes active.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
