### PR TITLE
ethernet: T8142: do not raise ValueError for non-existing interfaces

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_ethernet.py
+++ b/smoketest/scripts/cli/test_interfaces_ethernet.py
@@ -154,16 +154,18 @@ class EthernetInterfaceTest(BasicInterfaceTest.TestCase):
                 self.assertEqual(int(tmp), 0)
 
     def test_non_existing_interface(self):
-        unknonw_interface = self._base_path + ['eth667']
-        self.cli_set(unknonw_interface)
+        unknonw_interface = 'eth667'
+        self.cli_set(self._base_path + [unknonw_interface])
 
         # check validate() - interface does not exist
-        with self.assertRaises(ConfigSessionError):
+        with self.assertRaises(ConfigSessionError) as cm:
             self.cli_commit()
+            self.assertIn(f'Interface "{unknonw_interface}" does not exist!',
+                          str(cm.exception))
 
         # we need to remove this wrong interface from the configuration
         # manually, else tearDown() will have problem in commit()
-        self.cli_delete(unknonw_interface)
+        self.cli_delete(self._base_path + [unknonw_interface])
 
     def test_speed_duplex_verify(self):
         for interface in self._interfaces:

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -386,11 +386,12 @@ def verify(ethernet):
     if 'deleted' in ethernet:
         return None
 
-    ethtool = Ethtool(ethernet['ifname'])
-    verify_interface_exists(ethernet, ethernet['ifname'])
+    ifname = ethernet['ifname']
+    verify_interface_exists(ethernet, ifname, state_required=True)
     verify_eapol(ethernet)
     verify_mirror_redirect(ethernet)
     # No need to check speed and duplex keys as both have default values
+    ethtool = Ethtool(ifname)
     verify_speed_duplex(ethernet, ethtool)
     verify_flow_control(ethernet, ethtool)
     verify_ring_buffer(ethernet, ethtool)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Call `verify_interface_exists()` with `state_required=True` to ensure the interface exists physically and is recognized by the kernel, rather than relying on its presence in the CLI configuration. Unlike bridge or bond interfaces, Ethernet interfaces are not virtual and must be physically present.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8142

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

```
vyos@vyos# set interfaces ethernet eth10000
vyos@vyos# commit
[ interfaces ethernet eth10000 ]
Interface "eth10000" does not exist!
[[interfaces ethernet eth10000]] failed
Commit failed
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
