### PR TITLE
pppoe-server: T8143: Set 'vpp-cp' option automatically if interface is in VPP

### DIFF
--- a/interface-definitions/include/version/pppoe-server-version.xml.i
+++ b/interface-definitions/include/version/pppoe-server-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/pppoe-server-version.xml.i -->
-<syntaxVersion component='pppoe-server' version='11'></syntaxVersion>
+<syntaxVersion component='pppoe-server' version='12'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/service_pppoe-server.xml.in
+++ b/interface-definitions/service_pppoe-server.xml.in
@@ -71,12 +71,6 @@
               </leafNode>
               #include <include/accel-ppp/vlan.xml.i>
               #include <include/accel-ppp/vlan-mon.xml.i>
-              <leafNode name="vpp-cp">
-                <properties>
-                  <help>Enable PPPoE control-plane integration with VPP</help>
-                  <valueless/>
-                </properties>
-              </leafNode>
             </children>
           </tagNode>
           <leafNode name="service-name">

--- a/smoketest/scripts/cli/test_service_pppoe-server.py
+++ b/smoketest/scripts/cli/test_service_pppoe-server.py
@@ -213,19 +213,6 @@ class TestServicePPPoEServer(BasicAccelPPPTest.TestCase):
         self.assertIn('accept-any-service=1', config)
         self.assertIn('accept-blank-service=1', config)
 
-    def test_accel_vpp_cp(self):
-        self.basic_config()
-        self.cli_commit()
-
-        self.set(['interface', interface, 'vpp-cp'])
-
-        # vpp-cp require VPP service to be started and interface is configured in VPP
-        with self.assertRaises(ConfigSessionError):
-            self.cli_commit()
-
-        # All other checks for PPPoE control-plane integration
-        # with VPP are verified in test_vpp.py
-
 
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -1562,9 +1562,8 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.cli_set(pppoe_base + ['client-ip-pool', pool, 'range', '192.0.2.0/24'])
         self.cli_set(pppoe_base + ['default-pool', pool])
 
-        # Enable PPPoE control-plane integration with VPP
-        self.cli_set(pppoe_base + ['interface', interface, 'vpp-cp'])
-        self.cli_set(pppoe_base + ['interface', f'{interface}.{vni}', 'vpp-cp'])
+        self.cli_set(pppoe_base + ['interface', interface])
+        self.cli_set(pppoe_base + ['interface', f'{interface}.{vni}'])
 
         self.cli_commit()
 
@@ -1572,6 +1571,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         config = read_file(config_file)
 
         # Validate configuration
+        # PPPoE on VPP-managed interfaces automatically get control-plane integration
         self.assertIn(f'interface={interface},vpp-cp=true', config)
         self.assertIn(f'interface={interface}.{vni},vpp-cp=true', config)
 

--- a/src/migration-scripts/pppoe-server/11-to-12
+++ b/src/migration-scripts/pppoe-server/11-to-12
@@ -1,0 +1,31 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# Delete 'vpp-cp' option from interface settings
+# because it will be set automatically (T8143)
+
+from vyos.configtree import ConfigTree
+
+base = ['service', 'pppoe-server']
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(base):
+        return
+
+    for interface in config.list_nodes(base + ['interface']):
+        base_path = base + ['interface', interface]
+        # Delete vpp-cp option from PPPoE interface settings
+        if config.exists(base_path + ['vpp-cp']):
+            config.delete(base_path + ['vpp-cp'])


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8143
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set service pppoe-server authentication mode 'noauth'
set service pppoe-server client-ip-pool first range '100.64.0.1-100.64.0.100'
set service pppoe-server default-pool 'first'
set service pppoe-server description 'test1'
set service pppoe-server gateway-address '100.64.0.1'
set service pppoe-server interface eth1
set vpp settings interface eth1 driver 'dpdk'
commit

vyos@vyos# cat /run/accel-pppd/pppoe.conf | grep interface
interface=eth1,vpp-cp=true
[edit]
vyos@vyos# sudo vppctl show pppoe control-plane binding
Dataplane Interface Control Interface
------------------- -----------------
eth1                tap4096
[edit]
```

```
vyos@vyos# /usr/libexec/vyos/tests/smoke/cli/test_vpp.py -k test_19_vpp_pppoe_mapping
test_19_vpp_pppoe_mapping (__main__.TestVPP.test_19_vpp_pppoe_mapping) ... ok

----------------------------------------------------------------------
Ran 1 test in 38.020s

OK
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
