### PR TITLE
vpp: T8255: Changed logging level variable name

### DIFF
--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -67,9 +67,9 @@ l2learn {
 
 {% if logging is vyos_defined %}
 logging {
-{%     if logging.default_log_level is vyos_defined %}
-    default-log-level {{ logging.default_log_level }}
-    default-syslog-log-level {{ logging.default_log_level }}
+{%     if logging.default_level is vyos_defined %}
+    default-log-level {{ logging.default_level }}
+    default-syslog-log-level {{ logging.default_level }}
 {%     endif %}
 }
 {% endif %}

--- a/interface-definitions/include/version/vpp-version.xml.i
+++ b/interface-definitions/include/version/vpp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/vpp-version.xml.i -->
-<syntaxVersion component='vpp' version='7'></syntaxVersion>
+<syntaxVersion component='vpp' version='8'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -809,9 +809,9 @@
             <help>Logging settings</help>
           </properties>
           <children>
-            <leafNode name="default-log-level">
+            <leafNode name="default-level">
               <properties>
-                <help>default-log-level</help>
+                <help>Default logging level</help>
                 <completionHelp>
                   <list>alert crit debug disabled emerg error info notice warn</list>
                 </completionHelp>

--- a/smoketest/configs/assert/vpp
+++ b/smoketest/configs/assert/vpp
@@ -47,3 +47,4 @@ set vpp settings interface eth2
 set vpp settings interface eth3
 set vpp settings interface eth4
 set vpp settings unix poll-sleep-usec '12'
+set vpp settings logging default-level 'debug'

--- a/smoketest/configs/vpp
+++ b/smoketest/configs/vpp
@@ -123,6 +123,9 @@ vpp {
         unix {
             poll-sleep-usec "12"
         }
+        logging {
+            default-log-level "debug"
+        }
     }
 }
 

--- a/src/migration-scripts/vpp/7-to-8
+++ b/src/migration-scripts/vpp/7-to-8
@@ -1,0 +1,30 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Rename `vpp settings logging default-log-level` to
+# `vpp settings logging default-level` (T8255)
+#
+
+from vyos.configtree import ConfigTree
+
+
+def _migrate_vpp_log(config: ConfigTree) -> None:
+    base = ['vpp', 'settings', 'logging']
+    if config.exists(base + ['default-log-level']):
+        config.rename(base + ['default-log-level'], 'default-level')
+
+
+def migrate(config: ConfigTree) -> None:
+    _migrate_vpp_log(config)


### PR DESCRIPTION
## Change summary
This commit changes logging settings naming:
  - before: `set vpp settings logging default-log-level <alert>`
  - after:  `set vpp settings logging default-level <alert>`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): change of CLI command

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8255

## Related PR(s)
* https://github.com/vyos/vyos-documentation/pull/1765

## How to test / Smoketest result
### Manual test
```
vyos@vyos# set vpp settings logging default-level debug
vyos@vyos# commit
vyos@vyos# cat /run/vpp/vpp.conf | grep log
    log /var/log/vpp.log
logging {
    default-log-level debug
    default-syslog-log-level debug
[edit]
```

### Smoketest
```
root@b161d478e5c2:/vyos/build# make testcvpp
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly