### PR TITLE
vpp: T8202: Remove XDP driver and options from CLI and config

### DIFF
--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -84,7 +84,6 @@ physmem {
 
 plugins {
     plugin default { disable }
-    plugin af_xdp_plugin.so { enable }
     plugin avf_plugin.so { enable }
     plugin dpdk_plugin.so { enable }
     plugin vmxnet3_plugin.so { enable }

--- a/interface-definitions/include/version/vpp-version.xml.i
+++ b/interface-definitions/include/version/vpp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/vpp-version.xml.i -->
-<syntaxVersion component='vpp' version='4'></syntaxVersion>
+<syntaxVersion component='vpp' version='5'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -649,25 +649,6 @@
               <constraintErrorMessage>Invalid interface name</constraintErrorMessage>
             </properties>
             <children>
-              <leafNode name="driver">
-                <properties>
-                  <help>Driver mode</help>
-                  <completionHelp>
-                    <list>dpdk xdp</list>
-                  </completionHelp>
-                  <valueHelp>
-                    <format>dpdk</format>
-                    <description>Data Plane Development Kit (DPDK)</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>xdp</format>
-                    <description>eXpress Data Path (XDP)</description>
-                  </valueHelp>
-                  <constraint>
-                    <regex>(dpdk|xdp)</regex>
-                  </constraint>
-                </properties>
-              </leafNode>
               #include <include/vpp/iface_rx_mode.xml.i>
               <node name="dpdk-options">
                 <properties>
@@ -727,57 +708,6 @@
                   <leafNode name="promisc">
                     <properties>
                       <help>Enable promisc mode on a vpp interface</help>
-                      <valueless/>
-                    </properties>
-                  </leafNode>
-                </children>
-              </node>
-              <node name="xdp-options">
-                <properties>
-                  <help>XDP settings</help>
-                </properties>
-                <children>
-                  <leafNode name="num-rx-queues">
-                    <properties>
-                      <help>Number of receive queues</help>
-                      <valueHelp>
-                        <format>u32:1-65535</format>
-                        <description>Number of receive queues to connect to</description>
-                      </valueHelp>
-                      <valueHelp>
-                        <format>all</format>
-                        <description>All</description>
-                      </valueHelp>
-                      <constraint>
-                        <regex>(all)</regex>
-                        <validator name="numeric" argument="--range 1-65535"/>
-                      </constraint>
-                    </properties>
-                    <defaultValue>all</defaultValue>
-                  </leafNode>
-                  <leafNode name="promisc">
-                    <properties>
-                      <help>Enable promisc mode on a real interface</help>
-                      <valueless/>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="rx-queue-size">
-                    <properties>
-                      <help>Receive queue size</help>
-                      #include <include/vpp/queue_size.xml.i>
-                    </properties>
-                    <defaultValue>0</defaultValue>
-                  </leafNode>
-                  <leafNode name="tx-queue-size">
-                    <properties>
-                      <help>Tranceive queue size</help>
-                      #include <include/vpp/queue_size.xml.i>
-                    </properties>
-                    <defaultValue>0</defaultValue>
-                  </leafNode>
-                  <leafNode name="zero-copy">
-                    <properties>
-                      <help>Enable zero-copy mode</help>
                       <valueless/>
                     </properties>
                   </leafNode>

--- a/python/vyos/vpp/config_verify.py
+++ b/python/vyos/vpp/config_verify.py
@@ -169,9 +169,14 @@ def verify_dev_driver(driver_type: str, driver: str) -> bool:
     if driver_type == 'dpdk':
         if driver in drivers_dpdk:
             return True
-    elif driver_type == 'xdp':
-        if driver in drivers_xdp:
-            return True
+    # XDP support is intentionally disabled (T8202).
+    # XDP is no longer configurable via the CLI.
+    # This logic is kept commented out to make it easy
+    # to reintroduce XDP if there is a clear need in the future.
+    #
+    # elif driver_type == 'xdp':
+    #     if driver in drivers_xdp:
+    #         return True
     else:
         raise ConfigError(f'"Driver type {driver_type} is wrong')
 

--- a/smoketest/configs/assert/vpp
+++ b/smoketest/configs/assert/vpp
@@ -42,8 +42,8 @@ set vpp interfaces loopback lo12 description 'Loop12'
 set vpp interfaces vxlan vxlan10 remote '192.0.2.2'
 set vpp interfaces vxlan vxlan10 source-address '192.0.2.1'
 set vpp interfaces vxlan vxlan10 vni '10'
-set vpp settings interface eth1 driver 'dpdk'
-set vpp settings interface eth2 driver 'dpdk'
-set vpp settings interface eth3 driver 'xdp'
-set vpp settings interface eth4 driver 'dpdk'
+set vpp settings interface eth1
+set vpp settings interface eth2
+set vpp settings interface eth3
+set vpp settings interface eth4
 set vpp settings unix poll-sleep-usec '12'

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -37,7 +37,6 @@ from vyos.vpp.utils import vpp_iface_name_transform
 PROCESS_NAME = 'vpp_main'
 VPP_CONF = '/run/vpp/vpp.conf'
 base_path = ['vpp']
-driver = 'dpdk'
 interface = 'eth1'
 
 
@@ -95,7 +94,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         # always forward to base class
         super().setUp()
 
-        self.cli_set(base_path + ['settings', 'interface', interface, 'driver', driver])
+        self.cli_set(base_path + ['settings', 'interface', interface])
         self.cli_set(base_path + ['settings', 'unix', 'poll-sleep-usec', '10'])
 
     def tearDown(self):
@@ -1128,15 +1127,16 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['settings', 'cpu', 'main-core', main_core])
         self.cli_set(base_path + ['settings', 'cpu', 'workers', workers])
 
-        # DPDK driver expect only dpdk-options and not xdp-options to be set
-        # expect raise ConfigError
-        self.cli_set(base_interface_path + ['xdp-options', 'zero-copy'])
+        # # DPDK driver expect only dpdk-options and not xdp-options to be set
+        # # expect raise ConfigError
+        # self.cli_set(base_interface_path + ['xdp-options', 'zero-copy'])
+        #
+        # with self.assertRaises(ConfigSessionError):
+        #     self.cli_commit()
+        #
+        # # delete xdp-options and apply commit
+        # self.cli_delete(base_interface_path + ['xdp-options'])
 
-        with self.assertRaises(ConfigSessionError):
-            self.cli_commit()
-
-        # delete xdp-options and apply commit
-        self.cli_delete(base_interface_path + ['xdp-options'])
         self.cli_commit()
 
         # check dpdk options in config file
@@ -1296,7 +1296,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         inside_prefix = '100.64.0.0/24'
         outside_prefix = '192.0.2.1/32'
 
-        self.cli_set(base_path + ['settings', 'interface', iface_out, 'driver', driver])
+        self.cli_set(base_path + ['settings', 'interface', iface_out])
         self.cli_set(base_cgnat + ['interface', 'inside', iface_inside])
         self.cli_set(base_cgnat + ['interface', 'outside', iface_out])
         self.cli_set(base_cgnat + ['rule', '100', 'inside-prefix', inside_prefix])
@@ -1384,7 +1384,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         static_local_addr = '100.64.0.55'
         sess_limit = '64000'
 
-        self.cli_set(base_path + ['settings', 'interface', iface_out, 'driver', driver])
+        self.cli_set(base_path + ['settings', 'interface', iface_out])
         self.cli_set(base_nat + ['interface', 'inside', iface_inside])
         self.cli_set(base_nat + ['interface', 'outside', iface_out])
         self.cli_set(
@@ -1501,7 +1501,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         for expected_entry in expected_entries:
             self.assertIn(expected_entry, out)
 
-        self.cli_set(base_path + ['settings', 'interface', iface_2, 'driver', driver])
+        self.cli_set(base_path + ['settings', 'interface', iface_2])
         self.cli_set(base_path + ['sflow', 'interface', iface_2])
 
         self.cli_commit()

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -448,7 +448,7 @@ def apply(ethernet):
         call_dependents()
 
     vpp_iface_config = dict_search(f'vpp.settings.interface.{ifname}', ethernet)
-    if vpp_iface_config and is_systemd_service_running('vpp.service'):
+    if vpp_iface_config is not None and is_systemd_service_running('vpp.service'):
         vpp_api = VPPControl()
 
         # Enable ip4-dhcp-client-detect feature for DHCP-configured interfaces.
@@ -460,14 +460,13 @@ def apply(ethernet):
 
         # If the interface is managed by the VPP DPDK driver, synchronize runtime
         # parameters between Linux and the corresponding VPP LCP interface
-        if vpp_iface_config.get('driver') == 'dpdk':
-            # Find LCP pair
-            lcp_pair = vpp_api.lcp_pair_find(vpp_name_hw=ifname)
+        # Find LCP pair
+        lcp_pair = vpp_api.lcp_pair_find(vpp_name_hw=ifname)
+        # Sync MTU to VPP LCP pair interface
+        if lcp_pair:
             lcp_name = lcp_pair.get('vpp_name_kernel')
-            # Sync MTU to VPP LCP pair interface
-            if lcp_name:
-                mtu = e.get_mtu()
-                vpp_api.set_iface_mtu(lcp_name, mtu)
+            mtu = e.get_mtu()
+            vpp_api.set_iface_mtu(lcp_name, mtu)
 
     return None
 

--- a/src/migration-scripts/vpp/4-to-5
+++ b/src/migration-scripts/vpp/4-to-5
@@ -1,0 +1,35 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# Delete node 'driver' and 'xdp-options' from CLI (T8202)
+
+
+from vyos.configtree import ConfigTree
+
+base = ['vpp', 'settings', 'interface']
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(base):
+        # Nothing to do
+        return
+
+    for iface_name in config.list_nodes(base):
+        base_driver = base + [iface_name, 'driver']
+        base_xdp_options = base + [iface_name, 'xdp-options']
+        if config.exists(base_driver):
+            # Delete 'driver' node
+            config.delete(base_driver)
+        if config.exists(base_xdp_options):
+            config.delete(base_xdp_options)


### PR DESCRIPTION
- Driver node is removed from the CLI (dpdk now is the only one driver and it is set automatically)
- Migration script removes 'driver' and 'xdp-options' nodes.
- XDP logic is commented out in config verification and CLI tests, preserving code for future use.
- The rest of XDP-related code remains untouched

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): remove xdp from cli

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8202
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-documentation/pull/1743
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
No `xdp-options` and `xdp` driver in the CLI. DPDK is the only and default driver:
```
vyos@vyos# set vpp settings interface eth1
Possible completions:
 > dpdk-options         DPDK settings
   rx-mode              Receive packet processing mode


[edit]
```
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... ok
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... ok
test_14_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_14_vpp_ipsec_xfrm_nl) ... ok
test_15_1_vpp_cgnat (__main__.TestVPP.test_15_1_vpp_cgnat) ... ok
test_15_2_vpp_cgnat_bond_with_vifs (__main__.TestVPP.test_15_2_vpp_cgnat_bond_with_vifs) ... ok
test_16_vpp_nat (__main__.TestVPP.test_16_vpp_nat) ... ok
test_17_vpp_sflow (__main__.TestVPP.test_17_vpp_sflow) ... ok
test_18_resource_limits (__main__.TestVPP.test_18_resource_limits) ... ok
test_19_vpp_pppoe_mapping (__main__.TestVPP.test_19_vpp_pppoe_mapping) ... ok
test_20_kernel_options_hugepages (__main__.TestVPP.test_20_kernel_options_hugepages) ... ok
test_21_static_arp (__main__.TestVPP.test_21_static_arp) ... ok
test_22_1_vpp_ipfix (__main__.TestVPP.test_22_1_vpp_ipfix) ... ok
test_22_2_vpp_ipfix_bond (__main__.TestVPP.test_22_2_vpp_ipfix_bond) ... ok

----------------------------------------------------------------------
Ran 26 tests in 814.026s

OK (skipped=1)
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
