### PR TITLE
T8242: interfaces add bidirectional support for interface adjust-mss

### DIFF
--- a/data/vyos-firewall-init.conf
+++ b/data/vyos-firewall-init.conf
@@ -20,6 +20,10 @@ table raw {
         type filter hook postrouting priority -300; policy accept;
     }
 
+    chain VYOS_TCP_MSS_PREROUTING {
+        type filter hook prerouting priority -300; policy accept;
+    }
+
     chain vyos_global_rpfilter {
         return
     }
@@ -38,6 +42,10 @@ table raw {
 table ip6 raw {
     chain VYOS_TCP_MSS {
         type filter hook postrouting priority -300; policy accept;
+    }
+
+    chain VYOS_TCP_MSS_PREROUTING {
+        type filter hook prerouting priority -300; policy accept;
     }
 
     chain vyos_global_rpfilter {

--- a/interface-definitions/include/interface/adjust-mss.xml.i
+++ b/interface-definitions/include/interface/adjust-mss.xml.i
@@ -20,4 +20,28 @@
     </constraint>
   </properties>
 </leafNode>
+<leafNode name="adjust-mss-direction">
+  <properties>
+    <help>Adjust TCP MSS direction</help>
+    <completionHelp>
+      <list>outbound inbound both</list>
+    </completionHelp>
+    <valueHelp>
+      <format>outbound</format>
+      <description>Adjust MSS for packets leaving this interface</description>
+    </valueHelp>
+    <valueHelp>
+      <format>inbound</format>
+      <description>Adjust MSS for packets entering this interface</description>
+    </valueHelp>
+    <valueHelp>
+      <format>both</format>
+      <description>Adjust MSS for both inbound and outbound packets</description>
+    </valueHelp>
+    <constraint>
+      <regex>(outbound|inbound|both)</regex>
+    </constraint>
+  </properties>
+  <defaultValue>outbound</defaultValue>
+</leafNode>
 <!-- include end -->

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -691,19 +691,84 @@ class Interface(Control):
             return None
         return self.set_interface('ipv6_cache_tmo', tmo)
 
-    def _cleanup_mss_rules(self, table, ifname):
-        commands = []
-        results = self._cmd(f'nft -a list chain {table} VYOS_TCP_MSS').split("\n")
-        for line in results:
-            if f'oifname "{ifname}"' in line:
-                handle_search = re.search('handle (\d+)', line)
-                if handle_search:
-                    self._cmd(f'nft delete rule {table} VYOS_TCP_MSS handle {handle_search[1]}')
+    _TCP_MSS_POSTROUTING_CHAIN = 'VYOS_TCP_MSS'
+    _TCP_MSS_PREROUTING_CHAIN = 'VYOS_TCP_MSS_PREROUTING'
+    _TCP_MSS_CHAIN_HOOKS = {
+        'raw': {
+            _TCP_MSS_POSTROUTING_CHAIN: 'type filter hook postrouting priority -300; policy accept;',
+            _TCP_MSS_PREROUTING_CHAIN: 'type filter hook prerouting priority -300; policy accept;',
+        },
+        'ip6 raw': {
+            _TCP_MSS_POSTROUTING_CHAIN: 'type filter hook postrouting priority -300; policy accept;',
+            _TCP_MSS_PREROUTING_CHAIN: 'type filter hook prerouting priority -300; policy accept;',
+        },
+    }
 
-    def set_tcp_ipv4_mss(self, mss):
+    def _ensure_mss_chain(self, table, chain):
+        try:
+            self._cmd(f'nft list chain {table} {chain}')
+        except OSError:
+            chain_definition = self._TCP_MSS_CHAIN_HOOKS[table][chain]
+            self._cmd(f"nft add chain {table} {chain} '{{ {chain_definition} }}'")
+
+    def _ensure_mss_chains(self, table):
+        for chain in self._TCP_MSS_CHAIN_HOOKS[table]:
+            self._ensure_mss_chain(table, chain)
+
+    def _cleanup_mss_rules(self, table, ifname):
+        self._ensure_mss_chains(table)
+        for chain in self._TCP_MSS_CHAIN_HOOKS[table]:
+            results = self._cmd(f'nft -a list chain {table} {chain}').split('\n')
+            for line in results:
+                if f'oifname "{ifname}"' in line or f'iifname "{ifname}"' in line:
+                    handle_search = re.search(r'handle (\d+)', line)
+                    if handle_search:
+                        self._cmd(
+                            f'nft delete rule {table} {chain} handle {handle_search[1]}'
+                        )
+
+    def _get_mss_match_options(self, direction, mss):
+        inbound_chain = (
+            self._TCP_MSS_POSTROUTING_CHAIN
+            if mss == 'clamp-mss-to-pmtu'
+            else self._TCP_MSS_PREROUTING_CHAIN
+        )
+        # Keep pre-direction configs working during upgrades.
+        if not direction:
+            direction = 'outbound'
+
+        direction_map = {
+            'outbound': [(self._TCP_MSS_POSTROUTING_CHAIN, 'oifname')],
+            'inbound': [(inbound_chain, 'iifname')],
+            'both': [
+                (self._TCP_MSS_POSTROUTING_CHAIN, 'oifname'),
+                (inbound_chain, 'iifname'),
+            ],
+        }
+
+        if direction not in direction_map:
+            raise ValueError(f'Invalid adjust-mss-direction "{direction}"')
+
+        return direction_map[direction]
+
+    def _add_fixed_mss_rule(self, table, chain, match_option, mss):
+        nft_prefix = f'nft add rule {table} {chain}'
+        base_cmd = f'{match_option} "{self.ifname}" tcp flags & (syn|rst) == syn'
+        low_mss = str(int(mss) + 1)
+        self._cmd(
+            f"{nft_prefix} '{base_cmd} tcp option maxseg size "
+            f"{low_mss}-65535 tcp option maxseg size set {mss}'"
+        )
+
+    def _add_clamp_mss_rule(self, table, chain, match_option):
+        nft_prefix = f'nft add rule {table} {chain}'
+        base_cmd = f'{match_option} "{self.ifname}" tcp flags & (syn|rst) == syn'
+        self._cmd(f"{nft_prefix} '{base_cmd} tcp option maxseg size set rt mtu'")
+
+    def set_tcp_ipv4_mss(self, mss, direction):
         """
-        Set IPv4 TCP MSS value advertised when TCP SYN packets leave this
-        interface. Value is in bytes.
+        Set IPv4 TCP MSS value advertised for TCP SYN packets crossing this
+        interface in requested direction. Value is in bytes.
 
         A value of 0 will disable the MSS adjustment
 
@@ -716,18 +781,19 @@ class Interface(Control):
             return None
 
         self._cleanup_mss_rules('raw', self.ifname)
-        nft_prefix = 'nft add rule raw VYOS_TCP_MSS'
-        base_cmd = f'oifname "{self.ifname}" tcp flags & (syn|rst) == syn'
         if mss == 'clamp-mss-to-pmtu':
-            self._cmd(f"{nft_prefix} '{base_cmd} tcp option maxseg size set rt mtu'")
-        elif int(mss) > 0:
-            low_mss = str(int(mss) + 1)
-            self._cmd(f"{nft_prefix} '{base_cmd} tcp option maxseg size {low_mss}-65535 tcp option maxseg size set {mss}'")
+            for chain, mss_direction in self._get_mss_match_options(direction, mss):
+                self._add_clamp_mss_rule('raw', chain, mss_direction)
+            return
 
-    def set_tcp_ipv6_mss(self, mss):
+        if int(mss) > 0:
+            for chain, mss_direction in self._get_mss_match_options(direction, mss):
+                self._add_fixed_mss_rule('raw', chain, mss_direction, mss)
+
+    def set_tcp_ipv6_mss(self, mss, direction):
         """
-        Set IPv6 TCP MSS value advertised when TCP SYN packets leave this
-        interface. Value is in bytes.
+        Set IPv6 TCP MSS value advertised for TCP SYN packets crossing this
+        interface in requested direction. Value is in bytes.
 
         A value of 0 will disable the MSS adjustment
 
@@ -740,13 +806,14 @@ class Interface(Control):
             return None
 
         self._cleanup_mss_rules('ip6 raw', self.ifname)
-        nft_prefix = 'nft add rule ip6 raw VYOS_TCP_MSS'
-        base_cmd = f'oifname "{self.ifname}" tcp flags & (syn|rst) == syn'
         if mss == 'clamp-mss-to-pmtu':
-            self._cmd(f"{nft_prefix} '{base_cmd} tcp option maxseg size set rt mtu'")
-        elif int(mss) > 0:
-            low_mss = str(int(mss) + 1)
-            self._cmd(f"{nft_prefix} '{base_cmd} tcp option maxseg size {low_mss}-65535 tcp option maxseg size set {mss}'")
+            for chain, mss_direction in self._get_mss_match_options(direction, mss):
+                self._add_clamp_mss_rule('ip6 raw', chain, mss_direction)
+            return
+
+        if int(mss) > 0:
+            for chain, mss_direction in self._get_mss_match_options(direction, mss):
+                self._add_fixed_mss_rule('ip6 raw', chain, mss_direction, mss)
 
     def set_arp_filter(self, arp_filter):
         """
@@ -847,7 +914,7 @@ class Interface(Control):
         results = self._cmd(f'nft -a list chain ip raw vyos_rpfilter').split("\n")
         for line in results:
             if f'iifname "{ifname}"' in line:
-                handle_search = re.search('handle (\d+)', line)
+                handle_search = re.search(r'handle (\d+)', line)
                 if handle_search:
                     self._cmd(f'nft delete rule ip raw vyos_rpfilter handle {handle_search[1]}')
 
@@ -876,7 +943,7 @@ class Interface(Control):
         results = self._cmd(f'nft -a list chain ip6 raw vyos_rpfilter').split("\n")
         for line in results:
             if f'iifname "{ifname}"' in line:
-                handle_search = re.search('handle (\d+)', line)
+                handle_search = re.search(r'handle (\d+)', line)
                 if handle_search:
                     self._cmd(f'nft delete rule ip6 raw vyos_rpfilter handle {handle_search[1]}')
 
@@ -1841,7 +1908,8 @@ class Interface(Control):
         # Configure MSS value for IPv4 TCP connections
         tmp = dict_search('ip.adjust_mss', config)
         value = tmp if (tmp != None) else '0'
-        self.set_tcp_ipv4_mss(value)
+        direction = dict_search('ip.adjust_mss_direction', config)
+        self.set_tcp_ipv4_mss(value, direction)
 
         # Configure ARP cache timeout in milliseconds - has default value
         tmp = dict_search('ip.arp_cache_timeout', config)
@@ -1908,7 +1976,8 @@ class Interface(Control):
         # Configure MSS value for IPv6 TCP connections
         tmp = dict_search('ipv6.adjust_mss', config)
         value = tmp if (tmp != None) else '0'
-        self.set_tcp_ipv6_mss(value)
+        direction = dict_search('ipv6.adjust_mss_direction', config)
+        self.set_tcp_ipv6_mss(value, direction)
 
         # IPv6 forwarding
         tmp = dict_search('ipv6.disable_forwarding', config)

--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -960,12 +960,93 @@ class BasicInterfaceTest:
                     tmp = get_interface_config(f'{interface}.{vif_s}')
                     self.assertEqual(tmp['linkinfo']['info_data']['protocol'], new_protocol.upper())
 
+        @staticmethod
+        def _expected_adjust_mss_directions(direction_supported, configured_direction):
+            if not direction_supported:
+                return {'outbound'}
+
+            if configured_direction == 'both':
+                return {'inbound', 'outbound'}
+
+            return {configured_direction}
+
+        @staticmethod
+        def _expected_adjust_mss_chains(mss, expected_directions):
+            expected_chains = {}
+            for direction in expected_directions:
+                expected_chains[direction] = (
+                    'postrouting'
+                    if direction == 'outbound' or mss == 'clamp-mss-to-pmtu'
+                    else 'prerouting'
+                )
+
+            return expected_chains
+
+        def _assert_adjust_mss_rules(
+            self,
+            postrouting_output,
+            prerouting_output,
+            interface,
+            mss,
+            expected_directions,
+        ):
+            expected_mss_clause = (
+                'tcp option maxseg size set rt mtu'
+                if mss == 'clamp-mss-to-pmtu'
+                else f'tcp option maxseg size set {mss}'
+            )
+
+            outbound_pattern = re.compile(
+                rf'(?:^|\s)(?:meta\s+)?oifname\s+"{re.escape(interface)}"(?:\s|$)'
+            )
+            inbound_pattern = re.compile(
+                rf'(?:^|\s)(?:meta\s+)?iifname\s+"{re.escape(interface)}"(?:\s|$)'
+            )
+
+            found_chains = {'outbound': set(), 'inbound': set()}
+            chain_outputs = (
+                ('postrouting', postrouting_output),
+                ('prerouting', prerouting_output),
+            )
+            for chain_name, chain_output in chain_outputs:
+                for line in chain_output.splitlines():
+                    if expected_mss_clause not in line:
+                        continue
+
+                    normalized_line = line.strip()
+                    if outbound_pattern.search(normalized_line):
+                        found_chains['outbound'].add(chain_name)
+                    if inbound_pattern.search(normalized_line):
+                        found_chains['inbound'].add(chain_name)
+
+            expected_chains = self._expected_adjust_mss_chains(mss, expected_directions)
+            for direction in ('outbound', 'inbound'):
+                expected = (
+                    {expected_chains[direction]}
+                    if direction in expected_directions
+                    else set()
+                )
+                self.assertSetEqual(
+                    found_chains[direction],
+                    expected,
+                    msg=(
+                        f'MSS rules for interface "{interface}" direction "{direction}" '
+                        f'expected in chains {sorted(expected)} but found '
+                        f'{sorted(found_chains[direction])}'
+                    ),
+                )
+
         def test_interface_ip_options(self):
             if not self._test_ip:
                 self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             arp_tmo = '300'
             mss = '1420'
+            mss_direction = 'both'
+            adjust_mss = cli_defined(self._base_path + ['ip'], 'adjust-mss')
+            adjust_mss_direction = cli_defined(
+                self._base_path + ['ip'], 'adjust-mss-direction'
+            )
 
             for interface in self._interfaces:
                 path = self._base_path + [interface]
@@ -973,8 +1054,10 @@ class BasicInterfaceTest:
                     self.cli_set(path + option.split())
 
                 # Options
-                if cli_defined(self._base_path + ['ip'], 'adjust-mss'):
+                if adjust_mss:
                     self.cli_set(path + ['ip', 'adjust-mss', mss])
+                if adjust_mss_direction:
+                    self.cli_set(path + ['ip', 'adjust-mss-direction', mss_direction])
 
                 if cli_defined(self._base_path + ['ip'], 'arp-cache-timeout'):
                     self.cli_set(path + ['ip', 'arp-cache-timeout', arp_tmo])
@@ -1008,13 +1091,27 @@ class BasicInterfaceTest:
 
             self.cli_commit()
 
+            mss_postrouting_output = ''
+            mss_prerouting_output = ''
+            expected_directions = None
+            if adjust_mss:
+                mss_postrouting_output = cmd('sudo nft list chain raw VYOS_TCP_MSS')
+                mss_prerouting_output = cmd(
+                    'sudo nft list chain raw VYOS_TCP_MSS_PREROUTING'
+                )
+                expected_directions = self._expected_adjust_mss_directions(
+                    adjust_mss_direction, mss_direction
+                )
+
             for interface in self._interfaces:
-                if cli_defined(self._base_path + ['ip'], 'adjust-mss'):
-                    base_options = f'oifname "{interface}"'
-                    out = cmd('sudo nft list chain raw VYOS_TCP_MSS')
-                    for line in out.splitlines():
-                        if line.startswith(base_options):
-                            self.assertIn(f'tcp option maxseg size set {mss}', line)
+                if adjust_mss:
+                    self._assert_adjust_mss_rules(
+                        mss_postrouting_output,
+                        mss_prerouting_output,
+                        interface,
+                        mss,
+                        expected_directions,
+                    )
 
                 if cli_defined(self._base_path + ['ip'], 'arp-cache-timeout'):
                     tmp = read_file(f'/proc/sys/net/ipv4/neigh/{interface}/base_reachable_time_ms')
@@ -1067,10 +1164,15 @@ class BasicInterfaceTest:
                 self.skipTest(MSG_TESTCASE_UNSUPPORTED)
 
             mss = '1400'
+            mss_direction = 'both'
             dad_transmits = '10'
             accept_dad = '0'
             source_validation = 'strict'
             interface_identifier = '::fffe'
+            adjust_mss = cli_defined(self._base_path + ['ipv6'], 'adjust-mss')
+            adjust_mss_direction = cli_defined(
+                self._base_path + ['ipv6'], 'adjust-mss-direction'
+            )
 
             for interface in self._interfaces:
                 path = self._base_path + [interface]
@@ -1078,8 +1180,10 @@ class BasicInterfaceTest:
                     self.cli_set(path + option.split())
 
                 # Options
-                if cli_defined(self._base_path + ['ipv6'], 'adjust-mss'):
+                if adjust_mss:
                     self.cli_set(path + ['ipv6', 'adjust-mss', mss])
+                if adjust_mss_direction:
+                    self.cli_set(path + ['ipv6', 'adjust-mss-direction', mss_direction])
 
                 if cli_defined(self._base_path + ['ipv6'], 'accept-dad'):
                     self.cli_set(path + ['ipv6', 'accept-dad', accept_dad])
@@ -1098,14 +1202,28 @@ class BasicInterfaceTest:
 
             self.cli_commit()
 
+            mss_postrouting_output = ''
+            mss_prerouting_output = ''
+            expected_directions = None
+            if adjust_mss:
+                mss_postrouting_output = cmd('sudo nft list chain ip6 raw VYOS_TCP_MSS')
+                mss_prerouting_output = cmd(
+                    'sudo nft list chain ip6 raw VYOS_TCP_MSS_PREROUTING'
+                )
+                expected_directions = self._expected_adjust_mss_directions(
+                    adjust_mss_direction, mss_direction
+                )
+
             for interface in self._interfaces:
                 proc_base = f'/proc/sys/net/ipv6/conf/{interface}'
-                if cli_defined(self._base_path + ['ipv6'], 'adjust-mss'):
-                    base_options = f'oifname "{interface}"'
-                    out = cmd('sudo nft list chain ip6 raw VYOS_TCP_MSS')
-                    for line in out.splitlines():
-                        if line.startswith(base_options):
-                            self.assertIn(f'tcp option maxseg size set {mss}', line)
+                if adjust_mss:
+                    self._assert_adjust_mss_rules(
+                        mss_postrouting_output,
+                        mss_prerouting_output,
+                        interface,
+                        mss,
+                        expected_directions,
+                    )
 
                 if cli_defined(self._base_path + ['ipv6'], 'accept-dad'):
                     tmp = read_file(f'{proc_base}/accept_dad')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add a new optional CLI leaf `adjust-mss-direction` under both
`interfaces ... ip` and `interfaces ... ipv6`.

Supported values:
- outbound (default, existing behavior)
- inbound
- both

Behavior:
- outbound: always installs MSS rewrite rules in postrouting using `oifname`
- inbound:
  - `clamp-mss-to-pmtu`: installs in postrouting using `iifname`
  - numeric MSS: installs in prerouting using `iifname` (so input traffic is covered)
- both: installs outbound + inbound rules according to the logic above

Implementation details:
- Extend MSS rule generation in `Interface` to be direction- and mode-aware
  (match key + nft chain selection).
- Add prerouting MSS chains (`VYOS_TCP_MSS_PREROUTING`) for IPv4/IPv6 raw tables.
- Keep backward compatibility by treating missing direction as `outbound`.
- Improve MSS cleanup to remove stale interface rules from both postrouting and
  prerouting chains, for both `oifname` and `iifname` matches.
- Wire direction config into the IPv4 and IPv6 interface update paths.
- Extend interface smoketests to validate:
  - direction behavior (`outbound` / `inbound` / `both`)
  - correct chain placement (postrouting vs prerouting)
  - both IPv4 and IPv6 MSS rule generation.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8242

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
