### PR TITLE
T6868: Monitoring Loki Basic Authentication Password Length Limit Inc…

### DIFF
--- a/interface-definitions/include/generic-password.xml.i
+++ b/interface-definitions/include/generic-password.xml.i
@@ -7,9 +7,9 @@
       <description>Password</description>
     </valueHelp>
     <constraint>
-      <regex>[[:ascii:]]{1,128}</regex>
+      <regex>[[:ascii:]]{1,512}</regex>
     </constraint>
-    <constraintErrorMessage>Password is limited to ASCII characters only, with a total length of 128</constraintErrorMessage>
+    <constraintErrorMessage>Password is limited to ASCII characters only, with a total length of 512</constraintErrorMessage>
   </properties>
 </leafNode>
 <!-- include end -->


### PR DESCRIPTION
Change Summary:

The currently configured limit of 128 Chars in interface-definitions/include/generic-password.xml.i prevents the usage of natively sending telemetry to the Grafana Cloud which uses much longer tokens. 

As per Information from Grafana, the Grafana Cloud token consist of several components that are put into a json structure, base64 encoded and have also a prefix. Contents of the Token:

Name of the Token (max 255)
Organization (currently 7 digits)
Secret (fixed 24)
Region (longest currently 20)

That beeing said, the length can easily exceed 255 chars. They dont expect the Password to be longer than 500 chars. 

I propose to simply set 512.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
https://vyos.dev/T6868

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
