### PR TITLE
T8270: fix yescrypt hash validation regex

### DIFF
--- a/interface-definitions/system_login.xml.in
+++ b/interface-definitions/system_login.xml.in
@@ -83,7 +83,7 @@
                         <regex>\$1\$[a-zA-Z0-9\./]*\$[a-zA-Z0-9\./]{22}</regex>
                         <regex>\$5\$(rounds=[0-9]+\$)?[a-zA-Z0-9\./]*\$[a-zA-Z0-9\./]{43}</regex>
                         <regex>\$6\$(rounds=[0-9]+\$)?[a-zA-Z0-9\./]*\$[a-zA-Z0-9\./]{86}</regex>
-                        <regex>\$y\$[./A-Za-z0-9]+\$[./A-Za-z0-9]{,86}\$[./A-Za-z0-9]{43}</regex>
+                        <regex>\$y\$[./A-Za-z0-9]+\$[./A-Za-z0-9]{0,86}\$[./A-Za-z0-9]{43}</regex>
                       </constraint>
                       <constraintErrorMessage>Invalid encrypted password for $VAR(../../@).</constraintErrorMessage>
                     </properties>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->


## Change summary
<!--- Provide a general summary of your changes in the Title above -->
The constraint regex in [system_login.xml.in](https://github.com/alexk37/vyos-1x/blob/984f41dcab36a2dee3c77908a3218594466647d6/interface-definitions/system_login.xml.in#L86) used the quantifier {,86} (0 to 86 characters).
OCaml’s re library (used by libvyosconfig/vyconf for reference-tree validation) does not support the {,n} form: it expects {n}, {n,m}, or {n,} with a leading number. For {,86} the parser hits Re__Parse_buffer.Parse_error, so validation rejects the value even when the hash is valid.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
https://vyos.dev/T8270

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-1x/pull/4739
* https://github.com/vyos/vyos-1x/pull/4720

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
vyos@vyos:~$ mkpasswd --method=yescrypt
Password: 
$y$j9T$0A5niykRhr.FN3L5BN6Pu0$Mm3rBik8U2Ear6oWJUEn016LQkYuo4RejCZgxJ6FdJ8

vyos@vyos# 
vyos@vyos# set system login user vyos authentication encrypted-password '$y$j9T$0A5niykRhr.FN3L5BN6Pu0$Mm3rBik8U2Ear6oWJUEn016LQkYuo4RejCZgxJ6FdJ8'
vyos@vyos# commit
vyos@vyos#
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
