### PR TITLE
T8171: Make vyos-smoketest more user-friendly

### DIFF
--- a/smoketest/bin/vyos-smoketest
+++ b/smoketest/bin/vyos-smoketest
@@ -18,25 +18,40 @@ import os
 
 from sys import exit
 from stat import S_IXOTH
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, TimeoutExpired
 
-success = True
+timeout_minutes = 20 # 20 minutes per test should be enough?..
+timeout_seconds = timeout_minutes * 60
+tests = []
+
 for root, dirs, files in os.walk('/usr/libexec/vyos/tests/smoke'):
     for name in files:
         test_file = os.path.join(root, name)
         mode = os.stat(test_file).st_mode
 
         if name.startswith("test_") and mode & S_IXOTH:
-            print('Running Testcase: ' + test_file)
-            process = Popen([test_file], stdout=PIPE)
-            (output, err) = process.communicate()
-            exit_code = process.wait()
-            # We do not want an instant fail - other tests should be run, too
-            if exit_code != 0:
-                success = False
+            tests.append(test_file)
 
-if success:
+fails = []
+n = len(tests)
+for i, test_file in enumerate(tests):
+    print(f'Running Testcase ({i+1}/{n}): {test_file}')
+    process = Popen([test_file], stdout=PIPE)
+    try:
+        (output, err) = process.communicate(timeout=timeout_seconds)
+        exit_code = process.returncode
+    except TimeoutExpired:
+        print(f'TIMEOUT ({timeout_minutes} minutes) expired - consider test failed!')
+        exit_code = 1
+        process.kill()
+    # We do not want an instant fail - other tests should be run, too
+    if exit_code != 0:
+        fails.append(test_file)
+
+if not len(fails):
+    print(f'SUCCESS! All {n} tests passed.')
     exit(0)
 
-print("ERROR: One or more tests failed!")
+print(f'ERROR: {len(fails)}/{n} tests failed:')
+print('* ' + '\n* '.join(fails))
 exit(1)


### PR DESCRIPTION
## Make vyos-smoketest more user-friendly

* Output progress before each test
* On finish, output list of failed tests if there were any.
* Output "TIMEOUT" as result of test if it hanged


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): Improve testing script

## Related Task(s)

* https://vyos.dev/T8171

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

Run `make test-no-interfaces`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
