### PR TITLE
vpp: T8183: Incorrect mapping in IPFIX for bond interfaces

### DIFF
--- a/data/config-mode-dependencies/vyos-vpp.json
+++ b/data/config-mode-dependencies/vyos-vpp.json
@@ -23,6 +23,7 @@
         "vpp_acl": ["vpp_acl"],
         "vpp_nat": ["vpp_nat"],
         "vpp_nat_cgnat": ["vpp_nat_cgnat"],
+        "vpp_ipfix": ["vpp_ipfix"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
     },
     "vpp_interfaces_ethernet": {

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -349,7 +349,7 @@
       <node name="ipfix" owner="${vyos_conf_scripts_dir}/vpp_ipfix.py">
         <properties>
           <help>IP Flow Information Export (IPFIX) configuration</help>
-          <priority>322</priority>
+          <priority>332</priority>
         </properties>
         <children>
           <tagNode name="collector">

--- a/src/conf_mode/vpp_interfaces_bonding.py
+++ b/src/conf_mode/vpp_interfaces_bonding.py
@@ -153,6 +153,10 @@ def get_config(config=None) -> dict:
     if conf.exists(['vpp', 'acl']):
         set_dependents('vpp_acl', conf)
 
+    # IPFIX dependency
+    if conf.exists(['vpp', 'ipfix']):
+        set_dependents('vpp_ipfix', conf)
+
     config['ifname'] = ifname
 
     return config

--- a/src/conf_mode/vpp_ipfix.py
+++ b/src/conf_mode/vpp_ipfix.py
@@ -19,6 +19,7 @@ from vyos import ConfigError
 from vyos.config import Config
 from vyos.vpp.ipfix import IPFIX
 from vyos.vpp.utils import cli_ifaces_list
+from vyos.vpp.utils import vpp_iface_name_transform
 
 
 def get_config(config=None) -> dict:
@@ -116,6 +117,7 @@ def apply(config):
 
     # Remove interfaces
     for iface, iface_conf in config.get('effective', {}).get('interface', {}).items():
+        iface = vpp_iface_name_transform(iface)
         direction = iface_conf.get('direction')
         which = iface_conf.get('flow_variant')
         i.flowprobe_interface_delete(iface, direction=direction, which=which)
@@ -158,6 +160,7 @@ def apply(config):
     # Interfaces
     if 'interface' in config:
         for iface, iface_config in config.get('interface', {}).items():
+            iface = vpp_iface_name_transform(iface)
             direction = iface_config.get('direction')
             which = iface_config.get('flow_variant')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8143
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set vpp settings interface eth0 driver dpdk
set vpp settings interface eth1 driver dpdk

set vpp interfaces bonding bond1 kernel-interface vpptun0
set vpp interfaces bonding bond1 member interface eth0
set vpp interfaces bonding bond1 member interface eth1

set vpp ipfix collector 127.0.0.2 source-address 127.0.0.1
set vpp ipfix interface bond1 
commit

vyos@vyos# run show vpp ipfix interfaces
Interface        VppIfIndex  Flow-variant    Direction
-------------  ------------  --------------  -----------
BondEthernet1             5  ip4             both
[edit]
```

```
vyos@vyos# /usr/libexec/vyos/tests/smoke/cli/test_vpp.py -k test_22_2_vpp_ipfix_bond
test_22_2_vpp_ipfix_bond (__main__.TestVPP.test_22_2_vpp_ipfix_bond) ... ok

----------------------------------------------------------------------
Ran 1 test in 39.888s

OK
[edit]
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
