### PR TITLE
vpp: T7811: Add rebind_gve_driver function for correct gve device handling

### DIFF
--- a/python/vyos/vpp/control_host.py
+++ b/python/vyos/vpp/control_host.py
@@ -85,6 +85,30 @@ def unbind_driver(bus_id: str, device_id: str) -> bool:
     return True
 
 
+def rebind_gve_driver(iface: str, bus_id: str, device_id: str) -> None:
+    """
+    Rebind a device to the gve kernel driver.
+
+    Args:
+        iface (str): Interface name
+        bus_id (str): Bus type (pci, vmbus, etc.)
+        device_id (str): device id on the bus (PCI address, VMBus UUID)
+    """
+    set_status(iface, 'down')
+
+    # Unbind the device from its current driver
+    unbind_driver(bus_id, device_id)
+
+    # Clear driver override (if set)
+    device_path = Path(f'/sys/bus/{bus_id}/devices/{device_id}').resolve()
+    (device_path / 'driver_override').write_text('')
+
+    # Bind the device to the gve kernel driver
+    Path(f'/sys/bus/{bus_id}/drivers/gve/bind').write_text(device_id)
+
+    set_status(iface, 'up')
+
+
 def probe_driver(bus_id: str, device_id: str) -> None:
     """Probe driver for a device on a bus
 

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -659,7 +659,13 @@ def generate(config):
 def initialize_interface(iface, driver, iface_config) -> None:
     # DPDK - rescan PCI to use a proper driver
     if driver == 'dpdk' and iface_config['original_driver'] not in not_pci_drv:
-        control_host.pci_rescan(iface_config['dev_id'])
+        # 'gve' devices require a specific unbind/bind process instead of a standard PCI rescan.
+        if iface_config['original_driver'] == 'gve':
+            control_host.rebind_gve_driver(
+                iface, iface_config['bus_id'], iface_config['dev_id']
+            )
+        else:
+            control_host.pci_rescan(iface_config['dev_id'])
         # rename to the proper name
         iface_new_name: str = control_host.get_eth_name(iface_config['dev_id'])
         control_host.rename_iface(iface_new_name, iface)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7811
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
 yos@VyOS-for-Smoke-Tests# python3 /usr/libexec/vyos/tests/smoke/cli/test_vpp.py 
test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
test_04_vpp_geneve (__main__.TestVPP.test_04_vpp_geneve) ... skipped 'Skipping this test geneve index always is 0'
test_05_vpp_loopback (__main__.TestVPP.test_05_vpp_loopback) ... ok
test_06_vpp_bonding (__main__.TestVPP.test_06_vpp_bonding) ... ok
test_07_vpp_bridge (__main__.TestVPP.test_07_vpp_bridge) ... ok
test_08_vpp_ipip (__main__.TestVPP.test_08_vpp_ipip) ... ok
test_09_vpp_xconnect (__main__.TestVPP.test_09_vpp_xconnect) ... ok
test_10_vpp_driver_options (__main__.TestVPP.test_10_vpp_driver_options) ... ok
test_11_vpp_cpu_settings (__main__.TestVPP.test_11_vpp_cpu_settings) ... ok
test_12_vpp_cpu_corelist_workers (__main__.TestVPP.test_12_vpp_cpu_corelist_workers) ... ok
test_13_1_buffer_page_size (__main__.TestVPP.test_13_1_buffer_page_size) ... ok
test_13_2_statseg_page_size (__main__.TestVPP.test_13_2_statseg_page_size) ... ok
test_13_3_mem_page_size (__main__.TestVPP.test_13_3_mem_page_size) ... ok
test_14_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_14_vpp_ipsec_xfrm_nl) ... ok
test_15_1_vpp_cgnat (__main__.TestVPP.test_15_1_vpp_cgnat) ... ok
test_15_2_vpp_cgnat_bond_with_vifs (__main__.TestVPP.test_15_2_vpp_cgnat_bond_with_vifs) ... ok
test_16_vpp_nat (__main__.TestVPP.test_16_vpp_nat) ... ok
test_17_vpp_sflow (__main__.TestVPP.test_17_vpp_sflow) ... ok
test_18_resource_limits (__main__.TestVPP.test_18_resource_limits) ... ok
test_19_vpp_pppoe_mapping (__main__.TestVPP.test_19_vpp_pppoe_mapping) ... ok
test_20_kernel_options_hugepages (__main__.TestVPP.test_20_kernel_options_hugepages) ... ok
test_21_static_arp (__main__.TestVPP.test_21_static_arp) ... ok
test_22_1_vpp_ipfix (__main__.TestVPP.test_22_1_vpp_ipfix) ... ok
test_22_2_vpp_ipfix_bond (__main__.TestVPP.test_22_2_vpp_ipfix_bond) ... ok

----------------------------------------------------------------------
Ran 26 tests in 649.481s

OK (skipped=1)
[edit]
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
