### PR TITLE
vpp: T8274: Remove dpdk-options section for num-* parameters

### DIFF
--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -178,17 +178,17 @@ dpdk {
 {%     if iface_config.driver == 'dpdk' %}
     dev {{ iface_config.dpdk_options.dev_id }} {
         name {{ iface }}
-{%         if iface_config.dpdk_options.num_rx_desc is vyos_defined %}
-        num-rx-desc {{ iface_config.dpdk_options.num_rx_desc }}
+{%         if iface_config.num_rx_desc is vyos_defined %}
+        num-rx-desc {{ iface_config.num_rx_desc }}
 {%         endif %}
-{%         if iface_config.dpdk_options.num_tx_desc is vyos_defined %}
-        num-tx-desc {{ iface_config.dpdk_options.num_tx_desc }}
+{%         if iface_config.num_tx_desc is vyos_defined %}
+        num-tx-desc {{ iface_config.num_tx_desc }}
 {%         endif %}
-{%         if iface_config.dpdk_options.num_rx_queues is vyos_defined %}
-        num-rx-queues {{ iface_config.dpdk_options.num_rx_queues }}
+{%         if iface_config.num_rx_queues is vyos_defined %}
+        num-rx-queues {{ iface_config.num_rx_queues }}
 {%         endif %}
-{%         if iface_config.dpdk_options.num_tx_queues is vyos_defined %}
-        num-tx-queues {{ iface_config.dpdk_options.num_tx_queues }}
+{%         if iface_config.num_tx_queues is vyos_defined %}
+        num-tx-queues {{ iface_config.num_tx_queues }}
 {%         endif %}
         }
 {%     endif %}

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -608,69 +608,56 @@
               <constraintErrorMessage>Invalid interface name</constraintErrorMessage>
             </properties>
             <children>
-              <node name="dpdk-options">
+              <leafNode name="num-rx-desc">
                 <properties>
-                  <help>DPDK settings</help>
+                  <help>Receive ring descriptors</help>
+                  <valueHelp>
+                    <format>u32:256-16384</format>
+                    <description>Number of descriptors in receive ring</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 256-16384"/>
+                  </constraint>
                 </properties>
-                <children>
-                  <leafNode name="num-rx-desc">
-                    <properties>
-                      <help>Receive ring descriptors</help>
-                      <valueHelp>
-                        <format>u32:256-16384</format>
-                        <description>Number of descriptors in receive ring</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 256-16384"/>
-                      </constraint>
-                    </properties>
-                    <defaultValue>1024</defaultValue>
-                  </leafNode>
-                  <leafNode name="num-tx-desc">
-                    <properties>
-                      <help>Tranceive ring descriptors</help>
-                      <valueHelp>
-                        <format>u32:256-8192</format>
-                        <description>Number of descriptors in tranceive ring</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 256-8192"/>
-                      </constraint>
-                    </properties>
-                    <defaultValue>1024</defaultValue>
-                  </leafNode>
-                  <leafNode name="num-rx-queues">
-                    <properties>
-                      <help>Number of receive queues</help>
-                      <valueHelp>
-                        <format>u32:1-8192</format>
-                        <description>Number of receive queues</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 1-8192"/>
-                      </constraint>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="num-tx-queues">
-                    <properties>
-                      <help>Number of tranceive queues</help>
-                      <valueHelp>
-                        <format>u32:1-8192</format>
-                        <description>Number of tranceive queues</description>
-                      </valueHelp>
-                      <constraint>
-                        <validator name="numeric" argument="--range 1-8192"/>
-                      </constraint>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="promisc">
-                    <properties>
-                      <help>Enable promisc mode on a vpp interface</help>
-                      <valueless/>
-                    </properties>
-                  </leafNode>
-                </children>
-              </node>
+                <defaultValue>1024</defaultValue>
+              </leafNode>
+              <leafNode name="num-tx-desc">
+                <properties>
+                  <help>Tranceive ring descriptors</help>
+                  <valueHelp>
+                    <format>u32:256-8192</format>
+                    <description>Number of descriptors in tranceive ring</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 256-8192"/>
+                  </constraint>
+                </properties>
+                <defaultValue>1024</defaultValue>
+              </leafNode>
+              <leafNode name="num-rx-queues">
+                <properties>
+                  <help>Number of receive queues</help>
+                  <valueHelp>
+                    <format>u32:1-8192</format>
+                    <description>Number of receive queues</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 1-8192"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="num-tx-queues">
+                <properties>
+                  <help>Number of tranceive queues</help>
+                  <valueHelp>
+                    <format>u32:1-8192</format>
+                    <description>Number of tranceive queues</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 1-8192"/>
+                  </constraint>
+                </properties>
+              </leafNode>
             </children>
           </tagNode>
           <node name="ipv6">

--- a/python/vyos/vpp/config_resource_checks/memory.py
+++ b/python/vyos/vpp/config_resource_checks/memory.py
@@ -189,12 +189,11 @@ def buffers_required(settings: dict) -> int:
         # if iface_config.get('driver') == 'xdp':
         #     continue
 
-        dpdk_options = iface_config.get('dpdk_options', {})
-        rx_queues = int(dpdk_options.get('num_rx_queues', 1))
-        rx_desc = int(dpdk_options.get('num_rx_desc'))
+        rx_queues = int(iface_config.get('num_rx_queues', 1))
+        rx_desc = int(iface_config.get('num_rx_desc'))
         # default TX queues is equal to number of worker threads
-        tx_queues = int(dpdk_options.get('num_tx_queues', workers))
-        tx_desc = int(dpdk_options.get('num_tx_desc'))
+        tx_queues = int(iface_config.get('num_tx_queues', workers))
+        tx_desc = int(iface_config.get('num_tx_desc'))
 
         # buffers for RX/TX queues for interface
         buffers_total += rx_queues * rx_desc + tx_queues * tx_desc

--- a/smoketest/configs/assert/vpp
+++ b/smoketest/configs/assert/vpp
@@ -45,7 +45,10 @@ set vpp interfaces vxlan vxlan10 vni '10'
 set vpp settings interface eth1
 set vpp settings interface eth2
 set vpp settings interface eth3
-set vpp settings interface eth4
+set vpp settings interface eth4 num-rx-desc '512'
+set vpp settings interface eth4 num-tx-desc '512'
+set vpp settings interface eth4 num-rx-queues '1'
+set vpp settings interface eth4 num-tx-queues '1'
 set vpp settings poll-sleep-usec '12'
 set vpp settings logging default-level 'debug'
 set vpp settings interface-rx-mode 'polling'

--- a/smoketest/configs/vpp
+++ b/smoketest/configs/vpp
@@ -120,6 +120,12 @@ vpp {
         }
         interface eth4 {
             driver "dpdk"
+            dpdk-options {
+                num-rx-desc "512"
+                num-tx-desc "512"
+                num-rx-queues "1"
+                num-tx-queues "1"
+            }
         }
         unix {
             poll-sleep-usec "12"

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -905,7 +905,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
 
         # Add check dependency ethernet => bridge
         self.cli_set(
-            base_path + ['settings', 'interface', interface, 'dpdk-options', 'promisc']
+            base_path + ['settings', 'interface', interface, 'num-rx-desc', '512']
         )
         self.cli_commit()
         # check bridge interface
@@ -1128,7 +1128,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
             self.assertNotIn(required_string, out)
 
     def test_10_vpp_driver_options(self):
-        dpdk_options = {
+        driver_options = {
             'num-rx-desc': '512',
             'num-tx-desc': '512',
             'num-rx-queues': '2',
@@ -1138,8 +1138,8 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
 
         base_interface_path = base_path + ['settings', 'interface', interface]
 
-        for option, value in dpdk_options.items():
-            self.cli_set(base_interface_path + ['dpdk-options', option, value])
+        for option, value in driver_options.items():
+            self.cli_set(base_interface_path + [option, value])
 
         # rx/tx queue configuration expect VPP workers to be set
         # expect raise ConfigError
@@ -1165,7 +1165,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         # check dpdk options in config file
         config = read_file(VPP_CONF)
 
-        for option, value in dpdk_options.items():
+        for option, value in driver_options.items():
             self.assertIn(f'{option} {value}', config)
 
     def test_11_vpp_cpu_cores(self):
@@ -1552,7 +1552,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
 
         # check if dependency is called and mapping is correct after changes in vpp script
         self.cli_set(
-            base_path + ['settings', 'interface', interface, 'dpdk-options', 'promisc']
+            base_path + ['settings', 'interface', interface, 'num-tx-desc', '512']
         )
         self.cli_commit()
 

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -554,21 +554,15 @@ def verify(config):
 
                 Warning(f'Not all RX queues will be connected to VPP for {iface}!')
 
-        if iface_config['driver'] == 'xdp' and 'dpdk_options' in iface_config:
-            raise ConfigError('DPDK options are not applicable for XDP driver!')
-
-        if iface_config['driver'] == 'dpdk' and 'xdp_options' in iface_config:
-            raise ConfigError('XDP options are not applicable for DPDK driver!')
-
-        if iface_config['driver'] == 'dpdk' and 'dpdk_options' in iface_config:
-            if 'num_rx_queues' in iface_config['dpdk_options']:
-                rx_queues = int(iface_config['dpdk_options']['num_rx_queues'])
+        if iface_config['driver'] == 'dpdk':
+            if 'num_rx_queues' in iface_config:
+                rx_queues = int(iface_config['num_rx_queues'])
                 verify_vpp_interfaces_dpdk_num_queues(
                     qtype='receive', num_queues=rx_queues, workers=cpu_cores
                 )
 
-            if 'num_tx_queues' in iface_config['dpdk_options']:
-                tx_queues = int(iface_config['dpdk_options']['num_tx_queues'])
+            if 'num_tx_queues' in iface_config:
+                tx_queues = int(iface_config['num_tx_queues'])
                 verify_vpp_interfaces_dpdk_num_queues(
                     qtype='transmit', num_queues=tx_queues, workers=cpu_cores
                 )
@@ -783,13 +777,6 @@ def apply(config):
             # add interfaces
             iproute = IPRoute()
             for iface, iface_config in config['settings']['interface'].items():
-                # promisc option for DPDK interfaces
-                if iface_config['driver'] == 'dpdk':
-                    if 'promisc' in iface_config['dpdk_options']:
-                        if_index = vpp_control.get_sw_if_index(iface)
-                        vpp_control.api.sw_interface_set_promisc(
-                            sw_if_index=if_index, promisc_on=True
-                        )
                 # add XDP interfaces
                 if iface_config['driver'] == 'xdp':
                     control_host.rename_iface(iface, f'defunct_{iface}')

--- a/src/migration-scripts/vpp/7-to-8
+++ b/src/migration-scripts/vpp/7-to-8
@@ -26,6 +26,11 @@
 # Convert `vpp settings interface <name> rx-mode` and `vpp kernel-interfaces <name> rx-mode`
 # to `vpp settings interfaces-rx-mode` by choose the worst value from all nodes (T8266)
 #
+# Get rid of 'dpdk-options' section for 'num-*' parameters:
+#  - `vpp settings interface <ethN> dpdk-options num-*`
+#  - `vpp settings interface <ethN> num-*`
+# and delete `vpp settings interface <ethN> dpdk-options promisc` (T8274)
+#
 
 from vyos.configtree import ConfigTree
 
@@ -155,6 +160,34 @@ def _migrate_vpp_interface_rx_mode(config: ConfigTree) -> None:
     _delete_rx_modes(kernel_interface_path)
 
 
+def _migrate_vpp_dpdk_options(config: ConfigTree) -> None:
+    base_path = ['vpp', 'settings', 'interface']
+    params = ['num-rx-desc', 'num-rx-queues', 'num-tx-desc', 'num-tx-queues']
+
+    if not config.exists(base_path):
+        return
+
+    for iface_name in config.list_nodes(base_path):
+        iface_path = base_path + [iface_name]
+        dpdk_path = iface_path + ['dpdk-options']
+
+        if config.exists(dpdk_path):
+            for param in params:
+                param_path = dpdk_path + [param]
+                new_param_path = iface_path + [param]
+
+                if config.exists(param_path):
+                    # Move `vpp settings interface <iface_name> dpdk-options num-*`
+                    # to `vpp settings interface <iface_name> num-*`
+                    config.copy(param_path, new_param_path)
+                    config.delete(param_path)
+
+        # Delete `vpp settings interface <iface_name> dpdk-options promisc`
+        promisc_path = dpdk_path + ['promisc']
+        if config.exists(promisc_path):
+            config.delete(promisc_path)
+
+
 def migrate(config: ConfigTree) -> None:
     if not config.exists(['vpp']):
         # Nothing to do
@@ -166,3 +199,4 @@ def migrate(config: ConfigTree) -> None:
     _migrate_vpp_ipsec(config)
     _migrate_vpp_cpu(config)
     _migrate_vpp_interface_rx_mode(config)
+    _migrate_vpp_dpdk_options(config)


### PR DESCRIPTION
## Change summary
Remove `dpdk-options` under `set vpp settings interface <ethN>` and move its child options to the interface level:
 - `num-rx-desc`
 - `num-rx-queues`
 - `num-tx-desc`
 - `num-tx-queues`

Also remove `set vpp settings interface <ethN> dpdk-options promisc`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): CLI changes

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8274

## Related PR(s)
* https://github.com/vyos/vyos-documentation/pull/1776

## How to test / Smoketest result
### Smoketest

Check migration script:
```
root@b15b6c12f4fe:/vyos/build# make testcvpp
...
DEBUG - Loaded migration result test for config "vpp"
DEBUG - ... completed: 0.003640
DEBUG - test_vpp (__main__.TestConfigVpp.test_vpp) ...  time: 53.229
DEBUG - ok
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 1 test in 53.243s
DEBUG - OK
```

Verify CLI tests:
```
root@b15b6c12f4fe:/vyos/build# make test-vpp
DEBUG - Running Testcase (1/1): /usr/libexec/vyos/tests/smoke/cli/test_vpp.py
DEBUG - test_01_vpp_basic (__main__.TestVPP.test_01_vpp_basic) ... ok
DEBUG - test_02_vpp_vxlan (__main__.TestVPP.test_02_vpp_vxlan) ... ok
...
DEBUG - test_21_2_vpp_ipfix_bond (__main__.TestVPP.test_21_2_vpp_ipfix_bond) ... ok
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 25 tests in 473.177s
DEBUG - OK (skipped=1)
DEBUG - SUCCESS! All 1 tests passed.
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly