### PR TITLE
firewall: T7569: Add custom nftables rules from a file

### DIFF
--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -7,6 +7,41 @@
     </properties>
     <children>
       #include <include/firewall/global-options.xml.i>
+      <node name="custom-rules">
+        <properties>
+          <help>Add custom nftables rules from a file (advanced users only)</help>
+        </properties>
+        <children>
+          <tagNode name="from-file">
+            <properties>
+              <help>Filename that contains custom nftables rules</help>
+              <valueHelp>
+                <format>txt</format>
+                <description>/path/to/nft-config.nft</description>
+              </valueHelp>
+              <constraint>
+                <validator name="path-check"/>
+              </constraint>
+              <constraintErrorMessage>Filename that contains custom nftables rules not found</constraintErrorMessage>
+            </properties>
+            <children>
+              <leafNode name="revision">
+                <properties>
+                  <help>Unique revision number for the custom rule changes</help>
+                  <valueHelp>
+                    <format>u32:0-999999</format>
+                    <description>Unique revision number for the custom rule changes</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-999999"/>
+                  </constraint>
+                  <constraintErrorMessage>Revision number must be between 0 and 999999</constraintErrorMessage>
+                </properties>
+              </leafNode>
+            </children>
+          </tagNode>
+        </children>
+      </node>
       <tagNode name="flowtable">
         <properties>
           <help>Flowtable</help>

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -19,6 +19,8 @@ import unittest
 from glob import glob
 from time import sleep
 
+from pathlib import Path
+
 from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.configsession import ConfigSessionError
@@ -1536,6 +1538,37 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         self.verify_nftables(nftables_search, 'ip6 vyos_filter')
 
+    def test_custom_nftables_rules(self):
+        config = """\
+        table ip test {
+                map flow_vmap {
+                        type ipv4_addr . ipv4_addr . inet_service . inet_proto : verdict
+                        flags interval
+                        counter
+                        elements = { 192.0.2.10 . 198.51.100.20 . 22 . tcp : accept,
+                                    0.0.0.0/0 . 203.0.113.5 . 23 . tcp : accept }
+                }
+
+                chain my_custom_chain {
+                        ip saddr . ip daddr . tcp dport . meta l4proto vmap @flow_vmap comment "My Custom Rule"
+                }
+        }
+        """
+
+        path = Path("/config/nft-configs/test.nft")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(config)
+
+        self.cli_set(['firewall', 'custom-rules', 'from-file', path, 'revision', '1'])
+        self.cli_commit()
+
+        nftables_search = [
+            ['map flow_vmap'],
+            ['type ipv4_addr . ipv4_addr . inet_service . inet_proto : verdict'],
+            ['chain my_custom_chain'],
+            ['ip saddr . ip daddr . tcp dport . meta l4proto vmap @flow_vmap comment "My Custom Rule"']
+        ]
+        self.verify_nftables(nftables_search, 'ip test')
 
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -17,6 +17,9 @@
 import os
 import re
 
+from pathlib import Path
+from shutil import copy2
+
 from glob import glob
 
 from sys import exit
@@ -489,6 +492,17 @@ def verify_hardware_offload(ifname):
         raise ConfigError(f'Interface "{ifname}" requires "offload hw-tc-offload"')
 
 def verify(firewall):
+    if 'custom_rules' in firewall:
+        base_path = Path('/config').resolve()
+        if dict_search('custom_rules.from_file', firewall) is None:
+            raise ConfigError("'from-file' must be defined")
+        for custom_rule, custom_rule_conf in dict_search('custom_rules.from_file', firewall).items():
+            custom_rule_path = Path(custom_rule).resolve()
+            if not custom_rule_path.is_relative_to(base_path):
+                raise ConfigError(f"Custom rule will not be persistent after upgrades if not in '/config' directory")
+            if not dict_search('revision', custom_rule_conf):
+                raise ConfigError(f"Custom rule {custom_rule} must have a revision number")
+
     if 'flowtable' in firewall:
         for flowtable, flowtable_conf in firewall['flowtable'].items():
             if 'interface' not in flowtable_conf:
@@ -647,6 +661,29 @@ def verify(firewall):
 def generate(firewall):
     render(nftables_conf, 'firewall/nftables.j2', firewall)
     render(sysctl_file, 'firewall/sysctl-firewall.conf.j2', firewall)
+    nftables_conf_path = Path(nftables_conf)
+
+    if dict_search('custom_rules.from_file', firewall):
+        custom_rules_path = Path('/config/vyos-custom-nft-rules')
+        if not custom_rules_path.exists():
+            custom_rules_path.mkdir(parents=True, exist_ok=True)
+
+        for custom_rule, custom_rule_conf in firewall['custom_rules']['from_file'].items():
+            original_path = Path(custom_rule)
+            revision = dict_search("revision", custom_rule_conf)
+            filename = f'{original_path.name}.rev{revision}'
+            updated_path = custom_rules_path / filename
+
+            if not updated_path.exists():
+                include_path = f'/tmp/{filename}'
+                copy2(original_path, f'/tmp/{filename}')
+            else:
+                include_path = custom_rules_path / filename
+
+            with open(nftables_conf_path, 'a') as f:
+                f.write(f'include "{include_path}"\n')
+
+            firewall['custom_rules']['from_file'][custom_rule]['path'] = str(custom_rules_path / filename)
 
     # Cleanup remote-group cache files
     if os.path.exists(firewall_config_dir):
@@ -707,6 +744,13 @@ def apply(firewall):
     # Double check just in case
     if install_result == 1:
         raise ConfigError(f'Failed to apply firewall: {output}')
+
+    if dict_search('custom_rules.from_file', firewall):
+        for custom_rule, custom_rule_conf in firewall['custom_rules']['from_file'].items():
+            original_path = Path(custom_rule)
+            destination_path = Path(custom_rule_conf['path'])
+            if not destination_path.exists():
+                copy2(original_path, destination_path)
 
     # Apply firewall global-options sysctl settings
     cmd(f'sysctl -f {sysctl_file}')

--- a/src/validators/path-check
+++ b/src/validators/path-check
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+#
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from sys import argv, exit
+from pathlib import Path
+
+if len(argv) != 2:
+    exit(1)
+
+path = Path(argv[1])
+
+if path.exists():
+    exit(0)
+else:
+    print(f"Error: Path not found: {path}")
+    exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
This change adds the ability to add raw nftables rules from `.nft` files. This provides a few benefits:

- Features that are not currently in the VyOS CLI can be applied.
  - This provides not only a way to handle edge cases for firewall configs, but acts as a measure for what features could be added to the CLI in the future.
- Allows commit/boot times to improve since the config is applied along with the atomic load of `nftables.conf` without needing the config to be directly in VyOS.
### Use Case example:
Imagine a customer with a very strict policy for allowed traffic. If they have 10k rules, that would not only make the processing of traffic very slow, but the config load and commit times would be horrible in VyOS. They could instead load the config from a file, and apply that to a map, which is a feature not currently in VyOS.

They could simply manage a CSV with values for: `srcip, dstip, dstport, proto, verdict` and run that against a python script that will output their nft file. All of those would then get added to a map which has O(1) lookup. So this would solve both the long commit/load times of the config, as well as the slow processing of rules.

The output file would look something like:
```
delete table ip my_custom_table
table ip my_custom_table {
        map flow_vmap {
                type ipv4_addr . ipv4_addr . inet_service . inet_proto : verdict
                flags interval
                counter
                elements = { 10.5.0.100 . 10.100.0.55 . 22 . tcp : accept,
                             10.5.0.101 . 10.100.0.55 . 23 . tcp : accept,
                             10.5.0.102 . 10.100.0.55 . 443 . tcp : accept }
        }

        chain my_custom_chain {
                type filter hook forward priority filter+15; policy drop;
                ip saddr . ip daddr . tcp dport . meta l4proto vmap @flow_vmap comment "TCP based Verdict Map"
        }
}
```
These were the times to generate a file with 10k elements in a map, as well as the time to apply that to nftables:
```
root@vyos:/home/vyos# time python3 test.py -n 10000
Wrote 10000 elements to flow_vmap.nft (table inet vyos_test, map flow_vmap)

real    0m0.047s
user    0m0.045s
sys     0m0.002s

root@vyos:/home/vyos# time nft -f flow_vmap.nft 

real    0m0.095s
user    0m0.034s
sys     0m0.055s
```
### Config tree:
```
├── firewall
│   ├── custom-rules
│   │   └── from-file
│   │   │   └── <file path>
│   │           └── revision
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7569

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
#### Create a file containing valid nftables config and place it somewhere within the `/config` directory:
```
table ip test {
        map flow_vmap {
                type ipv4_addr . ipv4_addr . inet_service . inet_proto : verdict
                flags interval
                counter
                elements = { 192.0.2.10 . 198.51.100.20 . 22 . tcp  : accept,
                             0.0.0.0/0 . 203.0.113.5 . 23 . tcp  : accept }
        }

        chain my_custom_chain {
                ip saddr . ip daddr . tcp dport . meta l4proto vmap @flow_vmap comment "My Custom Rule"
        }
}
```
#### Apply the configuration:
```
set firewall custom-rules from-file /config/test.nft revision 1
```
#### Verify config was applied to nftables:
```
vyos@vyos# sudo nft list table test
table ip test {
        map flow_vmap {
                type ipv4_addr . ipv4_addr . inet_service . inet_proto : verdict
                flags interval
                counter
                elements = { 192.0.2.10 . 198.51.100.20 . 22 . tcp counter packets 0 bytes 0 : accept,
                             0.0.0.0/0 . 203.0.113.5 . 23 . tcp counter packets 0 bytes 0 : accept }
        }

        chain my_custom_chain {
                ip saddr . ip daddr . tcp dport . meta l4proto vmap @flow_vmap comment "My Custom Rule"
        }
}
```
#### Smoketest results:
```
test_bridge_firewall (__main__.TestFirewall.test_bridge_firewall) ... ok
test_custom_nftables_rules (__main__.TestFirewall.test_custom_nftables_rules) ... ok
test_cyclic_jump_validation (__main__.TestFirewall.test_cyclic_jump_validation) ... ok
test_disable_conntrack_per_chain (__main__.TestFirewall.test_disable_conntrack_per_chain) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
test_geoip (__main__.TestFirewall.test_geoip) ... ok
test_gre_match (__main__.TestFirewall.test_gre_match) ... ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipsec_metadata_match (__main__.TestFirewall.test_ipsec_metadata_match) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_dynamic_groups (__main__.TestFirewall.test_ipv4_dynamic_groups) ... ok
test_ipv4_global_state (__main__.TestFirewall.test_ipv4_global_state) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_remote_group (__main__.TestFirewall.test_ipv4_remote_group) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_dynamic_groups (__main__.TestFirewall.test_ipv6_dynamic_groups) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_ipv6_remote_group (__main__.TestFirewall.test_ipv6_remote_group) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
test_remote_group (__main__.TestFirewall.test_remote_group) ... ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_timeout_sysctl (__main__.TestFirewall.test_timeout_sysctl) ... ok
test_wildcard_interfaces (__main__.TestFirewall.test_wildcard_interfaces) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... ok
test_zone_with_default_firewall (__main__.TestFirewall.test_zone_with_default_firewall) ... ok
test_zone_with_vrf (__main__.TestFirewall.test_zone_with_vrf) ... ok
test_zone_without_member (__main__.TestFirewall.test_zone_without_member) ... ok

----------------------------------------------------------------------
Ran 33 tests in 81.218s

OK
```

#### Handling errors in user created `.nft` files:
There is already a `nft -c` operation applied to `nftables.conf`, which will catch any errors in the user's syntax

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
