### PR TITLE
vpp: T8254: Move 'nat44' and 'settings nat44' sections to 'nat nat44'

### DIFF
--- a/data/config-mode-dependencies/vyos-vpp.json
+++ b/data/config-mode-dependencies/vyos-vpp.json
@@ -12,7 +12,7 @@
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],
         "vpp_acl": ["vpp_acl"],
         "vpp_ipfix": ["vpp_ipfix"],
-        "vpp_nat": ["vpp_nat"],
+        "vpp_nat_nat44": ["vpp_nat_nat44"],
         "vpp_nat_cgnat": ["vpp_nat_cgnat"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"],
         "vpp_sflow": ["vpp_sflow"],
@@ -21,7 +21,7 @@
     "vpp_interfaces_bonding": {
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],
         "vpp_acl": ["vpp_acl"],
-        "vpp_nat": ["vpp_nat"],
+        "vpp_nat_nat44": ["vpp_nat_nat44"],
         "vpp_nat_cgnat": ["vpp_nat_cgnat"],
         "vpp_ipfix": ["vpp_ipfix"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
@@ -29,34 +29,34 @@
     "vpp_interfaces_ethernet": {
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],
         "vpp_acl": ["vpp_acl"],
-        "vpp_nat": ["vpp_nat"],
+        "vpp_nat_nat44": ["vpp_nat_nat44"],
         "vpp_nat_cgnat": ["vpp_nat_cgnat"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
     },
     "vpp_interfaces_geneve": {
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],
         "vpp_acl": ["vpp_acl"],
-        "vpp_nat": ["vpp_nat"],
+        "vpp_nat_nat44": ["vpp_nat_nat44"],
         "vpp_nat_cgnat": ["vpp_nat_cgnat"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
     },
     "vpp_interfaces_gre": {
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],
         "vpp_acl": ["vpp_acl"],
-        "vpp_nat": ["vpp_nat"],
+        "vpp_nat_nat44": ["vpp_nat_nat44"],
         "vpp_nat_cgnat": ["vpp_nat_cgnat"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
     },
     "vpp_interfaces_ipip": {
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],
         "vpp_acl": ["vpp_acl"],
-        "vpp_nat": ["vpp_nat"],
+        "vpp_nat_nat44": ["vpp_nat_nat44"],
         "vpp_nat_cgnat": ["vpp_nat_cgnat"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
     },
     "vpp_interfaces_loopback": {
         "vpp_acl": ["vpp_acl"],
-        "vpp_nat": ["vpp_nat"],
+        "vpp_nat_nat44": ["vpp_nat_nat44"],
         "vpp_nat_cgnat": ["vpp_nat_cgnat"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
     },
@@ -64,13 +64,13 @@
         "vpp_interfaces_bridge": ["vpp_interfaces_bridge"],
         "vpp_interfaces_xconnect": ["vpp_interfaces_xconnect"],
         "vpp_acl": ["vpp_acl"],
-        "vpp_nat": ["vpp_nat"],
+        "vpp_nat_nat44": ["vpp_nat_nat44"],
         "vpp_nat_cgnat": ["vpp_nat_cgnat"],
         "vpp_kernel_interface": ["vpp_kernel-interfaces"]
     },
     "vpp_kernel_interfaces": {
         "vpp_nat_cgnat": ["vpp_nat_cgnat"],
-        "vpp_nat": ["vpp_nat"]
+        "vpp_nat_nat44": ["vpp_nat_nat44"]
     }
 }
 

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -879,92 +879,6 @@
             </leafNode>
           </children>
         </node>
-        <node name="nat44">
-          <properties>
-            <help>NAT settings</help>
-          </properties>
-          <children>
-            <node name="timeout">
-              <properties>
-                <help>NAT44 session timeouts</help>
-              </properties>
-              <children>
-                <leafNode name="icmp">
-                  <properties>
-                    <help>ICMP timeout</help>
-                    <valueHelp>
-                      <format>u32</format>
-                      <description>Timeout in seconds (default: 60)</description>
-                    </valueHelp>
-                  </properties>
-                  <defaultValue>60</defaultValue>
-                </leafNode>
-                <leafNode name="tcp-established">
-                  <properties>
-                    <help>TCP established timeout</help>
-                    <valueHelp>
-                      <format>u32</format>
-                      <description>TCP established timeout in seconds (default: 7440)</description>
-                    </valueHelp>
-                  </properties>
-                  <defaultValue>7440</defaultValue>
-                </leafNode>
-                <leafNode name="tcp-transitory">
-                  <properties>
-                    <help>TCP transitory timeout</help>
-                    <valueHelp>
-                      <format>u32</format>
-                      <description>Timeout in seconds (default: 240)</description>
-                    </valueHelp>
-                  </properties>
-                  <defaultValue>240</defaultValue>
-                </leafNode>
-                <leafNode name="udp">
-                  <properties>
-                    <help>UDP timeout</help>
-                    <valueHelp>
-                      <format>u32</format>
-                      <description>Timeout in seconds (default: 300)</description>
-                    </valueHelp>
-                  </properties>
-                  <defaultValue>300</defaultValue>
-                </leafNode>
-              </children>
-            </node>
-            <leafNode name="session-limit">
-              <properties>
-                <help>Maximum number of sessions per thread</help>
-                <valueHelp>
-                  <format>u32</format>
-                  <description>Number of sessions</description>
-                </valueHelp>
-                <constraint>
-                  <validator name="numeric" argument="--range 1-4294967295"/>
-                </constraint>
-                <constraintErrorMessage>Number of sessions must be between 1 and 4294967295</constraintErrorMessage>
-              </properties>
-              <defaultValue>64512</defaultValue>
-            </leafNode>
-            <leafNode name="workers">
-              <properties>
-                <help>List of NAT workers</help>
-                <valueHelp>
-                  <format>&lt;id&gt;</format>
-                  <description>Worker id</description>
-                </valueHelp>
-                <valueHelp>
-                  <format>&lt;idN&gt;-&lt;idM&gt;</format>
-                  <description>Worker id range (use '-' as delimiter)</description>
-                </valueHelp>
-                <constraint>
-                  <validator name="numeric" argument="--allow-range --range 0-512"/>
-                </constraint>
-                <constraintErrorMessage>Not a valid value or range</constraintErrorMessage>
-                <multi/>
-              </properties>
-            </leafNode>
-          </children>
-        </node>
         <node name="physmem">
           <properties>
             <help>Physical memory settings</help>
@@ -1203,212 +1117,273 @@
             </node>
           </children>
         </node>
-      </children>
-    </node>
-    <node name="nat44" owner="${vyos_conf_scripts_dir}/vpp_nat.py">
-      <properties>
-        <help>NAT44</help>
-        <priority>330</priority>
-      </properties>
-      <children>
-        <node name="interface">
+        <node name="nat44" owner="${vyos_conf_scripts_dir}/vpp_nat_nat44.py">
           <properties>
-            <help>NAT interface setting</help>
+            <help>NAT44</help>
+            <priority>330</priority>
           </properties>
           <children>
-            <leafNode name="inside">
+            <node name="timeout">
               <properties>
-                <help>NAT inside interface</help>
-                <completionHelp>
-                  <script>${vyos_completion_dir}/list_interfaces</script>
-                </completionHelp>
-                <multi/>
-              </properties>
-            </leafNode>
-            <leafNode name="outside">
-              <properties>
-                <help>NAT outside interface</help>
-                <completionHelp>
-                  <script>${vyos_completion_dir}/list_interfaces</script>
-                </completionHelp>
-                <multi/>
-              </properties>
-            </leafNode>
-          </children>
-        </node>
-        <node name="address-pool">
-          <properties>
-            <help>NAT address pool</help>
-          </properties>
-          <children>
-            <node name="translation">
-              <properties>
-                <help>NAT translation pool</help>
+                <help>NAT44 session timeouts</help>
               </properties>
               <children>
-                #include <include/vpp/nat_address_range.xml.i>
-                #include <include/vpp/nat_interface.xml.i>
+                <leafNode name="icmp">
+                  <properties>
+                    <help>ICMP timeout</help>
+                    <valueHelp>
+                      <format>u32</format>
+                      <description>Timeout in seconds (default: 60)</description>
+                    </valueHelp>
+                  </properties>
+                  <defaultValue>60</defaultValue>
+                </leafNode>
+                <leafNode name="tcp-established">
+                  <properties>
+                    <help>TCP established timeout</help>
+                    <valueHelp>
+                      <format>u32</format>
+                      <description>TCP established timeout in seconds (default: 7440)</description>
+                    </valueHelp>
+                  </properties>
+                  <defaultValue>7440</defaultValue>
+                </leafNode>
+                <leafNode name="tcp-transitory">
+                  <properties>
+                    <help>TCP transitory timeout</help>
+                    <valueHelp>
+                      <format>u32</format>
+                      <description>Timeout in seconds (default: 240)</description>
+                    </valueHelp>
+                  </properties>
+                  <defaultValue>240</defaultValue>
+                </leafNode>
+                <leafNode name="udp">
+                  <properties>
+                    <help>UDP timeout</help>
+                    <valueHelp>
+                      <format>u32</format>
+                      <description>Timeout in seconds (default: 300)</description>
+                    </valueHelp>
+                  </properties>
+                  <defaultValue>300</defaultValue>
+                </leafNode>
               </children>
             </node>
-            <node name="twice-nat">
+            <leafNode name="session-limit">
               <properties>
-                <help>NAT twice-nat pool</help>
-              </properties>
-              <children>
-                #include <include/vpp/nat_address_range.xml.i>
-                #include <include/vpp/nat_interface.xml.i>
-              </children>
-            </node>
-          </children>
-        </node>
-        <node name="static">
-          <properties>
-            <help>Static NAT rules</help>
-          </properties>
-          <children>
-            <tagNode name="rule">
-              <properties>
-                <help>Rule number for NAT</help>
+                <help>Maximum number of sessions per thread</help>
                 <valueHelp>
                   <format>u32</format>
-                  <description>Number of NAT rule</description>
+                  <description>Number of sessions</description>
                 </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-4294967295"/>
+                </constraint>
+                <constraintErrorMessage>Number of sessions must be between 1 and 4294967295</constraintErrorMessage>
               </properties>
-              <children>
-                #include <include/generic-description.xml.i>
-                <node name="external">
-                  <properties>
-                    <help>NAT external parameters</help>
-                  </properties>
-                  <children>
-                    <leafNode name="address">
-                      <properties>
-                        <help>IP address</help>
-                        <valueHelp>
-                          <format>ipv4</format>
-                          <description>IPv4 address</description>
-                        </valueHelp>
-                        <constraint>
-                          <validator name="ipv4-address"/>
-                        </constraint>
-                      </properties>
-                    </leafNode>
-                    #include <include/port-number.xml.i>
-                  </children>
-                </node>
-                <node name="local">
-                  <properties>
-                    <help>NAT local parameters</help>
-                  </properties>
-                  <children>
-                    <leafNode name="address">
-                      <properties>
-                        <help>IP address</help>
-                        <valueHelp>
-                          <format>ipv4</format>
-                          <description>IPv4 address</description>
-                        </valueHelp>
-                        <constraint>
-                          <validator name="ipv4-address"/>
-                        </constraint>
-                      </properties>
-                    </leafNode>
-                    #include <include/port-number.xml.i>
-                  </children>
-                </node>
-                <node name="options">
-                  <properties>
-                    <help>NAT static mapping options</help>
-                  </properties>
-                  <children>
-                    <leafNode name="twice-nat">
-                      <properties>
-                        <help>Rewrite source IP addresses on packets sent from outside to inside</help>
-                        <valueless/>
-                      </properties>
-                    </leafNode>
-                    <leafNode name="self-twice-nat">
-                      <properties>
-                        <help>Rewrite source IP addresses on packets sent only from a local address to an external address</help>
-                        <valueless/>
-                      </properties>
-                    </leafNode>
-                    <leafNode name="out-to-in-only">
-                      <properties>
-                        <help>Only apply rule for traffic from outside to inside interfaces</help>
-                        <valueless/>
-                      </properties>
-                    </leafNode>
-                    <leafNode name="twice-nat-address">
-                      <properties>
-                        <help>Force use of specific IP address from twice-nat address pool</help>
-                        <valueHelp>
-                          <format>ipv4</format>
-                          <description>IPv4 address</description>
-                        </valueHelp>
-                        <constraint>
-                          <validator name="ipv4-address"/>
-                        </constraint>
-                      </properties>
-                    </leafNode>
-                  </children>
-                </node>
-                #include <include/vpp/nat_protocol.xml.i>
-              </children>
-            </tagNode>
-          </children>
-        </node>
-        <node name="exclude">
-          <properties>
-            <help>Exclude packets matching these rules from NAT</help>
-          </properties>
-          <children>
-            <tagNode name="rule">
+              <defaultValue>64512</defaultValue>
+            </leafNode>
+            <node name="interface">
               <properties>
-                <help>Rule number</help>
-                <valueHelp>
-                  <format>u32</format>
-                  <description>Number of rule</description>
-                </valueHelp>
+                <help>NAT interface setting</help>
               </properties>
               <children>
-                <leafNode name="local-address">
+                <leafNode name="inside">
                   <properties>
-                    <help>IP address of the internal (local) device</help>
-                    <valueHelp>
-                      <format>ipv4</format>
-                      <description>IPv4 address</description>
-                    </valueHelp>
-                    <constraint>
-                      <validator name="ipv4-address"/>
-                    </constraint>
-                  </properties>
-                </leafNode>
-                <leafNode name="local-port">
-                  <properties>
-                    <help>Port number used by connection on internal device</help>
-                    <valueHelp>
-                      <format>u32:1-65535</format>
-                      <description>Numeric IP port</description>
-                    </valueHelp>
-                    <constraint>
-                      <validator name="numeric" argument="--range 1-65535"/>
-                    </constraint>
-                    <constraintErrorMessage>Port number must be in range 1 to 65535</constraintErrorMessage>
-                  </properties>
-                </leafNode>
-                #include <include/vpp/nat_protocol.xml.i>
-                <leafNode name="external-interface">
-                  <properties>
-                    <help>External interface</help>
+                    <help>NAT inside interface</help>
                     <completionHelp>
                       <script>${vyos_completion_dir}/list_interfaces</script>
                     </completionHelp>
+                    <multi/>
                   </properties>
                 </leafNode>
-                #include <include/generic-description.xml.i>
+                <leafNode name="outside">
+                  <properties>
+                    <help>NAT outside interface</help>
+                    <completionHelp>
+                      <script>${vyos_completion_dir}/list_interfaces</script>
+                    </completionHelp>
+                    <multi/>
+                  </properties>
+                </leafNode>
               </children>
-            </tagNode>
+            </node>
+            <node name="address-pool">
+              <properties>
+                <help>NAT address pool</help>
+              </properties>
+              <children>
+                <node name="translation">
+                  <properties>
+                    <help>NAT translation pool</help>
+                  </properties>
+                  <children>
+                    #include <include/vpp/nat_address_range.xml.i>
+                    #include <include/vpp/nat_interface.xml.i>
+                  </children>
+                </node>
+                <node name="twice-nat">
+                  <properties>
+                    <help>NAT twice-nat pool</help>
+                  </properties>
+                  <children>
+                    #include <include/vpp/nat_address_range.xml.i>
+                    #include <include/vpp/nat_interface.xml.i>
+                  </children>
+                </node>
+              </children>
+            </node>
+            <node name="static">
+              <properties>
+                <help>Static NAT rules</help>
+              </properties>
+              <children>
+                <tagNode name="rule">
+                  <properties>
+                    <help>Rule number for NAT</help>
+                    <valueHelp>
+                      <format>u32</format>
+                      <description>Number of NAT rule</description>
+                    </valueHelp>
+                  </properties>
+                  <children>
+                    #include <include/generic-description.xml.i>
+                    <node name="external">
+                      <properties>
+                        <help>NAT external parameters</help>
+                      </properties>
+                      <children>
+                        <leafNode name="address">
+                          <properties>
+                            <help>IP address</help>
+                            <valueHelp>
+                              <format>ipv4</format>
+                              <description>IPv4 address</description>
+                            </valueHelp>
+                            <constraint>
+                              <validator name="ipv4-address"/>
+                            </constraint>
+                          </properties>
+                        </leafNode>
+                        #include <include/port-number.xml.i>
+                      </children>
+                    </node>
+                    <node name="local">
+                      <properties>
+                        <help>NAT local parameters</help>
+                      </properties>
+                      <children>
+                        <leafNode name="address">
+                          <properties>
+                            <help>IP address</help>
+                            <valueHelp>
+                              <format>ipv4</format>
+                              <description>IPv4 address</description>
+                            </valueHelp>
+                            <constraint>
+                              <validator name="ipv4-address"/>
+                            </constraint>
+                          </properties>
+                        </leafNode>
+                        #include <include/port-number.xml.i>
+                      </children>
+                    </node>
+                    <node name="options">
+                      <properties>
+                        <help>NAT static mapping options</help>
+                      </properties>
+                      <children>
+                        <leafNode name="twice-nat">
+                          <properties>
+                            <help>Rewrite source IP addresses on packets sent from outside to inside</help>
+                            <valueless/>
+                          </properties>
+                        </leafNode>
+                        <leafNode name="self-twice-nat">
+                          <properties>
+                            <help>Rewrite source IP addresses on packets sent only from a local address to an external address</help>
+                            <valueless/>
+                          </properties>
+                        </leafNode>
+                        <leafNode name="out-to-in-only">
+                          <properties>
+                            <help>Only apply rule for traffic from outside to inside interfaces</help>
+                            <valueless/>
+                          </properties>
+                        </leafNode>
+                        <leafNode name="twice-nat-address">
+                          <properties>
+                            <help>Force use of specific IP address from twice-nat address pool</help>
+                            <valueHelp>
+                              <format>ipv4</format>
+                              <description>IPv4 address</description>
+                            </valueHelp>
+                            <constraint>
+                              <validator name="ipv4-address"/>
+                            </constraint>
+                          </properties>
+                        </leafNode>
+                      </children>
+                    </node>
+                    #include <include/vpp/nat_protocol.xml.i>
+                  </children>
+                </tagNode>
+              </children>
+            </node>
+            <node name="exclude">
+              <properties>
+                <help>Exclude packets matching these rules from NAT</help>
+              </properties>
+              <children>
+                <tagNode name="rule">
+                  <properties>
+                    <help>Rule number</help>
+                    <valueHelp>
+                      <format>u32</format>
+                      <description>Number of rule</description>
+                    </valueHelp>
+                  </properties>
+                  <children>
+                    <leafNode name="local-address">
+                      <properties>
+                        <help>IP address of the internal (local) device</help>
+                        <valueHelp>
+                          <format>ipv4</format>
+                          <description>IPv4 address</description>
+                        </valueHelp>
+                        <constraint>
+                          <validator name="ipv4-address"/>
+                        </constraint>
+                      </properties>
+                    </leafNode>
+                    <leafNode name="local-port">
+                      <properties>
+                        <help>Port number used by connection on internal device</help>
+                        <valueHelp>
+                          <format>u32:1-65535</format>
+                          <description>Numeric IP port</description>
+                        </valueHelp>
+                        <constraint>
+                          <validator name="numeric" argument="--range 1-65535"/>
+                        </constraint>
+                        <constraintErrorMessage>Port number must be in range 1 to 65535</constraintErrorMessage>
+                      </properties>
+                    </leafNode>
+                    #include <include/vpp/nat_protocol.xml.i>
+                    <leafNode name="external-interface">
+                      <properties>
+                        <help>External interface</help>
+                        <completionHelp>
+                          <script>${vyos_completion_dir}/list_interfaces</script>
+                        </completionHelp>
+                      </properties>
+                    </leafNode>
+                    #include <include/generic-description.xml.i>
+                  </children>
+                </tagNode>
+              </children>
+            </node>
           </children>
         </node>
       </children>

--- a/op-mode-definitions/show_vpp_nat44.xml.in
+++ b/op-mode-definitions/show_vpp_nat44.xml.in
@@ -4,40 +4,44 @@
     <children>
       <node name="vpp">
         <children>
-          <node name="nat44">
-            <properties>
-              <help>Show VPP NAT44 information</help>
-            </properties>
+          <node name="nat">
             <children>
-              <node name="static">
+              <node name="nat44">
                 <properties>
-                  <help>Show VPP NAT44 static mapping</help>
+                  <help>Show VPP NAT44 information</help>
                 </properties>
-                <command>sudo ${vyos_op_scripts_dir}/show_vpp_nat44.py show_static</command>
-              </node>
-              <node name="sessions">
-                <properties>
-                  <help>Show VPP NAT44 sessions</help>
-                </properties>
-                <command>sudo ${vyos_op_scripts_dir}/show_vpp_nat44.py show_sessions</command>
-              </node>
-              <node name="summary">
-                <properties>
-                  <help>Show VPP NAT44 summary</help>
-                </properties>
-                <command>sudo ${vyos_op_scripts_dir}/show_vpp_nat44.py show_summary</command>
-              </node>
-              <node name="addresses">
-                <properties>
-                  <help>Show VPP NAT44 pool addresses</help>
-                </properties>
-                <command>sudo ${vyos_op_scripts_dir}/show_vpp_nat44.py show_addresses</command>
-              </node>
-              <node name="interfaces">
-                <properties>
-                  <help>Show VPP NAT44 interfaces</help>
-                </properties>
-                <command>sudo ${vyos_op_scripts_dir}/show_vpp_nat44.py show_interfaces</command>
+                <children>
+                  <node name="static">
+                    <properties>
+                      <help>Show VPP NAT44 static mapping</help>
+                    </properties>
+                    <command>sudo ${vyos_op_scripts_dir}/vpp_nat_nat44.py show_static</command>
+                  </node>
+                  <node name="sessions">
+                    <properties>
+                      <help>Show VPP NAT44 sessions</help>
+                    </properties>
+                    <command>sudo ${vyos_op_scripts_dir}/vpp_nat_nat44.py show_sessions</command>
+                  </node>
+                  <node name="summary">
+                    <properties>
+                      <help>Show VPP NAT44 summary</help>
+                    </properties>
+                    <command>sudo ${vyos_op_scripts_dir}/vpp_nat_nat44.py show_summary</command>
+                  </node>
+                  <node name="addresses">
+                    <properties>
+                      <help>Show VPP NAT44 pool addresses</help>
+                    </properties>
+                    <command>sudo ${vyos_op_scripts_dir}/vpp_nat_nat44.py show_addresses</command>
+                  </node>
+                  <node name="interfaces">
+                    <properties>
+                      <help>Show VPP NAT44 interfaces</help>
+                    </properties>
+                    <command>sudo ${vyos_op_scripts_dir}/vpp_nat_nat44.py show_interfaces</command>
+                  </node>
+                </children>
               </node>
             </children>
           </node>

--- a/python/vyos/vpp/config_verify.py
+++ b/python/vyos/vpp/config_verify.py
@@ -417,26 +417,6 @@ def verify_vpp_settings_cpu_corelist_workers(cpu_settings: dict):
         )
 
 
-def verify_vpp_nat44_workers(workers: int, nat44_workers: list):
-    if workers < 1:
-        raise ConfigError(
-            '"nat44 workers" requires cpu workers or corelist-workers to be set!'
-        )
-    try:
-        nat_workers = cpu_checks.worker_cores_list(
-            iface='nat44', worker_ranges=nat44_workers
-        )
-    except ValueError as e:
-        raise ConfigError(str(e))
-
-    invalid_workers = [str(el) for el in nat_workers if el not in range(workers)]
-    if invalid_workers:
-        raise ConfigError(
-            f'Cannot set VPP "nat44 workers": worker(s) #{",".join(invalid_workers)} not available. '
-            f'Available worker ids: {",".join(map(str, range(workers)))}'
-        )
-
-
 def verify_vpp_statseg_size(settings: dict):
     statseg_size = mem_checks.statseg_size(settings)
 

--- a/python/vyos/vpp/control_vpp.py
+++ b/python/vyos/vpp/control_vpp.py
@@ -439,25 +439,6 @@ class VPPControl:
                 return iface.interface_dev_type
         return None
 
-    @_Decorators.api_call
-    def set_nat44_session_limit(self, session_limit: int) -> None:
-        """Set NAT44 session limit
-
-        Args:
-            session_limit (int): Maximum number of sessions per thread
-        """
-        self.__vpp_api_client.api.nat44_set_session_limit(
-            session_limit=session_limit,
-        )
-
-    @_Decorators.api_call
-    def set_nat_workers(self, workers: int) -> None:
-        """Set NAT44 session limit
-
-        Args:
-            workers (int): Bitmask of workers list
-        """
-        self.__vpp_api_client.api.nat_set_workers(worker_mask=workers)
 
     @property
     def connected(self) -> bool:

--- a/python/vyos/vpp/nat/nat44.py
+++ b/python/vyos/vpp/nat/nat44.py
@@ -228,6 +228,16 @@ class Nat44:
         """Enable/disable NAT44 forwarding"""
         self.vpp.api.nat44_forwarding_enable_disable(enable=enable)
 
+    def set_nat44_session_limit(self, session_limit: int) -> None:
+        """Set NAT44 session limit
+
+        Args:
+            session_limit (int): Maximum number of sessions per thread
+        """
+        self.vpp.api.nat44_set_session_limit(
+            session_limit=session_limit,
+        )
+
     def enable_ipfix(self):
         """Enable NAT44 IPFIX logging"""
         self.vpp.api.nat44_ei_ipfix_enable_disable(enable=True)

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -1388,9 +1388,8 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         lines = out.split('\n')
         self.assertTrue(len(lines) == 3)
 
-    def test_16_vpp_nat(self):
-        base_nat = base_path + ['nat44']
-        base_nat_settings = base_path + ['settings', 'nat44']
+    def test_16_vpp_nat44(self):
+        base_nat = base_path + ['nat', 'nat44']
         exclude_local_addr = '100.64.0.52'
         exclude_local_port = '22'
         iface_out = 'eth0'
@@ -1437,15 +1436,11 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
             base_nat + ['static', 'rule', '100', 'local', 'address', static_local_addr]
         )
 
-        self.cli_set(base_nat_settings + ['session-limit', sess_limit])
-        self.cli_set(base_nat_settings + ['timeout', 'icmp', timeout_icmp])
-        self.cli_set(
-            base_nat_settings + ['timeout', 'tcp-established', timeout_tcp_est]
-        )
-        self.cli_set(
-            base_nat_settings + ['timeout', 'tcp-transitory', timeout_tcp_trans]
-        )
-        self.cli_set(base_nat_settings + ['timeout', 'udp', timeout_udp])
+        self.cli_set(base_nat + ['session-limit', sess_limit])
+        self.cli_set(base_nat + ['timeout', 'icmp', timeout_icmp])
+        self.cli_set(base_nat + ['timeout', 'tcp-established', timeout_tcp_est])
+        self.cli_set(base_nat + ['timeout', 'tcp-transitory', timeout_tcp_trans])
+        self.cli_set(base_nat + ['timeout', 'udp', timeout_udp])
         self.cli_commit()
 
         # Check addresses

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -357,12 +357,12 @@ def verify_vpp_remove_vif(ethernet: dict):
         # Known paths that already use VLAN interfaces
         r'(nat\.cgnat\.interface\.inside)|'
         r'(nat\.cgnat\.interface\.outside)|'
-        r'(nat44\.interface\.inside)|'
-        r'(nat44\.interface\.outside)|'
+        r'(nat\.nat44\.interface\.inside)|'
+        r'(nat\.nat44\.interface\.outside)|'
         # Potential paths for VLAN interfaces
-        r'(nat44\.address_pool\.translation\.interface)|'
-        r'(nat44\.address_pool\.twice_nat\.interface)|'
-        r'(nat44\.exclude\.rule\.(\d)+\.external_interface)|'
+        r'(nat\.nat44\.address_pool\.translation\.interface)|'
+        r'(nat\.nat44\.address_pool\.twice_nat\.interface)|'
+        r'(nat\.nat44\.exclude\.rule\.(\d)+\.external_interface)|'
         r'(interfaces\.bonding\.bond(\d)+\.member\.interface)|'
         r'(interfaces\.bridge\.br(\d)+\.member\.interface)|'
         r'(interfaces\.xconnect\.xcon(\d)+\.member\.interface)|'

--- a/src/conf_mode/vpp_interfaces_bonding.py
+++ b/src/conf_mode/vpp_interfaces_bonding.py
@@ -144,8 +144,8 @@ def get_config(config=None) -> dict:
                 set_dependents('vpp_kernel_interface', conf, iface)
 
     # NAT dependency
-    if conf.exists(['vpp', 'nat44']):
-        set_dependents('vpp_nat', conf)
+    if conf.exists(['vpp', 'nat', 'nat44']):
+        set_dependents('vpp_nat_nat44', conf)
     if conf.exists(['vpp', 'nat', 'cgnat']):
         set_dependents('vpp_nat_cgnat', conf)
 

--- a/src/conf_mode/vpp_interfaces_gre.py
+++ b/src/conf_mode/vpp_interfaces_gre.py
@@ -115,8 +115,8 @@ def get_config(config=None) -> dict:
                 set_dependents('vpp_kernel_interface', conf, iface)
 
     # NAT dependency
-    if conf.exists(['vpp', 'nat44']):
-        set_dependents('vpp_nat', conf)
+    if conf.exists(['vpp', 'nat', 'nat44']):
+        set_dependents('vpp_nat_nat44', conf)
     if conf.exists(['vpp', 'nat', 'cgnat']):
         set_dependents('vpp_nat_cgnat', conf)
 

--- a/src/conf_mode/vpp_interfaces_ipip.py
+++ b/src/conf_mode/vpp_interfaces_ipip.py
@@ -114,8 +114,8 @@ def get_config(config=None) -> dict:
                 set_dependents('vpp_kernel_interface', conf, iface)
 
     # NAT dependency
-    if conf.exists(['vpp', 'nat44']):
-        set_dependents('vpp_nat', conf)
+    if conf.exists(['vpp', 'nat', 'nat44']):
+        set_dependents('vpp_nat_nat44', conf)
     if conf.exists(['vpp', 'nat', 'cgnat']):
         set_dependents('vpp_nat_cgnat', conf)
 

--- a/src/conf_mode/vpp_interfaces_loopback.py
+++ b/src/conf_mode/vpp_interfaces_loopback.py
@@ -104,8 +104,8 @@ def get_config(config=None) -> dict:
                 set_dependents('vpp_kernel_interface', conf, iface)
 
     # NAT dependency
-    if conf.exists(['vpp', 'nat44']):
-        set_dependents('vpp_nat', conf)
+    if conf.exists(['vpp', 'nat', 'nat44']):
+        set_dependents('vpp_nat_nat44', conf)
     if conf.exists(['vpp', 'nat', 'cgnat']):
         set_dependents('vpp_nat_cgnat', conf)
 

--- a/src/conf_mode/vpp_interfaces_vxlan.py
+++ b/src/conf_mode/vpp_interfaces_vxlan.py
@@ -121,8 +121,8 @@ def get_config(config=None) -> dict:
                 set_dependents('vpp_kernel_interface', conf, iface)
 
     # NAT dependency
-    if conf.exists(['vpp', 'nat44']):
-        set_dependents('vpp_nat', conf)
+    if conf.exists(['vpp', 'nat', 'nat44']):
+        set_dependents('vpp_nat_nat44', conf)
     if conf.exists(['vpp', 'nat', 'cgnat']):
         set_dependents('vpp_nat_cgnat', conf)
 

--- a/src/conf_mode/vpp_kernel-interfaces.py
+++ b/src/conf_mode/vpp_kernel-interfaces.py
@@ -82,8 +82,8 @@ def get_config(config=None) -> dict:
 
     if conf.exists(['vpp', 'nat', 'cgnat']):
         set_dependents('vpp_nat_cgnat', conf)
-    if conf.exists(['vpp', 'nat44']):
-        set_dependents('vpp_nat', conf)
+    if conf.exists(['vpp', 'nat', 'nat44']):
+        set_dependents('vpp_nat_nat44', conf)
 
     config['ifname'] = ifname
 

--- a/src/migration-scripts/vpp/7-to-8
+++ b/src/migration-scripts/vpp/7-to-8
@@ -16,6 +16,9 @@
 # Rename `vpp settings logging default-log-level` to
 # `vpp settings logging default-level` (T8255)
 #
+# Move 'vpp nat44' and 'vpp settings nat44' to 'vpp nat nat44'.
+# Drop settings for nat workers (T8254)
+
 
 from vyos.configtree import ConfigTree
 
@@ -26,5 +29,36 @@ def _migrate_vpp_log(config: ConfigTree) -> None:
         config.rename(base + ['default-log-level'], 'default-level')
 
 
+def _migrate_vpp_nat44(config: ConfigTree) -> None:
+    base_path = ['vpp', 'nat44']
+    new_base_path = ['vpp', 'nat', 'nat44']
+    settings_path = ['vpp', 'settings', 'nat44']
+
+    if not config.exists(base_path):
+        # Nothing to do
+        return
+
+    if not config.exists(['vpp', 'nat']):
+        config.set(['vpp', 'nat'])
+
+    # copy "vpp nat44" to "vpp nat nat44"
+    config.copy(base_path, new_base_path)
+    config.delete(base_path)
+
+    # move 'vpp settings nat44' to 'vpp nat nat44'
+    if config.exists(settings_path):
+        if config.exists(settings_path + ['session-limit']):
+            session_limit = config.return_value(settings_path + ['session-limit'])
+            config.set(new_base_path + ['session-limit'], value=session_limit)
+        if config.exists(settings_path + ['timeout']):
+            config.copy(settings_path + ['timeout'], new_base_path + ['timeout'])
+        config.delete(settings_path)
+
+
 def migrate(config: ConfigTree) -> None:
+    if not config.exists(['vpp']):
+        # Nothing to do
+        return
+
     _migrate_vpp_log(config)
+    _migrate_vpp_nat44(config)

--- a/src/op_mode/vpp_nat_nat44.py
+++ b/src/op_mode/vpp_nat_nat44.py
@@ -50,7 +50,7 @@ def _verify(func):
     @wraps(func)
     def _wrapper(*args, **kwargs):
         config = ConfigTreeQuery()
-        base = 'vpp nat44'
+        base = 'vpp nat nat44'
         if not config.exists(base):
             raise vyos.opmode.UnconfiguredSubsystem(f'{base} is not configured')
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Change CLI

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8254
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-documentation/pull/1766
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# /usr/libexec/vyos/tests/smoke/cli/test_vpp.py -k test_16_vpp_nat44
test_16_vpp_nat44 (__main__.TestVPP.test_16_vpp_nat44) ... ok

----------------------------------------------------------------------
Ran 1 test in 87.744s

OK

vyos@vyos# set vpp nat
Possible completions:
 > cgnat                Carrier-grade NAT (CGNAT)
 > nat44                NAT44


[edit]
vyos@vyos# set vpp nat nat44
Possible completions:
 > address-pool         NAT address pool
 > exclude              Exclude packets matching these rules from NAT
 > interface            NAT interface setting
   session-limit        Maximum number of sessions per thread (default: 64512)
 > static               Static NAT rules
 > timeout              NAT44 session timeouts
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
