### PR TITLE
T8272: fix unit conversion issue in logrotate.j2 template

### DIFF
--- a/data/templates/rsyslog/logrotate.j2
+++ b/data/templates/rsyslog/logrotate.j2
@@ -6,7 +6,7 @@
   notifempty
   create
   rotate {{ file_options.archive.file }}
-  size={{ file_options.archive.size | int // 1024 }}k
+  size={{ file_options.archive.size }}k
 }
 
 {%     endfor %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->


## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Logrotate file size is expected to be entered in kbytes, but the system wrongly applies unit conversion dividing the value by 1024:

`size={{ file_options.archive.size | int // 1024 }}k`

The fix is to render the value as it is, with no conversion applied

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8272

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Before the fix:

```
vyos@vyos# set system syslog file myfile archive size 512

vyos@vyos# commit

vyos@vyos# cat /etc/logrotate.d/vyos-rsyslog-user
### Autogenerated by system_syslog.py ###
/var/log/user/myfile {
  missingok
  notifempty
  create
  rotate 50
  size=0k
}
```

After the fix:

```
vyos@vyos# set system syslog file myfile archive size 512
vyos@vyos# commit
vyos@vyos# cat /etc/logrotate.d/vyos-rsyslog-user
### Autogenerated by system_syslog.py ###
/var/log/user/myfile {
  missingok
  notifempty
  create
  rotate 50
  size=512k
}
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
