### PR TITLE
tech-support: T8215: Extend tech-support archive and report generation

### DIFF
--- a/op-mode-definitions/generate_tech-support_archive.xml.in
+++ b/op-mode-definitions/generate_tech-support_archive.xml.in
@@ -11,7 +11,7 @@
             <properties>
               <help>Generate tech support archive to defined location</help>
               <completionHelp>
-                <list> &lt;file&gt; &lt;scp://user:passwd@host&gt; &lt;ftp://user:passwd@host&gt;</list>
+                <list> &lt;file&gt; &lt;directory/&gt; &lt;scp://user:passwd@host&gt; &lt;ftp://user:passwd@host&gt;</list>
               </completionHelp>
             </properties>
             <command>${vyos_op_scripts_dir}/generate_tech-support_archive.py $4</command>

--- a/python/vyos/utils/file.py
+++ b/python/vyos/utils/file.py
@@ -339,3 +339,18 @@ def file_compare(file1: str, file2: str) -> bool:
             return False
 
         return True
+
+
+def get_name_from_path(path) -> str:
+    """
+    Extracts the base name (without extension) from a file path.
+
+    Args:
+        path (str | pathlib.Path): The file path to extract the name from.
+
+    Returns:
+        str: The base name without file extension.
+    """
+    base = os.path.basename(path)
+    name, _ = base.split('.', maxsplit=1)
+    return name

--- a/python/vyos/utils/process.py
+++ b/python/vyos/utils/process.py
@@ -321,3 +321,9 @@ def ip_cmd(args, json=True):
     else:
         res = cmd(f"ip {args}")
         return res
+
+
+def wrap_op(cmd: str) -> str:
+    """Returns a command with the VyOS operational mode wrapper."""
+
+    return f'/opt/vyatta/bin/vyatta-op-cmd-wrapper {cmd}'

--- a/smoketest/scripts/cli/test_techsupport_archive.py
+++ b/smoketest/scripts/cli/test_techsupport_archive.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+#
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import io
+import re
+import contextlib
+import pathlib
+import tarfile
+import unittest
+
+from base_vyostest_shim import VyOSUnitTestSHIM
+from vyos.utils.process import call
+from vyos.utils.file import get_name_from_path
+
+base_path = ['generate tech-support archive']
+testdir = pathlib.Path('/tmp/_test_techsupport_archive')
+
+
+def tar_gz_paths(archive_path: pathlib.Path, max_depth: int = 5) -> set:
+    """
+    Return all member paths inside `archive_path`.
+
+    Nested archives are expanded recursively and represented as:
+      "inner.tar.gz::path/inside/inner"
+    """
+
+    def is_nested(name: str) -> bool:
+        nested_suffixes = ('.tar.gz', '.tgz', '.tar')
+        return name.lower().endswith(nested_suffixes)
+
+    out = set()
+
+    def walk_bytes(data: bytes, prefix: str, depth: int):
+        if depth > max_depth:
+            return
+
+        bio = io.BytesIO(data)
+        with tarfile.open(fileobj=bio, mode='r:*') as tf:
+            for member in tf.getmembers():
+                out.add(f'{prefix}::{member.name}' if prefix else member.name)
+
+                if member.isreg() and is_nested(member.name) and depth < max_depth:
+                    file = tf.extractfile(member)
+                    if file is None:
+                        continue
+
+                    sub_prefix = f'{prefix}::{member.name}' if prefix else member.name
+                    walk_bytes(file.read(), sub_prefix, depth + 1)
+
+    walk_bytes(archive_path.read_bytes(), prefix='', depth=0)
+
+    return out
+
+
+@contextlib.contextmanager
+def stub_files(file_paths: list[str]):
+    """
+    Context manager for tests.
+
+    Creates a temporary set of files and removes it after use.
+    Example:
+        with stub_files(['a.txt', 'dir/b.txt']):
+            pass
+    """
+
+    paths = [pathlib.Path(file_path) for file_path in file_paths]
+
+    try:
+        for path in paths:
+            if path.parent.exists():
+                path.touch()
+
+        yield
+
+    finally:
+        for path in paths:
+            path.unlink(missing_ok=True)
+
+
+class TestTechSupportArchive(VyOSUnitTestSHIM.TestCase):
+    def tearDown(self):
+        # always forward to base class
+        super().tearDown()
+
+        if testdir.exists():
+            call(f'sudo rm -rf {testdir}')
+
+    def _check_path(self, path: str | pathlib.Path, state: bool, err_message: str):
+        if isinstance(path, str):
+            path = pathlib.Path(path)
+
+        if state:
+            self.assertTrue(path.exists(), err_message)
+        else:
+            self.assertFalse(path.exists(), err_message)
+
+    def _extract_archive_path(self, output: str) -> pathlib.Path:
+        match = re.search(r'located in ([^\s]+\.tar\.gz)', output)
+        path = match.group(1) if match else None
+
+        err_message = (
+            'It is not possible to extract the path to the resulting '
+            'archive from stdout:'
+            f'\n```\n{output}\n```'
+        )
+        assert path is not None, err_message
+
+        return pathlib.Path(path)
+
+    def _extract_archive_inner_path_prefix(self, archive_path: pathlib.Path):
+        # Convert
+        #   `bdbdd9a4807f_tech-support-archive_2026-02-02T15-33-26.tar.gz`
+        # to
+        #   `bdbdd9a4807f_tech-support-archive_2026-02-02T15-33-26`
+
+        return get_name_from_path(archive_path)
+
+    def assertPathExists(self, path: str):
+        err_message = f'Path `{path}` does not exist after generating a archive'
+        self._check_path(path, True, err_message)
+
+    def assertNotPathExists(self, path: str):
+        err_message = f'Path `{path}` still exists after generating a archive'
+        self._check_path(path, False, err_message)
+
+    def assertExpectedArcPaths(
+        self, archive_path: pathlib.Path, expected_paths: list[str]
+    ):
+        actual = tar_gz_paths(archive_path)
+        expected = frozenset(expected_paths)
+
+        missing = sorted(expected - actual)
+
+        if missing:
+            lines = [f'Archive paths mismatch: {archive_path}', 'Missing:']
+            lines += [f'  - {p}' for p in missing]
+            raise AssertionError('\n'.join(lines))
+
+    def assertNotExpectedArcPaths(
+        self, archive_path: pathlib.Path, unexpected_paths: list[str]
+    ):
+        actual = tar_gz_paths(archive_path)
+        unexpected = frozenset(unexpected_paths)
+
+        extra = sorted(actual & unexpected)
+
+        if extra:
+            lines = [f'Archive paths mismatch: {archive_path}', 'Unexpected:']
+            lines += [f'  - {p}' for p in extra]
+            raise AssertionError('\n'.join(lines))
+
+    def test_general_archive_structure(self):
+        output = self.op_mode(base_path)
+
+        archive_path = self._extract_archive_path(output)
+        self.assertPathExists(archive_path)
+        self.assertEqual(str(archive_path.parent), '/tmp')
+
+        prefix = self._extract_archive_inner_path_prefix(archive_path)
+        self.assertExpectedArcPaths(
+            archive_path,
+            [
+                f'{prefix}/show_tech-support_report/vyos-main-info',
+                f'{prefix}/config.tar.gz::opt/vyatta/etc/config/config.boot',
+                f'{prefix}/core-dump.tar.gz::var/core',
+                f'{prefix}/home.tar.gz::home/vyos/.profile',
+                f'{prefix}/root.tar.gz::root/.profile',
+                f'{prefix}/run.tar.gz::run',
+                f'{prefix}/tmp.tar.gz::tmp/vyos-config-status',
+                f'{prefix}/topology-logical.png',
+                f'{prefix}/topology.png',
+                f'{prefix}/var-log.tar.gz::var/log/journal',
+            ],
+        )
+
+        if archive_path.exists():
+            call(f'sudo rm -f {archive_path}')
+
+    def test_excluded_archive_files(self):
+        fake_files = [
+            '/opt/vyatta/etc/config/_test_fake_vyos.iso',
+            '/home/vyos/_test_fake_vyos.iso',
+            '/tmp/_test_fake_vyos.iso',
+            '/opt/vyatta/etc/config/_test_fake_archive.tar.gz',
+            '/home/vyos/_test_fake_archive.tar.gz',
+            '/tmp/_test_fake_archive.tar.gz',
+            '/home/vyos/drops-debug_9999-12-31T23-59-59',
+            '/home/vyos/ffffffffffff_tech-support-archive_9999-12-31T23-59-59',
+            '/tmp/drops-debug_9999-12-31T23-59-59',
+            '/tmp/ffffffffffff_tech-support-archive_9999-12-31T23-59-59',
+        ]
+        with stub_files(fake_files):
+            output = self.op_mode(base_path)
+
+        archive_path = self._extract_archive_path(output)
+        self.assertPathExists(archive_path)
+
+        prefix = self._extract_archive_inner_path_prefix(archive_path)
+        self.assertNotExpectedArcPaths(
+            archive_path,
+            [
+                f'{prefix}/config.tar.gz::opt/vyatta/etc/config/_test_fake_vyos.iso',
+                f'{prefix}/home.tar.gz::home/vyos/_test_fake_vyos.iso',
+                f'{prefix}/tmp.tar.gz::tmp/_test_fake_vyos.iso',
+                f'{prefix}/var.tar.gz::var/log/messages',
+                f'{prefix}/var.tar.gz::var/log/messages.1',
+                f'{prefix}/config.tar.gz::opt/vyatta/etc/config/_test_fake_archive.tar.gz',
+                f'{prefix}/home.tar.gz::home/vyos/_test_fake_archive.tar.gz',
+                f'{prefix}/tmp.tar.gz::tmp/_test_fake_archive.tar.gz',
+                f'{prefix}/home.tar.gz::home/vyos/drops-debug_9999-12-31T23-59-59',
+                f'{prefix}/home.tar.gz::home/vyos/ffffffffffff_tech-support-archive_9999-12-31T23-59-59',
+                f'{prefix}/tmp.tar.gz::tmp/drops-debug_9999-12-31T23-59-59',
+                f'{prefix}/tmp.tar.gz::tmp/ffffffffffff_tech-support-archive_9999-12-31T23-59-59',
+            ],
+        )
+
+        if archive_path.exists():
+            call(f'sudo rm -f {archive_path}')
+
+    def test_custom_archive_path(self):
+        output = self.op_mode(base_path + [str(testdir / 'foo')])
+
+        archive_path = self._extract_archive_path(output)
+        self.assertPathExists(archive_path)
+        self.assertEqual(archive_path.parent, testdir)
+        self.assertEqual(archive_path.name, 'foo.tar.gz')
+
+    def test_custom_directory_archive_path(self):
+        output = self.op_mode(base_path + [str(testdir) + '/bar/'])
+
+        archive_path = self._extract_archive_path(output)
+        self.assertPathExists(archive_path)
+        self.assertEqual(archive_path.parent.name, 'bar')
+        self.assertEqual(archive_path.suffix, '.gz')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/smoketest/scripts/cli/test_techsupport_report.py
+++ b/smoketest/scripts/cli/test_techsupport_report.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+#
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pathlib
+import shutil
+import unittest
+
+from base_vyostest_shim import VyOSUnitTestSHIM
+from vyos.defaults import directories
+from vyos.utils.process import cmd
+
+base_path = ['show tech-support report']
+script_path = directories['op_mode'] + '/show_techsupport_report.py'
+testdir = pathlib.Path('/tmp/_test_techsupport_report')
+
+all_blocks = (
+    'vyos-main-info',
+    'routing-info',
+    'frr-info',
+    'proc-and-sysctl-info',
+    'net-and-processes-info',
+    'ethtool-info',
+    'lspci-and-numa-info',
+    'nftables-info',
+    'dpkg-and-modules-info',
+    'system-resources-info',
+    'ipsec-debug-info',
+    'vpp-info',
+)
+
+
+class TestTechSupportReport(VyOSUnitTestSHIM.TestCase):
+    def _gen_section_header(self, name: str) -> str:
+        length = len(name)
+        return '=' * length + '\n' + name + '\n' + '=' * length + '\n'
+
+    def assertSectionIn(self, name: str, report: str):
+        header = self._gen_section_header(name)
+        self.assertIn(header, report, f'Report does not contain section `{name}`')
+
+    def assertSectionNotIn(self, name: str, report: str):
+        header = self._gen_section_header(name)
+        self.assertNotIn(
+            header, report, f'Report contains unnecessary section `{name}`'
+        )
+
+    def test_full_report(self):
+        report = self.op_mode(base_path)
+        for block in all_blocks:
+            self.assertSectionIn(block, report)
+
+    def test_filtered_report(self):
+        blocks = (
+            'vyos-main-info',
+            'proc-and-sysctl-info',
+        )
+
+        report = cmd([script_path, '--reports'] + list(blocks))
+
+        for block in blocks:
+            self.assertSectionIn(block, report)
+
+        missing_blocks = frozenset(all_blocks) - frozenset(blocks)
+        for block in missing_blocks:
+            self.assertSectionNotIn(block, report)
+
+    def test_directory_output(self):
+        cmd([script_path, '--outdir', str(testdir)])
+
+        for block in all_blocks:
+            file_path = testdir / block
+            err_message = f'File `{file_path}` does not exist after generating a report'
+
+            self.assertTrue(file_path.exists(), err_message)
+            self.assertSectionIn(block, file_path.read_text())
+
+        shutil.rmtree(testdir, ignore_errors=True)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/src/op_mode/generate_tech-support_archive.py
+++ b/src/op_mode/generate_tech-support_archive.py
@@ -13,40 +13,57 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 import argparse
 import glob
 from datetime import datetime
 from pathlib import Path
 from shutil import rmtree
-
 from socket import gethostname
 from sys import exit
 from tarfile import open as tar_open
+
+from vyos.defaults import directories
 from vyos.utils.process import call
-from vyos.utils.process import rc_cmd
+from vyos.utils.process import cmd
+from vyos.utils.file import get_name_from_path
 from vyos.remote import upload
 
-def op(cmd: str) -> str:
-    """Returns a command with the VyOS operational mode wrapper."""
-    return f'/opt/vyatta/bin/vyatta-op-cmd-wrapper {cmd}'
 
-def save_stdout(command: str, file: Path) -> None:
-    rc, stdout = rc_cmd(command)
-    body: str = f'''### {command} ###
-Command: {command}
-Exit code: {rc}
-Stdout:
-{stdout}
+# Example: bdbdd9a4807f_tech-support-archive_2026-02-02T13-53-18
+ARCHIVE_PATTERN = '_tech-support-archive_'
+# Example: drops-debug_2026-02-02T13-53-18
+ARCHIVE_TMP_DIR_PATTERN = 'drops-debug_'
+DEFAULT_TMP_DIR = '/tmp'
+EXCLUDED_ARCHIVE_EXT = ('.iso', '.gz', '.tar', '.zip')
 
-'''
-    with file.open(mode='a') as f:
-        f.write(body)
+
 def __rotate_logs(path: str, log_pattern:str):
     files_list = glob.glob(f'{path}/{log_pattern}')
     if len(files_list) > 5:
         oldest_file = min(files_list, key=os.path.getctime)
         os.remove(oldest_file)
+
+
+def __save_show_report_files(reports_dir: Path):
+    """
+    Save result of execution `show tech-support report` command
+    :param reports_dir: path to the result directory
+    :type reports_dir: pathlib.Path
+    """
+
+    vyos_op_scripts_dir = directories['op_mode']
+    script_path = f'{vyos_op_scripts_dir}/show_techsupport_report.py'
+    arguments = [
+        '--launched-from-generate-archive',
+        '--outdir',
+        str(reports_dir),
+    ]
+    output = cmd([script_path] + arguments)
+
+    if output.strip():
+        print(output)
 
 
 def __generate_archived_files(location_path: str) -> None:
@@ -55,6 +72,33 @@ def __generate_archived_files(location_path: str) -> None:
     :param location_path: path to temporary directory
     :type location_path: str
     """
+
+    # sync/flush journald before archiving /var/log/journal
+    cmd(['journalctl', '--sync'])
+    cmd(['journalctl', '--flush'])
+
+    def __tar_filter(tarinfo):
+        # path inside tar, because we set arcname=... below
+        name = tarinfo.name
+        basename = os.path.basename(name)
+
+        # /var/log: exclude /var/log/messages and /var/log/messages.*
+        if name.startswith('var/log/messages'):
+            if basename == 'messages' or basename.startswith('messages.'):
+                return None
+
+        # /tmp, /home: exclude previous tech-support archives and temporary archive directories
+        if name.startswith(('tmp/', 'home/')):
+            if ARCHIVE_PATTERN in name or basename.startswith(ARCHIVE_TMP_DIR_PATTERN):
+                return None
+
+        # /home, /opt/vyatta/etc/config, /tmp: exclude general archives
+        if name.startswith(('home/', 'opt/vyatta/etc/config/', 'tmp/')):
+            if basename.lower().endswith(EXCLUDED_ARCHIVE_EXT):
+                return None
+
+        return tarinfo
+
     # Dictionary arhive_name:directory_to_arhive
     archive_dict = {
         'etc': '/etc',
@@ -63,22 +107,23 @@ def __generate_archived_files(location_path: str) -> None:
         'root': '/root',
         'tmp': '/tmp',
         'core-dump': '/var/core',
-        'config': '/opt/vyatta/etc/config'
+        'config': '/opt/vyatta/etc/config',
+        'run': '/run',
     }
-    # Dictionary arhive_name:excluding pattern
-    archive_excludes = {
-        # Old location of archives
-        'config': 'tech-support-archive',
-        # New locations of arhives
-        'tmp': 'tech-support-archive'
-    }
+
     for archive_name, path in archive_dict.items():
-        archive_file: str = f'{location_path}/{archive_name}.tar.gz'
+        if not os.path.exists(path):
+            continue
+
+        arcname = str(path).lstrip('/')  # e.g. /etc -> 'etc'
+
+        archive_file = f'{location_path}/{archive_name}.tar.gz'
         with tar_open(name=archive_file, mode='x:gz') as tar_file:
-            if archive_name in archive_excludes:
-                tar_file.add(path, filter=lambda x: None if str(archive_excludes[archive_name]) in str(x.name) else x)
-            else:
-                tar_file.add(path)
+            try:
+                tar_file.add(path, arcname=arcname, filter=__tar_filter)
+            except (PermissionError, OSError) as e:
+                print(f'Unable to read `{path}` to archive files:', e)
+                continue  # skip paths we can't read
 
 
 def __generate_main_archive_file(archive_file: str, tmp_dir_path: str) -> None:
@@ -89,8 +134,10 @@ def __generate_main_archive_file(archive_file: str, tmp_dir_path: str) -> None:
     :param tmp_dir_path: path to arhive memeber
     :type tmp_dir_path: str
     """
+
+    arcname = get_name_from_path(archive_file)
     with tar_open(name=archive_file, mode='x:gz') as tar_file:
-        tar_file.add(tmp_dir_path, arcname=os.path.basename(tmp_dir_path))
+        tar_file.add(tmp_dir_path, arcname=arcname)
 
 def __generate_topology_snapshots(output_dir: Path) -> None:
     """
@@ -109,61 +156,100 @@ def __generate_topology_snapshots(output_dir: Path) -> None:
     call(['lstopo', '--logical', '--output-format', 'png', str(logical_topo)])
 
 
+def __resolve_main_archive_path(input_path: str, default_archive_name: str) -> Path:
+    """
+    Normalize path for saving a .tar.gz file based on rules:
+
+    Rules:
+      - file               -> file.tar.gz
+      - file.tar           -> file.tar.gz
+      - file.tgz           -> file.tgz
+      - dir/               -> dir/{default_archive_name}
+      - ../dir/file.tar.gz -> (unchanged)
+      - file.zip           -> file.tar.gz
+
+    :param input_path: user's provided path to the archive
+    :param default_archive_name: name of archive if user didn't provide it
+    """
+
+    path = Path(input_path)
+
+    # Case 1: default temporary directory -> extend by default name of file
+    if input_path == DEFAULT_TMP_DIR:
+        return path / default_archive_name
+
+    # Case 2: already .tar.gz -> return unchanged
+    if path.name.endswith(('.tar.gz', '.tgz')):
+        return path
+
+    # Case 3: already .tar -> .tar.gz
+    if path.name.endswith('.tar'):
+        return path.with_suffix('.tar.gz')
+
+    # Case 4: directory (explicit trailing slash OR existing directory)
+    if input_path.endswith(('/', '\\')) or path.is_dir():
+        dir_path = path
+        return dir_path / default_archive_name
+
+    # Default behavior for any other extension
+    return path.with_suffix('.tar.gz')
+
+
 if __name__ == '__main__':
-    defualt_tmp_dir = '/tmp'
     parser = argparse.ArgumentParser()
-    parser.add_argument("path", nargs='?', default=defualt_tmp_dir)
+    parser.add_argument('path', nargs='?', default=DEFAULT_TMP_DIR)
     args = parser.parse_args()
-    location_path = args.path[:-1] if args.path[-1] == '/' else args.path
 
     hostname: str = gethostname()
-    time_now: str = datetime.now().isoformat(timespec='seconds').replace(":", "-")
+    time_now: str = datetime.now().isoformat(timespec='seconds').replace(':', '-')
+    default_archive_inner_dir = f'{hostname}{ARCHIVE_PATTERN}{time_now}'
+    default_archive_name = f'{default_archive_inner_dir}.tar.gz'
 
-    remote = False
-    tmp_path = ''
-    tmp_dir_path = ''
-    if 'ftp://' in args.path or 'scp://' in args.path:
-        remote = True
-        tmp_path = defualt_tmp_dir
+    is_remote = args.path.startswith(('ftp://', 'scp://'))
+    if is_remote:
+        base_tmp_path = DEFAULT_TMP_DIR
+        archive_dest_path = Path(f'{base_tmp_path}/{default_archive_name}')
     else:
-        tmp_path = location_path
-    archive_pattern = f'_tech-support-archive_'
-    archive_file_name = f'{hostname}{archive_pattern}{time_now}.tar.gz'
+        # Define destination path to the main archive file based on a rules
+        archive_dest_path = __resolve_main_archive_path(args.path, default_archive_name)
+        base_tmp_path = str(archive_dest_path.parent)
+        default_archive_name = archive_dest_path.name
+        default_archive_inner_dir = get_name_from_path(archive_dest_path.name)
 
     # Log rotation in tmp directory
-    if tmp_path == defualt_tmp_dir:
-        __rotate_logs(tmp_path, f'*{archive_pattern}*')
+    if base_tmp_path == DEFAULT_TMP_DIR:
+        __rotate_logs(base_tmp_path, f'*{ARCHIVE_PATTERN}*')
 
     # Temporary directory creation
-    tmp_dir_path = f'{tmp_path}/drops-debug_{time_now}'
-    tmp_dir: Path = Path(tmp_dir_path)
+    tmp_dir: Path = Path(f'{base_tmp_path}/{ARCHIVE_TMP_DIR_PATTERN}{time_now}')
     tmp_dir.mkdir(parents=True)
 
-    report_file: Path = Path(f'{tmp_dir_path}/show_tech-support_report.txt')
-    report_file.touch()
+    # Directory which contains list of 'tech-support' reports
+    reports_dir: Path = Path(f'{tmp_dir}/show_tech-support_report')
 
     # Call the topology snapshot function here
     __generate_topology_snapshots(tmp_dir)
 
     try:
+        # Generate files using `show tech-support report` command
+        __save_show_report_files(reports_dir)
 
-        save_stdout(op('show tech-support report'), report_file)
         # Generate included archives
-        __generate_archived_files(tmp_dir_path)
+        __generate_archived_files(tmp_dir)
 
         # Generate main archive
-        __generate_main_archive_file(f'{tmp_path}/{archive_file_name}', tmp_dir_path)
-        # Delete temporary directory
-        rmtree(tmp_dir)
+        __generate_main_archive_file(archive_dest_path, tmp_dir)
+
         # Upload to remote site if it is scpecified
-        if remote:
-            upload(f'{tmp_path}/{archive_file_name}', args.path)
-        print(f'Debug file is generated and located in {location_path}/{archive_file_name}')
+        if is_remote:
+            upload_uri = args.path
+            upload(str(archive_dest_path), upload_uri)
     except Exception as err:
         print(f'Error during generating a debug file: {err}')
-        # cleanup
-        if tmp_dir.exists():
-            rmtree(tmp_dir)
+    else:
+        print(f'Debug file is generated and located in {archive_dest_path}')
     finally:
-        # cleanup
+        # Delete temporary directory
+        if tmp_dir.exists():
+            rmtree(tmp_dir, ignore_errors=True)
         exit()

--- a/src/op_mode/show_techsupport_report.py
+++ b/src/op_mode/show_techsupport_report.py
@@ -16,235 +16,321 @@
 
 import os
 import sys
-from typing import List
+import argparse
+from pathlib import Path
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Callable
+from typing import Optional
+from typing import Sequence
+
 from vyos.ifconfig import Section
 from vyos.ifconfig import Interface
 from vyos.utils.process import rc_cmd
+from vyos.utils.process import wrap_op as op
 
 
-def print_header(command: str) -> None:
-    """Prints a command with headers '-'.
-
-    Example:
-
-    % print_header('Example command')
-
-    ---------------
-    Example command
-    ---------------
-    """
-    header_length = len(command) * '-'
-    print(f"\n{header_length}\n{command}\n{header_length}")
+@dataclass(frozen=True)
+class BaseSpec:
+    # Available only for 'show tech-support report' (not 'generate tech-support archive')
+    report_only: Optional[bool] = field(kw_only=True, default=False)
 
 
-def execute_command(command: str, header_text: str) -> None:
-    """Executes a command and prints the output with a header.
+@dataclass(frozen=True)
+class CommandSpec(BaseSpec):
+    header: str  # Display header for a command section
+    command: str  # Shell command to execute
 
-    Example:
-    % execute_command('uptime', "Uptime of the system")
 
-    --------------------
-    Uptime of the system
-    --------------------
-    20:21:57 up  9:04,  5 users,  load average: 0.00, 0.00, 0.0
+@dataclass(frozen=True)
+class FuncSpec(BaseSpec):
+    name: str  # Display name for a function section
+    fn: Callable[
+        ['Runner'], None
+    ]  # Callable that receives a Runner and writes output via it
 
-    """
-    print_header(header_text)
-    try:
-        rc, output = rc_cmd(command)
+
+class OutputSink:
+    """Writes output to stdout and/or a file, depending on parameters"""
+
+    def __init__(self, *, file_path: Optional[Path]):
+        # Target file path; None means stdout
+        self._file_path = file_path
+        self._fh = None
+
+    def __enter__(self) -> 'OutputSink':
+        # Open output file if not writing to stdout
+        if not self.is_stdout:
+            self._file_path.parent.mkdir(parents=True, exist_ok=True)
+            # Use text mode, overwrite per run
+            self._fh = self._file_path.open('w', encoding='utf-8', errors='replace')
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        if self._fh is not None:
+            self._fh.close()
+            self._fh = None
+
+    @property
+    def is_stdout(self):
+        # True when output is directed to stdout
+        return self._file_path is None
+
+    def write(self, text: str):
         # Enable unbuffered print param to improve responsiveness of printed
         # output to end user
-        print(output, flush=True)
-    # Exit gracefully when user interrupts program output
-    # Flush standard streams; redirect remaining output to devnull
-    # Resolves T5633: Bug #1 and 3
-    except (BrokenPipeError, KeyboardInterrupt):
-        os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno()) # pylint: disable = no-member
-        sys.exit(1)
-    except Exception as e:
-        print(f"Error executing command: {command}")
-        print(f"Error message: {e}")
+        if self.is_stdout:
+            print(text, end='', flush=True)
+        else:
+            if self._fh is not None:
+                self._fh.write(text)
+                self._fh.flush()
 
 
-def op(cmd: str) -> str:
-    """Returns a command with the VyOS operational mode wrapper."""
-    return f'/opt/vyatta/bin/vyatta-op-cmd-wrapper {cmd}'
+class Runner:
+    """Executes commands and writes output to the provided sink"""
+
+    def __init__(self, sink: OutputSink):
+        self.sink = sink
+
+    def exec(self, command: str, header: str = None):
+        texts = []
+
+        if header:
+            texts.append(header)
+        texts.append(f'Command: {command}')
+
+        try:
+            # Start a new section for this command
+            self.section('\n'.join(texts))
+
+            rc, output = rc_cmd(command)
+            # Ensure output ends with newline when present
+            if output and not output.endswith('\n'):
+                output += '\n'
+
+            self.sink.write(output)
+            if rc not in (0, None):
+                self.sink.write(
+                    f'Command `{command}` returned non-zero ({rc}) exit status\n'
+                )
+        except (BrokenPipeError, KeyboardInterrupt):
+            raise
+        except Exception as e:
+            self.sink.write(f'Error executing command: {command}\n')
+            self.sink.write(f'Error message: {e}\n')
+
+    def section(self, title: str):
+        """Just print a section header without running a command"""
+        self.sink.write(header_block(title))
 
 
-def get_ethernet_interfaces() -> List[Interface]:
+def header_block(title: str, delimiter='-') -> str:
+    """Create an underline/overline header block for multiline text."""
+    lines = title.splitlines()
+    max_len = max(len(line) for line in lines)
+    line = delimiter * max_len
+    title_block = '\n'.join(lines)
+    return f'\n{line}\n{title_block}\n{line}\n'
+
+
+def select_reports(args: argparse.Namespace) -> dict[str, tuple[BaseSpec]]:
+    reports = REPORTS.copy()
+    requested = args.reports
+
+    if requested:
+        missing = [r for r in requested if r not in reports]
+        if missing:
+            known = ', '.join(sorted(reports.keys()))
+            raise SystemExit(f'Unknown report(s): {", ".join(missing)}. Known: {known}')
+
+        reports = {name: reports[name] for name in requested}
+
+    if args.launched_from_generate_archive:
+        for key in reports.keys():
+            items = reports[key]
+            reports[key] = {item for item in items if not item.report_only}
+
+    return reports
+
+
+def execute_item(item: BaseSpec, runner: Runner) -> None:
+    if isinstance(item, CommandSpec):
+        runner.exec(item.command, item.header)
+    elif isinstance(item, FuncSpec):
+        runner.section(item.name)
+        item.fn(runner)
+    else:
+        assert False, f'Unsupported report type: {type(item)}'
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description='VyOS tech-support command collector')
+    p.add_argument(
+        '--outdir',
+        type=Path,
+        default=None,
+        help=(
+            'Directory to write report files into (one file per report group). '
+            'If this option is omitted, files are written to stdout.'
+        ),
+    )
+    p.add_argument(
+        '--reports',
+        nargs='*',
+        default=[],
+        help=(
+            'Which report groups to run (default: all). '
+            'Example: --reports vyos-main-info'
+        ),
+    )
+    p.add_argument(
+        '--launched-from-generate-archive',
+        action='store_true',
+        default=False,
+        help=(
+            'A boolean flag indicates that command executed for generating '
+            'tech-support archive (`generate tech-support archive`). '
+            'In this case some sections will be ignored because already available in archive.'
+        ),
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: Sequence[str]):
+    args = parse_args(argv)
+
+    # Select which reports to execute
+    chosen = select_reports(args)
+
+    # Execute each report and write to its own sink
+    for report_name, commands in chosen.items():
+        # Use a per-report output file when `outdir` is provided
+        file_path = (args.outdir / report_name) if args.outdir else None
+
+        with OutputSink(file_path=file_path) as sink:
+            runner = Runner(sink)
+            try:
+                # Write top-level report header
+                sink.write(header_block(report_name, delimiter='='))
+
+                # Execute each item in the report
+                for item in commands:
+                    execute_item(item, runner)
+            except (BrokenPipeError, KeyboardInterrupt):
+                if sink.is_stdout:
+                    # Exit gracefully when user interrupts program output
+                    # Flush standard streams; redirect remaining output to devnull
+                    # Resolves T5633: Bug #1 and 3
+                    os.dup2(
+                        os.open(os.devnull, os.O_WRONLY),
+                        sys.stdout.fileno(),  # pylint: disable = no-member
+                    )
+                sys.exit(1)
+
+
+def get_ethernet_interfaces() -> list[Interface]:
     """Returns a list of Ethernet interfaces."""
     return Section.interfaces('ethernet')
 
 
-def show_version() -> None:
-    """Prints the VyOS version and package changes."""
-    execute_command(op('show version'), 'VyOS Version and Package Changes')
-
-
-def show_config_file() -> None:
-    """Prints the contents of a configuration file with a header."""
-    execute_command('cat /opt/vyatta/etc/config/config.boot', 'Configuration file')
-
-
-def show_running_config() -> None:
-    """Prints the running configuration."""
-    execute_command(op('show configuration'), 'Running configuration')
-
-
-def show_package_repository_config() -> None:
-    """Prints the package repository configuration file."""
-    execute_command('cat /etc/apt/sources.list', 'Package Repository Configuration File')
-    execute_command('ls -l /etc/apt/sources.list.d/', 'Repositories')
-
-
-def show_user_startup_scripts() -> None:
-    """Prints the user startup scripts."""
-    execute_command('cat /config/scripts/vyos-preconfig-bootup.script', 'User Startup Scripts (Preconfig)')
-    execute_command('cat /config/scripts/vyos-postconfig-bootup.script', 'User Startup Scripts (Postconfig)')
-
-
-def show_frr_config() -> None:
-    """Prints the FRR configuration."""
-    execute_command('vtysh -c "show run"', 'FRR configuration')
-
-
-def show_interfaces() -> None:
-    """Prints the interfaces."""
-    execute_command(op('show interfaces'), 'Interfaces')
-
-
-def show_interface_statistics() -> None:
-    """Prints the interface statistics."""
-    execute_command('ip -s link show', 'Interface statistics')
-
-
-def show_physical_interface_statistics() -> None:
+def show_physical_interface_statistics(r: Runner):
     """Prints the physical interface statistics."""
-    execute_command('/usr/bin/true', 'Physical Interface statistics')
+
     for iface in get_ethernet_interfaces():
-        # Exclude vlans
-        if '.' in iface:
+        if '.' in iface:  # exclude VLANs
             continue
-        execute_command(f'ethtool --driver {iface}', f'ethtool --driver {iface}')
-        execute_command(f'ethtool --statistics {iface}', f'ethtool --statistics {iface}')
-        execute_command(f'ethtool --show-ring {iface}', f'ethtool --show-ring {iface}')
-        execute_command(f'ethtool --show-coalesce {iface}', f'ethtool --show-coalesce {iface}')
-        execute_command(f'ethtool --pause {iface}', f'ethtool --pause {iface}')
-        execute_command(f'ethtool --show-features {iface}', f'ethtool --show-features {iface}')
-        execute_command(f'ethtool --phy-statistics {iface}', f'ethtool --phy-statistics {iface}')
-    execute_command('netstat --interfaces', 'netstat --interfaces')
-    execute_command('netstat --listening', 'netstat --listening')
-    execute_command('cat /proc/net/dev', 'cat /proc/net/dev')
+
+        r.exec(f'ethtool --driver {iface}')
+        r.exec(f'ethtool --statistics {iface}')
+        r.exec(f'ethtool --show-ring {iface}')
+        r.exec(f'ethtool --show-coalesce {iface}')
+        r.exec(f'ethtool --pause {iface}')
+        r.exec(f'ethtool --show-features {iface}')
+        r.exec(f'ethtool --phy-statistics {iface}')
+        r.exec(f'ethtool --module-info {iface}')
+
+    for path in Path('/run/udev/vyos').glob('*'):
+        if path.is_file():
+            r.exec(f'cat {path.resolve()}')
 
 
-def show_bridge() -> None:
-    """Show bridge interfaces."""
-    execute_command(op('show bridge'), 'Show bridge')
+def _exec_list_op(r: Runner, commands: list):
+    for command in commands:
+        r.exec(op(command))
 
 
-def show_arp() -> None:
-    """Prints ARP entries."""
-    execute_command(op('show arp'), 'ARP Table (Total entries)')
-    execute_command(op('show ipv6 neighbors'), 'show ipv6 neighbors')
-
-
-def show_route() -> None:
+def show_route(r: Runner):
     """Prints routing information."""
 
-    cmd_list_route = [
-        "show ip route bgp | head -108",
-        "show ip route cache",
-        "show ip route connected",
-        "show ip route forward",
-        "show ip route isis | head -108",
-        "show ip route kernel",
-        "show ip route ospf | head -108",
-        "show ip route rip",
-        "show ip route static",
-        "show ip route summary",
-        "show ip route supernets-only",
-        "show ip route table all",
-        "show ip route vrf all",
-        "show ipv6 route bgp | head -108",
-        "show ipv6 route cache",
-        "show ipv6 route connected",
-        "show ipv6 route forward",
-        "show ipv6 route isis",
-        "show ipv6 route kernel",
-        "show ipv6 route ospfv3",
-        "show ipv6 route rip",
-        "show ipv6 route static",
-        "show ipv6 route summary",
-        "show ipv6 route table all",
-        "show ipv6 route vrf all",
+    commands = [
+        'show ip route bgp | head -108',
+        'show ip route connected',
+        'show ip route forward | head -108',
+        'show ip route isis | head -108',
+        'show ip route kernel',
+        'show ip route ospf | head -108',
+        'show ip route rip | head -108',
+        'show ip route static',
+        'show ip route summary',
+        'show ip route supernets-only | head -108',
+        'show ip route table all | head -108',
+        'show ip route vrf all | head -108',
+        'show ipv6 route bgp | head -108',
+        'show ipv6 route connected',
+        'show ipv6 route forward | head -108',
+        'show ipv6 route isis | head -108',
+        'show ipv6 route kernel',
+        'show ipv6 route ospfv3 | head -108',
+        'show ipv6 route rip | head -108',
+        'show ipv6 route static',
+        'show ipv6 route summary',
+        'show ipv6 route table all | head -108',
+        'show ipv6 route vrf all | head -108',
     ]
-    for command in cmd_list_route:
-        execute_command(op(command), command)
+    _exec_list_op(r, commands)
 
 
-def show_firewall() -> None:
-    """Prints firweall information."""
-    execute_command('sudo nft list ruleset', 'nft list ruleset')
+def show_evpn(r: Runner):
+    """Prints EVPN information."""
+
+    commands = [
+        'show evpn mac vni all',
+        'show evpn next-hops vni all',
+        'show evpn rmac vni all',
+        'show evpn access-vlan',
+        'show evpn arp-cache vni all',
+        'show evpn es',
+        'show evpn es-evi',
+    ]
+    _exec_list_op(r, commands)
 
 
-def show_system() -> None:
-    """Prints system parameters."""
-    execute_command(op('show version'), 'Show System Version')
-    execute_command(op('show system storage'), 'Show System Storage')
-    execute_command(op('show system image details'), 'Show System Image Details')
+def show_mpls(r: Runner):
+    """Prints MPLS information."""
+
+    commands = [
+        'show mpls pseudowire',
+        'show mpls table',
+        'show mpls ldp binding',
+        'show mpls ldp discovery',
+        'show mpls ldp interface',
+        'show mpls ldp neighbor',
+    ]
+    _exec_list_op(r, commands)
 
 
-def show_date() -> None:
-    """Print the current date."""
-    execute_command('date', 'Current Time')
+def show_rpki(r: Runner):
+    """Prints RPKI information."""
+
+    commands = [
+        'show rpki cache-server',
+        'show rpki cache-connection',
+    ]
+    _exec_list_op(r, commands)
 
 
-def show_installed_packages() -> None:
-    """Prints installed packages."""
-    execute_command('dpkg --list', 'Installed Packages')
-
-
-def show_loaded_modules() -> None:
-    """Prints loaded modules /proc/modules"""
-    execute_command('cat /proc/modules', 'Loaded Modules')
-
-
-def show_cpu_statistics() -> None:
-    """Prints CPU statistics."""
-    execute_command('/usr/bin/true', 'CPU')
-    execute_command('lscpu', 'Installed CPU\'s')
-    execute_command('top --iterations 1 --batch-mode --accum-time-toggle', 'Cumulative CPU Time Used by Running Processes')
-    execute_command('cat /proc/loadavg', 'Load Average')
-
-
-def show_system_interrupts() -> None:
-    """Prints system interrupts."""
-    execute_command('cat /proc/interrupts', 'Hardware Interrupt Counters')
-
-
-def show_soft_irqs() -> None:
-    """Prints soft IRQ's."""
-    execute_command('cat /proc/softirqs', 'Soft IRQ\'s')
-
-
-def show_softnet_statistics() -> None:
-    """Prints softnet statistics."""
-    execute_command('cat /proc/net/softnet_stat', 'cat /proc/net/softnet_stat')
-
-
-def show_running_processes() -> None:
-    """Prints current running processes"""
-    execute_command('ps -ef', 'Running Processes')
-
-
-def show_memory_usage() -> None:
-    """Prints memory usage"""
-    execute_command('/usr/bin/true', 'Memory')
-    execute_command('cat /proc/meminfo', 'Installed Memory')
-    execute_command('free', 'Memory Usage')
-
-
-def list_disks():
+def _list_disks():
     disks = set()
     with open('/proc/partitions') as partitions_file:
         for line in partitions_file:
@@ -254,60 +340,211 @@ def list_disks():
     return disks
 
 
-def show_storage() -> None:
+def show_storage(r: Runner):
     """Prints storage information."""
-    execute_command('cat /proc/devices', 'Devices')
-    execute_command('cat /proc/partitions', 'Partitions')
 
-    for disk in list_disks():
-        execute_command(f'fdisk --list /dev/{disk}', f'Partitioning for disk {disk}')
+    r.exec('cat /proc/mounts', 'Mount table')
+    r.exec('cat /proc/partitions', 'Partitions table')
 
+    for disk in _list_disks():
+        r.exec(f'fdisk --list /dev/{disk}', f'Partitioning for disk {disk}')
 
-def main():
-    # Configuration data
-    show_version()
-    show_config_file()
-    show_running_config()
-    show_package_repository_config()
-    show_user_startup_scripts()
-    show_frr_config()
-
-    # Interfaces
-    show_interfaces()
-    show_interface_statistics()
-    show_physical_interface_statistics()
-    show_bridge()
-    show_arp()
-
-    # Routing
-    show_route()
-
-    # Firewall
-    show_firewall()
-
-    # System
-    show_system()
-    show_date()
-    show_installed_packages()
-    show_loaded_modules()
-
-    # CPU
-    show_cpu_statistics()
-    show_system_interrupts()
-    show_soft_irqs()
-    show_softnet_statistics()
-
-    # Memory
-    show_memory_usage()
-
-    # Storage
-    show_storage()
-
-    # Processes
-    show_running_processes()
-
-    # TODO: Get information from clouds
+    r.exec('df -ah', 'Filesystem usage')
+    r.exec('df -ahi', 'Filesystem inode usage')
 
 
-if __name__ == "__main__":
-    main()
+def show_kernel_interface_counters(r: Runner):
+    """Prints kernel network interface counters by fixed format."""
+
+    headers = (
+        'bytes',
+        'packets',
+        'errs',
+        'drop',
+        'fifo',
+        'frame',
+        'compressed',
+        'multicast',
+    )
+    new_headers = (
+        ['Interface'] + [f'RX-{h}' for h in headers] + [f'TX-{h}' for h in headers]
+    )
+    echo_template = ' '.join(new_headers)
+    awk_template = ','.join([f'${i}' for i in range(1, len(new_headers) + 1)])
+
+    cmd = (
+        """(echo "{0}" && awk 'NR>2 {{print {1}}}' /proc/net/dev) | column -t""".format(
+            echo_template, awk_template
+        )
+    )
+    r.exec(cmd, 'cat /proc/net/dev | column -t')
+
+
+REPORTS: dict[str, tuple[BaseSpec]] = {
+    'vyos-main-info': (
+        CommandSpec('VyOS version and package info', op('show version')),
+        CommandSpec(
+            'Running configuration (commands)', op('show configuration commands')
+        ),
+        CommandSpec('Running configuration (structured)', op('show configuration')),
+        CommandSpec(
+            'Configuration file (config.boot)',
+            'cat /opt/vyatta/etc/config/config.boot',
+            report_only=True,  # Ignored because already exists in 'tech-support archive'
+        ),
+        CommandSpec('Interfaces summary', op('show interfaces')),
+        CommandSpec('Bridge status', op('show bridge')),
+        CommandSpec('ARP table', op('show arp')),
+        CommandSpec('IPv6 neighbor table', op('show ipv6 neighbors')),
+        CommandSpec('System storage overview', op('show system storage')),
+        CommandSpec('Installed images details', op('show system image details')),
+        CommandSpec(
+            'User startup script (preconfig)',
+            'cat /config/scripts/vyos-preconfig-bootup.script',
+            report_only=True,
+        ),
+        CommandSpec(
+            'User startup script (postconfig)',
+            'cat /config/scripts/vyos-postconfig-bootup.script',
+            report_only=True,
+        ),
+    ),
+    'routing-info': (
+        FuncSpec('Routing table (IPv4/IPv6)', show_route),
+        CommandSpec('BFD peers', op('show bfd peers')),
+        FuncSpec('EVPN status', show_evpn),
+        FuncSpec('MPLS status', show_mpls),
+        FuncSpec('RPKI status', show_rpki),
+    ),
+    'frr-info': (
+        CommandSpec('FRR running configuration', 'vtysh -c "show running-config"'),
+        CommandSpec('FRR memory usage', 'vtysh -c "show memory"'),
+        CommandSpec('FRR work queues', 'vtysh -c "show work-queues"'),
+        CommandSpec('FRR IPv4 nexthop tracking (NHT)', 'vtysh -c "show ip nht"'),
+        CommandSpec('FRR IPv6 nexthop tracking (NHT)', 'vtysh -c "show ipv6 nht"'),
+        CommandSpec('FRR DMVPN status', 'vtysh -c "show dmvpn"'),
+        CommandSpec('FRR event CPU stats', 'vtysh -c "show event cpu"'),
+        CommandSpec('FRR event poll stats', 'vtysh -c "show event poll"'),
+        CommandSpec('FRR event timers', 'vtysh -c "show event timers"'),
+        CommandSpec(
+            'FRR SRv6 locator',
+            'vtysh -c "show segment-routing srv6 locator"',
+        ),
+        CommandSpec(
+            'FRR SRv6 manager',
+            'vtysh -c "show segment-routing srv6 manager"',
+        ),
+    ),
+    'proc-and-sysctl-info': (
+        CommandSpec('System load average', 'cat /proc/loadavg'),
+        FuncSpec('Kernel network interface counters', show_kernel_interface_counters),
+        CommandSpec('Loaded kernel modules', 'cat /proc/modules'),
+        CommandSpec('Hardware interrupt counters', 'cat /proc/interrupts'),
+        CommandSpec('SoftIRQ counters', 'cat /proc/softirqs'),
+        CommandSpec('Softnet statistics', 'cat /proc/net/softnet_stat'),
+        CommandSpec('Memory info', 'cat /proc/meminfo'),
+        CommandSpec(
+            'NUMA node memory info',
+            'cat /sys/devices/system/node/node*/meminfo',
+        ),
+        CommandSpec('VM statistics', 'cat /proc/vmstat'),
+        CommandSpec('Registered character/block devices', 'cat /proc/devices'),
+        CommandSpec('Kernel command line', 'cat /proc/cmdline'),
+        CommandSpec('All sysctl values', 'sysctl -a'),
+    ),
+    'net-and-processes-info': (
+        CommandSpec('Network interfaces', 'netstat --interfaces'),
+        CommandSpec('Listening sockets', 'netstat --listening'),
+        CommandSpec('Socket summary', 'ss -s'),
+        CommandSpec('All sockets with details', 'ss -a -e -m -p'),
+        CommandSpec('Full process listing', 'ps -eF'),
+    ),
+    'ethtool-info': (
+        CommandSpec(
+            'Link details and interface counters',
+            'ip -s -d link show',
+        ),
+        FuncSpec('Physical interface statistics', show_physical_interface_statistics),
+    ),
+    'lspci-and-numa-info': (
+        CommandSpec('PCI devices', 'lspci -knnv'),
+        CommandSpec('', 'numactl --hardware'),
+        CommandSpec('', 'numastat -cm'),
+    ),
+    'nftables-info': (
+        CommandSpec('nftables ruleset', 'nft list ruleset'),
+        CommandSpec('VyOS firewall configuration', op('show firewall')),
+        CommandSpec('VyOS firewall zone policy', op('show firewall zone-policy')),
+    ),
+    'dpkg-and-modules-info': (
+        CommandSpec('Installed packages', 'dpkg --list'),
+        CommandSpec(
+            'Diff dpkg status (image vs running system)',
+            'diff /usr/lib/live/mount/rootfs/*.squashfs/var/lib/dpkg/status /var/lib/dpkg/status',
+        ),
+        CommandSpec('APT sources list', 'cat /etc/apt/sources.list'),
+        CommandSpec(
+            'APT sources.d directory listing', 'ls -l /etc/apt/sources.list.d/'
+        ),
+        CommandSpec('Loaded kernel modules', 'lsmod'),
+    ),
+    'system-resources-info': (
+        CommandSpec('Current time (date)', 'date'),
+        CommandSpec('CPU information', 'lscpu'),
+        CommandSpec(
+            'Per-process cumulative CPU usage snapshot (top batch, accumulated)',
+            'top --iterations 1 --batch-mode --accum-time-toggle',
+        ),
+        CommandSpec('atop snapshot (CPU view)', 'atop -a -y -1 -c -g -C 1 1 | tee'),
+        CommandSpec('atop snapshot (memory view)', 'atop -a -y -1 -c -m -M 1 1 | tee'),
+        CommandSpec('atop snapshot (disk view)', 'atop -a -y -1 -c -d -D 1 1 | tee'),
+        CommandSpec('atop snapshot (network view)', 'atop -a -y -1 -c -n -N 1 1 | tee'),
+        CommandSpec('Memory usage', 'free -lhv'),
+        FuncSpec('Storage overview', show_storage),
+    ),
+    'ipsec-debug-info': (
+        CommandSpec('strongSwan connections', 'swanctl -L'),
+        CommandSpec('strongSwan loaded connections', 'swanctl -l'),
+        CommandSpec('strongSwan policies', 'swanctl -P'),
+        CommandSpec('XFRM security associations', 'ip x sa show'),
+        CommandSpec('XFRM policies', 'ip x policy show'),
+        CommandSpec('XFRM state', 'ip xfrm state'),
+        CommandSpec('Tunnels', 'ip tunnel show'),
+        CommandSpec('Addresses', 'ip address'),
+        CommandSpec('Policy routing rules', 'ip rule show'),
+        CommandSpec('Routes', 'ip route | head -100'),
+        CommandSpec('Routes from table 220', 'ip route show table 220'),
+    ),
+    'vpp-info': (
+        CommandSpec('', 'cat /run/vpp/vpp.conf'),
+        CommandSpec('', 'vppctl show version verbose cmdline'),
+        CommandSpec('', 'vppctl show hardware-interfaces'),
+        CommandSpec('', 'vppctl show interface address'),
+        CommandSpec('', 'vppctl show interface'),
+        CommandSpec('', 'vppctl show errors'),
+        CommandSpec('', 'vppctl show runtime'),
+        CommandSpec(
+            '',
+            'vppctl show memory api-segment stats-segment numa-heaps main-heap map verbose',
+        ),
+        CommandSpec('', 'vppctl show buffers'),
+        CommandSpec('', 'vppctl show physmem detail'),
+        CommandSpec('', 'vppctl show physmem map'),
+        CommandSpec('', 'vppctl show cpu'),
+        CommandSpec('', 'vppctl show threads'),
+        CommandSpec('', 'vppctl show node counters'),
+        CommandSpec('', 'vppctl show l2fib'),
+        CommandSpec('', 'vppctl show bridge-domain'),
+        CommandSpec('', 'vppctl show ip fib | head -100'),
+        CommandSpec('', 'vppctl show ip neighbors'),
+        CommandSpec('', 'vppctl show ip6 fib | head -100'),
+        CommandSpec('', 'vppctl show ip6 neighbors'),
+        CommandSpec('', 'vppctl show mpls fib'),
+        CommandSpec('', 'vppctl show mpls tunnel'),
+        CommandSpec('', 'vppctl show trace'),
+    ),
+}
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/src/opt/vyatta/share/vyatta-op/functions/interpreter/vyatta-op-run
+++ b/src/opt/vyatta/share/vyatta-op/functions/interpreter/vyatta-op-run
@@ -169,9 +169,18 @@ _vyatta_op_run ()
 
     _vyatta_op_last_comp=${_vyatta_op_last_comp_init}
     false; estat=$?
-    stty echo 2> /dev/null # turn echo on, this is a workaround for bug 7570
-                           # not a fix we need to look at why the readline library 
-                           # is getting confused on paged help text.
+
+    # Only touch terminal settings when `stdout` is a real TTY.
+    # When output is piped (e.g. via `sudo ... | cat`), running `stty` can interfere
+    # with non-interactive execution and produce corrupted/indented output.
+    if [ -t 1 ]; then
+
+      # Turn echo on, this is a workaround for bug 7570
+      # not a fix we need to look at why the readline library
+      # is getting confused on paged help text.
+      stty echo 2> /dev/null
+
+    fi
 
     i=1
     declare -a args  # array of expanded arguments


### PR DESCRIPTION
## Change summary

- Exclude .iso files from `/config` and `/home/*` to avoid large images
- Exclude previous debug-archived from new archives
- Include `/run` directory contents
- Add kernel modules information (`lsmod`)
- Add PCI details (`lspci -knnv`)
- Include full `/config` directory
- Add FRR info (`vtysh`)
- Add VPP info (`vppctl`)
- Add NUMA details (`numactl --hardware`, `numastat -cm`)

Full list of commands here: https://vyos.dev/T8215

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8215

## How to test / Smoketest result

### Manual test

Show full tech-support report:
```
vyos@vyos:~$ show tech-support report
==============
vyos-main-info
==============

-----------------------------
VyOS version and package info
-----------------------------
Version:          VyOS 999.202601130754
Release train:    current
Release flavor:   generic
...
```

Show filtered tech-support report in specified directory (can be useful for debug):
```
vyos@vyos:~$ ${vyos_op_scripts_dir}/show_techsupport_report.py --reports ethtool-info --outdir ./reports
vyos@vyos:~$ cat ./reports/ethtool-info
============
ethtool-info
============

-----------------------------------
Link details and interface counters
-----------------------------------
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00 promiscuity 0 allmulti 0 minmtu 0 maxmtu 0 addrgenmode none numtxqueues 1 numrxqueues 1 gso_max_size 65536 gso_max_segs 65535 tso_max_size 524280 tso_max_segs 65535 gro_max_size 65536 
    RX:  bytes packets errors dropped  missed   mcast           
        219456    2976      0       0       0       0 
    TX:  bytes packets errors dropped carrier collsns           
        219456    2976      0       0       0       0 
...
```

Generate tech-support archive in /tmp directory:
```
vyos@vyos:~$ generate tech-support archive
Debug file is generated and located in /tmp/vyos_tech-support-archive_2026-02-04T08-54-00.tar.gz
```

### Smoketest
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_techsupport_report.py
test_directory_output (__main__.TestTechSupportReport.test_directory_output) ... ok
test_filtered_report (__main__.TestTechSupportReport.test_filtered_report) ... ok
test_full_report (__main__.TestTechSupportReport.test_full_report) ... ok
----------------------------------------------------------------------
Ran 3 tests in 26.714s
OK
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_techsupport_archive.py
test_custom_archive_path (__main__.TestTechSupportArchive.test_custom_archive_path) ... ok
test_excluded_archive_files (__main__.TestTechSupportArchive.test_excluded_archive_files) ... ok
test_general_archive_structure (__main__.TestTechSupportArchive.test_general_archive_structure) ... ok
----------------------------------------------------------------------
Ran 3 tests in 43.112s
OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly