### PR TITLE
srv6: T6977: add srv6 encapsulation source-address

### DIFF
--- a/data/templates/frr/zebra.segment_routing.frr.j2
+++ b/data/templates/frr/zebra.segment_routing.frr.j2
@@ -1,23 +1,32 @@
 !
-{% if srv6.locator is vyos_defined %}
+{% if srv6 is vyos_defined %}
 segment-routing
  srv6
+{%     if srv6.encapsulation is vyos_defined %}
+  encapsulation
+{%         if srv6.encapsulation.source_address is vyos_defined %}
+   source-address {{ srv6.encapsulation.source_address }}
+{%         endif %}
+  exit
+{%     endif %}
+{%     if srv6.locator is vyos_defined %}
   locators
-{%     for locator, locator_config in srv6.locator.items() %}
+{%         for locator, locator_config in srv6.locator.items() %}
    locator {{ locator }}
-{%         if locator_config.prefix is vyos_defined %}
+{%             if locator_config.prefix is vyos_defined %}
     prefix {{ locator_config.prefix }} block-len {{ locator_config.block_len }} node-len {{ locator_config.node_len }} func-bits {{ locator_config.func_bits }}
-{%         endif %}
-{%         if locator_config.behavior_usid is vyos_defined %}
+{%             endif %}
+{%             if locator_config.behavior_usid is vyos_defined %}
     behavior usid
-{%         endif %}
-{%         if locator_config.format is vyos_defined %}
+{%             endif %}
+{%             if locator_config.format is vyos_defined %}
     format {{ locator_config.format }}
-{%         endif %}
+{%             endif %}
     exit
     !
-{%     endfor %}
+{%         endfor %}
   exit
+{%     endif %}
   !
 exit
 !

--- a/interface-definitions/protocols_segment-routing.xml.in
+++ b/interface-definitions/protocols_segment-routing.xml.in
@@ -61,6 +61,14 @@
               <help>Segment-Routing SRv6 configuration</help>
             </properties>
             <children>
+              <node name="encapsulation">
+                <properties>
+                  <help>Segment Routing SRv6 encapsulation</help>
+                </properties>
+                <children>
+                  #include <include/source-address-ipv6.xml.i>
+                </children>
+              </node>
               <tagNode name="locator">
                 <properties>
                   <help>Segment-Routing SRv6 locators configuration</help>

--- a/op-mode-definitions/show-segment-routing.xml.in
+++ b/op-mode-definitions/show-segment-routing.xml.in
@@ -18,6 +18,12 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
               </node>
+              <node name="manager">
+                <properties>
+                  <help>Verify SRv6 manager</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>
+              </node>
             </children>
           </node>
         </children>

--- a/smoketest/scripts/cli/test_protocols_segment-routing.py
+++ b/smoketest/scripts/cli/test_protocols_segment-routing.py
@@ -158,6 +158,23 @@ class TestProtocolsSegmentRouting(VyOSUnitTestSHIM.TestCase):
             if 'usid' in locator_config:
                 self.assertIn('    behavior usid', frrconfig)
 
+    def test_srv6_encap_source_addr(self):
+        # Set an IPv6 address for SRv6 encapsulation source
+        source6 = '2001:db8::1'
+
+        # SRv6 must be enabled on at least one interface
+        for interface in Section.interfaces('ethernet', vlan=False):
+            self.cli_set(base_path + ['interface', interface, 'srv6'])
+
+        self.cli_set(base_path + ['srv6', 'encapsulation', 'source-address', source6])
+        self.cli_commit()
+
+        frrconfig = self.getFRRconfig('segment-routing', stop_section='^exit')
+        self.assertIn('segment-routing', frrconfig)
+        self.assertIn(' srv6', frrconfig)
+        self.assertIn('  encapsulation', frrconfig)
+        self.assertIn(f'   source-address {source6}', frrconfig)
+
     def test_srv6_sysctl(self):
         interfaces = Section.interfaces('ethernet', vlan=False)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add configuration option for setting the source address of the outer encapsulation IPv6 header on SRv6 traffic:
https://docs.frrouting.org/en/latest/zebra.html#clicmd-source-address-X-X-X-X

```
protocols 
 segment-routing {
  srv6 {
    encapsulation {
      source-address "2001:db8::1"
    }
  }
 }
}
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6977

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/1115

## How to test / Smoketest result
```
$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_segment-routing.py
test_srv6 (__main__.TestProtocolsSegmentRouting.test_srv6) ... ok
test_srv6_encap_source_addr (__main__.TestProtocolsSegmentRouting.test_srv6_encap_source_addr) ... ok
test_srv6_sysctl (__main__.TestProtocolsSegmentRouting.test_srv6_sysctl) ... ok

----------------------------------------------------------------------
Ran 3 tests in 9.384s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
