### PR TITLE
T8232: Simplify and extend config_dict construction

### DIFF
--- a/libvyosconfig/Makefile
+++ b/libvyosconfig/Makefile
@@ -42,8 +42,8 @@ all: sharedlib
 PHONY: depends
 depends:
 	sudo sh -c 'eval $$(opam env --root=/opt/opam --set-root) ;\
-		opam pin add vyos1x-config https://github.com/vyos/vyos1x-config.git#6cf3918875b11dd94f9dc380b4083cc4258da74c -y ; \
-		opam pin add vyconf https://github.com/vyos/vyconf.git#ee86cf713f45d3bcd735440f432b5b7b57a31ca8 -y'
+		opam pin add vyos1x-config https://github.com/vyos/vyos1x-config.git#6ebd5d80f9a212beba6352494392ae811f66d64e -y ; \
+		opam pin add vyconf https://github.com/vyos/vyconf.git#2c16a5ad7171362d71ff241adab873fa3752b784 -y'
 
 sharedlib: depends $(BUILDDIR)/libvyosconfig$(EXTDLL)
 

--- a/libvyosconfig/lib/bindings.ml
+++ b/libvyosconfig/lib/bindings.ml
@@ -94,6 +94,31 @@ let write_internal c_ptr file =
     with Internal.Write_error msg ->
         error_message := msg
 
+let render_json_reference_tree c_ptr =
+    RT.render_json (Root.get c_ptr)
+
+let read_internal_reference_tree file =
+    (* alert exn Internal.read_internal:
+        [Internal.Read_error] caught
+     *)
+    try
+        error_message := "";
+        let rt = (IR.read_internal[@alert "-exn"]) file in
+        Ctypes.Root.create rt
+    with Internal.Read_error msg ->
+        error_message := msg; Ctypes.null
+
+let write_internal_reference_tree c_ptr file =
+    (* alert exn Internal.write_internal:
+        [Internal.Write_error] caught
+     *)
+    try
+        error_message := "";
+        let ct = Root.get c_ptr in
+        (IR.write_internal[@alert "-exn"]) ct file
+    with Internal.Write_error msg ->
+        error_message := msg
+
 let create_node c_ptr path =
     (* alert exn CT.create_node:
         [Vytree.Empty_path] caught
@@ -465,7 +490,6 @@ let validate_tree_filter c_ptr rt_cache_path validator_dir =
     with Internal.Read_error msg ->
         error_message := msg; c_ptr
 
-
 module Stubs(I : Cstubs_inverted.INTERNAL) =
 struct
 
@@ -480,6 +504,9 @@ struct
   let () = I.internal "to_commands" ((ptr void) @-> string @-> returning string) render_commands
   let () = I.internal "read_internal" (string @-> returning (ptr void)) read_internal
   let () = I.internal "write_internal" ((ptr void) @-> string @-> returning void) write_internal
+  let () = I.internal "to_json_reference_tree" ((ptr void) @-> returning string) render_json_reference_tree
+  let () = I.internal "read_internal_reference_tree" (string @-> returning (ptr void)) read_internal_reference_tree
+  let () = I.internal "write_internal_reference_tree" ((ptr void) @-> string @-> returning void) write_internal_reference_tree
   let () = I.internal "create_node" ((ptr void) @-> string @-> returning int) create_node
   let () = I.internal "set_add_value" ((ptr void) @-> string @-> string @-> returning int) set_add_value
   let () = I.internal "set_replace_value" ((ptr void) @-> string @-> string @-> returning int) set_replace_value

--- a/libvyosconfig/lib/bindings.ml
+++ b/libvyosconfig/lib/bindings.ml
@@ -12,6 +12,7 @@ module RT = Reference_tree
 module TA = Tree_alg
 module CM = Commit
 module VC = Vycall_client
+module CDict = Config_dict
 
 module I = Internal.Make(Config_tree)
 module IR = Internal.Make(Reference_tree)
@@ -490,6 +491,14 @@ let validate_tree_filter c_ptr rt_cache_path validator_dir =
     with Internal.Read_error msg ->
         error_message := msg; c_ptr
 
+let config_dict c_ptr_c c_ptr_r c_ptr_m path get_node with_defaults =
+    let ct = Root.get c_ptr_c in
+    let rt = Root.get c_ptr_r in
+    let mask = Root.get c_ptr_m in
+    let path = split_on_whitespace path in
+    let with_node = not get_node in
+    CDict.config_dict ~with_defaults:with_defaults ~with_first_node:with_node rt ct mask path
+
 module Stubs(I : Cstubs_inverted.INTERNAL) =
 struct
 
@@ -532,4 +541,5 @@ struct
   let () = I.internal "reference_tree_to_json" (string @-> string @-> string @-> returning int) reference_tree_to_json
   let () = I.internal "mask_tree" ((ptr void) @-> (ptr void) @-> returning (ptr void)) mask_tree
   let () = I.internal "validate_tree_filter" ((ptr void) @-> string @-> string @-> returning (ptr void)) validate_tree_filter
+  let () = I.internal "config_dict" ((ptr void) @-> (ptr void) @-> (ptr void) @-> string @-> bool @-> bool @-> returning string) config_dict
 end

--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -224,20 +224,20 @@ class ConfigTree(object):
 
     def __eq__(self, other):
         if isinstance(other, ConfigTree):
-            return self.__equal(self._get_config(), other._get_config())
+            return self.__equal(self.get_tree(), other.get_tree())
         return False
 
     def __str__(self):
         return self.to_string()
 
-    def _get_config(self):
+    def get_tree(self):
         return self.__config
 
     def get_version_string(self):
         return self.__version
 
     def write_cache(self, file_name):
-        self.__write_internal(self._get_config(), file_name.encode())
+        self.__write_internal(self.get_tree(), file_name.encode())
 
     def to_string(self, ordered_values=False, no_version=False):
         config_string = self.__to_string(self.__config, ordered_values).decode()
@@ -495,7 +495,7 @@ def diff_compare(left, right, path=[], commands=False, libpath=LIBPATH):
     __get_error.argtypes = []
     __get_error.restype = c_char_p
 
-    res = __diff_compare(commands, path_str, left._get_config(), right._get_config())
+    res = __diff_compare(commands, path_str, left.get_tree(), right.get_tree())
     res = res.decode()
     if res == '#1@':
         msg = __get_error().decode()
@@ -521,7 +521,7 @@ def union(left, right, libpath=LIBPATH):
     __get_error.argtypes = []
     __get_error.restype = c_char_p
 
-    res = __tree_union(left._get_config(), right._get_config())
+    res = __tree_union(left.get_tree(), right.get_tree())
     tree = ConfigTree(address=res)
 
     return tree
@@ -543,7 +543,7 @@ def merge(left, right, destructive=False, libpath=LIBPATH):
     __get_error.argtypes = []
     __get_error.restype = c_char_p
 
-    res = __tree_merge(destructive, left._get_config(), right._get_config())
+    res = __tree_merge(destructive, left.get_tree(), right.get_tree())
     tree = ConfigTree(address=res)
 
     return tree
@@ -562,7 +562,7 @@ def mask_inclusive(left, right, libpath=LIBPATH):
         __get_error.argtypes = []
         __get_error.restype = c_char_p
 
-        res = __mask_tree(left._get_config(), right._get_config())
+        res = __mask_tree(left.get_tree(), right.get_tree())
     except Exception as e:
         raise ConfigTreeError(e)
     if not res:
@@ -657,7 +657,7 @@ def validate_tree_filter(
         __get_error.argtypes = []
         __get_error.restype = c_char_p
         res = __validate_tree_filter(
-            config_tree._get_config(), cache_path.encode(), validator_dir.encode()
+            config_tree.get_tree(), cache_path.encode(), validator_dir.encode()
         )
     except Exception as e:
         raise ConfigTreeError(e)
@@ -706,7 +706,7 @@ class DiffTree:
         check_path(path)
         path_str = ' '.join(map(str, path)).encode()
 
-        res = self.__diff_tree(path_str, left._get_config(), right._get_config())
+        res = self.__diff_tree(path_str, left.get_tree(), right.get_tree())
 
         # full diff config_tree and python dict representation
         self.full = ConfigTree(address=res)

--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -188,6 +188,17 @@ class ConfigTree(object):
         self.__equal.argtypes = [c_void_p, c_void_p]
         self.__equal.restype = c_bool
 
+        self.__config_dict = self.__lib.config_dict
+        self.__config_dict.argtypes = [
+            c_void_p,
+            c_void_p,
+            c_void_p,
+            c_char_p,
+            c_bool,
+            c_bool,
+        ]
+        self.__config_dict.restype = c_char_p
+
         if address is not None:
             self.__config = address
             self.__version = ''
@@ -471,6 +482,23 @@ class ConfigTree(object):
         res = self.__get_subtree(self.__config, path_str, with_node)
         subt = ConfigTree(address=res)
         return subt
+
+    def config_dict(
+        self, ref_tree, path, mask, get_first_key=False, with_defaults=False
+    ):
+        check_path(path)
+        path_str = ' '.join(map(str, path)).encode()
+
+        res_json = self.__config_dict(
+            self.__config,
+            ref_tree.get_tree(),
+            mask.get_tree(),
+            path_str,
+            get_first_key,
+            with_defaults,
+        ).decode()
+        res = json.loads(res_json)
+        return res
 
 
 def diff_compare(left, right, path=[], commands=False, libpath=LIBPATH):

--- a/python/vyos/defaults.py
+++ b/python/vyos/defaults.py
@@ -99,3 +99,5 @@ SSH_DSA_DEPRECATION_WARNING: str = \
 'Support for SSH-DSA keys is deprecated and will be removed in VyOS 1.6. ' \
 'Please update affected keys to a supported algorithm (e.g., RSA, ECDSA or ' \
 'ED25519) to avoid authentication failures after the upgrade.'
+
+reference_tree_cache = '/usr/share/vyos/reftree.cache'

--- a/python/vyos/referencetree.py
+++ b/python/vyos/referencetree.py
@@ -1,0 +1,81 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+from ctypes import cdll, c_char_p, c_void_p, c_bool
+
+from vyos.defaults import reference_tree_cache
+
+LIBPATH = '/usr/lib/libvyosconfig.so.0'
+
+
+class ReferenceTreeError(Exception):
+    pass
+
+
+class ReferenceTree:
+    # pylint: disable=too-many-instance-attributes
+    def __init__(self, cache_file=reference_tree_cache, libpath=LIBPATH):
+        self.__pointer = None
+        self.__lib = cdll.LoadLibrary(libpath)
+
+        # Import functions
+        self.__get_error = self.__lib.get_error
+        self.__get_error.argtypes = []
+        self.__get_error.restype = c_char_p
+
+        self.__read_internal = self.__lib.read_internal_reference_tree
+        self.__read_internal.argtypes = [c_char_p]
+        self.__read_internal.restype = c_void_p
+
+        self.__write_internal = self.__lib.write_internal_reference_tree
+        self.__write_internal.argtypes = [c_void_p, c_char_p]
+
+        self.__to_json = self.__lib.to_json_reference_tree
+        self.__to_json.argtypes = [c_void_p]
+        self.__to_json.restype = c_char_p
+
+        self.__destroy = self.__lib.destroy
+        self.__destroy.argtypes = [c_void_p]
+
+        self.__equal = self.__lib.equal
+        self.__equal.argtypes = [c_void_p, c_void_p]
+        self.__equal.restype = c_bool
+
+        pointer = self.__read_internal(cache_file.encode())
+        if pointer is None:
+            msg = self.__get_error().decode()
+            raise ValueError(f'Failed to read internal rep: {msg}')
+        self.__pointer = pointer
+
+    def __del__(self):
+        if self.__pointer is not None:
+            self.__destroy(self.__pointer)
+
+    def __eq__(self, other):
+        if isinstance(other, ReferenceTree):
+            return self.__equal(self.get_tree(), other.get_tree())
+        return False
+
+    def __str__(self):
+        return self.to_json()
+
+    def get_tree(self):
+        return self.__pointer
+
+    def write_cache(self, file_name):
+        self.__write_internal(self.get_tree(), file_name.encode())
+
+    def to_json(self):
+        return self.__to_json(self.__pointer).decode()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Add bindings for alternative config_dict construction, and a reference_tree class for basic example and future development.

Note that the core vyos1x-config config_dict construction is in place, but it will not be considered as a replacement or alternative for `get_config_dict` until some later point, pending further development.

The bindings and class introduced below do not affect any other functionality or development.

A basic example is given below, followed by the example for the original problematic and discussion here:
https://github.com/vyos/vyos-1x/pull/4757#issuecomment-3427922703
where the pruning step has been replaced by a 'mask' argument excluding those masked paths from addition of default values if not present in the actual config.

Things to note about the examples:
- ordering of output differs for the two approaches, as ordering for the reference tree has not been normalized
- the mask object is a `config_tree` object, with `reference_tree` paths, as makes sense on consideration; namely, no tag node _values_ are included in the paths
-  the mask, by definition, prevents default values from being added below the terminal node of its paths, _unless_ the config itself has set that path
- options regarding key mangling and multi_to_list now become simply a matter of the internal JSON renderer, and will be added in a separate task

Basic example:

```python
vyos@vyos:~$ config
[edit]
vyos@vyos# ipython3
Python 3.11.2 (main, Apr 28 2025, 14:11:48) [GCC 12.2.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.5.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from vyos.config import Config

In [2]: config = Config()

In [3]: base = ['interfaces', 'ethernet']

In [4]: A = config.get_config_dict(base + ['eth2'], with_recursive_defaults=True, get_first_key=True)

In [5]: A
Out[5]: 
{'address': ['192.168.137.2/24'],
 'hw-id': '52:54:00:a2:4a:7b',
 'offload': {'gro': {}, 'gso': {}, 'sg': {}, 'tso': {}},
 'speed': 'auto',
 'ipv6': {'dup-addr-detect-transmits': '1',
  'accept-dad': '1',
  'base-reachable-time': '30'},
 'ip': {'arp-cache-timeout': '30'},
 'duplex': 'auto',
 'dhcp-options': {'default-route-distance': '210'}}

In [6]: from vyos.referencetree import ReferenceTree

In [7]: from vyos.configtree import ConfigTree

In [8]: rt = ReferenceTree()

In [9]: ct = config._session_config

In [10]: mask = ConfigTree('')

In [11]: mask.set(base + ['ipv6'])

In [12]: B = ct.config_dict(rt, base + ['eth2'], mask, get_first_key=True, with_defaults=True)

In [13]: B
Out[13]: 
{'dhcp-options': {'default-route-distance': '210'},
 'duplex': 'auto',
 'ip': {'arp-cache-timeout': '30'},
 'speed': 'auto',
 'address': '192.168.137.2/24',
 'hw-id': '52:54:00:a2:4a:7b',
 'offload': {'gro': {}, 'gso': {}, 'sg': {}, 'tso': {}}}

```

Firewall example:

```python
vyos@vyos:~$ config
[edit]
vyos@vyos# set firewall ipv4 output filter rule 1 action accept
vyos@vyos# commit
...
In [14]: base = ['firewall']

In [15]: A = config.get_config_dict(base, with_recursive_defaults=True, get_first_key=True)

In [16]: A
Out[16]: 
{'ipv4': {'output': {'filter': {'rule': {'1': {'action': 'accept'}},
    'default-action': 'accept'},
   'raw': {'default-action': 'accept'}},
  'prerouting': {'raw': {'default-action': 'accept'}},
  'input': {'filter': {'default-action': 'accept'}},
  'forward': {'filter': {'default-action': 'accept'}}},
 'ipv6': {'prerouting': {'raw': {'default-action': 'accept'}},
  'output': {'raw': {'default-action': 'accept'},
   'filter': {'default-action': 'accept'}},
  'input': {'filter': {'default-action': 'accept'}},
  'forward': {'filter': {'default-action': 'accept'}}},
 'bridge': {'prerouting': {'filter': {'default-action': 'accept'}},
  'output': {'filter': {'default-action': 'accept'}},
  'input': {'filter': {'default-action': 'accept'}},
  'forward': {'filter': {'default-action': 'accept'}}},
 'global-options': {'ipv6-src-route': 'disable',
  'ipv6-source-validation': 'disable',
  'ipv6-receive-redirects': 'disable',
  'twa-hazards-protection': 'disable',
  'timeout': {'udp': {'stream': '180', 'other': '30'},
   'tcp': {'time-wait': '120',
    'syn-sent': '120',
    'syn-recv': '60',
    'last-ack': '30',
    'fin-wait': '120',
    'established': '432000',
    'close': '10',
    'close-wait': '60'},
   'other': '600',
   'icmp': '30'},
  'syn-cookies': 'enable',
  'source-validation': 'disable',
  'send-redirects': 'enable',
  'resolver-interval': '300',
  'receive-redirects': 'disable',
  'log-martians': 'enable',
  'ip-src-route': 'disable',
  'directed-broadcast': 'enable',
  'broadcast-ping': 'disable',
  'all-ping': 'enable'}}

In [17]: mask = ConfigTree('')

In [18]: for p in ('ipv4', 'ipv6', 'bridge'):
    ...:     for q in ('forward', 'input', 'output', 'prerouting'):
    ...:         mask.set(base + [p, q])
    ...: 

In [19]: mask.to_json()
Out[19]: '{"firewall": {"bridge": {"prerouting": {},"output": {},"input": {},"forward": {}},"ipv4": {"prerouting": {},"output": {},"input": {},"forward": {}},"ipv6": {"prerouting": {},"output": {},"input": {},"forward": {}}}}'

In [20]: B = ct.config_dict(rt, base, mask, get_first_key=True, with_defaults=True)

In [21]: B
Out[21]: 
{'global-options': {'all-ping': 'enable',
  'broadcast-ping': 'disable',
  'directed-broadcast': 'enable',
  'ip-src-route': 'disable',
  'log-martians': 'enable',
  'receive-redirects': 'disable',
  'resolver-interval': '300',
  'send-redirects': 'enable',
  'source-validation': 'disable',
  'syn-cookies': 'enable',
  'timeout': {'icmp': '30',
   'other': '600',
   'tcp': {'close-wait': '60',
    'close': '10',
    'established': '432000',
    'fin-wait': '120',
    'last-ack': '30',
    'syn-recv': '60',
    'syn-sent': '120',
    'time-wait': '120'},
   'udp': {'other': '30', 'stream': '180'}},
  'twa-hazards-protection': 'disable',
  'ipv6-receive-redirects': 'disable',
  'ipv6-source-validation': 'disable',
  'ipv6-src-route': 'disable'},
 'ipv4': {'output': {'filter': {'default-action': 'accept',
    'rule': {'1': {'action': 'accept'}}},
   'raw': {'default-action': 'accept'}}}}

```

Sanity checks of performance show the two approaches are comparable for basic test configs, but testing performance at scale will also be confined to a separate task.

Finally, note that this approach allows easy internalization, as XML properties, of those masks which prove to be globally useful, then obviating step [18], above.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): Refine and extend an existing construction

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/vyos1x-config/pull/65
https://github.com/vyos/vyconf/pull/42


## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
