### PR TITLE
policy-route: T8244: add suppress-prefix-length support for PBR ip rules

### DIFF
--- a/interface-definitions/policy_route.xml.in
+++ b/interface-definitions/policy_route.xml.in
@@ -234,6 +234,25 @@
                 </children>
               </node>
               #include <include/policy/route-common.xml.i>
+              <node name="set">
+                <properties>
+                  <help>Packet modifications</help>
+                </properties>
+                <children>
+                  <leafNode name="suppress-prefix-length">
+                    <properties>
+                      <help>Suppress route prefixes up to specified length during lookup</help>
+                      <valueHelp>
+                        <format>u32:0-128</format>
+                        <description>Suppress matching routes with prefix length less than or equal to this value</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-128"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
               #include <include/firewall/dscp.xml.i>
               #include <include/firewall/packet-options.xml.i>
               #include <include/firewall/hop-limit.xml.i>
@@ -301,6 +320,25 @@
                 </children>
               </node>
               #include <include/policy/route-common.xml.i>
+              <node name="set">
+                <properties>
+                  <help>Packet modifications</help>
+                </properties>
+                <children>
+                  <leafNode name="suppress-prefix-length">
+                    <properties>
+                      <help>Suppress route prefixes up to specified length during lookup</help>
+                      <valueHelp>
+                        <format>u32:0-32</format>
+                        <description>Suppress matching routes with prefix length less than or equal to this value</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--range 0-32"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
               #include <include/firewall/icmp.xml.i>
               #include <include/firewall/dscp.xml.i>
               #include <include/firewall/packet-options.xml.i>

--- a/smoketest/scripts/cli/test_policy_route.py
+++ b/smoketest/scripts/cli/test_policy_route.py
@@ -17,12 +17,14 @@
 import unittest
 
 from base_vyostest_shim import VyOSUnitTestSHIM
+from vyos.configsession import ConfigSessionError
 
 mark = '100'
 conn_mark = '555'
 conn_mark_set = '111'
 table_mark_offset = 0x7fffffff
 table_id = '101'
+table_suppress_prefix_len = '8'
 vrf = 'PBRVRF'
 vrf_table_id = '102'
 interface = 'eth0'
@@ -172,6 +174,118 @@ class TestPolicyRoute(VyOSUnitTestSHIM.TestCase):
         ]
 
         self.verify_rules(ip_rule_search)
+
+    def test_pbr_table_suppress_prefix_length(self):
+        self.cli_set(['policy', 'route', 'suppress', 'rule', '1', 'protocol', 'tcp'])
+        self.cli_set(
+            ['policy', 'route', 'suppress', 'rule', '1', 'destination', 'port', '443']
+        )
+        self.cli_set(
+            ['policy', 'route', 'suppress', 'rule', '1', 'set', 'table', 'main']
+        )
+        self.cli_set(
+            [
+                'policy',
+                'route',
+                'suppress',
+                'rule',
+                '1',
+                'set',
+                'suppress-prefix-length',
+                table_suppress_prefix_len,
+            ]
+        )
+        self.cli_set(['policy', 'route6', 'suppress6', 'rule', '1', 'protocol', 'tcp'])
+        self.cli_set(
+            ['policy', 'route6', 'suppress6', 'rule', '1', 'destination', 'port', '443']
+        )
+        self.cli_set(
+            ['policy', 'route6', 'suppress6', 'rule', '1', 'set', 'table', 'main']
+        )
+        self.cli_set(
+            [
+                'policy',
+                'route6',
+                'suppress6',
+                'rule',
+                '1',
+                'set',
+                'suppress-prefix-length',
+                table_suppress_prefix_len,
+            ]
+        )
+        self.cli_set(['policy', 'route', 'suppress', 'interface', interface])
+        self.cli_set(['policy', 'route6', 'suppress6', 'interface', interface])
+
+        self.cli_commit()
+
+        main_table_id = '254'
+        mark_hex = "{0:#010x}".format(table_mark_offset - int(main_table_id))
+
+        nftables_search = [
+            [f'iifname "{interface}"', 'jump VYOS_PBR_UD_suppress'],
+            ['tcp dport 443', 'meta mark set ' + mark_hex],
+        ]
+        self.verify_nftables(nftables_search, 'ip vyos_mangle')
+
+        nftables6_search = [
+            [f'iifname "{interface}"', 'jump VYOS_PBR6_UD_suppress6'],
+            ['tcp dport 443', 'meta mark set ' + mark_hex],
+        ]
+        self.verify_nftables(nftables6_search, 'ip6 vyos_mangle')
+
+        ip_rule_search = [
+            [
+                'fwmark ' + hex(table_mark_offset - int(main_table_id)),
+                'suppress_prefixlength ' + table_suppress_prefix_len,
+            ]
+        ]
+        self.verify_rules(ip_rule_search, addr_family='inet')
+        self.verify_rules(ip_rule_search, addr_family='inet6')
+
+    def test_pbr_table_suppress_prefix_length_conflict(self):
+        self.cli_set(['policy', 'route', 'smoketest', 'rule', '1', 'protocol', 'tcp'])
+        self.cli_set(
+            ['policy', 'route', 'smoketest', 'rule', '1', 'destination', 'port', '443']
+        )
+        self.cli_set(
+            ['policy', 'route', 'smoketest', 'rule', '1', 'set', 'table', table_id]
+        )
+        self.cli_set(
+            [
+                'policy',
+                'route',
+                'smoketest',
+                'rule',
+                '1',
+                'set',
+                'suppress-prefix-length',
+                table_suppress_prefix_len,
+            ]
+        )
+        self.cli_set(['policy', 'route', 'smoketest', 'rule', '2', 'protocol', 'tcp'])
+        self.cli_set(
+            ['policy', 'route', 'smoketest', 'rule', '2', 'destination', 'port', '8443']
+        )
+        self.cli_set(
+            ['policy', 'route', 'smoketest', 'rule', '2', 'set', 'table', table_id]
+        )
+        self.cli_set(
+            [
+                'policy',
+                'route',
+                'smoketest',
+                'rule',
+                '2',
+                'set',
+                'suppress-prefix-length',
+                '1',
+            ]
+        )
+        self.cli_set(['policy', 'route', 'smoketest', 'interface', interface])
+
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
 
 
     def test_pbr_vrf(self):

--- a/src/conf_mode/policy_route.py
+++ b/src/conf_mode/policy_route.py
@@ -47,6 +47,23 @@ valid_groups = [
     'interface_group'
 ]
 
+
+def get_rule_table_id(rule_conf):
+    set_table = dict_search_args(rule_conf, 'set', 'table')
+    set_vrf = dict_search_args(rule_conf, 'set', 'vrf')
+    if set_vrf:
+        if set_vrf == 'default':
+            return int(rt_global_vrf)
+        table_id = get_vrf_tableid(set_vrf)
+        if table_id is None:
+            return None
+        return int(table_id)
+    if set_table:
+        if set_table == 'main':
+            return int(rt_global_table)
+        return int(set_table)
+    return None
+
 def geoip_updated(conf):
     updated = False
 
@@ -131,6 +148,22 @@ def verify_rule(policy, name, rule_conf, ipv6, rule_id):
         if 'vrf' in rule_conf['set'] and 'table' in rule_conf['set']:
             raise ConfigError(f'{name} rule {rule_id}: Cannot set both forwarding route table and VRF')
 
+        suppress_prefix_len = dict_search_args(
+            rule_conf, 'set', 'suppress_prefix_length'
+        )
+        if suppress_prefix_len is not None:
+            if 'vrf' not in rule_conf['set'] and 'table' not in rule_conf['set']:
+                raise ConfigError(
+                    f'{name} rule {rule_id}: suppress-prefix-length requires set table or set vrf'
+                )
+
+            max_prefix_len = 128 if ipv6 else 32
+            if int(suppress_prefix_len) > max_prefix_len:
+                raise ConfigError(
+                    f'{name} rule {rule_id}: suppress-prefix-length must be between 0 and '
+                    f'{max_prefix_len} for this policy family'
+                )
+
     tcp_flags = dict_search_args(rule_conf, 'tcp', 'flags')
     if tcp_flags:
         if dict_search_args(rule_conf, 'protocol') != 'tcp':
@@ -174,6 +207,37 @@ def verify_rule(policy, name, rule_conf, ipv6, rule_id):
                 if rule_conf['protocol'] not in ['tcp', 'udp', 'tcp_udp']:
                     raise ConfigError('Protocol must be tcp, udp, or tcp_udp when specifying a port or port-group')
 
+
+def verify_suppress_prefix_consistency(policy):
+    for route in ['route', 'route6']:
+        if route not in policy:
+            continue
+
+        suppress_per_table = {}
+        for name, pol_conf in policy[route].items():
+            if 'rule' not in pol_conf:
+                continue
+
+            for rule_id, rule_conf in pol_conf['rule'].items():
+                table_id = get_rule_table_id(rule_conf)
+                if table_id is None:
+                    continue
+
+                suppress_prefix_len = dict_search_args(
+                    rule_conf, 'set', 'suppress_prefix_length'
+                )
+
+                if table_id not in suppress_per_table:
+                    suppress_per_table[table_id] = suppress_prefix_len
+                    continue
+
+                if suppress_per_table[table_id] != suppress_prefix_len:
+                    raise ConfigError(
+                        f'{name} rule {rule_id}: table {table_id} has conflicting suppress-prefix-length '
+                        f'with another policy route rule'
+                    )
+
+
 def verify(policy):
     for route in ['route', 'route6']:
         ipv6 = route == 'route6'
@@ -182,6 +246,8 @@ def verify(policy):
                 if 'rule' in pol_conf:
                     for rule_id, rule_conf in pol_conf['rule'].items():
                         verify_rule(policy, name, rule_conf, ipv6, rule_id)
+
+    verify_suppress_prefix_consistency(policy)
 
     return None
 
@@ -196,30 +262,28 @@ def apply_table_marks(policy):
     for route in ['route', 'route6']:
         if route in policy:
             cmd_str = 'ip' if route == 'route' else 'ip -6'
-            tables = []
+            tables = set()
             for name, pol_conf in policy[route].items():
                 if 'rule' in pol_conf:
                     for rule_id, rule_conf in pol_conf['rule'].items():
-                        vrf_table_id = None
-                        set_table = dict_search_args(rule_conf, 'set', 'table')
-                        set_vrf = dict_search_args(rule_conf, 'set', 'vrf')
-                        if set_vrf:
-                            if set_vrf == 'default':
-                                vrf_table_id = rt_global_vrf
-                            else:
-                                vrf_table_id = get_vrf_tableid(set_vrf)
-                        elif set_table:
-                            if set_table == 'main':
-                                vrf_table_id = rt_global_table
-                            else:
-                                vrf_table_id = set_table
+                        vrf_table_id = get_rule_table_id(rule_conf)
                         if vrf_table_id is not None:
-                            vrf_table_id = int(vrf_table_id)
+                            suppress_prefix_len = dict_search_args(
+                                rule_conf, 'set', 'suppress_prefix_length'
+                            )
                             if vrf_table_id in tables:
                                 continue
-                            tables.append(vrf_table_id)
+                            tables.add(vrf_table_id)
                             table_mark = mark_offset - vrf_table_id
-                            cmd(f'{cmd_str} rule add pref {vrf_table_id} fwmark {table_mark} table {vrf_table_id}')
+                            ip_rule_cmd = (
+                                f'{cmd_str} rule add pref {vrf_table_id} fwmark {table_mark} '
+                                f'table {vrf_table_id}'
+                            )
+                            if suppress_prefix_len is not None:
+                                ip_rule_cmd += (
+                                    f' suppress_prefixlength {suppress_prefix_len}'
+                                )
+                            cmd(ip_rule_cmd)
 
 def cleanup_table_marks():
     for cmd_str in ['ip', 'ip -6']:


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add support for route suppression in policy routing by introducing `set suppress-prefix-length` for `policy route` and `policy route6` rules.

This maps to Linux ip rule `suppress_prefixlength`, allowing operators to reuse main-table routes while suppressing prefixes up to a configured length.

What changed:
- Added new CLI leaf:
  - `set suppress-prefix-length <0-128>`
  - wired into policy route common rule schema
- Extended policy route apply logic to append:
  - `suppress_prefixlength <N>` to generated `ip rule add ...` commands
- Added validation:
  - `suppress-prefix-length` requires `set table` or `set vrf`
  - range constrained by address family:
    - IPv4: 0..32
    - IPv6: 0..128
  - prevent conflicting suppress values for the same resolved table id
- Added smoketests:
  - positive test for IPv4/IPv6 `suppress_prefixlength` rule presence
  - negative test ensuring commit fails on conflicting values for same table

Files:
- interface-definitions/include/policy/route-common.xml.i
- interface-definitions/include/policy/route-set-suppress-prefix-length.xml.i
- src/conf_mode/policy_route.py
- smoketest/scripts/cli/test_policy_route.py
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8244

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4991

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
