### PR TITLE
http-api: T7090: Implement background configure operations for REST API

### DIFF
--- a/src/helpers/vyos_config_sync.py
+++ b/src/helpers/vyos_config_sync.py
@@ -40,9 +40,12 @@ logger.name = os.path.basename(__file__)
 API_HEADERS = {'Content-Type': 'application/json'}
 
 
-def post_request(url: str,
-                 data: str,
-                 headers: Dict[str, str]) -> requests.Response:
+def post_request(
+    url: str,
+    data: str,
+    params: Dict[str, Any],
+    headers: Dict[str, str],
+) -> requests.Response:
     """Sends a POST request to the specified URL
 
     Args:
@@ -54,11 +57,14 @@ def post_request(url: str,
         requests.Response: The response object representing the server's response to the request
     """
 
-    response = requests.post(url,
-                             data=data,
-                             headers=headers,
-                             verify=False,
-                             timeout=timeout)
+    response = requests.post(
+        url,
+        data=data,
+        params=params,
+        headers=headers,
+        verify=False,
+        timeout=timeout,
+    )
     return response
 
 
@@ -116,6 +122,10 @@ def set_remote_config(
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     url = f'https://{address}:{port}/configure-section'
+    params = {
+        # Ask the remote API to perform the configure and commit workflow asynchronously
+        'in_background': True,
+    }
     data = json.dumps({
         'op': op,
         'mask': mask,
@@ -124,7 +134,7 @@ def set_remote_config(
     })
 
     try:
-        config = post_request(url, data, headers)
+        config = post_request(url, data, params, headers)
         return config.json()
     except requests.exceptions.RequestException as e:
         print(f"An error occurred: {e}")

--- a/src/services/api/background.py
+++ b/src/services/api/background.py
@@ -1,0 +1,179 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+import time
+import functools
+from collections import deque
+from enum import Enum
+from threading import Lock
+from typing import Any
+from typing import Callable
+from typing import Optional
+from uuid import uuid4
+
+from fastapi import BackgroundTasks
+from pydantic import BaseModel
+from pydantic import StrictStr
+from pydantic import StrictInt
+
+
+def _ts():
+    """Return current Unix timestamp (seconds since epoch)"""
+    return int(time.time())
+
+
+class BackgroundOpStatus(str, Enum):
+    queued = 'queued'
+    running = 'running'
+    succeeded = 'succeeded'
+    failed = 'failed'
+
+    @property
+    def is_completed(self):
+        """True if the operation is in a terminal state (succeeded/failed)"""
+        return self in (BackgroundOpStatus.succeeded, BackgroundOpStatus.failed)
+
+
+class BackgroundOpRecord(BaseModel):
+    """Metadata and outcome for a single background operation"""
+
+    op_id: StrictStr
+    created_at: StrictInt
+    started_at: Optional[StrictInt] = None
+    finished_at: Optional[StrictInt] = None
+    status: BackgroundOpStatus = BackgroundOpStatus.queued
+    result: Optional[Any] = None
+    error: Optional[StrictStr] = None
+
+
+class BackgroundOpError(Exception):
+    """Raised when a background operation cannot be enqueued/executed"""
+
+    pass
+
+
+class BackgroundOpManager:
+    """
+    In-memory FIFO operation queue.
+
+    Uses BackgroundTasks to schedule a `drain()` call after the response,
+    so `enqueue()` is fast and non-blocking for the client.
+    """
+
+    DEFAULT_MAX_QUEUE_SIZE = 128
+
+    def __init__(self, max_queue_size: int = DEFAULT_MAX_QUEUE_SIZE):
+        # max number of queued (pending) operations allowed at a time
+        self._max_queue_size = max_queue_size
+
+        # FIFO queue of operation IDs waiting to be executed
+        self._queue = deque()
+        self._jobs = {}
+        self._workers = {}
+
+        # protects _queue/_jobs/_workers/_drain_scheduled from concurrent access
+        self._mx = Lock()
+
+        # whether a drain task has already been scheduled via BackgroundTasks
+        self._drain_scheduled = False
+
+    def enqueue(
+        self,
+        background_tasks: BackgroundTasks,
+        func: Callable,
+        *args,
+        **kwargs,
+    ) -> BackgroundOpRecord:
+        """Enqueue a function for background execution and return its record"""
+
+        assert isinstance(background_tasks, BackgroundTasks)
+        assert callable(func), '`func` argument should be function or lambda'
+
+        with self._mx:
+            if len(self._queue) >= self._max_queue_size:
+                raise BackgroundOpError(
+                    f'Background operation queue is full ({self._max_queue_size})'
+                )
+
+            op_id = str(uuid4())
+            record = BackgroundOpRecord(op_id=op_id, created_at=_ts())
+
+            self._jobs[op_id] = record
+            # store the callable for later execution (outside the lock)
+            self._workers[op_id] = functools.partial(func, *args, **kwargs)
+            self._queue.append(op_id)
+
+            if not self._drain_scheduled:
+                # schedule a single drain() call after the current response
+                background_tasks.add_task(self.drain)
+                self._drain_scheduled = True
+
+            # Best-effort pruning: keep history bounded by dropping oldest completed records
+            if len(self._jobs) > self._max_queue_size:
+                oldest = min(self._jobs.values(), key=lambda record: record.created_at)
+                if oldest.status.is_completed:
+                    del self._jobs[oldest.op_id]
+
+        return record
+
+    def drain(self):
+        """Run queued operations sequentially until the queue is empty"""
+
+        while True:
+            with self._mx:
+                if not self._queue:
+                    # allow future enqueue() calls to schedule the next drain()
+                    self._drain_scheduled = False
+                    return
+
+                op_id = self._queue.popleft()
+                record = self._jobs[op_id]
+                func = self._workers.pop(op_id)
+
+                record.status = BackgroundOpStatus.running
+                record.started_at = _ts()
+
+            # execute outside the lock to avoid blocking enqueues/status reads
+            result = error = status = None
+            try:
+                result = func()
+            except Exception as e:  # noqa: BLE001
+                status = BackgroundOpStatus.failed
+                error = str(e)
+            else:
+                status = BackgroundOpStatus.succeeded
+
+            with self._mx:
+                record.result = result
+                record.error = error
+                record.status = status
+                record.finished_at = _ts()
+
+    def get_record(self, op_id: str) -> BackgroundOpRecord | None:
+        """Return a deep copy of a single record"""
+
+        with self._mx:
+            record = self._jobs.get(op_id)
+            return record.copy(deep=True) if record else None
+
+    def get_records(self) -> list:
+        """Return deep copies of all records, sorted oldest-first by created_at"""
+
+        with self._mx:
+            records = [record.copy(deep=True) for record in self._jobs.values()]
+
+        # stable-ish ordering (oldest first)
+        records.sort(key=lambda record: record.created_at)
+        return records


### PR DESCRIPTION
## Change summary
Large config commits (`service config-sync`) can block the REST API request path and sometimes must be deferred (e.g., when changing `service https`).

This commit introduces an in-memory background operation manager that queues (FIFO) full configure operations (commands + commit/commit-confirm) as single jobs, tracks status/result, and exposes active operations via `/retrieve/background-operations`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7090

## How to test / Smoketest result
### Manual test

1. Configure two routers and sync of `firewall` section:
```
# Router 1
set service config-sync mode 'load'
set service config-sync secondary address '172.168.99.3'
set service config-sync secondary key 'NOT_SECRET_KEY'
set service config-sync secondary port '443'
set service config-sync section firewall

# Router 2
set service https api rest
set service https api keys id KEY key 'NOT_SECRET_KEY'
set service https listen-address '0.0.0.0'
```

2. Using `add_fw_config_primary.sh` script from [this task](https://vyos.dev/T7090) generate firewall rules:
```
vyos@1e1e72e3b3d7# ./add_fw_config_primary.sh
How many lines do you want to add to the config? \nEnter a number between 10 and 20000:  10
Valid input: 10
Adding firewall rules from: 2 to 4
 Starting with set commands at
Fri Jan 23 14:13:54 UTC 2026
Do you want to commit the changes? (yes/no): yes
Starting commit at
Fri Jan 23 14:13:57 UTC 2026
INFO:vyos_config_sync:Config synchronization: Mode=load, Secondary=172.168.99.3
Commit completed at
Fri Jan 23 14:14:00 UTC 2026
[edit]
```

4. Verify that firewall rules applied on **the second** router:
```
vyos@e89322c6a5c6# run sh conf comm | match firewall
set firewall ipv4 name client_to_dmz rule 2 action 'accept'
set firewall ipv4 name client_to_dmz rule 2 destination port '82'
set firewall ipv4 name client_to_dmz rule 2 protocol 'tcp'
set firewall ipv4 name client_to_dmz rule 3 action 'accept'
set firewall ipv4 name client_to_dmz rule 3 destination port '83'
set firewall ipv4 name client_to_dmz rule 3 protocol 'tcp'
set firewall ipv4 name client_to_dmz rule 4 action 'accept'
set firewall ipv4 name client_to_dmz rule 4 destination port '84'
set firewall ipv4 name client_to_dmz rule 4 protocol 'tcp'
```

5. Get list of background operations by REST API:
```
vyos@1e1e72e3b3d7:~$ curl -k -X 'POST' \
  'https://172.168.99.3:443/retrieve/background-operations' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "key": "NOT_SECRET_KEY"
}' | jq .

{"success": true, "data": {"operations": [
  {
    "op_id": "2b1773ba-aa35-4c54-af09-e98c923e2571",
    "created_at": 1769156996,
    "started_at": 1769157004,
    "finished_at": 1769157007,
    "status": "succeeded",
    "result": "",
    "error": null
  }
]}, "error": null}
```

### Smoketest 
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_https.py
...
test_api_configure_background (__main__.TestHTTPSService.test_api_configure_background) ... ok
test_api_configure_background_ops_over_max (__main__.TestHTTPSService.test_api_configure_background_ops_over_max) ... ok
test_api_configure_section_background (__main__.TestHTTPSService.test_api_configure_section_background) ... ok
...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly