### PR TITLE
vpp: T8258: Move `poll-sleep-usec` out of `unix` section

### DIFF
--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -8,10 +8,8 @@ unix {
     gid vpp
     systemd-notify
     # exec /etc/vpp/bootstrap.vpp
-{% if unix is vyos_defined %}
-{%     if unix.poll_sleep_usec is vyos_defined %}
-    poll-sleep-usec {{ unix.poll_sleep_usec }}
-{%     endif %}
+{% if poll_sleep_usec is vyos_defined %}
+    poll-sleep-usec {{ poll_sleep_usec }}
 {% endif %}
 }
 

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -891,26 +891,19 @@
             </leafNode>
           </children>
         </node>
-        <node name="unix">
+        <leafNode name="poll-sleep-usec">
           <properties>
-            <help>Unix settings</help>
+            <help>Add a fixed-sleep between main loop poll</help>
+            <valueHelp>
+              <format>u32:0-500000</format>
+              <description>Sleep interval in microseconds</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 0-500000"/>
+            </constraint>
           </properties>
-          <children>
-            <leafNode name="poll-sleep-usec">
-              <properties>
-                <help>Add a fixed-sleep between main loop poll</help>
-                <valueHelp>
-                  <format>u32:0-500000</format>
-                  <description>Sleep interval in microseconds</description>
-                </valueHelp>
-                <constraint>
-                  <validator name="numeric" argument="--range 0-500000"/>
-                </constraint>
-              </properties>
-              <defaultValue>0</defaultValue>
-            </leafNode>
-          </children>
-        </node>
+          <defaultValue>0</defaultValue>
+        </leafNode>
       </children>
     </node>
     <node name="sflow" owner="${vyos_conf_scripts_dir}/vpp_sflow.py">

--- a/smoketest/configs/assert/vpp
+++ b/smoketest/configs/assert/vpp
@@ -46,5 +46,5 @@ set vpp settings interface eth1
 set vpp settings interface eth2
 set vpp settings interface eth3
 set vpp settings interface eth4
-set vpp settings unix poll-sleep-usec '12'
+set vpp settings poll-sleep-usec '12'
 set vpp settings logging default-level 'debug'

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -95,7 +95,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         super().setUp()
 
         self.cli_set(base_path + ['settings', 'interface', interface])
-        self.cli_set(base_path + ['settings', 'unix', 'poll-sleep-usec', '10'])
+        self.cli_set(base_path + ['settings', 'poll-sleep-usec', '10'])
 
     def tearDown(self):
         try:
@@ -128,7 +128,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
             self.cli_commit()
 
         self.cli_set(base_path + ['settings', 'cpu', 'main-core', main_core])
-        self.cli_set(base_path + ['settings', 'unix', 'poll-sleep-usec', poll_sleep])
+        self.cli_set(base_path + ['settings', 'poll-sleep-usec', poll_sleep])
 
         # commit changes
         self.cli_commit()
@@ -302,7 +302,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.assertEqual(kernel_address, current_address)
 
         # change vpp settings
-        self.cli_set(base_path + ['settings', 'unix', 'poll-sleep-usec', '5'])
+        self.cli_set(base_path + ['settings', 'poll-sleep-usec', '5'])
         self.cli_commit()
 
         config = read_file(VPP_CONF)
@@ -1662,7 +1662,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Change VPP configuration
-        self.cli_set(base_path + ['settings', 'unix', 'poll-sleep-usec', '50'])
+        self.cli_set(base_path + ['settings', 'poll-sleep-usec', '50'])
 
         # Ensure arp entry is not disappeared
         _, neighbors = rc_cmd('sudo ip neighbor')

--- a/src/migration-scripts/vpp/7-to-8
+++ b/src/migration-scripts/vpp/7-to-8
@@ -21,15 +21,23 @@
 #
 # Delete 'ipsec' node and all settings and replace it with single 'ipsec-acceleration' flag (T8262)
 
-
 from vyos.configtree import ConfigTree
 
+def _migrate_vpp_unix_settings(config: ConfigTree) -> None:
+    base_path = ['vpp', 'settings']
+    old_base_path = base_path + ['unix']
+    old_path = old_base_path + ['poll-sleep-usec']
+    new_path = base_path + ['poll-sleep-usec']
+
+    if config.exists(old_path):
+        poll_sleep_usec = config.return_value(old_path)
+        config.set(new_path, value=poll_sleep_usec)
+        config.delete(old_base_path)
 
 def _migrate_vpp_log(config: ConfigTree) -> None:
     base = ['vpp', 'settings', 'logging']
     if config.exists(base + ['default-log-level']):
         config.rename(base + ['default-log-level'], 'default-level')
-
 
 def _migrate_vpp_nat44(config: ConfigTree) -> None:
     base_path = ['vpp', 'nat44']
@@ -69,6 +77,7 @@ def migrate(config: ConfigTree) -> None:
         # Nothing to do
         return
 
+    _migrate_vpp_unix_settings(config)
     _migrate_vpp_log(config)
     _migrate_vpp_nat44(config)
     _migrate_vpp_ipsec(config)


### PR DESCRIPTION
## Change summary
Instead of `vpp settings unix poll-sleep-usec` use `vpp settings poll-sleep-usec` command to configure the parameter.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): CLI changes

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8258

## Related PR(s)
* https://github.com/vyos/vyos-documentation/pull/1767

## How to test / Smoketest result
### Smoketest

```
root@b15b6c12f4fe:/vyos/build# make test-vpp
DEBUG - Running Testcase (1/1): /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
DEBUG - test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
DEBUG - test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
DEBUG - test_03_vpp_gre (__main__.TestVPP.test_03_vpp_gre) ... ok
...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly