### PR TITLE
T8243: dhcp: add RFC9463 DNR support for Kea DHCPv4/DHCPv6

### DIFF
--- a/interface-definitions/include/dhcp/dnr-common.xml.i
+++ b/interface-definitions/include/dhcp/dnr-common.xml.i
@@ -1,0 +1,24 @@
+<!-- include start from dhcp/dnr-common.xml.i -->
+<leafNode name="priority">
+  <properties>
+    <help>DNR service priority</help>
+    <valueHelp>
+      <format>u32:0-65535</format>
+      <description>Lower value means higher preference</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 0-65535"/>
+    </constraint>
+    <constraintErrorMessage>DNR priority must be between 0 and 65535</constraintErrorMessage>
+  </properties>
+</leafNode>
+<leafNode name="authentication-domain-name">
+  <properties>
+    <help>Authentication domain name (ADN) for encrypted DNS resolver</help>
+    <constraint>
+      <validator name="fqdn"/>
+    </constraint>
+    <constraintErrorMessage>Invalid authentication domain name</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/dhcp/dnr-service-parameters.xml.i
+++ b/interface-definitions/include/dhcp/dnr-service-parameters.xml.i
@@ -1,0 +1,32 @@
+<!-- include start from dhcp/dnr-service-parameters.xml.i -->
+<node name="service-parameter">
+  <properties>
+    <help>DNR service parameter</help>
+  </properties>
+  <children>
+    <leafNode name="alpn">
+      <properties>
+        <help>Application-Layer Protocol Negotiation (ALPN)</help>
+        <completionHelp>
+          <list>dot doq h2 h3</list>
+        </completionHelp>
+        <constraint>
+          <regex>[A-Za-z0-9._-]+</regex>
+        </constraint>
+        <constraintErrorMessage>ALPN identifier may only contain letters, digits, dot, underscore, and hyphen</constraintErrorMessage>
+        <multi/>
+      </properties>
+    </leafNode>
+    #include <include/port-number.xml.i>
+    <leafNode name="dohpath">
+      <properties>
+        <help>Relative DoH URI template path (plain paths auto-append {?dns}; custom templates must include {?dns})</help>
+        <constraint>
+          <regex>[[:graph:]]+</regex>
+        </constraint>
+        <constraintErrorMessage>DoH path must not contain whitespace</constraintErrorMessage>
+      </properties>
+    </leafNode>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/dhcp/dnr-v4.xml.i
+++ b/interface-definitions/include/dhcp/dnr-v4.xml.i
@@ -1,0 +1,32 @@
+<!-- include start from dhcp/dnr-v4.xml.i -->
+<tagNode name="dnr">
+  <properties>
+    <help>Discovery of Network-designated Resolvers (DNR)</help>
+    <valueHelp>
+      <format>u32:1-9999</format>
+      <description>DNR instance identifier</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-9999"/>
+    </constraint>
+    <constraintErrorMessage>DNR instance identifier must be between 1 and 9999</constraintErrorMessage>
+  </properties>
+  <children>
+    #include <include/dhcp/dnr-common.xml.i>
+    <leafNode name="address">
+      <properties>
+        <help>IPv4 address of encrypted DNS resolver</help>
+        <valueHelp>
+          <format>ipv4</format>
+          <description>IPv4 resolver address</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv4-address"/>
+        </constraint>
+        <multi/>
+      </properties>
+    </leafNode>
+    #include <include/dhcp/dnr-service-parameters.xml.i>
+  </children>
+</tagNode>
+<!-- include end -->

--- a/interface-definitions/include/dhcp/dnr-v6.xml.i
+++ b/interface-definitions/include/dhcp/dnr-v6.xml.i
@@ -1,0 +1,32 @@
+<!-- include start from dhcp/dnr-v6.xml.i -->
+<tagNode name="dnr">
+  <properties>
+    <help>Discovery of Network-designated Resolvers (DNR)</help>
+    <valueHelp>
+      <format>u32:1-9999</format>
+      <description>DNR instance identifier</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-9999"/>
+    </constraint>
+    <constraintErrorMessage>DNR instance identifier must be between 1 and 9999</constraintErrorMessage>
+  </properties>
+  <children>
+    #include <include/dhcp/dnr-common.xml.i>
+    <leafNode name="address">
+      <properties>
+        <help>IPv6 address of encrypted DNS resolver</help>
+        <valueHelp>
+          <format>ipv6</format>
+          <description>IPv6 resolver address</description>
+        </valueHelp>
+        <constraint>
+          <validator name="ipv6-address"/>
+        </constraint>
+        <multi/>
+      </properties>
+    </leafNode>
+    #include <include/dhcp/dnr-service-parameters.xml.i>
+  </children>
+</tagNode>
+<!-- include end -->

--- a/interface-definitions/include/dhcp/option-v4.xml.i
+++ b/interface-definitions/include/dhcp/option-v4.xml.i
@@ -7,6 +7,7 @@
     #include <include/dhcp/captive-portal.xml.i>
     #include <include/dhcp/domain-name.xml.i>
     #include <include/dhcp/domain-search.xml.i>
+    #include <include/dhcp/dnr-v4.xml.i>
     #include <include/dhcp/ntp-server.xml.i>
     #include <include/name-server-ipv4.xml.i>
     <leafNode name="bootfile-name">

--- a/interface-definitions/include/dhcp/option-v6.xml.i
+++ b/interface-definitions/include/dhcp/option-v6.xml.i
@@ -6,6 +6,7 @@
   <children>
     #include <include/dhcp/captive-portal.xml.i>
     #include <include/dhcp/domain-search.xml.i>
+    #include <include/dhcp/dnr-v6.xml.i>
     #include <include/name-server-ipv6.xml.i>
     <leafNode name="capwap-controller">
       <properties>

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -96,6 +96,99 @@ def kea_test_config(process: str, config_path: str) -> tuple[bool, str]:
     find = re.search(r'Error encountered:\s([^\n$]+)', output)
     return (False, find[1] if find else None)
 
+
+def _kea_dnr_sort_key(instance_id):
+    value = str(instance_id)
+    if value.isdigit():
+        return (0, int(value))
+    return (1, value)
+
+
+def _kea_dnr_normalize_list(value):
+    if value is None:
+        return []
+
+    if isinstance(value, list):
+        return value
+
+    return [value]
+
+
+def _kea_dnr_parse_service_parameters(service_parameter):
+    if not service_parameter:
+        return ''
+
+    params = []
+
+    alpn = _kea_dnr_normalize_list(service_parameter.get('alpn'))
+    if alpn:
+        params.append('alpn=' + r'\,'.join(alpn))
+
+    if 'port' in service_parameter:
+        params.append(f'port={int(service_parameter["port"])}')
+
+    if 'dohpath' in service_parameter:
+        dohpath = service_parameter['dohpath']
+        # Kea expects "{?dns}" in dohpath. To keep CLI ergonomic, append it for
+        # plain paths (e.g. "/dns-query"), normalize common "{dns}" typo, but
+        # reject unrelated templates that do not include "{?dns}".
+        if '{?dns}' not in dohpath:
+            if '{dns}' in dohpath:
+                dohpath = dohpath.replace('{dns}', '{?dns}')
+            elif '{' in dohpath or '}' in dohpath:
+                raise ConfigError(
+                    'DNR service-parameter "dohpath" custom URI template must '
+                    'include "{?dns}" (plain paths and "{dns}" are auto-normalized)'
+                )
+            else:
+                dohpath = f'{dohpath}{{?dns}}'
+
+        # RFC 9463 allows pipe in dohpath, it must be escaped for Kea parser.
+        # Keep this idempotent by only escaping pipes that are not already escaped.
+        dohpath = re.sub(r'(?<!\\)\|', r'\\|', dohpath)
+        params.append(f'dohpath={dohpath}')
+
+    return ' '.join(params)
+
+
+def _kea_parse_dnr_instances(dnr_config):
+    if not dnr_config:
+        return []
+
+    entries = []
+
+    for instance_id, instance_config in sorted(
+        dnr_config.items(), key=lambda entry: _kea_dnr_sort_key(entry[0])
+    ):
+        if 'priority' not in instance_config:
+            raise ConfigError(
+                f'DNR instance "{instance_id}" requires "priority" to be configured'
+            )
+
+        if 'authentication_domain_name' not in instance_config:
+            raise ConfigError(
+                f'DNR instance "{instance_id}" requires '
+                '"authentication-domain-name" to be configured'
+            )
+
+        priority = int(instance_config['priority'])
+        data_fields = [str(priority), instance_config['authentication_domain_name']]
+
+        address = _kea_dnr_normalize_list(instance_config.get('address'))
+        service_parameter = _kea_dnr_parse_service_parameters(
+            instance_config.get('service_parameter')
+        )
+
+        if address or service_parameter:
+            data_fields.append(' '.join(address))
+
+        if service_parameter:
+            data_fields.append(service_parameter)
+
+        entries.append(', '.join(data_fields))
+
+    return entries
+
 def kea_parse_options(config):
     options = []
 
@@ -153,6 +246,10 @@ def kea_parse_options(config):
         options.append(
             {'name': 'unifi-controller', 'data': unifi_controller, 'space': 'ubnt'}
         )
+
+    dnr_entries = _kea_parse_dnr_instances(config.get('dnr'))
+    if dnr_entries:
+        options.append({'name': 'v4-dnr', 'data': ' | '.join(dnr_entries)})
 
     return options
 
@@ -279,6 +376,11 @@ def kea6_parse_options(config):
         options.append(
             {'name': 'tftp-servers', 'code': 2, 'space': 'cisco', 'data': cisco_tftp}
         )
+
+    dnr_entries = _kea_parse_dnr_instances(config.get('dnr'))
+    if dnr_entries:
+        for dnr_entry in dnr_entries:
+            options.append({'name': 'v6-dnr', 'data': dnr_entry})
 
     return options
 

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -482,6 +482,100 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         # Check for running process
         self.verify_service_running()
 
+    def test_dhcp_single_pool_dnr_option(self):
+        shared_net_name = 'SMOKE-DNR'
+        range_0_start = inc_ip(subnet, 10)
+        range_0_stop = inc_ip(subnet, 20)
+        dnr_ipv4 = inc_ip(subnet, 100)
+
+        pool = base_path + ['shared-network-name', shared_net_name, 'subnet', subnet]
+        self.cli_set(pool + ['subnet-id', '1'])
+        self.cli_set(pool + ['range', '0', 'start', range_0_start])
+        self.cli_set(pool + ['range', '0', 'stop', range_0_stop])
+
+        self.cli_set(pool + ['option', 'dnr', '10', 'priority', '100'])
+        self.cli_set(
+            pool
+            + [
+                'option',
+                'dnr',
+                '10',
+                'authentication-domain-name',
+                'resolver1.example',
+            ]
+        )
+        self.cli_set(pool + ['option', 'dnr', '10', 'address', dnr_ipv4])
+        self.cli_set(pool + ['option', 'dnr', '10', 'service-parameter', 'alpn', 'dot'])
+        self.cli_set(pool + ['option', 'dnr', '10', 'service-parameter', 'alpn', 'doq'])
+        self.cli_set(pool + ['option', 'dnr', '10', 'service-parameter', 'port', '853'])
+        self.cli_set(
+            pool
+            + [
+                'option',
+                'dnr',
+                '10',
+                'service-parameter',
+                'dohpath',
+                '/dns-query{dns}',
+            ]
+        )
+
+        self.cli_set(pool + ['option', 'dnr', '20', 'priority', '200'])
+        self.cli_set(
+            pool
+            + [
+                'option',
+                'dnr',
+                '20',
+                'authentication-domain-name',
+                'resolver2.example',
+            ]
+        )
+
+        self.cli_commit()
+
+        config = read_file(KEA4_CONF)
+        obj = loads(config)
+
+        dnr_data = (
+            f'100, resolver1.example, {dnr_ipv4}, '
+            'alpn=dot\\,doq port=853 dohpath=/dns-query{?dns} | '
+            '200, resolver2.example'
+        )
+        self.verify_config_object(
+            obj,
+            ['Dhcp4', 'shared-networks', 0, 'subnet4', 0, 'option-data'],
+            {'name': 'v4-dnr', 'data': dnr_data},
+        )
+
+        self.verify_service_running()
+
+    def test_dhcp_dnr_http_alpn_requires_dohpath(self):
+        shared_net_name = 'SMOKE-DNR-VERIFY'
+        range_0_start = inc_ip(subnet, 10)
+        range_0_stop = inc_ip(subnet, 20)
+
+        pool = base_path + ['shared-network-name', shared_net_name, 'subnet', subnet]
+        self.cli_set(pool + ['subnet-id', '1'])
+        self.cli_set(pool + ['range', '0', 'start', range_0_start])
+        self.cli_set(pool + ['range', '0', 'stop', range_0_stop])
+
+        self.cli_set(pool + ['option', 'dnr', '10', 'priority', '100'])
+        self.cli_set(
+            pool
+            + [
+                'option',
+                'dnr',
+                '10',
+                'authentication-domain-name',
+                'resolver.example',
+            ]
+        )
+        self.cli_set(pool + ['option', 'dnr', '10', 'service-parameter', 'alpn', 'h2'])
+
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
     def test_dhcp_single_pool_options_scoped(self):
         shared_net_name = 'SMOKE-2'
 

--- a/smoketest/scripts/cli/test_service_dhcpv6-server.py
+++ b/smoketest/scripts/cli/test_service_dhcpv6-server.py
@@ -216,6 +216,110 @@ class TestServiceDHCPv6Server(VyOSUnitTestSHIM.TestCase):
         # Check for running process
         self.assertTrue(process_named_running(PROCESS_NAME))
 
+    def test_dnr_options(self):
+        shared_net_name = 'SMOKE-DNR'
+        range_start = inc_ip(subnet, 256)  # ::100
+        range_stop = inc_ip(subnet, 65535)  # ::ffff
+        dnr_ipv6_1 = inc_ip(subnet, 100)
+        dnr_ipv6_2 = inc_ip(subnet, 101)
+
+        pool = base_path + ['shared-network-name', shared_net_name, 'subnet', subnet]
+        self.cli_set(pool + ['subnet-id', '1'])
+        self.cli_set(pool + ['interface', interface])
+        self.cli_set(pool + ['range', '1', 'start', range_start])
+        self.cli_set(pool + ['range', '1', 'stop', range_stop])
+
+        self.cli_set(pool + ['option', 'dnr', '10', 'priority', '100'])
+        self.cli_set(
+            pool
+            + [
+                'option',
+                'dnr',
+                '10',
+                'authentication-domain-name',
+                'resolver1.example',
+            ]
+        )
+        self.cli_set(pool + ['option', 'dnr', '10', 'address', dnr_ipv6_1])
+        self.cli_set(pool + ['option', 'dnr', '10', 'address', dnr_ipv6_2])
+        self.cli_set(pool + ['option', 'dnr', '10', 'service-parameter', 'alpn', 'dot'])
+        self.cli_set(pool + ['option', 'dnr', '10', 'service-parameter', 'alpn', 'h2'])
+        self.cli_set(pool + ['option', 'dnr', '10', 'service-parameter', 'port', '853'])
+        self.cli_set(
+            pool
+            + [
+                'option',
+                'dnr',
+                '10',
+                'service-parameter',
+                'dohpath',
+                '/dns-query{dns}',
+            ]
+        )
+
+        self.cli_set(pool + ['option', 'dnr', '20', 'priority', '200'])
+        self.cli_set(
+            pool
+            + [
+                'option',
+                'dnr',
+                '20',
+                'authentication-domain-name',
+                'resolver2.example',
+            ]
+        )
+
+        self.cli_commit()
+
+        config = read_file(KEA6_CONF)
+        obj = loads(config)
+
+        self.verify_config_object(
+            obj,
+            ['Dhcp6', 'shared-networks', 0, 'subnet6', 0, 'option-data'],
+            {
+                'name': 'v6-dnr',
+                'data': (
+                    f'100, resolver1.example, {dnr_ipv6_1} {dnr_ipv6_2}, '
+                    'alpn=dot\\,h2 port=853 dohpath=/dns-query{?dns}'
+                ),
+            },
+        )
+        self.verify_config_object(
+            obj,
+            ['Dhcp6', 'shared-networks', 0, 'subnet6', 0, 'option-data'],
+            {'name': 'v6-dnr', 'data': '200, resolver2.example'},
+        )
+
+        self.assertTrue(process_named_running(PROCESS_NAME))
+
+    def test_dnr_http_alpn_requires_dohpath(self):
+        shared_net_name = 'SMOKE-DNR-VERIFY'
+        range_start = inc_ip(subnet, 256)
+        range_stop = inc_ip(subnet, 65535)
+
+        pool = base_path + ['shared-network-name', shared_net_name, 'subnet', subnet]
+        self.cli_set(pool + ['subnet-id', '1'])
+        self.cli_set(pool + ['interface', interface])
+        self.cli_set(pool + ['range', '1', 'start', range_start])
+        self.cli_set(pool + ['range', '1', 'stop', range_stop])
+
+        self.cli_set(pool + ['option', 'dnr', '10', 'priority', '100'])
+        self.cli_set(
+            pool
+            + [
+                'option',
+                'dnr',
+                '10',
+                'authentication-domain-name',
+                'resolver.example',
+            ]
+        )
+        self.cli_set(pool + ['option', 'dnr', '10', 'service-parameter', 'alpn', 'h3'])
+
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
 
     def test_prefix_delegation(self):
         shared_net_name = 'SMOKE-2'

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -242,6 +242,45 @@ def verify_ddns_domain_servers(domain_type, domain):
             raise ConfigError(f'{domain_type} DNS servers {", ".join(invalid_servers)} in DDNS configuration need to have an IP address')
     return None
 
+
+def verify_dnr_dohpath_requirement(option, scope):
+    if 'dnr' not in option:
+        return None
+
+    for instance, config in option['dnr'].items():
+        service_parameter = config.get('service_parameter')
+        if not service_parameter:
+            continue
+
+        if 'dohpath' in service_parameter:
+            dohpath = service_parameter['dohpath']
+            if (
+                '{?dns}' not in dohpath
+                and '{dns}' not in dohpath
+                and ('{' in dohpath or '}' in dohpath)
+            ):
+                raise ConfigError(
+                    f'{scope}: DNR instance "{instance}" has invalid '
+                    '"service-parameter dohpath" URI template. '
+                    'Custom templates must include "{?dns}" '
+                    '(plain paths and "{dns}" are auto-normalized)'
+                )
+
+        alpn = service_parameter.get('alpn')
+        if not alpn:
+            continue
+
+        alpn_values = alpn if isinstance(alpn, list) else [alpn]
+        if any(proto in {'h2', 'h3'} for proto in alpn_values):
+            if 'dohpath' not in service_parameter:
+                raise ConfigError(
+                    f'{scope}: DNR instance "{instance}" requires '
+                    '"service-parameter dohpath" when ALPN includes h2/h3'
+                )
+
+    return None
+
+
 def verify(dhcp):
     # bail out early - looks like removal from running config
     if not dhcp or 'disable' in dhcp:
@@ -264,6 +303,11 @@ def verify(dhcp):
 
     # A shared-network requires a subnet definition
     for network, network_config in dhcp['shared_network_name'].items():
+        if 'option' in network_config:
+            verify_dnr_dohpath_requirement(
+                network_config['option'], f'Shared-network "{network}"'
+            )
+
         if 'disable' in network_config:
             disabled_shared_networks += 1
 
@@ -292,6 +336,11 @@ def verify(dhcp):
                             f'DHCP static-route "{route}" requires router to be defined!'
                         )
 
+            if 'option' in subnet_config:
+                verify_dnr_dohpath_requirement(
+                    subnet_config['option'], f'Subnet "{subnet}"'
+                )
+
             # If a client class has been specified then it must exist
             if 'client_class' in subnet_config:
                 client_class = subnet_config['client_class']
@@ -312,6 +361,12 @@ def verify(dhcp):
                         client_class = range_config['client_class']
                         if client_class not in dhcp.get('client_class', {}):
                             raise ConfigError(f'Client class "{client_class}" set in range "{range}" but does not exist')
+
+                    if 'option' in range_config:
+                        verify_dnr_dohpath_requirement(
+                            range_config['option'],
+                            f'Range "{range}" in subnet "{subnet}"',
+                        )
 
                     # Start/Stop address must be inside network
                     for key in ['start', 'stop']:
@@ -365,6 +420,12 @@ def verify(dhcp):
                 used_mac = []
                 used_duid = []
                 for mapping, mapping_config in subnet_config['static_mapping'].items():
+                    if 'option' in mapping_config:
+                        verify_dnr_dohpath_requirement(
+                            mapping_config['option'],
+                            f'Static-mapping "{mapping}" in subnet "{subnet}"',
+                        )
+
                     if 'ip_address' in mapping_config:
                         if ip_address(mapping_config['ip_address']) not in ip_network(
                             subnet

--- a/src/conf_mode/service_dhcpv6-server.py
+++ b/src/conf_mode/service_dhcpv6-server.py
@@ -102,6 +102,45 @@ def get_config(config=None):
 
     return dhcpv6
 
+
+def verify_dnr_dohpath_requirement(option, scope):
+    if 'dnr' not in option:
+        return None
+
+    for instance, config in option['dnr'].items():
+        service_parameter = config.get('service_parameter')
+        if not service_parameter:
+            continue
+
+        if 'dohpath' in service_parameter:
+            dohpath = service_parameter['dohpath']
+            if (
+                '{?dns}' not in dohpath
+                and '{dns}' not in dohpath
+                and ('{' in dohpath or '}' in dohpath)
+            ):
+                raise ConfigError(
+                    f'{scope}: DNR instance "{instance}" has invalid '
+                    '"service-parameter dohpath" URI template. '
+                    'Custom templates must include "{?dns}" '
+                    '(plain paths and "{dns}" are auto-normalized)'
+                )
+
+        alpn = service_parameter.get('alpn')
+        if not alpn:
+            continue
+
+        alpn_values = alpn if isinstance(alpn, list) else [alpn]
+        if any(proto in {'h2', 'h3'} for proto in alpn_values):
+            if 'dohpath' not in service_parameter:
+                raise ConfigError(
+                    f'{scope}: DNR instance "{instance}" requires '
+                    '"service-parameter dohpath" when ALPN includes h2/h3'
+                )
+
+    return None
+
+
 def verify(dhcpv6):
     # bail out early - looks like removal from running config
     if not dhcpv6 or 'disable' in dhcpv6:
@@ -117,6 +156,11 @@ def verify(dhcpv6):
     subnet_ids = []
     listen_ok = False
     for network, network_config in dhcpv6['shared_network_name'].items():
+        if 'option' in network_config:
+            verify_dnr_dohpath_requirement(
+                network_config['option'], f'Shared-network "{network}"'
+            )
+
         # A shared-network requires a subnet definition
         if 'subnet' not in network_config:
             raise ConfigError(f'No DHCPv6 lease subnets configured for "{network}". '\
@@ -124,6 +168,11 @@ def verify(dhcpv6):
                               'each shared network!')
 
         for subnet, subnet_config in network_config['subnet'].items():
+            if 'option' in subnet_config:
+                verify_dnr_dohpath_requirement(
+                    subnet_config['option'], f'Subnet "{subnet}"'
+                )
+
             if 'subnet_id' not in subnet_config:
                 raise ConfigError(f'Unique subnet ID not specified for subnet "{subnet}"')
 
@@ -137,6 +186,12 @@ def verify(dhcpv6):
                 range6_stop = []
 
                 for num, range_config in subnet_config['range'].items():
+                    if 'option' in range_config:
+                        verify_dnr_dohpath_requirement(
+                            range_config['option'],
+                            f'Range "{num}" in subnet "{subnet}"',
+                        )
+
                     if 'start' in range_config:
                         start = range_config['start']
 
@@ -145,11 +200,11 @@ def verify(dhcpv6):
                         stop = range_config['stop']
 
                         # Start address must be inside network
-                        if not ip_address(start) in ip_network(subnet):
+                        if ip_address(start) not in ip_network(subnet):
                             raise ConfigError(f'Range start address "{start}" is not in subnet "{subnet}"!')
 
                         # Stop address must be inside network
-                        if not ip_address(stop) in ip_network(subnet):
+                        if ip_address(stop) not in ip_network(subnet):
                              raise ConfigError(f'Range stop address "{stop}" is not in subnet "{subnet}"!')
 
                         # Stop address must be greater or equal to start address
@@ -220,6 +275,12 @@ def verify(dhcpv6):
             # Static mappings don't require anything (but check if IP is in subnet if it's set)
             if 'static_mapping' in subnet_config:
                 for mapping, mapping_config in subnet_config['static_mapping'].items():
+                    if 'option' in mapping_config:
+                        verify_dnr_dohpath_requirement(
+                            mapping_config['option'],
+                            f'Static-mapping "{mapping}" in subnet "{subnet}"',
+                        )
+
                     if 'ipv6_address' in mapping_config:
                         # Static address must be in subnet
                         if ip_address(mapping_config['ipv6_address']) not in ip_network(subnet):


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add CLI support for Discovery of Network-designated Resolvers (DNR) under DHCP option trees and render it to Kea option-data.

- Add new DNR nodes for DHCPv4 and DHCPv6 option config:
  - priority
  - authentication-domain-name
  - address (v4/v6)
  - service-parameter (alpn/port/dohpath/raw)
- Map DNR config in python/vyos/kea.py:
  - DHCPv4: emit a single v4-dnr option with instances joined by "|"
  - DHCPv6: emit one v6-dnr option per instance
- Add smoke tests for DHCPv4 and DHCPv6 DNR rendering.

Note: SLAAC/RA DNR is not part of this commit; current router-advert backend (radvd) does not expose RFC9463 DNR option support.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8243
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
