### PR TITLE
T8279: recover config data provided by legacy image upgrade tools

### DIFF
--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -312,6 +312,23 @@ bind_mount_boot ()
     fi
 }
 
+# this is called before migration and bind_mount_slash_config to check for
+# upgrade data installed by legacy image update tools
+copy_legacy_config_path ()
+{
+    if [ -d /config ] ; then
+        if [ -f /config/.upgraded ] ; then
+            rm -f /config/.upgraded
+            cp -a /config /opt/vyatta/etc
+            chgrp -R vyattacfg /opt/vyatta/etc/config
+            chmod -R 775 /opt/vyatta/etc/config
+            chmod 660 /opt/vyatta/etc/config/config.boot
+            touch /opt/vyatta/etc/config/.vyatta_config
+            rm -rf /config
+        fi
+    fi
+}
+
 bind_mount_slash_config ()
 {
     if [ -d /opt/vyatta/etc/config ]
@@ -577,6 +594,8 @@ start ()
     # If for any reason FRR was not started by system_frr.py - start it anyways.
     # This is a safety net!
     systemctl start frr.service
+
+    disabled copy_legacy_config_path || copy_legacy_config_path
 
     disabled bootfile || init_bootfile
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

When upgrading from systems using the legacy image update tools (1.3.x), config data is copied to a now non-standard path. Add check on first boot into target image to recover source image config data.

This is a basic workaround, however, it will provide the expected continuity of config data when upgrading 1.3.x -> 1.4.5/1.5 (those versions with the corrected /config bind mount).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
