### PR TITLE
T8291: Add explicit CLI support for marking DNS forwarding upstreams as DoT and remove ambiguous implicit DoT behavior on port 853.

### DIFF
--- a/data/templates/dns-forwarding/recursor.conf.j2
+++ b/data/templates/dns-forwarding/recursor.conf.j2
@@ -35,6 +35,9 @@ local-port={{ port }}
 # dnssec
 dnssec={{ dnssec }}
 
+# disable implicit DoT for forwarders on port 853
+dot-to-port-853=no
+
 {% if dns64_prefix is vyos_defined %}
 # dns64-prefix
 dns64-prefix={{ dns64_prefix }}
@@ -70,4 +73,3 @@ ecs-ipv4-bits={{ options.ecs_ipv4_bits }}
 {% if options.edns_subnet_allow_list is vyos_defined %}
 edns-subnet-allow-list={{ options.edns_subnet_allow_list | join(',') }}
 {% endif %}
-

--- a/interface-definitions/include/name-server-ipv4-ipv6-port.xml.i
+++ b/interface-definitions/include/name-server-ipv4-ipv6-port.xml.i
@@ -16,8 +16,11 @@
   </properties>
   <children>
     #include <include/port-number.xml.i>
-    <leafNode name="port">
-      <defaultValue>53</defaultValue>
+    <leafNode name="dot">
+      <properties>
+        <help>Use DNS over TLS (DoT) for this upstream DNS server</help>
+        <valueless/>
+      </properties>
     </leafNode>
   </children>
 </tagNode>

--- a/interface-definitions/include/version/dns-forwarding-version.xml.i
+++ b/interface-definitions/include/version/dns-forwarding-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/dns-forwarding-version.xml.i -->
-<syntaxVersion component='dns-forwarding' version='4'></syntaxVersion>
+<syntaxVersion component='dns-forwarding' version='5'></syntaxVersion>
 <!-- include end -->

--- a/smoketest/scripts/cli/test_service_dns_forwarding.py
+++ b/smoketest/scripts/cli/test_service_dns_forwarding.py
@@ -41,6 +41,14 @@ def get_config_value(key, file=CONFIG_FILE):
     tmp = re.findall(r'\n{}=+(.*)'.format(key), tmp)
     return tmp[0]
 
+
+def get_upstream_port(upstream_data):
+    if 'port' in upstream_data:
+        return upstream_data['port']
+    if 'dot' in upstream_data:
+        return '853'
+    return '53'
+
 class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -131,6 +139,10 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         tmp = get_config_value('local-port')
         self.assertEqual(tmp, '53')
 
+        # implicit DoT on port 853 must be disabled
+        tmp = get_config_value('dot-to-port-853')
+        self.assertEqual(tmp, 'no')
+
     def test_dnssec(self):
         # DNSSEC option testing
         options = ['off', 'process-no-validate', 'process', 'log-fail', 'validate']
@@ -156,14 +168,48 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         tmp = get_config_value(r'\+.', file=FORWARD_FILE)
-        canonical_entries = [(lambda h, p: f"{bracketize_ipv6(h)}:{p['port'] if 'port' in p else 53}")(h, p)
-                             for (h, p) in nameservers.items()]
+        canonical_entries = [
+            (lambda h, p: f"{bracketize_ipv6(h)}:{get_upstream_port(p)}")(h, p)
+            for (h, p) in nameservers.items()
+        ]
         self.assertEqual(tmp, ', '.join(canonical_entries))
 
         # Do not use local /etc/hosts file in name resolution
         # default: yes
         tmp = get_config_value('export-etc-hosts')
         self.assertEqual(tmp, 'yes')
+
+    def test_external_nameserver_dot(self):
+        nameservers = {
+            '192.0.2.3': {'dot': {}},
+            '2001:db8::3': {'dot': {}, 'port': '853'},
+        }
+
+        for h, p in nameservers.items():
+            if 'port' in p:
+                self.cli_set(base_path + ['name-server', h, 'port', p['port']])
+            if 'dot' in p:
+                self.cli_set(base_path + ['name-server', h, 'dot'])
+
+        self.cli_commit()
+
+        tmp = get_config_value(r'\+.', file=FORWARD_FILE)
+        canonical_entries = [
+            (lambda h, p: f"{bracketize_ipv6(h)}:{get_upstream_port(p)}")(h, p)
+            for (h, p) in nameservers.items()
+        ]
+        self.assertEqual(tmp, ', '.join(canonical_entries))
+
+    def test_external_nameserver_dot_custom_port(self):
+        nameserver = '192.0.2.4'
+        port = '1053'
+        self.cli_set(base_path + ['name-server', nameserver, 'dot'])
+        self.cli_set(base_path + ['name-server', nameserver, 'port', port])
+
+        self.cli_commit()
+
+        tmp = get_config_value(r'\+.', file=FORWARD_FILE)
+        self.assertIn(f'{nameserver}:{port}', tmp)
 
     def test_domain_forwarding(self):
         domains = ['vyos.io', 'vyos.net', 'vyos.com']
@@ -190,16 +236,56 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         hosts_conf = read_file(HOSTSD_FILE)
         for domain in domains:
             # Test 'recursion-desired' flag for the first domain only
-            if domain == domains[0]: key =f'\+{domain}'
-            else: key =f'{domain}'
+            if domain == domains[0]:
+                key = fr'\+{domain}'
+            else:
+                key = f'{domain}'
             tmp = get_config_value(key, file=FORWARD_FILE)
-            canonical_entries = [(lambda h, p: f"{bracketize_ipv6(h)}:{p['port'] if 'port' in p else 53}")(h, p)
-                        for (h, p) in nameservers.items()]
+            canonical_entries = [
+                (lambda h, p: f"{bracketize_ipv6(h)}:{get_upstream_port(p)}")(h, p)
+                for (h, p) in nameservers.items()
+            ]
             self.assertEqual(tmp, ', '.join(canonical_entries))
 
             # Test 'negative trust anchor' flag for the second domain only
             if domain == domains[1]:
                 self.assertIn(f'addNTA("{domain}", "static")', hosts_conf)
+
+    def test_domain_forwarding_dot(self):
+        domain = 'dot.vyos.io'
+        nameservers = {
+            '192.0.2.10': {'dot': {}},
+            '2001:db8::10': {'dot': {}},
+        }
+
+        for h, p in nameservers.items():
+            if 'port' in p:
+                self.cli_set(
+                    base_path + ['domain', domain, 'name-server', h, 'port', p['port']]
+                )
+            if 'dot' in p:
+                self.cli_set(base_path + ['domain', domain, 'name-server', h, 'dot'])
+
+        self.cli_commit()
+
+        tmp = get_config_value(domain, file=FORWARD_FILE)
+        canonical_entries = [
+            (lambda h, p: f"{bracketize_ipv6(h)}:{get_upstream_port(p)}")(h, p)
+            for (h, p) in nameservers.items()
+        ]
+        self.assertEqual(tmp, ', '.join(canonical_entries))
+
+    def test_domain_forwarding_dot_custom_port(self):
+        domain = 'dot-port.vyos.io'
+        self.cli_set(base_path + ['domain', domain, 'name-server', '192.0.2.11', 'dot'])
+        self.cli_set(
+            base_path + ['domain', domain, 'name-server', '192.0.2.11', 'port', '1053']
+        )
+
+        self.cli_commit()
+
+        tmp = get_config_value(domain, file=FORWARD_FILE)
+        self.assertIn('192.0.2.11:1053', tmp)
 
     def test_no_rfc1918_forwarding(self):
         self.cli_set(base_path + ['no-serve-rfc1918'])

--- a/src/conf_mode/service_dns_forwarding.py
+++ b/src/conf_mode/service_dns_forwarding.py
@@ -238,6 +238,20 @@ def get_config(config=None):
 
     return dns
 
+def get_name_server_port(name_server_data):
+    if not name_server_data:
+        return 53
+    if 'port' in name_server_data:
+        return int(name_server_data['port'])
+    if 'dot' in name_server_data:
+        return 853
+    return 53
+
+
+def canonicalize_name_server(name_server, name_server_data):
+    return f'{bracketize_ipv6(name_server)}:{get_name_server_port(name_server_data)}'
+
+
 def verify(dns):
     # bail out early - looks like removal from running config
     if not dns:
@@ -337,10 +351,12 @@ def apply(dns):
         hc.delete_name_servers([hostsd_tag])
         if 'name_server' in dns:
             # 'name_server' is of the form
-            # {'192.0.2.1': {'port': 53}, '2001:db8::1': {'port': 853}, ...}
+            # {'192.0.2.1': {}, '2001:db8::1': {'dot': {}}, ...}
             # canonicalize them as ['192.0.2.1:53', '[2001:db8::1]:853', ...]
-            nslist = [(lambda h, p: f"{bracketize_ipv6(h)}:{p['port']}")(h, p)
-                      for (h, p) in dns['name_server'].items()]
+            nslist = [
+                (lambda h, p: canonicalize_name_server(h, p))(h, p)
+                for (h, p) in dns['name_server'].items()
+            ]
             hc.add_name_servers({hostsd_tag: nslist})
 
         # delete all nameserver tags
@@ -380,10 +396,12 @@ def apply(dns):
             zones = dns['domain']
             for domain in zones.keys():
                 # 'name_server' is of the form
-                # {'192.0.2.1': {'port': 53}, '2001:db8::1': {'port': 853}, ...}
+                # {'192.0.2.1': {}, '2001:db8::1': {'dot': {}}, ...}
                 # canonicalize them as ['192.0.2.1:53', '[2001:db8::1]:853', ...]
-                zones[domain]['name_server'] = [(lambda h, p: f"{bracketize_ipv6(h)}:{p['port']}")(h, p)
-                                                for (h, p) in zones[domain]['name_server'].items()]
+                zones[domain]['name_server'] = [
+                    (lambda h, p: canonicalize_name_server(h, p))(h, p)
+                    for (h, p) in zones[domain]['name_server'].items()
+                ]
             hc.add_forward_zones(zones)
 
         # hostsd generates NTAs for the authoritative zones

--- a/src/migration-scripts/dns-forwarding/4-to-5
+++ b/src/migration-scripts/dns-forwarding/4-to-5
@@ -1,0 +1,53 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# T8291:
+#   - "service dns forwarding name-server ... dot" introduces explicit DoT.
+#   - "dot-to-port-853" is disabled to avoid implicit DoT upgrades.
+#   - To preserve behavior for upgraded configs that relied on implicit DoT,
+#     add "dot" to upstreams explicitly configured with port 853.
+
+from vyos.configtree import ConfigTree
+
+base = ['service', 'dns', 'forwarding']
+
+
+def migrate_name_servers(config: ConfigTree, name_servers_base) -> None:
+    if not config.exists(name_servers_base):
+        return
+
+    for name_server in config.list_nodes(name_servers_base):
+        ns_base = name_servers_base + [name_server]
+        port_path = ns_base + ['port']
+        dot_path = ns_base + ['dot']
+
+        if config.exists(dot_path) or not config.exists(port_path):
+            continue
+
+        if str(config.return_value(port_path)) == '853':
+            config.set(dot_path)
+
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(base):
+        # Nothing to do
+        return
+
+    migrate_name_servers(config, base + ['name-server'])
+
+    domain_base = base + ['domain']
+    if config.exists(domain_base):
+        for domain in config.list_nodes(domain_base):
+            migrate_name_servers(config, domain_base + [domain, 'name-server'])


### PR DESCRIPTION
### Change summary
Add explicit CLI support for marking DNS forwarding upstreams as DoT and remove ambiguous implicit DoT behavior on port 853.

- Add new `dot` node under upstream DNS server config (shared include, reused in both paths):
  - `service dns forwarding name-server <ip> dot`
  - `service dns forwarding domain <domain> name-server <ip> dot`
- Keep using the common `port-number` include (no duplicated port XML node).
- Refactor upstream canonicalization in `service_dns_forwarding.py`:
  - default port `53`
  - if `dot` is set and no port is provided, default to `853`
  - explicit `port` is respected (including non-853)
- Remove the previous validation that rejected `dot` when port was not `853`.
- Disable implicit recursor behavior `port 853 => DoT` by setting:
  - `dot-to-port-853=no` in generated `recursor.conf`
- Extend smoketests for:
  - global upstream `dot`
  - domain upstream `dot`
  - custom DoT ports
  - `dot-to-port-853=no` rendering check

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

### Related Task(s)
https://vyos.dev/T8291
### Related PR(s)
N/A

### How to test / Smoketest result
1. Configure plain upstream on port 853 (without `dot`) and commit:
   - `set service dns forwarding name-server 192.0.2.1 port 853`
   - Verify generated `recursor.conf` contains `dot-to-port-853=no`
   - Verify `recursor.forward-zones.conf` contains `192.0.2.1:853`
2. Configure explicit `dot` upstream with default port:
   - `set service dns forwarding name-server 192.0.2.2 dot`
   - Verify `recursor.forward-zones.conf` contains `192.0.2.2:853`
3. Configure explicit `dot` upstream with custom port:
   - `set service dns forwarding name-server 192.0.2.3 dot`
   - `set service dns forwarding name-server 192.0.2.3 port 1053`
   - Commit should succeed
   - Verify `recursor.forward-zones.conf` contains `192.0.2.3:1053`
4. Repeat `dot` checks for `service dns forwarding domain <domain> name-server ...`

### Checklist:
- [x] I have read the CONTRIBUTING document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components SMOKETESTS if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly