### PR TITLE
T8187: fix watchdog timeout validation if kernel min/max timeout are zero

### DIFF
--- a/src/conf_mode/system_watchdog.py
+++ b/src/conf_mode/system_watchdog.py
@@ -63,7 +63,7 @@ def _read_sysfs_int(path: Path) -> Optional[int]:
 def _get_watchdog_timeout_limits() -> tuple[int, int]:
     """Return (min_timeout, max_timeout) from sysfs if available.
 
-    If sysfs is unavailable (device not present/loaded yet), fall back to a
+    If sysfs is unavailable (device not present/loaded yet) or zero, fall back to a
     conservative common kernel max of 65535 seconds.
     """
 
@@ -74,10 +74,8 @@ def _get_watchdog_timeout_limits() -> tuple[int, int]:
     max_timeout = _read_sysfs_int(WATCHDOG_SYSFS / 'max_timeout')
 
     # Some drivers may not expose min/max. Fall back to sane defaults.
-    if min_timeout is None:
-        min_timeout = 1
-    if max_timeout is None:
-        max_timeout = 65535
+    min_timeout = min_timeout if min_timeout and min_timeout > 0 else 1
+    max_timeout = max_timeout if max_timeout and max_timeout > 0 else 65535
 
     return min_timeout, max_timeout
 


### PR DESCRIPTION
## Change summary
Fix vyos watchdog validation if kernel is reporting zero value for min or max timeout.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T8187

## Related PR(s)
N/A

## How to test / Smoketest result
```
# Confirm watchdog is available:
$ wdctl
> Device:        /dev/watchdog0
> Identity:      iTCO_wdt [version 0]
> Timeout:       30 seconds
> Timeleft:       2 seconds

# Check kernel reported timeout
grep '' /sys/class/watchdog/watchdog0/*_timeout
> /sys/class/watchdog/watchdog0/max_timeout:0
> /sys/class/watchdog/watchdog0/min_timeout:0

# Setup watchdog in VyOS:
set system watchdog
confirm
> [ system watchdog ]
> 'timeout' must be <= 0 seconds (driver maximum)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
