### PR TITLE
isis: T8158: fix lsp-timers

### DIFF
--- a/data/templates/frr/isisd.frr.j2
+++ b/data/templates/frr/isisd.frr.j2
@@ -114,17 +114,9 @@ advertise-passive-only
 {% if log_adjacency_changes is vyos_defined %}
  log-adjacency-changes
 {% endif %}
-{% if lsp_gen_interval is vyos_defined %}
- lsp-gen-interval {{ lsp_gen_interval }}
-{% endif %}
+ lsp-timers gen-interval {{ lsp_gen_interval }} refresh-interval {{ lsp_refresh_interval }} max-lifetime {{ max_lsp_lifetime }}
 {% if lsp_mtu is vyos_defined %}
  lsp-mtu {{ lsp_mtu }}
-{% endif %}
-{% if lsp_refresh_interval is vyos_defined %}
- lsp-refresh-interval  {{ lsp_refresh_interval }}
-{% endif %}
-{% if max_lsp_lifetime is vyos_defined %}
- max-lsp-lifetime {{ max_lsp_lifetime }}
 {% endif %}
 {% if ldp_sync.holddown is vyos_defined %}
  mpls ldp-sync holddown {{ ldp_sync.holddown }}

--- a/interface-definitions/include/isis/protocol-common-config.xml.i
+++ b/interface-definitions/include/isis/protocol-common-config.xml.i
@@ -98,6 +98,7 @@
       <validator name="numeric" argument="--range 1-120"/>
     </constraint>
   </properties>
+  <defaultValue>30</defaultValue>
 </leafNode>
 <leafNode name="lsp-mtu">
   <properties>
@@ -116,13 +117,14 @@
   <properties>
     <help>LSP refresh interval</help>
     <valueHelp>
-      <format>u32:1-65235</format>
+      <format>u32:2-65235</format>
       <description>LSP refresh interval in seconds</description>
     </valueHelp>
     <constraint>
-      <validator name="numeric" argument="--range 1-65235"/>
+      <validator name="numeric" argument="--range 2-65235"/>
     </constraint>
   </properties>
+  <defaultValue>900</defaultValue>
 </leafNode>
 <leafNode name="max-lsp-lifetime">
   <properties>
@@ -135,6 +137,7 @@
       <validator name="numeric" argument="--range 1-65535"/>
     </constraint>
   </properties>
+  <defaultValue>1200</defaultValue>
 </leafNode>
 <leafNode name="metric-style">
   <properties>

--- a/src/conf_mode/protocols_isis.py
+++ b/src/conf_mode/protocols_isis.py
@@ -252,6 +252,15 @@ def verify(config_dict):
         if int(len(isis['fast_reroute']['lfa']['remote']['prefix_list'].items())) > 1:
             raise ConfigError(f'LFA remote prefix-list has more than one configured. Cannot have more than one configured.')
 
+    # Check for lsp-timers violations
+    # Must be in sync with FRR yang limitations in yang/frr-isisd.yang
+    if int(isis['lsp_gen_interval']) >= int(isis['lsp_refresh_interval']):
+        raise ConfigError(f'lsp-gen-interval must be less then lsp-refresh-interval')
+    if int(isis['max_lsp_lifetime']) < int(isis['lsp_refresh_interval']) + 300:
+        raise ConfigError(
+            f'max-lsp-lifetime must be greater or equal to lsp-refresh-interval + 300'
+        )
+
     return None
 
 def generate(config_dict):


### PR DESCRIPTION
## Fix lsp-timers

There are three configuration values in VyOS isis XML:

* lsp-gen-interval
* lsp-refresh-interval
* max-lsp-lifetime

In FRR they have the following restrictions in yang model:
* refresh-interval, default 900
* maximum-lifetime >= refresh-interval + 300 (350-65535), default 1200
* generation-interval < refresh-interval (1..120), default 30

When setting these values in separate steps we can get error e.g.: libyang: Must condition ". >= ../refresh-interval + 300" not satisfied.

even when all restrictions are satisfied.

To fix the issue:

1. Write default values in our XML.
2. Check these restrictions in protocol_isis.py
3. Use FRR command `lsp-timers` that sets all these values in one go

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T8158

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

Tested manually with configuration:

```
set protocols isis dynamic-hostname
set protocols isis interface dum0 passive
set protocols isis level 'level-2'
set protocols isis log-adjacency-changes
set protocols isis max-lsp-lifetime '65535'
set protocols isis metric-style 'wide'
set protocols isis net '49.0000.0000.0000.0001.00'
set protocols isis purge-originator
set protocols isis redistribute ipv4 connected level-2 route-map 'RM4-NOC'
set protocols isis redistribute ipv6 connected level-2 route-map 'RM6-NOC'
commit
```

And then adding

```
set protocols isis max-lsp-lifetime '65535'
set protocols isis lsp-refresh-interval '65235'
commit
```

In Sagitta this leads to error, in Rolling doesn't, but setting wrong values leads to silentlly ignoring failure with error available in logs only:

```
Jan 08 14:33:55 r1 isisd[3770]: libyang: Must condition ". >= ../refresh-interval + 300" not satisfied. (Data location "/frr-isisd:isis/instance[area-tag='VyOS'][vrf='default']/lsp/timers/level-1/maximum-lifetime".)
Jan 08 14:33:55 r1 isisd[3770]: libyang: Must condition ". >= ../refresh-interval + 300" not satisfied. (Data location "/frr-isisd:isis/instance[area-tag='VyOS'][vrf='default']/lsp/timers/level-2/maximum-lifetime".)
Jan 08 14:33:55 r1 isisd[3770]: [EC 100663340] nb_candidate_commit_prepare: failed to validate candidate configuration
```

For commands:
```
set protocols isis max-lsp-lifetime '50000'
set protocols isis lsp-refresh-interval '60000'
commit
```

After PR on commit try we get:

```
vyos@r1# set protocols isis max-lsp-lifetime '50000'
[edit]
vyos@r1# set protocols isis lsp-refresh-interval '60000'
[edit]
vyos@r1# commit
[ protocols isis ]
max-lsp-lifetime must be greater or equal to lsp-refresh-interval + 300
[[protocols isis]] failed
Commit failed
[edit]

```

FRR PR https://github.com/FRRouting/frr/pull/6166 fully describes pluses of `lsp-timers` command.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly