### PR TITLE
T7866: Fix not all CPUs have model name key

### DIFF
--- a/src/op_mode/cpu.py
+++ b/src/op_mode/cpu.py
@@ -47,7 +47,7 @@ def _format_cpus(cpu_data):
 def _get_summary_data():
     count = get_core_count()
     cpu_data = get_cpus()
-    models = [c['model name'] for c in cpu_data]
+    models = [c.get('model name', 'unknown') for c in cpu_data]
     env = {'count': count, "models": models}
 
     return env


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Not all platrorms have the `Model` key in the output of the /proc/cpuinfo
For example for ARM CPU:
```
vyos@vyos:~$ cat /proc/cpuinfo 
processor	: 0
BogoMIPS	: 48.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 asimddp sha512 asimdfhm dit uscat ilrcpc flagm sb paca pacg dcpodp flagm2 frint
CPU implementer	: 0x61
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0x000
CPU revision	: 0
...
```

Use `unknown` if we cannot detect it
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T7866

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Before fix:
```
vyos@vyos:~$ show hardware cpu summary 
Traceback (most recent call last):
  File "/usr/libexec/vyos/op_mode/cpu.py", line 77, in <module>
    res = vyos.opmode.run(sys.modules[__name__])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/opmode.py", line 312, in run
    res = func(**args)
          ^^^^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/cpu.py", line 67, in show_summary
    cpu_summary_data = _get_summary_data()
                       ^^^^^^^^^^^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/cpu.py", line 50, in _get_summary_data
    models = [c['model name'] for c in cpu_data]
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/libexec/vyos/op_mode/cpu.py", line 50, in <listcomp>
    models = [c['model name'] for c in cpu_data]
              ~^^^^^^^^^^^^^^
KeyError: 'model name'
vyos@vyos:~$ 
```
After the fix:
```
vyos@vyos:~$ show hardware cpu summary 
Physical CPU cores: 4
CPU model(s): unknown, unknown, unknown, unknown
vyos@vyos:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
