### PR TITLE
T8170: VPP fix IPFIX op-mode commands if VPP is not configured

### DIFF
--- a/src/op_mode/vpp.py
+++ b/src/op_mode/vpp.py
@@ -371,14 +371,17 @@ class VPPShow:
 # -----------------------------
 # VyOS IPFIX op-mode entries
 # -----------------------------
+@_verify('ipfix interface')
 def show_ipfix_interfaces(raw: bool):
     return VPPShow().ipfix_interfaces(raw)
 
 
+@_verify('ipfix collector')
 def show_ipfix_collectors(raw: bool):
     return VPPShow().ipfix_collectors(raw)
 
 
+@_verify('ipfix')
 def show_ipfix_table(raw: bool):
     return VPPShow().ipfix_table(raw)
 


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Fix the VPP op-mode commands traceback errror for the IPFIX feature if VPP is not configured
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T8170

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Without VPP configuration, try to check the op-mode for the IPFIX feature:
Before fix:
```
vyos@r14:~$ show vpp ipfix interfaces 
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/vpp.py", line 414, in <module>
    res = vyos.opmode.run(sys.modules[__name__])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/opmode.py", line 312, in run
    res = func(**args)
          ^^^^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/vpp.py", line 375, in show_ipfix_interfaces
    return VPPShow().ipfix_interfaces(raw)
           ^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/vpp.py", line 72, in __init__
    self.vpp = VPPControl()
               ^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/vpp/control_vpp.py", line 109, in __init__
    raise VPPIOError(2, 'Cannot connect to VPP API')
vpp_papi.vpp_papi.VPPIOError: [Errno 2] Cannot connect to VPP API
vyos@r14:~$ 

```

After the fix:
```
vyos@r14:~$ show vpp ipfix interfaces 
"vpp ipfix interface" is not configured
vyos@r14:~$ 
vyos@r14:~$ show vpp ipfix collectors 
"vpp ipfix collector" is not configured
vyos@r14:~$ 
vyos@r14:~$ show vpp ipfix table 
"vpp ipfix" is not configured
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
