### PR TITLE
T8292: Fix ndp-proxy verify key mismatch for prefix rules

### DIFF
--- a/smoketest/scripts/cli/test_service_ndp-proxy.py
+++ b/smoketest/scripts/cli/test_service_ndp-proxy.py
@@ -18,6 +18,7 @@ import unittest
 
 from base_vyostest_shim import VyOSUnitTestSHIM
 
+from vyos.configsession import ConfigSessionError
 from vyos.ifconfig import Section
 from vyos.utils.process import cmd
 from vyos.utils.process import process_named_running
@@ -65,6 +66,64 @@ class TestServiceNDPProxy(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f'router yes', config)
             self.assertIn(f'timeout 500', config) # default value
             self.assertIn(f'ttl 30000', config) # default value
+
+    def test_prefix_mode_interface_requires_interface(self):
+        interface = Section.interfaces('ethernet')[0]
+        prefix_path = base_path + ['interface', interface, 'prefix', '2001:db8::/64']
+        self.cli_set(base_path + ['interface', interface])
+        self.cli_commit()
+
+        self.cli_set(prefix_path + ['mode', 'interface'])
+
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+    def test_prefix_mode_interface_with_interface(self):
+        interface = Section.interfaces('ethernet')[0]
+        prefix_path = base_path + ['interface', interface, 'prefix', '2001:db8::/64']
+        self.cli_set(base_path + ['interface', interface])
+        self.cli_set(prefix_path + ['mode', 'interface'])
+        self.cli_set(prefix_path + ['interface', interface])
+        self.cli_commit()
+
+        config = getConfigSection(f'proxy {interface}')
+        self.assertIn('rule 2001:db8::/64 {', config)
+        self.assertIn(f'iface {interface}', config)
+
+    def test_prefix_mode_auto_rejects_interface(self):
+        interface = Section.interfaces('ethernet')[0]
+        prefix_path = base_path + ['interface', interface, 'prefix', '2001:db8::/64']
+        self.cli_set(base_path + ['interface', interface])
+        self.cli_commit()
+
+        self.cli_set(prefix_path + ['mode', 'auto'])
+        self.cli_set(prefix_path + ['interface', interface])
+
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+    def test_disabled_prefix_skips_validation(self):
+        interface = Section.interfaces('ethernet')[0]
+        prefix_path = base_path + ['interface', interface, 'prefix', '2001:db8::/64']
+        self.cli_set(base_path + ['interface', interface])
+        self.cli_set(prefix_path + ['mode', 'interface'])
+        self.cli_set(prefix_path + ['disable'])
+
+        self.cli_commit()
+
+        config = getConfigSection(f'proxy {interface}')
+        self.assertNotIn('rule 2001:db8::/64 {', config)
+
+    def test_disabled_interface_skips_validation(self):
+        interface = Section.interfaces('ethernet')[0]
+        prefix_path = base_path + ['interface', interface, 'prefix', '2001:db8::/64']
+        self.cli_set(base_path + ['interface', interface, 'disable'])
+        self.cli_set(prefix_path + ['mode', 'interface'])
+
+        self.cli_commit()
+
+        config = cmd(f'cat {NDPPD_CONF}')
+        self.assertNotIn(f'proxy {interface} {{', config)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/src/conf_mode/service_ndp-proxy.py
+++ b/src/conf_mode/service_ndp-proxy.py
@@ -48,18 +48,33 @@ def verify(ndpp):
     if not ndpp:
         return None
 
-    if 'interface' in ndpp:
-        for interface, interface_config in ndpp['interface'].items():
-            verify_interface_exists(ndpp, interface)
+    if 'interface' not in ndpp:
+        return None
 
-            if 'rule' in interface_config:
-                for rule, rule_config in interface_config['rule'].items():
-                    if rule_config['mode'] == 'interface' and 'interface' not in rule_config:
-                        raise ConfigError(f'Rule "{rule}" uses interface mode but no interface defined!')
+    for interface, interface_config in ndpp['interface'].items():
+        if 'disable' in interface_config:
+            continue
 
-                    if rule_config['mode'] != 'interface' and 'interface' in rule_config:
-                        if interface_config['mode'] != 'interface' and 'interface' in interface_config:
-                            raise ConfigError(f'Rule "{rule}" does not use interface mode, thus interface can not be defined!')
+        verify_interface_exists(ndpp, interface)
+
+        if 'prefix' not in interface_config:
+            continue
+
+        for prefix, prefix_config in interface_config['prefix'].items():
+            if 'disable' in prefix_config:
+                continue
+
+            mode = prefix_config.get('mode')
+            prefix_interface = prefix_config.get('interface')
+
+            if mode == 'interface':
+                if not prefix_interface:
+                    raise ConfigError(f'Prefix "{prefix}" uses interface mode but no interface defined!')
+                verify_interface_exists(ndpp, prefix_interface)
+                continue
+
+            if prefix_interface:
+                raise ConfigError(f'Prefix "{prefix}" does not use interface mode, thus interface can not be defined!')
 
     return None
 


### PR DESCRIPTION
### Change summary
Switch `verify()` to validate the real config tree (`interface -> prefix`) instead of non-existent `rule` nodes.
This enforces:
- `mode interface` requires `prefix ... interface`
- non-`interface` modes must not set `prefix ... interface`
- referenced interface exists when `mode` is `interface`
### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

### Related Task(s)
https://vyos.dev/T8292

### Related PR(s)


### Checklist:
- [x] I have read the CONTRIBUTING document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components SMOKETESTS if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

### Smoketest
```
vyos@vyos# /usr/libexec/vyos/tests/smoke/cli/test_service_ndp-proxy.py
test_basic (__main__.TestServiceNDPProxy.test_basic) ... ok
test_disabled_interface_skips_validation (__main__.TestServiceNDPProxy.test_disabled_interface_skips_validation) ... ok
test_disabled_prefix_skips_validation (__main__.TestServiceNDPProxy.test_disabled_prefix_skips_validation) ... ok
test_prefix_mode_auto_rejects_interface (__main__.TestServiceNDPProxy.test_prefix_mode_auto_rejects_interface) ... ok
test_prefix_mode_interface_requires_interface (__main__.TestServiceNDPProxy.test_prefix_mode_interface_requires_interface) ... ok
test_prefix_mode_interface_with_interface (__main__.TestServiceNDPProxy.test_prefix_mode_interface_with_interface) ... ok

----------------------------------------------------------------------
Ran 6 tests in 13.570s

OK
```