### PR TITLE
T8188: Preserve static IPv4 addresses flushed by dhclient

### DIFF
--- a/src/etc/dhcp/dhclient-enter-hooks.d/03-vyos-ipwrapper
+++ b/src/etc/dhcp/dhclient-enter-hooks.d/03-vyos-ipwrapper
@@ -1,10 +1,47 @@
-# redefine ip command to use FRR when it is available
+# redefine ip command to use FRR when it is available and preserve static addresses
 
 # default route distance
 IF_METRIC=${IF_METRIC:-210}
 
 # Check if interface is inside a VRF
 VRF_OPTION=$(/usr/sbin/ip --json --detail link show ${interface} | jq -r '.[0] | select(.linkinfo.info_slave_kind == "vrf") | "vrf \(.master)"')
+
+# Flush only DHCP (dynamic) addresses from interface, preserving static addresses
+#
+#  When dhclient renews/rebinds a lease, it calls:
+#      ip -4 addr flush dev <interface>
+#  This removes ALL IPv4 addresses, including static addresses configured
+#  via VyOS (e.g., "set interfaces ethernet eth0 address 192.168.1.1/24").
+#
+#  The ip() wrapper below intercepts the "ip -4 addr flush" command and replaces
+#  it with a selective flush that only removes addresses marked as "dynamic" by
+#  the kernel. DHCP-assigned addresses have the "dynamic" flag set automatically.
+_flush_dhcp_addrs() {
+    local dev="${1:-$interface}"
+
+    logmsg info "Selectively flushing only dynamic (DHCP) addresses from ${dev}"
+
+    local addrs
+    addrs=$(/usr/sbin/ip -4 -j addr show dev "${dev}" 2>&1 | jq -r '
+      .[] | .addr_info[]? | select(.family == "inet" and .dynamic == true)
+      | "\(.local)/\(.prefixlen)"
+    ' 2>&1)
+    if [ $? -ne 0 ]; then
+        logmsg warn "Failed to list dynamic IPv4 addresses on ${dev}; skipping selective flush. ip/jq error output: $addrs"
+        return 0
+    fi
+
+    while IFS= read -r addr; do
+        if [ -n "$addr" ]; then
+            logmsg info "Removing dynamic address ${addr} from ${dev}"
+            if ! /usr/sbin/ip -4 addr del "${addr}" dev "${dev}" 2>&1; then
+                logmsg warn "Failed to remove dynamic address ${addr} from ${dev}"
+            fi
+        fi
+    done <<< "$addrs"
+
+    return 0
+}
 
 # get status of FRR
 function frr_alive () {
@@ -90,6 +127,20 @@ function vtysh_conf () {
 
 # replace ip command with this wrapper
 function ip () {
+    # Intercept: ip -4 addr flush dev <interface>
+    # to preserve static addresses (only remove dynamic/DHCP addresses)
+    if [ "$1" = "-4" ] && [ "$2" = "addr" ] && [ "$3" = "flush" ]; then
+        logmsg info "Intercepting 'ip -4 addr flush' to preserve static addresses"
+        shift 3
+        local dev=""
+        while [ $# -gt 0 ]; do
+            [ "$1" = "dev" ] && dev="$2" && break
+            shift
+        done
+        _flush_dhcp_addrs "${dev:-$interface}"
+        return $?
+    fi
+
     # pass comand to system `ip` if this is not related to routes change
     if [ "$2" != "route" ] ; then
         logmsg info "Passing command to /usr/sbin/ip: \"$@\""


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
When dhclient renews/rebinds a lease, it calls "ip -4 addr flush dev
<interface>". This removes ALL IPv4 addresses, including static
addresses configured via VyOS (e.g., "set interfaces ethernet eth0
address 192.168.1.1/24").
The new hook intercepts the "ip -4 addr flush" command and replaces
it with a selective flush that only removes addresses marked as
"dynamic" by the kernel. DHCP-assigned addresses have the "dynamic" flag
set automatically.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8188
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# run show conf comm | grep eth1
set interfaces ethernet eth1 address 'dhcp'
set interfaces ethernet eth1 address '100.0.0.1/24'
set interfaces ethernet eth1 address '200.0.0.10/24'
set interfaces ethernet eth1 hw-id '0c:9c:d0:3d:00:01'
set interfaces ethernet eth1 mtu '1500'
```
Before:
```
vyos@vyos# run show interfaces
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address          MAC                VRF        MTU  S/L    Description
-----------  ------------------  -----------------  -------  -----  -----  -------------
eth0         -                   0c:9c:d0:3d:00:00  default   1500  u/D
eth1         100.0.0.1/24        0c:9c:d0:3d:00:01  default   1500  u/u
             200.0.0.10/24
             192.168.100.10/24
eth2         -                   0c:9c:d0:3d:00:02  default   1500  u/D
eth3         10.217.32.116/24    0c:9c:d0:3d:00:03  default   1500  u/u
lo           127.0.0.1/8         00:00:00:00:00:00  default  65536  u/u
             ::1/128

vyos@vyos# run renew dhcp interface eth1
Restarting DHCP client on interface eth1...
[edit]
vyos@vyos# run show interfaces
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address          MAC                VRF        MTU  S/L    Description
-----------  ------------------  -----------------  -------  -----  -----  -------------
eth0         -                   0c:9c:d0:3d:00:00  default   1500  u/D
eth1         192.168.100.10/24  0c:9c:d0:3d:00:01  default   1500  u/u
eth2         -                   0c:9c:d0:3d:00:02  default   1500  u/D
eth3         10.217.32.116/24    0c:9c:d0:3d:00:03  default   1500  u/u
lo           127.0.0.1/8         00:00:00:00:00:00  default  65536  u/u
             ::1/128
[edit]

```
After:
```
vyos@vyos# run renew dhcp interface eth1
Restarting DHCP client on interface eth1...
[edit]
vyos@vyos# run show interfaces
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address          MAC                VRF        MTU  S/L    Description
-----------  ------------------  -----------------  -------  -----  -----  -------------
eth0         -                   0c:9c:d0:3d:00:00  default   1500  u/D
eth1         100.0.0.1/24        0c:9c:d0:3d:00:01  default   1500  u/u
             200.0.0.10/24
             192.168.100.10/24
eth2         -                   0c:9c:d0:3d:00:02  default   1500  u/D
eth3         10.217.32.116/24    0c:9c:d0:3d:00:03  default   1500  u/u
lo           127.0.0.1/8         00:00:00:00:00:00  default  65536  u/u
             ::1/128
[edit]
```
LOGS:
```
Mar 06 11:01:22 vyos systemd[1]: Stopping DHCP client on eth1...
Mar 06 11:01:22 vyos dhclient[9014]: Killed old client process
Mar 06 11:01:22 vyos dhclient[9014]: Killed old client process
Mar 06 11:01:23 vyos dhclient[9014]: Internet Systems Consortium DHCP Client 4.4.3-P1
Mar 06 11:01:23 vyos dhclient[9014]: Internet Systems Consortium DHCP Client 4.4.3-P1
Mar 06 11:01:23 vyos dhclient[9014]: Copyright 2004-2022 Internet Systems Consortium.
Mar 06 11:01:23 vyos dhclient[9014]: All rights reserved.
Mar 06 11:01:23 vyos dhclient[9014]: For info, please visit https://www.isc.org/software/dhcp/
Mar 06 11:01:23 vyos dhclient[9014]: Copyright 2004-2022 Internet Systems Consortium.
Mar 06 11:01:23 vyos dhclient[9014]: All rights reserved.
Mar 06 11:01:23 vyos dhclient[9014]: For info, please visit https://www.isc.org/software/dhcp/
Mar 06 11:01:23 vyos dhclient[9014]:
Mar 06 11:01:23 vyos dhclient[9014]: Listening on LPF/eth1/0c:9c:d0:3d:00:01
Mar 06 11:01:23 vyos dhclient[9014]: Listening on LPF/eth1/0c:9c:d0:3d:00:01
Mar 06 11:01:23 vyos dhclient[9014]: Sending on   LPF/eth1/0c:9c:d0:3d:00:01
Mar 06 11:01:23 vyos dhclient[9014]: Sending on   Socket/fallback
Mar 06 11:01:23 vyos dhclient[9014]: DHCPRELEASE of 192.168.100.10 on eth1 to 192.168.100.1 port 67
Mar 06 11:01:23 vyos dhclient[9014]: Sending on   LPF/eth1/0c:9c:d0:3d:00:01
Mar 06 11:01:23 vyos dhclient[9014]: Sending on   Socket/fallback
Mar 06 11:01:23 vyos dhclient[9014]: DHCPRELEASE of 192.168.100.10 on eth1 to 192.168.100.1 port 67
Mar 06 11:01:23 vyos dhclient-script-vyos[9015]: Current dhclient PID: 9014, Parent PID: 1, IP version: 4, All dhclients for interface eth1: 9014
Mar 06 11:01:24 vyos dhclient-script-vyos[9015]: Intercepting 'ip -4 addr flush' to preserve static addresses
Mar 06 11:01:24 vyos dhclient-script-vyos[9015]: Selectively flushing only dynamic (DHCP) addresses from eth1
Mar 06 11:01:24 vyos dhclient-script-vyos[9015]: Removing dynamic address 192.168.100.10/24 from eth1
Mar 06 11:01:24 vyos dhclient-script-vyos[9015]: Deleting search domains with tag "dhcp-eth1" via vyos-hostsd-client
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
