### PR TITLE
T8153: PPPoE IPv6 autoconf: no Router Solicitation sent and default IPv6 route not installed after successful dial-up

### DIFF
--- a/python/vyos/ifconfig/pppoe.py
+++ b/python/vyos/ifconfig/pppoe.py
@@ -15,6 +15,7 @@
 
 from vyos.ifconfig.interface import Interface
 from vyos.utils.assertion import assert_range
+from vyos.utils.dict import dict_search
 from vyos.utils.network import get_interface_config
 
 @Interface.register
@@ -139,3 +140,7 @@ class PPPoEIf(Interface):
             self._cmd(f'vtysh -c "conf t" {vrf} -c "ip route 0.0.0.0/0 {self.ifname} tag 210 {distance}"')
             if 'ipv6' in config:
                 self._cmd(f'vtysh -c "conf t" {vrf} -c "ipv6 route ::/0 {self.ifname} tag 210 {distance}"')
+
+        # kick RS when IPv6 is up.
+        if 'autoconf' in dict_search('ipv6.address', config):
+            self._cmd(f'rdisc6 --single --retry 3 {self.ifname}')

--- a/src/etc/ppp/ipv6-up.d/99-vyos-pppoe-callback
+++ b/src/etc/ppp/ipv6-up.d/99-vyos-pppoe-callback
@@ -1,0 +1,1 @@
+../ip-up.d/99-vyos-pppoe-callback


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
When PPPoE comes up with IPv6 SLAAC (ipv6 address autoconf), VyOS may not send Router Solicitation and therefore fails to learn/install the IPv6 default route.

Trigger rdisc6 after PPPoE is up when 'ipv6.address autoconf' is configured. This makes the IPv6 default route appear immediately without manual intervention.

Workaround of linking ip-up.d scripts into ipv6-up.d is also used to ensure the IPv6 PPP hook scripts are executed consistently.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8153
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
