### PR TITLE
vpp: T8262: Refactor IPsec settings to use only 'ipsec-acceleration' flag

### DIFF
--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -120,7 +120,7 @@ plugins {
 
 crypto-engines {
     default { disable }
-{% if ipsec is vyos_defined %}
+{% if ipsec_acceleration is vyos_defined %}
     ipsecmb { enable }
     native { enable }
     openssl { enable }
@@ -201,18 +201,18 @@ dpdk {
     uio-bind-force
 }
 
-{% if ipsec is vyos_defined %}
+{% if ipsec_acceleration is vyos_defined %}
 linux-xfrm-nl {
      enable-route-mode-ipsec
-     interface {{ ipsec.interface_type }}
-{%     if ipsec.netlink.batch_delay_ms is vyos_defined %}
-     nl-batch-delay-ms {{ ipsec.netlink.batch_delay_ms }}
+     interface ipsec
+{%     if lcp.netlink.batch_delay_ms is vyos_defined %}
+     nl-batch-delay-ms {{ lcp.netlink.batch_delay_ms }}
 {%     endif %}
-{%     if ipsec.netlink.batch_size is vyos_defined %}
-     nl-batch-size {{ ipsec.netlink.batch_size }}
+{%     if lcp.netlink.batch_size is vyos_defined %}
+     nl-batch-size {{ lcp.netlink.batch_size }}
 {%     endif %}
-{%     if ipsec.netlink.rx_buffer_size is vyos_defined %}
-     nl-rx-buffer-size {{ ipsec.netlink.rx_buffer_size }}
+{%     if lcp.netlink.rx_buffer_size is vyos_defined %}
+     nl-rx-buffer-size {{ lcp.netlink.rx_buffer_size }}
 {%     endif %}
 }
 {% endif %}

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -742,34 +742,12 @@
               </leafNode>
             </children>
           </node>
-          <node name="ipsec">
+          <leafNode name="ipsec-acceleration">
             <properties>
-              <help>IPsec settings</help>
+              <help>Enable IPsec acceleration</help>
+              <valueless/>
             </properties>
-            <children>
-              <leafNode name="interface-type">
-                <properties>
-                  <help>IPsec interface type</help>
-                  <completionHelp>
-                    <list>ipsec ipip</list>
-                  </completionHelp>
-                  <valueHelp>
-                    <format>ipsec</format>
-                    <description>IPsec interface type</description>
-                  </valueHelp>
-                  <valueHelp>
-                    <format>ipip</format>
-                    <description>IPIP tunnel interface type</description>
-                  </valueHelp>
-                  <constraint>
-                    <regex>(ipsec|ipip)</regex>
-                  </constraint>
-                </properties>
-                <defaultValue>ipsec</defaultValue>
-              </leafNode>
-              #include <include/vpp/netlink.xml.i>
-            </children>
-          </node>
+          </leafNode>
           <node name="l2learn">
             <properties>
               <help>Level 2 MAC address learning settings</help>

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -1274,14 +1274,15 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
             self.assertEqual(conf['memory']['main-heap-page-size'], size)
 
     def test_14_vpp_ipsec_xfrm_nl(self):
-        base_ipsec = base_path + ['settings', 'ipsec']
+        base_lcp = base_path + ['settings', 'lcp']
         batch_delay = '250'
         batch_size = '150'
         rx_buffer_zise = '1024'
 
-        self.cli_set(base_ipsec + ['netlink', 'batch-delay-ms', batch_delay])
-        self.cli_set(base_ipsec + ['netlink', 'batch-size', batch_size])
-        self.cli_set(base_ipsec + ['netlink', 'rx-buffer-size', rx_buffer_zise])
+        self.cli_set(base_path + ['settings', 'ipsec-acceleration'])
+        self.cli_set(base_lcp + ['netlink', 'batch-delay-ms', batch_delay])
+        self.cli_set(base_lcp + ['netlink', 'batch-size', batch_size])
+        self.cli_set(base_lcp + ['netlink', 'rx-buffer-size', rx_buffer_zise])
         self.cli_commit()
 
         config_entries = (
@@ -1297,13 +1298,6 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         config = read_file(VPP_CONF)
         for config_entry in config_entries:
             self.assertIn(config_entry, config)
-
-        # set IPsec tunnel-type ipip
-        self.cli_set(base_ipsec + ['interface-type', 'ipip'])
-        self.cli_commit()
-
-        config = read_file(VPP_CONF)
-        self.assertIn('interface ipip', config)
 
     def test_15_1_vpp_cgnat(self):
         base_cgnat = base_path + ['nat', 'cgnat']

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -305,10 +305,6 @@ def get_config(config=None):
 
     config = config_dict_merge(default_values, config)
 
-    # Ignore default XML values if config doesn't exists
-    if not conf.exists(base_settings + ['ipsec']):
-        del config['settings']['ipsec']
-
     # add running config
     if effective_config:
         default_values_effective = conf.get_config_defaults(

--- a/src/migration-scripts/vpp/7-to-8
+++ b/src/migration-scripts/vpp/7-to-8
@@ -18,6 +18,8 @@
 #
 # Move 'vpp nat44' and 'vpp settings nat44' to 'vpp nat nat44'.
 # Drop settings for nat workers (T8254)
+#
+# Delete 'ipsec' node and all settings and replace it with single 'ipsec-acceleration' flag (T8262)
 
 
 from vyos.configtree import ConfigTree
@@ -54,6 +56,13 @@ def _migrate_vpp_nat44(config: ConfigTree) -> None:
             config.copy(settings_path + ['timeout'], new_base_path + ['timeout'])
         config.delete(settings_path)
 
+def _migrate_vpp_ipsec(config: ConfigTree) -> None:
+    base = ['vpp', 'settings']
+
+    if config.exists(base + ['ipsec']):
+        config.set(base + ['ipsec-acceleration'])
+        config.delete(base + ['ipsec'])
+
 
 def migrate(config: ConfigTree) -> None:
     if not config.exists(['vpp']):
@@ -62,3 +71,4 @@ def migrate(config: ConfigTree) -> None:
 
     _migrate_vpp_log(config)
     _migrate_vpp_nat44(config)
+    _migrate_vpp_ipsec(config)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): CLI change

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8262
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-documentation/pull/1768
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpp.py -k test_14_vpp_ipsec_xfrm_nl
test_14_vpp_ipsec_xfrm_nl (__main__.TestVPP.test_14_vpp_ipsec_xfrm_nl) ... ok

----------------------------------------------------------------------
Ran 1 test in 54.489s

OK

vyos@vyos# set vpp settings
Possible completions:
 > buffers              Buffer settings
 > cpu                  CPU settings
+> interface            Interface
   ipsec-acceleration   Enable IPsec acceleration
 > ipv6                 IPv6 settings
 > l2learn              Level 2 MAC address learning settings
 > lcp                  Linux control plane setting
 > logging              Logging settings
 > memory               Memory settings
 > nat44                NAT settings
 > physmem              Physical memory settings
 > statseg              Stats settings
 > unix                 Unix settings

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
