### PR TITLE
T8257: image install search previous needs to consider legacy bind mount

### DIFF
--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -272,12 +272,18 @@ def search_previous_installation(disks: list[str]) -> None:
     print('Searching for data from previous installations')
     image_data = []
     encrypted_configs = []
+    legacy_bind_mount = False
     for disk_name in disks:
         for partition in disk.partition_list(disk_name):
             if disk.partition_mount(partition, mnt_tmp):
                 if Path(mnt_tmp + '/boot').exists():
                     for path in Path(mnt_tmp + '/boot').iterdir():
-                        if path.joinpath('rw/opt/vyatta/etc/config/.vyatta_config').exists():
+                        if path.joinpath('rw/config/.vyatta_config').exists():
+                            legacy_bind_mount = True
+                            image_data.append((path.name, partition))
+                        elif path.joinpath(
+                            'rw/opt/vyatta/etc/config/.vyatta_config'
+                        ).exists():
                             image_data.append((path.name, partition))
                 if Path(mnt_tmp + '/luks').exists():
                     for path in Path(mnt_tmp + '/luks').iterdir():
@@ -330,7 +336,12 @@ def search_previous_installation(disks: list[str]) -> None:
     disk.partition_mount(image_drive, mnt_tmp)
 
     if not encrypted:
-        copytree(f'{mnt_tmp}/boot/{image_name}/rw/opt/vyatta/etc/config', mnt_config)
+        if legacy_bind_mount:
+            copytree(f'{mnt_tmp}/boot/{image_name}/rw/config', mnt_config)
+        else:
+            copytree(
+                f'{mnt_tmp}/boot/{image_name}/rw/opt/vyatta/etc/config', mnt_config
+            )
     else:
         copy(f'{mnt_tmp}/luks/{image_name}', mnt_encrypted_config)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

This is the converse problem to https://vyos.dev/T7994: normalization of the config bind mount in https://vyos.dev/T7836 means that when searching for previous installations one searches in `{mount_path}/opt/vyatta/etc/config`. However, when searching for previous installations _that were themselves created_ with the legacy bind mount (<= 1.4.4), the `config.boot` file resident there is not the saved version, but rather the baseline created by the original installation. One must therefore search both the legacy path `{mount_path}/config` as well as the normalized path. This is well defined, as the legacy path only exists in the `{mount_path}` in the case of legacy bind mount.

Note that this is not an issue for upgrades using add system image.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Test by mounting ISO with this PR to the cdrom drive of an existing 1.4.4 vm and install from booted cd. The correct config.boot is copied. Similarly, installing over existing 1.5 images behave correctly after https://vyos.dev/T7994.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
