### PR TITLE
vpp: T8125: Enable ip4-dhcp-client-detect feature if interface address is configured as DHCP

### DIFF
--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -114,6 +114,8 @@ plugins {
     # plugin wireguard_plugin.so { enable }
     # ACL
     plugin acl_plugin.so { enable }
+    # DHCP plugin
+    plugin dhcp_plugin.so { enable }
 }
 
 

--- a/python/vyos/vpp/control_vpp.py
+++ b/python/vyos/vpp/control_vpp.py
@@ -494,3 +494,34 @@ class VPPControl:
                 cp_sw_if_index=self.get_sw_if_index(vpp_pair_name),
                 is_add=is_add,
             )
+
+    @_Decorators.api_call
+    def enable_dhcp_client(self, ifname: str) -> None:
+        """Enable DHCP client detection on a given interface
+
+        Args:
+            ifname (str): name of an interface in kernel
+        """
+        iface_index = self.get_sw_if_index(ifname)
+        feature_is_enabled = self.__vpp_api_client.api.feature_is_enabled(
+            sw_if_index=iface_index,
+            feature_name='ip4-dhcp-client-detect',
+            arc_name='ip4-unicast',
+        )
+        if not feature_is_enabled.is_enabled:
+            self.__vpp_api_client.api.dhcp_client_detect_enable_disable(
+                sw_if_index=iface_index,
+                enable=True,
+            )
+
+    @_Decorators.api_call
+    def disable_dhcp_client(self, ifname: str) -> None:
+        """Disable DHCP client detection on a given interface
+
+        Args:
+            ifname (str): name of an interface in kernel
+        """
+        self.__vpp_api_client.api.dhcp_client_detect_enable_disable(
+            sw_if_index=self.get_sw_if_index(ifname),
+            enable=False,
+        )

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -139,6 +139,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
             'plugin default { disable }',
             'plugin dpdk_plugin.so { enable }',
             'plugin linux_cp_plugin.so { enable }',
+            'plugin dhcp_plugin.so { enable }',
             'dev 0000:00:00.0',
             'uio-bind-force',
         )
@@ -174,6 +175,14 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         # delete mtu settings
         self.cli_delete(['interfaces', 'ethernet', interface, 'mtu'])
         self.cli_commit()
+
+        # set interface address as dhcp
+        self.cli_set(['interfaces', 'ethernet', interface, 'address', 'dhcp'])
+        self.cli_commit()
+
+        # check 'ip4-dhcp-client-detect' feature is enabled on interface
+        _, out = rc_cmd(f'sudo vppctl show interface features {interface}')
+        self.assertIn(f'ip4-dhcp-client-detect', out)
 
     def test_02_vpp_vxlan(self):
         vni = '23'

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -447,17 +447,27 @@ def apply(ethernet):
     if 'static_arp' in ethernet:
         call_dependents()
 
-    # If the interface is managed by the VPP DPDK driver, synchronize runtime
-    # parameters between Linux and the corresponding VPP LCP interface
-    if dict_search(f'vpp.settings.interface.{ifname}.driver', ethernet) == 'dpdk':
+    vpp_iface_config = dict_search(f'vpp.settings.interface.{ifname}', ethernet)
+    if vpp_iface_config and is_systemd_service_running('vpp.service'):
         vpp_api = VPPControl()
-        # Find LCP pair
-        lcp_pair = vpp_api.lcp_pair_find(vpp_name_hw=ifname)
-        lcp_name = lcp_pair.get('vpp_name_kernel')
-        # Sync MTU to VPP LCP pair interface
-        if lcp_name:
-            mtu = e.get_mtu()
-            vpp_api.set_iface_mtu(lcp_name, mtu)
+
+        # Enable ip4-dhcp-client-detect feature for DHCP-configured interfaces.
+        # This feature is required for VPP to process DHCP packets and assign addresses.
+        if 'dhcp' in ethernet.get('address', []):
+            vpp_api.enable_dhcp_client(ifname)
+        else:
+            vpp_api.disable_dhcp_client(ifname)
+
+        # If the interface is managed by the VPP DPDK driver, synchronize runtime
+        # parameters between Linux and the corresponding VPP LCP interface
+        if vpp_iface_config.get('driver') == 'dpdk':
+            # Find LCP pair
+            lcp_pair = vpp_api.lcp_pair_find(vpp_name_hw=ifname)
+            lcp_name = lcp_pair.get('vpp_name_kernel')
+            # Sync MTU to VPP LCP pair interface
+            if lcp_name:
+                mtu = e.get_mtu()
+                vpp_api.set_iface_mtu(lcp_name, mtu)
 
     return None
 


### PR DESCRIPTION
DHCP address cannot be assigned on VPP interfaces without enabling the 'ip4-dhcp-client-detect' feature

NOTE: When switching from DPDK to XDP (for vmxnet3), the 'ip4-dhcp-client-detect' feature does not work and the DHCP address is not assigned on the interface. Configuring XDP initially works correctly.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8125
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set interfaces ethernet eth1 address 'dhcp'
set vpp settings interface eth1 driver 'dpdk'
```
Before the fix
```
vyos@vyos# run show interfaces
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address          MAC                VRF        MTU  S/L    Description
-----------  ------------------  -----------------  -------  -----  -----  -------------
eth0         -                   0c:58:8e:4c:00:00  default   1500  u/D
eth1         -                   0c:58:8e:4c:00:01  default   1500  u/u
eth2         10.20.40.141/24     0c:58:8e:4c:00:02  default   1500  u/u
eth3         10.217.32.131/24    0c:58:8e:4c:00:03  default   1500  u/u
lo           127.0.0.1/8         00:00:00:00:00:00  default  65536  u/u
             ::1/128
[edit]
vyos@vyos# sudo vppctl show interface address
eth1 (up):
local0 (dn):
tap4096 (up):
[edit]
```
After the fix address is assigned
```
vyos@vyos# run show interfaces
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address          MAC                VRF        MTU  S/L    Description
-----------  ------------------  -----------------  -------  -----  -----  -------------
eth0         -                   0c:58:8e:4c:00:00  default   1500  u/D
eth1         192.168.111.100/24  0c:58:8e:4c:00:01  default   1500  u/u
eth2         10.20.40.141/24     0c:58:8e:4c:00:02  default   1500  u/u
eth3         10.217.32.131/24    0c:58:8e:4c:00:03  default   1500  u/u
lo           127.0.0.1/8         00:00:00:00:00:00  default  65536  u/u
             ::1/128
vyos@vyos# sudo vppctl show interface address
eth1 (up):
  L3 192.168.111.100/24
local0 (dn):
tap4096 (up):
```

```
vyos@vyos# /usr/libexec/vyos/tests/smoke/cli/test_vpp.py -k test_01_vpp_basic
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok

----------------------------------------------------------------------
Ran 1 test in 118.370s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
