### PR TITLE
dns: T7924: Fix dns-dynamic migration error when `service` path is missing

### DIFF
--- a/smoketest/configs/assert/dns-dynamic
+++ b/smoketest/configs/assert/dns-dynamic
@@ -1,0 +1,33 @@
+set interfaces ethernet eth0 address 'dhcp'
+set interfaces ethernet eth1 address 'dhcp'
+set interfaces loopback lo
+set service dns dynamic name rfc2136-PDNS-eth0 address interface 'eth0'
+set service dns dynamic name rfc2136-PDNS-eth0 host-name 'sub.example.com'
+set service dns dynamic name rfc2136-PDNS-eth0 key '/config/auth/../config.boot'
+set service dns dynamic name rfc2136-PDNS-eth0 protocol 'nsupdate'
+set service dns dynamic name rfc2136-PDNS-eth0 server '192.168.101.15'
+set service dns dynamic name rfc2136-PDNS-eth0 zone 'example.com'
+set service dns dynamic name service-dyndns-eth1 address interface 'eth1'
+set service dns dynamic name service-dyndns-eth1 host-name 'my-dyndns-hostname'
+set service dns dynamic name service-dyndns-eth1 password 'my-password'
+set service dns dynamic name service-dyndns-eth1 protocol 'dyndns2'
+set service dns dynamic name service-dyndns-eth1 username 'my-login'
+set service ntp allow-client address '0.0.0.0/0'
+set service ntp allow-client address '::/0'
+set service ntp server time1.vyos.net
+set service ntp server time2.vyos.net
+set service ntp server time3.vyos.net
+set system config-management commit-revisions '100'
+set system conntrack modules ftp
+set system conntrack modules h323
+set system conntrack modules nfs
+set system conntrack modules pptp
+set system conntrack modules sip
+set system conntrack modules sqlnet
+set system conntrack modules tftp
+set system console device ttyS0 speed '115200'
+set system host-name 'vyos'
+set system login user vyos authentication encrypted-password '$6$YuG5oKoRYQnbnxk$P2eZNlIwXJP82JFyFrF2g4ZoOZr6zgLHK.SDJVoqWDGefKkRrJijUZODAVMLeWU.9EGM48YtG9MwfuewWoOGE.'
+set system login user vyos authentication plaintext-password ''
+set system syslog local facility all level 'info'
+set system syslog local facility local7 level 'debug'

--- a/smoketest/configs/dns-dynamic
+++ b/smoketest/configs/dns-dynamic
@@ -1,0 +1,84 @@
+interfaces {
+    ethernet eth0 {
+        address dhcp
+    }
+    ethernet eth1 {
+        address dhcp
+    }
+    loopback lo {
+    }
+}
+service {
+    dns {
+        dynamic {
+            interface eth0 {
+                rfc2136 PDNS {
+                    key /config/auth/../config.boot
+                    record sub.example.com
+                    server 192.168.101.15
+                    zone example.com
+                }
+            }
+            interface eth1 {
+                service dyndns {
+                    host-name my-dyndns-hostname
+                    login my-login
+                    password my-password
+                }
+            }
+        }
+    }
+}
+system {
+    config-management {
+        commit-revisions 100
+    }
+    conntrack {
+        modules {
+            ftp
+            h323
+            nfs
+            pptp
+            sip
+            sqlnet
+            tftp
+        }
+    }
+    console {
+        device ttyS0 {
+            speed 115200
+        }
+    }
+    host-name vyos
+    login {
+        user vyos {
+            authentication {
+                encrypted-password $6$YuG5oKoRYQnbnxk$P2eZNlIwXJP82JFyFrF2g4ZoOZr6zgLHK.SDJVoqWDGefKkRrJijUZODAVMLeWU.9EGM48YtG9MwfuewWoOGE.
+                plaintext-password ""
+            }
+        }
+    }
+    ntp {
+        server time1.vyos.net {
+        }
+        server time2.vyos.net {
+        }
+        server time3.vyos.net {
+        }
+    }
+    syslog {
+        global {
+            facility all {
+                level info
+            }
+            facility protocols {
+                level debug
+            }
+        }
+    }
+}
+
+
+// Warning: Do not remove the following line.
+// vyos-config-version: "broadcast-relay@1:cluster@1:config-management@1:conntrack@3:conntrack-sync@2:container@1:dhcp-relay@2:dhcp-server@6:dhcpv6-server@1:dns-forwarding@3:firewall@5:https@2:interfaces@23:ipoe-server@1:ipsec@5:isis@1:l2tp@3:lldp@1:mdns@1:nat@5:ntp@1:pppoe-server@5:pptp@2:qos@1:quagga@8:rpki@1:salt@1:snmp@2:ssh@2:sstp@3:system@21:vrrp@2:vyos-accel-ppp@2:wanloadbalance@3:webproxy@2:zone-policy@1"
+// Release version: 1.3.8

--- a/src/migration-scripts/dns-dynamic/1-to-2
+++ b/src/migration-scripts/dns-dynamic/1-to-2
@@ -51,8 +51,10 @@ def migrate(config: ConfigTree) -> None:
         # Migrate "service dns dynamic address <interface> service <service> protocol dnsexit"
         #      to "service dns dynamic address <interface> service <service> protocol dnsexit2"
         for address in config.list_nodes(address_path):
-            for svc_cfg in config.list_nodes(address_path + [address, 'service']):
-                if config.exists(address_path + [address, 'service', svc_cfg, 'protocol']):
-                    protocol = config.return_value(address_path + [address, 'service', svc_cfg, 'protocol'])
-                    if protocol == 'dnsexit':
-                        config.set(address_path + [address, 'service', svc_cfg, 'protocol'], 'dnsexit2')
+            service_path = address_path + [address, 'service']
+            if config.exists(service_path):
+                for svc_cfg in config.list_nodes(service_path):
+                    if config.exists(service_path + [svc_cfg, 'protocol']):
+                        protocol = config.return_value(service_path + [svc_cfg, 'protocol'])
+                        if protocol == 'dnsexit':
+                            config.set(service_path + [svc_cfg, 'protocol'], 'dnsexit2')


### PR DESCRIPTION
## Change summary
Handle absent `service dns dynamic address <iface> service` nodes during 1-to-2 migration to prevent ConfigTreeError.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7924

## How to test / Smoketest result
### Manual test

1. Using **VyOS 1.3** configure dynamic DNS settings (RFC 2136):
```
sudo touch /config/auth/pdns.key
set service dns dynamic interface eth0 rfc2136 PDNS key '/config/auth/pdns.key'
set service dns dynamic interface eth0 rfc2136 PDNS record 'sub.example.com'
set service dns dynamic interface eth0 rfc2136 PDNS server '192.168.101.15'
set service dns dynamic interface eth0 rfc2136 PDNS zone 'example.com'
```

2. Upgrade version of router to **1.4** or **1.5** and verify migration:
```
vyos@vyos:~$ show conf comm | match dns
set service dns dynamic name rfc2136-PDNS-eth0 address interface 'eth0'
set service dns dynamic name rfc2136-PDNS-eth0 host-name 'sub.example.com'
set service dns dynamic name rfc2136-PDNS-eth0 key '/config/auth/pdns.key'
set service dns dynamic name rfc2136-PDNS-eth0 protocol 'nsupdate'
set service dns dynamic name rfc2136-PDNS-eth0 server '192.168.101.15'
set service dns dynamic name rfc2136-PDNS-eth0 zone 'example.com'
```

### Smoketest
```
root@b161d478e5c2:/vyos-build# ./build-vyos-image ...
root@b161d478e5c2:/vyos-build# scripts/check-qemu-install --debug --configd --match="dns-dynamic" --cpu 2 --memory 7 --configtest --iso $(find . -name live-*.iso)
 INFO - Executing load config tests
...
DEBUG - Loaded migration result test for config "dns-dynamic"
DEBUG - ... completed: 0.003165
DEBUG - test_dns_dynamic (__main__.TestConfigDnsDynamic.test_dns_dynamic) ...  time: 35.052
DEBUG - ok
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 1 test in 35.066s
DEBUG - OK
...
 INFO - Configtest finished successfully!
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly