### PR TITLE
smoketest: T8248: fix process_named_running() after switching salt-minion build

### DIFF
--- a/smoketest/scripts/cli/test_service_salt-minion.py
+++ b/smoketest/scripts/cli/test_service_salt-minion.py
@@ -23,7 +23,6 @@ from vyos.utils.process import process_named_running
 from vyos.utils.file import read_file
 from vyos.utils.process import cmd
 
-PROCESS_NAME = 'salt-minion'
 SALT_CONF = '/etc/salt/minion'
 base_path = ['service', 'salt-minion']
 
@@ -47,7 +46,7 @@ class TestServiceSALT(VyOSUnitTestSHIM.TestCase):
 
     def tearDown(self):
         # Check for running process
-        self.assertTrue(process_named_running(PROCESS_NAME))
+        self.assertTrue(process_named_running('python3.11', '/usr/bin/salt-minion'))
 
         # delete testing SALT config
         self.cli_delete(base_path)
@@ -57,7 +56,7 @@ class TestServiceSALT(VyOSUnitTestSHIM.TestCase):
         # from the CI) salt-minion process is not killed by systemd. Apparently
         # no issue on VMWare.
         if cmd('systemd-detect-virt') != 'kvm':
-            self.assertFalse(process_named_running(PROCESS_NAME))
+            self.assertFalse(process_named_running('python3.11', '/usr/bin/salt-minion'))
         # always forward to base class
         super().tearDown()
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

After removing the salt-minion upstream repo and building salt from source in https://github.com/vyos/vyos-build/pull/1112 the binary ships its own Python interpreter which must be accounted for in our smoketests.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8248

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/1112

## How to test / Smoketest result

```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_salt-minion.py
test_default (__main__.TestServiceSALT.test_default) ... ok
test_options (__main__.TestServiceSALT.test_options) ... ok

----------------------------------------------------------------------
Ran 2 tests in 22.791s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
