### PR TITLE
utils: T8018: add unbuffered output support to popen()

### DIFF
--- a/src/op_mode/container.py
+++ b/src/op_mode/container.py
@@ -94,8 +94,7 @@ def add_image(name: str):
                     rc, out = rc_cmd(cmd)
                     if rc != 0: raise vyos.opmode.InternalError(out)
 
-    rc, output = rc_cmd(f'podman image pull {name}')
-    print(output)
+    rc, output = rc_cmd(f'podman image pull {name}', buffered=False)
     if rc != 0:
         raise vyos.opmode.InternalError(output)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Instead of executing the command passed to popen() and waiting for it to finish before printing its output, add a function argument to disable buffered mode.

When buffered mode (the default) is turned off, each line emitted by the process is flushed immediately to the calling TTY.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8018

## How to test / Smoketest result

[Screencast_20260202_213551.webm](https://github.com/user-attachments/assets/0bfc2cf3-d60b-44fe-8a21-39a453c5be9e)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
