### PR TITLE
firewall: T8247: Allow both protocol names and numbers consistently

### DIFF
--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -51,6 +51,21 @@ firewall_config_dir = "/config/firewall"
 
 sysctl_file = r'/run/sysctl/10-vyos-firewall.conf'
 
+# Protocol number to name mapping (IANA Protocol Numbers)
+# This ensures consistent handling of numeric protocol specifications
+PROTOCOL_NUMBER_TO_NAME = {
+    '1': 'icmp',
+    '2': 'igmp',
+    '6': 'tcp',
+    '17': 'udp',
+    '47': 'gre',
+    '50': 'esp',
+    '51': 'ah',
+    '58': 'ipv6-icmp',
+    '89': 'ospf',
+    '132': 'sctp',
+}
+
 valid_groups = [
     'address_group',
     'domain_group',
@@ -252,6 +267,16 @@ def verify_rule(firewall, family, hook, priority, rule_id, rule_conf):
             verify_jump_target(firewall, hook, target, family, recursive=True)
         else:
             verify_jump_target(firewall, hook, target, family, recursive=False)
+
+    # Normalize protocol number to name for consistent handling
+    # This allows numeric protocol specifications (e.g., "6" for TCP) to work
+    # consistently across all rule validations
+    if 'protocol' in rule_conf:
+        protocol = str(rule_conf['protocol'])
+
+        # Convert protocol number to name if it's a known mapping
+        if protocol in PROTOCOL_NUMBER_TO_NAME:
+            rule_conf['protocol'] = PROTOCOL_NUMBER_TO_NAME[protocol]
 
     if rule_conf['action'] == 'offload':
         if 'offload_target' not in rule_conf:


### PR DESCRIPTION
## Related Task(s)
https://vyos.dev/T8247

## Change summary
Fixes inconsistent handling of protocol specification in firewall configuration. When users specify protocol by IANA number (e.g., `6` for TCP), certain options like port specifications, TCP flags, and GRE settings would fail validation because the checks compare against string names.

This PR normalizes protocol numbers to their string names early in `verify_rule()` so all subsequent validations work consistently.

**Example of the bug:**
```bash
# This works
set firewall ipv4 name RULE rule 1 protocol 6

# This fails with "Protocol must be tcp, udp, or tcp_udp when specifying a port"
set firewall ipv4 name RULE rule 2 protocol 6
set firewall ipv4 name RULE rule 2 destination port 443
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Related PR(s)
<!-- N/A -->

## Component(s) name
`src/conf_mode/firewall.py`

## How to test
```
#!/bin/vbash
source /opt/vyatta/etc/functions/script-template

# Safeguard: ensure script runs with vyattacfg group
if [ "$(id -g -n)" != 'vyattacfg' ] ; then
    exec sg vyattacfg -c "/bin/vbash $(readlink -f $0) $@"
fi

echo "=========================================="
echo "Firewall Protocol Number Test Script"
echo "Task: T8247"
echo "=========================================="

configure

# Initial setup - create base rule
echo ""
echo "[Setup] Creating base firewall rules..."
set firewall ipv4 name RULE default-action drop
set firewall ipv4 name RULE rule 1 action accept
set firewall ipv6 name RULE6 default-action drop
set firewall ipv6 name RULE6 rule 1 action accept
commit
echo "[Setup] Base rules created."

# ==========================================
# Test 1: Port specification (TCP) - Numeric protocol
# ==========================================
echo ""
echo "[Test 1a] Port specification with numeric protocol (6 = TCP)..."
echo "[Before]"
run show firewall ipv4 name RULE rule 1
set firewall ipv4 name RULE rule 1 protocol 6
set firewall ipv4 name RULE rule 1 destination port 443
if commit; then
    echo "[Test 1a] PASSED: Numeric protocol 6 with port 443 accepted."
    echo "[After]"
    run show firewall ipv4 name RULE rule 1
else
    echo "[Test 1a] FAILED: Numeric protocol 6 with port 443 rejected."
fi
# Cleanup
delete firewall ipv4 name RULE rule 1 protocol
delete firewall ipv4 name RULE rule 1 destination
commit

# ==========================================
# Test 1b: Port specification (TCP) - String protocol
# ==========================================
echo ""
echo "[Test 1b] Port specification with string protocol (tcp)..."
echo "[Before]"
run show firewall ipv4 name RULE rule 1
set firewall ipv4 name RULE rule 1 protocol tcp
set firewall ipv4 name RULE rule 1 destination port 443
if commit; then
    echo "[Test 1b] PASSED: String protocol tcp with port 443 accepted."
    echo "[After]"
    run show firewall ipv4 name RULE rule 1
else
    echo "[Test 1b] FAILED: String protocol tcp with port 443 rejected."
fi
# Cleanup
delete firewall ipv4 name RULE rule 1 protocol
delete firewall ipv4 name RULE rule 1 destination
commit

# ==========================================
# Test 2a: Port specification (UDP) - Numeric protocol
# ==========================================
echo ""
echo "[Test 2a] Port specification with numeric protocol (17 = UDP)..."
echo "[Before]"
run show firewall ipv4 name RULE rule 1
set firewall ipv4 name RULE rule 1 protocol 17
set firewall ipv4 name RULE rule 1 destination port 53
if commit; then
    echo "[Test 2a] PASSED: Numeric protocol 17 with port 53 accepted."
    echo "[After]"
    run show firewall ipv4 name RULE rule 1
else
    echo "[Test 2a] FAILED: Numeric protocol 17 with port 53 rejected."
fi
# Cleanup
delete firewall ipv4 name RULE rule 1 protocol
delete firewall ipv4 name RULE rule 1 destination
commit

# ==========================================
# Test 2b: Port specification (UDP) - String protocol
# ==========================================
echo ""
echo "[Test 2b] Port specification with string protocol (udp)..."
echo "[Before]"
run show firewall ipv4 name RULE rule 1
set firewall ipv4 name RULE rule 1 protocol udp
set firewall ipv4 name RULE rule 1 destination port 53
if commit; then
    echo "[Test 2b] PASSED: String protocol udp with port 53 accepted."
    echo "[After]"
    run show firewall ipv4 name RULE rule 1
else
    echo "[Test 2b] FAILED: String protocol udp with port 53 rejected."
fi
# Cleanup
delete firewall ipv4 name RULE rule 1 protocol
delete firewall ipv4 name RULE rule 1 destination
commit

# ==========================================
# Test 3a: TCP flags - Numeric protocol
# ==========================================
echo ""
echo "[Test 3a] TCP flags with numeric protocol (6 = TCP)..."
echo "[Before]"
run show firewall ipv4 name RULE rule 1
set firewall ipv4 name RULE rule 1 protocol 6
set firewall ipv4 name RULE rule 1 tcp flags syn
if commit; then
    echo "[Test 3a] PASSED: Numeric protocol 6 with tcp flags syn accepted."
    echo "[After]"
    run show firewall ipv4 name RULE rule 1
else
    echo "[Test 3a] FAILED: Numeric protocol 6 with tcp flags syn rejected."
fi
# Cleanup
delete firewall ipv4 name RULE rule 1 protocol
delete firewall ipv4 name RULE rule 1 tcp
commit

# ==========================================
# Test 3b: TCP flags - String protocol
# ==========================================
echo ""
echo "[Test 3b] TCP flags with string protocol (tcp)..."
echo "[Before]"
run show firewall ipv4 name RULE rule 1
set firewall ipv4 name RULE rule 1 protocol tcp
set firewall ipv4 name RULE rule 1 tcp flags syn
if commit; then
    echo "[Test 3b] PASSED: String protocol tcp with tcp flags syn accepted."
    echo "[After]"
    run show firewall ipv4 name RULE rule 1
else
    echo "[Test 3b] FAILED: String protocol tcp with tcp flags syn rejected."
fi
# Cleanup
delete firewall ipv4 name RULE rule 1 protocol
delete firewall ipv4 name RULE rule 1 tcp
commit

# ==========================================
# Test 4a: GRE matching - Numeric protocol
# ==========================================
echo ""
echo "[Test 4a] GRE matching with numeric protocol (47 = GRE)..."
echo "[Before]"
run show firewall ipv4 name RULE rule 1
set firewall ipv4 name RULE rule 1 protocol 47
set firewall ipv4 name RULE rule 1 gre flags checksum unset
set firewall ipv4 name RULE rule 1 gre key 100
if commit; then
    echo "[Test 4a] PASSED: Numeric protocol 47 with GRE options accepted."
    echo "[After]"
    run show firewall ipv4 name RULE rule 1
else
    echo "[Test 4a] FAILED: Numeric protocol 47 with GRE options rejected."
fi
# Cleanup
delete firewall ipv4 name RULE rule 1 protocol
delete firewall ipv4 name RULE rule 1 gre
commit

# ==========================================
# Test 4b: GRE matching - String protocol
# ==========================================
echo ""
echo "[Test 4b] GRE matching with string protocol (gre)..."
echo "[Before]"
run show firewall ipv4 name RULE rule 1
set firewall ipv4 name RULE rule 1 protocol gre
set firewall ipv4 name RULE rule 1 gre flags checksum unset
set firewall ipv4 name RULE rule 1 gre key 100
if commit; then
    echo "[Test 4b] PASSED: String protocol gre with GRE options accepted."
    echo "[After]"
    run show firewall ipv4 name RULE rule 1
else
    echo "[Test 4b] FAILED: String protocol gre with GRE options rejected."
fi
# Cleanup
delete firewall ipv4 name RULE rule 1 protocol
delete firewall ipv4 name RULE rule 1 gre
commit

# ==========================================
# Test 5a: synproxy action - Numeric protocol
# ==========================================
echo ""
echo "[Test 5a] synproxy action with numeric protocol (6 = TCP)..."
echo "[Before]"
run show firewall ipv4 name RULE rule 1
set firewall ipv4 name RULE rule 1 action synproxy
set firewall ipv4 name RULE rule 1 protocol 6
set firewall ipv4 name RULE rule 1 synproxy tcp mss 1460
if commit; then
    echo "[Test 5a] PASSED: Numeric protocol 6 with synproxy accepted."
    echo "[After]"
    run show firewall ipv4 name RULE rule 1
else
    echo "[Test 5a] FAILED: Numeric protocol 6 with synproxy rejected."
fi
# Cleanup
delete firewall ipv4 name RULE rule 1 action
set firewall ipv4 name RULE rule 1 action accept
delete firewall ipv4 name RULE rule 1 protocol
delete firewall ipv4 name RULE rule 1 synproxy
commit

# ==========================================
# Test 5b: synproxy action - String protocol
# ==========================================
echo ""
echo "[Test 5b] synproxy action with string protocol (tcp)..."
echo "[Before]"
run show firewall ipv4 name RULE rule 1
set firewall ipv4 name RULE rule 1 action synproxy
set firewall ipv4 name RULE rule 1 protocol tcp
set firewall ipv4 name RULE rule 1 synproxy tcp mss 1460
if commit; then
    echo "[Test 5b] PASSED: String protocol tcp with synproxy accepted."
    echo "[After]"
    run show firewall ipv4 name RULE rule 1
else
    echo "[Test 5b] FAILED: String protocol tcp with synproxy rejected."
fi
# Cleanup
delete firewall ipv4 name RULE rule 1 action
set firewall ipv4 name RULE rule 1 action accept
delete firewall ipv4 name RULE rule 1 protocol
delete firewall ipv4 name RULE rule 1 synproxy
commit

# ==========================================
# Test 6a: ICMP protocol (IPv4) - Numeric protocol
# ==========================================
echo ""
echo "[Test 6a] ICMP with numeric protocol (1 = ICMP)..."
echo "[Before]"
run show firewall ipv4 name RULE rule 1
set firewall ipv4 name RULE rule 1 protocol 1
set firewall ipv4 name RULE rule 1 icmp type-name echo-request
if commit; then
    echo "[Test 6a] PASSED: Numeric protocol 1 with ICMP type accepted."
    echo "[After]"
    run show firewall ipv4 name RULE rule 1
else
    echo "[Test 6a] FAILED: Numeric protocol 1 with ICMP type rejected."
fi
# Cleanup
delete firewall ipv4 name RULE rule 1 protocol
delete firewall ipv4 name RULE rule 1 icmp
commit

# ==========================================
# Test 6b: ICMP protocol (IPv4) - String protocol
# ==========================================
echo ""
echo "[Test 6b] ICMP with string protocol (icmp)..."
echo "[Before]"
run show firewall ipv4 name RULE rule 1
set firewall ipv4 name RULE rule 1 protocol icmp
set firewall ipv4 name RULE rule 1 icmp type-name echo-request
if commit; then
    echo "[Test 6b] PASSED: String protocol icmp with ICMP type accepted."
    echo "[After]"
    run show firewall ipv4 name RULE rule 1
else
    echo "[Test 6b] FAILED: String protocol icmp with ICMP type rejected."
fi
# Cleanup
delete firewall ipv4 name RULE rule 1 protocol
delete firewall ipv4 name RULE rule 1 icmp
commit

# ==========================================
# Test 7a: ICMPv6 protocol (IPv6) - Numeric protocol
# ==========================================
echo ""
echo "[Test 7a] ICMPv6 with numeric protocol (58 = ICMPv6)..."
echo "[Before]"
run show firewall ipv6 name RULE6 rule 1
set firewall ipv6 name RULE6 rule 1 protocol 58
set firewall ipv6 name RULE6 rule 1 icmpv6 type-name echo-request
if commit; then
    echo "[Test 7a] PASSED: Numeric protocol 58 with ICMPv6 type accepted."
    echo "[After]"
    run show firewall ipv6 name RULE6 rule 1
else
    echo "[Test 7a] FAILED: Numeric protocol 58 with ICMPv6 type rejected."
fi
# Cleanup
delete firewall ipv6 name RULE6 rule 1 protocol
delete firewall ipv6 name RULE6 rule 1 icmpv6
commit

# ==========================================
# Test 7b: ICMPv6 protocol (IPv6) - String protocol
# ==========================================
echo ""
echo "[Test 7b] ICMPv6 with string protocol (ipv6-icmp)..."
echo "[Before]"
run show firewall ipv6 name RULE6 rule 1
set firewall ipv6 name RULE6 rule 1 protocol ipv6-icmp
set firewall ipv6 name RULE6 rule 1 icmpv6 type-name echo-request
if commit; then
    echo "[Test 7b] PASSED: String protocol ipv6-icmp with ICMPv6 type accepted."
    echo "[After]"
    run show firewall ipv6 name RULE6 rule 1
else
    echo "[Test 7b] FAILED: String protocol ipv6-icmp with ICMPv6 type rejected."
fi
# Cleanup
delete firewall ipv6 name RULE6 rule 1 protocol
delete firewall ipv6 name RULE6 rule 1 icmpv6
commit

# ==========================================
# Final cleanup - remove base rules
# ==========================================
echo ""
echo "[Cleanup] Removing base firewall rules..."
delete firewall ipv4 name RULE
delete firewall ipv6 name RULE6
commit

exit

echo ""
echo "=========================================="
echo "All tests completed!"
echo "=========================================="
```
## Test result
[test_firewall_protocol_result.txt](https://github.com/user-attachments/files/25197770/test_firewall_protocol_result.txt)
[test_firewall_protocol.sh](https://github.com/user-attachments/files/25197771/test_firewall_protocol.sh)

```
admin@Y-ANDOU-VYOS15.Y-ANDOU-01:~$ grep 'Test [0-9]' test_firewall_protocol_result.txt
[Test 1a] Port specification with numeric protocol (6 = TCP)...
[Test 1a] PASSED: Numeric protocol 6 with port 443 accepted.
[Test 1b] Port specification with string protocol (tcp)...
[Test 1b] PASSED: String protocol tcp with port 443 accepted.
[Test 2a] Port specification with numeric protocol (17 = UDP)...
[Test 2a] PASSED: Numeric protocol 17 with port 53 accepted.
[Test 2b] Port specification with string protocol (udp)...
[Test 2b] PASSED: String protocol udp with port 53 accepted.
[Test 3a] TCP flags with numeric protocol (6 = TCP)...
[Test 3a] PASSED: Numeric protocol 6 with tcp flags syn accepted.
[Test 3b] TCP flags with string protocol (tcp)...
[Test 3b] PASSED: String protocol tcp with tcp flags syn accepted.
[Test 4a] GRE matching with numeric protocol (47 = GRE)...
[Test 4a] PASSED: Numeric protocol 47 with GRE options accepted.
[Test 4b] GRE matching with string protocol (gre)...
[Test 4b] PASSED: String protocol gre with GRE options accepted.
[Test 5a] synproxy action with numeric protocol (6 = TCP)...
[Test 5a] PASSED: Numeric protocol 6 with synproxy accepted.
[Test 5b] synproxy action with string protocol (tcp)...
[Test 5b] PASSED: String protocol tcp with synproxy accepted.
[Test 6a] ICMP with numeric protocol (1 = ICMP)...
[Test 6a] PASSED: Numeric protocol 1 with ICMP type accepted.
[Test 6b] ICMP with string protocol (icmp)...
[Test 6b] PASSED: String protocol icmp with ICMP type accepted.
[Test 7a] ICMPv6 with numeric protocol (58 = ICMPv6)...
[Test 7a] PASSED: Numeric protocol 58 with ICMPv6 type accepted.
[Test 7b] ICMPv6 with string protocol (ipv6-icmp)...
[Test 7b] PASSED: String protocol ipv6-icmp with ICMPv6 type accepted.
```


## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

---
Requested by: @Nyandorew