### PR TITLE
update-check: T7945: Improve reliability during early boot and error handling

### DIFF
--- a/src/system/vyos-system-update-check.py
+++ b/src/system/vyos-system-update-check.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
             remote_version = jmespath.search('[0].version', remote_data)
             if local_version != remote_version and remote_version:
                 call(f'wall -n "Update available: {remote_version} \nUpdate URL: {url}"')
-                # MOTD used in /run/motd.d/10-update
+                # MOTD used in /run/motd.d/10-vyos-update
                 motd_file.parent.mkdir(exist_ok=True)
                 motd_file.write_text(f'---\n'
                                      f'Current version: {local_version}\n'


### PR DESCRIPTION
## Change summary
During early boot not all resources are ready for HTTP request, so `vyos.version.get_remote_version` may fail once and the update check is then delayed for [12 hours](https://github.com/vyos/vyos-1x/blob/911f8653a813868f2cf805a3a1662eaf16375188/src/system/vyos-system-update-check.py#L69-L70) (line 69-70), leaving the router unaware of updates.

Fix by adding retries/backoff and improved error handling so transient startup network failures don't suppress update checks for the next interval.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7945

## How to test / Smoketest result

### Manual test

1. Configure URL to check new version of VyOS:
```
vyos@vyos# set system update-check auto-check
vyos@vyos# set system update-check url 'https://raw.githubusercontent.com/vyos/vyos-nightly-build/refs/heads/current/version.json'
vyos@vyos# commit

Update available: 2026.02.03-0027-rolling
Update URL: https://github.com/vyos/vyos-nightly-build/releases/download/2026.0
2.03-0027-rolling/vyos-2026.02.03-0027-rolling-generic-amd64.iso

[edit]
vyos@vyos# save
vyos@vyos# ls -la /run/motd.d
total 12
drwxr-xr-x  2 root root  100 Feb 10 13:15 .
drwxr-xr-x 45 root root 1260 Feb 10 13:21 ..
-rw-r--r--  1 root root  122 Feb 10 13:15 01-vyos-nonproduction
-rw-r--r--  1 root root   95 Feb 10 13:22 10-vyos-update
-rw-r--r--  1 root root    1 Feb 10 13:15 92-vyos-user-dsa-deprecation-warning
[edit]
vyos@vyos# run reboot now
```

2. After reboot of the VM `10-vyos-update` file and a message about new version should appear:
```
...
---
WARNING: This VyOS system is not a stable long-term support version and
         is not intended for production use.
---
Current version: 999.202602061411
Update available: 2026.02.03-0027-rolling
---
vyos@vyos:~$ ls -la /run/motd.d
total 12
drwxr-xr-x  2 root root  100 Feb 10 13:23 .
drwxr-xr-x 45 root root 1260 Feb 10 13:24 ..
-rw-r--r--  1 root root  122 Feb 10 13:23 01-vyos-nonproduction
-rw-r--r--  1 root root   95 Feb 10 13:23 10-vyos-update
-rw-r--r--  1 root root    1 Feb 10 13:23 92-vyos-user-dsa-deprecation-warning
```

3. Verify validation of `system update-check url`:
```
vyos@vyos# set system update-check url 'http://example.com/not-found'
[edit]
vyos@vyos# commit
[ system update-check ]

WARNING: "system update-check url" has a valid URL but unable to
retrieve data from the server: HTTPError

[edit]
vyos@vyos# set system update-check url 'http://10.0.2.2:8080/closed-port'
[edit]
vyos@vyos# commit
[ system update-check ]

WARNING: "system update-check url" has a valid URL but unable to
retrieve data from the server: ConnectionError
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly