### PR TITLE
op-mode: T8154: fix tcpdump KeyboardInterrupt on Ctrl+C

### DIFF
--- a/python/vyos/utils/io.py
+++ b/python/vyos/utils/io.py
@@ -111,3 +111,14 @@ def select_entry(l: list, list_msg: str = '', prompt_msg: str = '',
     select = ask_input(prompt_msg, default=default_entry, numeric_only=True,
                        valid_responses=valid_entry)
     return next(filter(lambda x: x[0] == select, en))[1]
+
+def catch_broken_pipe(func):
+    import os
+    import sys
+    def wrapped(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except (BrokenPipeError, KeyboardInterrupt):
+            # Flush output to /dev/null and bail out.
+            os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno()) # pylint: disable = no-member
+    return wrapped

--- a/src/op_mode/interfaces.py
+++ b/src/op_mode/interfaces.py
@@ -13,9 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-#
 
-import os
 import re
 import sys
 import glob
@@ -30,21 +28,13 @@ from vyos.ifconfig import Section
 from vyos.ifconfig import Interface
 from vyos.ifconfig import VRRP
 from vyos.utils.dict import dict_set_nested
+from vyos.utils.io import catch_broken_pipe
 from vyos.utils.network import get_interface_vrf
 from vyos.utils.network import interface_exists
 from vyos.utils.process import cmd
 from vyos.utils.process import rc_cmd
 from vyos.utils.process import call
 from vyos.configquery import op_mode_config_dict
-
-def catch_broken_pipe(func):
-    def wrapped(*args, **kwargs):
-        try:
-            func(*args, **kwargs)
-        except (BrokenPipeError, KeyboardInterrupt):
-            # Flush output to /dev/null and bail out.
-            os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno()) # pylint: disable = no-member
-    return wrapped
 
 # The original implementation of filtered_interfaces has signature:
 # (ifnames: list, iftypes: typing.Union[str, list], vif: bool, vrrp: bool) -> intf: Interface:

--- a/src/op_mode/tcpdump.py
+++ b/src/op_mode/tcpdump.py
@@ -16,6 +16,7 @@
 
 import sys
 
+from vyos.utils.io import catch_broken_pipe
 from vyos.utils.process import call
 
 options = {
@@ -50,8 +51,6 @@ options = {
         'help': 'Parse packets with increased detail output, including link-level headers and extended decoding protocol sanity checks.'
     },
 }
-
-tcpdump = 'sudo /usr/bin/tcpdump'
 
 class List(list):
     def first(self):
@@ -92,7 +91,8 @@ def complete(prefix):
     return [o for o in options if o.startswith(prefix)]
 
 
-def convert(command, args):
+def convert(args):
+    command = 'sudo /usr/bin/tcpdump'
     while args:
         shortname = args.first()
         longnames = complete(shortname)
@@ -109,6 +109,9 @@ def convert(command, args):
                 command=command, value=args.first())
     return command
 
+@catch_broken_pipe
+def run_tcpdump(command: str, ifname: str) -> None:
+    call(f'{command} -i {ifname}')
 
 if __name__ == '__main__':
     args = List(sys.argv[1:])
@@ -161,5 +164,4 @@ if __name__ == '__main__':
                 sys.stdout.write(helplines)
                 sys.exit(0)
 
-    command = convert(tcpdump, args)
-    call(f'{command} -i {ifname}')
+    run_tcpdump(convert(args), ifname)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

MIgrate the already available `catch_broken_pipe` decorator to `vyos.utils.io` so we can make use of it also in the tcpdump op-mode command.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8154

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-1x/pull/4924

## How to test / Smoketest result
```
vyos@vyos:~$ monitor traffic interface eth0.10 numeric filter 'port 53' | match '1.1.1.1'
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on eth0.10, link-type EN10MB (Ethernet), snapshot length 262144 bytes
^C0 packets captured
0 packets received by filter
0 packets dropped by kernel
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
