### PR TITLE
T8144: fix and correct TPM and VPP test result reporting in smoke test workflow

### DIFF
--- a/.github/workflows/package-smoketest.yml
+++ b/.github/workflows/package-smoketest.yml
@@ -175,11 +175,11 @@ jobs:
         id: test
         shell: bash
         run: |
-          sudo make ${{ needs.set_config.outputs.test_cli_command }} && EXIT_CODE=0 || EXIT_CODE=$?
-          if [[ $EXIT_CODE == 0 ]]; then
+          if sudo make ${{ needs.set_config.outputs.test_cli_command }}; then
             echo "exit_code=success" >> $GITHUB_OUTPUT
           else
             echo "exit_code=fail" >> $GITHUB_OUTPUT
+            exit 1
           fi
 
   test_smoketest_cli_vpp:
@@ -209,11 +209,11 @@ jobs:
         id: test
         shell: bash
         run: |
-          sudo make test-vpp && EXIT_CODE=0 || EXIT_CODE=$?
-          if [[ $EXIT_CODE == 0 ]]; then
+          if sudo make test-vpp; then
             echo "exit_code=success" >> $GITHUB_OUTPUT
           else
             echo "exit_code=fail" >> $GITHUB_OUTPUT
+            exit 1
           fi
 
   test_interfaces_cli:
@@ -242,11 +242,11 @@ jobs:
         id: test
         shell: bash
         run: |
-          sudo make test-interfaces && EXIT_CODE=0 || EXIT_CODE=$?
-          if [[ $EXIT_CODE == 0 ]]; then
+          if sudo make test-interfaces; then
             echo "exit_code=success" >> $GITHUB_OUTPUT
           else
             echo "exit_code=fail" >> $GITHUB_OUTPUT
+            exit 1
           fi
 
   test_config_load:
@@ -275,11 +275,11 @@ jobs:
         id: test
         shell: bash
         run: |
-          sudo make testc && EXIT_CODE=0 || EXIT_CODE=$?
-          if [[ $EXIT_CODE == 0 ]]; then
+          if sudo make testc; then
             echo "exit_code=success" >> $GITHUB_OUTPUT
           else
             echo "exit_code=fail" >> $GITHUB_OUTPUT
+            exit 1
           fi
 
   test_config_load_vpp:
@@ -309,11 +309,11 @@ jobs:
         id: test
         shell: bash
         run: |
-          sudo make testcvpp && EXIT_CODE=0 || EXIT_CODE=$?
-          if [[ $EXIT_CODE == 0 ]]; then
+          if sudo make testcvpp; then
             echo "exit_code=success" >> $GITHUB_OUTPUT
           else
             echo "exit_code=fail" >> $GITHUB_OUTPUT
+            exit 1
           fi
 
   test_raid1_install:
@@ -342,11 +342,11 @@ jobs:
         id: test
         shell: bash
         run: |
-          sudo make testraid && EXIT_CODE=0 || EXIT_CODE=$?
-          if [[ $EXIT_CODE == 0 ]]; then
+          if sudo make testraid; then
             echo "exit_code=success" >> $GITHUB_OUTPUT
           else
             echo "exit_code=fail" >> $GITHUB_OUTPUT
+            exit 1
           fi
 
   test_encrypted_config_tpm:
@@ -376,11 +376,11 @@ jobs:
         id: test
         shell: bash
         run: |
-          sudo make testtpm && EXIT_CODE=0 || EXIT_CODE=$?
-          if [[ $EXIT_CODE == 0 ]]; then
+          if sudo make testtpm; then
             echo "exit_code=success" >> $GITHUB_OUTPUT
           else
             echo "exit_code=fail" >> $GITHUB_OUTPUT
+            exit 1
           fi
 
   result:

--- a/.github/workflows/package-smoketest.yml
+++ b/.github/workflows/package-smoketest.yml
@@ -402,7 +402,7 @@ jobs:
         uses: mshick/add-pr-comment@v2
         with:
           message: |
-            CI integration ${{ (needs.test_smoketest_cli.outputs.exit_code == 'success' && needs.test_interfaces_cli.outputs.exit_code == 'success' && needs.test_config_load.outputs.exit_code == 'success' && needs.test_raid1_install.outputs.exit_code == 'success' && (needs.test_smoketest_cli_vpp.result != 'failure') && (needs.test_config_load_vpp.result != 'failure') && (needs.test_encrypted_config_tpm.result != 'failure')) && '👍 passed!' || '❌ failed!' }}
+            CI integration ${{ (needs.test_smoketest_cli.outputs.exit_code == 'success' && needs.test_interfaces_cli.outputs.exit_code == 'success' && needs.test_config_load.outputs.exit_code == 'success' && needs.test_raid1_install.outputs.exit_code == 'success' && (needs.test_smoketest_cli_vpp.outputs.exit_code != 'fail') && (needs.test_config_load_vpp.outputs.exit_code != 'fail') && (needs.test_encrypted_config_tpm.outputs.exit_code != 'fail')) && '👍 passed!' || '❌ failed!' }}
 
             ### Details
 
@@ -412,9 +412,9 @@ jobs:
             * CLI Smoketests (interfaces only) ${{ needs.test_interfaces_cli.outputs.exit_code == 'success' && '👍 passed' || '❌ failed' }}
             * Config tests ${{ needs.test_config_load.outputs.exit_code == 'success' && '👍 passed' || '❌ failed' }}
             * RAID1 tests ${{ needs.test_raid1_install.outputs.exit_code == 'success' && '👍 passed' || '❌ failed' }}
-            * CLI Smoketests VPP ${{ needs.test_smoketest_cli_vpp.result == 'success' && '👍 passed' || needs.test_smoketest_cli_vpp.result == 'failure' && '❌ failed' || needs.test_smoketest_cli_vpp.result == 'skipped' && '⏭️ skipped' || '⏭️ skipped' }}
-            * Config tests VPP ${{ needs.test_config_load_vpp.result == 'success' && '👍 passed' || needs.test_config_load_vpp.result == 'failure' && '❌ failed' || needs.test_config_load_vpp.result == 'skipped' && '⏭️ skipped' || '⏭️ skipped' }}
-            * TPM tests ${{ needs.test_encrypted_config_tpm.result == 'success' && '👍 passed' || needs.test_encrypted_config_tpm.result == 'failure' && '❌ failed' || needs.test_encrypted_config_tpm.result == 'skipped' && '⏭️ skipped' || '⏭️ skipped' }}
+            * CLI Smoketests VPP ${{ needs.test_smoketest_cli_vpp.outputs.exit_code == 'success' && '👍 passed' || needs.test_smoketest_cli_vpp.outputs.exit_code == 'fail' && '❌ failed' || '⏭️ skipped' }}
+            * Config tests VPP ${{ needs.test_config_load_vpp.outputs.exit_code == 'success' && '👍 passed' || needs.test_config_load_vpp.outputs.exit_code == 'fail' && '❌ failed' || '⏭️ skipped' }}
+            * TPM tests ${{ needs.test_encrypted_config_tpm.outputs.exit_code == 'success' && '👍 passed' || needs.test_encrypted_config_tpm.outputs.exit_code == 'fail' && '❌ failed' || '⏭️ skipped' }}
 
           message-id: "SMOKETEST_RESULTS"
           allow-repeats: false


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
## Problem
Failed TPM and VPP tests were incorrectly displayed as passed in PR comments due to checking job `.result` instead of test `.outputs.exit_code`.
Also Updated the workflow to report the status as-is without masking the failure.

## Solution
Use `.outputs.exit_code` consistently for all test result checks:
- ✅ `exit_code == 'success'` → '👍 passed'
- ❌ `exit_code == 'fail'` → '❌ failed'
- ⏭️ Undefined → '⏭️ skipped'

## Files Changed
- `.github/workflows/package-smoketest.yml`

## Test/Validation
- Validated with https://github.com/vyos/gh-action-test-vyos-1x/pull/243

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx --> https://vyos.dev/T8144

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
