### PR TITLE
T8218: Fixed pull request branch fetching issue post Github pull_request_targte policy update

### DIFF
--- a/.github/workflows/trigger-rebuild-repo-package.yml
+++ b/.github/workflows/trigger-rebuild-repo-package.yml
@@ -25,7 +25,7 @@ jobs:
     needs: get_repo_name
     uses: vyos/.github/.github/workflows/trigger-rebuild-repo-package.yml@current
     with:
-      branch: ${{ github.ref_name }}
+      branch: ${{ github.event.pull_request.base.ref }}
       package_name: ${{ needs.get_repo_name.outputs.PACKAGE_NAME }}
     secrets:
       REMOTE_OWNER: ${{ secrets.REMOTE_OWNER }}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
This was occuring after the pull_request_target update trigger update with all the required base branches (Github policy change)
${{ github.ref_name }} is getting as "current" eventhough pr target is other branch (circinus).
This change fixes incorrect branch resolution when the workflow is triggered via `pull_request_target`.

Previously, the workflow used `github.ref_name`, which resolves to the branch containing the workflow file (e.g., `current`) rather than the actual PR target branch. This caused builds to always run against `current`, even when the PR target was `circinus` or `sagitta`.

The workflow now correctly derives the target branch from:
`github.event.pull_request.base.ref`

This ensures the rebuild job is triggered with the correct branch name for forked and non-forked pull requests targeting `current`, `circinus`, or `sagitta`.

No functional behavior outside branch selection is changed.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx --> https://vyos.dev/T8218

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
