### PR TITLE
T7513: vyos-1x: CGNAT Exclude Rule CLI support

### DIFF
--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -868,6 +868,51 @@
                 #include <include/generic-description.xml.i>
               </children>
             </tagNode>
+            <node name="exclude">
+              <properties>
+                <help>Exclude packets matching these rules from CGNAT</help>
+              </properties>
+              <children>
+                <tagNode name="rule">
+                  <properties>
+                    <help>Rule number</help>
+                    <valueHelp>
+                      <format>u32</format>
+                      <description>Number of rule</description>
+                    </valueHelp>
+                  </properties>
+                  <children>
+                    <leafNode name="local-address">
+                      <properties>
+                        <help>IP address of the internal (local) device</help>
+                        <valueHelp>
+                          <format>ipv4</format>
+                          <description>IPv4 address</description>
+                        </valueHelp>
+                        <constraint>
+                          <validator name="ipv4-address"/>
+                        </constraint>
+                      </properties>
+                    </leafNode>
+                    <leafNode name="local-port">
+                      <properties>
+                        <help>Port number used by connection on internal device</help>
+                        <valueHelp>
+                          <format>u32:1-65535</format>
+                          <description>Numeric IP port</description>
+                        </valueHelp>
+                        <constraint>
+                          <validator name="numeric" argument="--range 1-65535"/>
+                        </constraint>
+                        <constraintErrorMessage>Port number must be in range 1 to 65535</constraintErrorMessage>
+                      </properties>
+                    </leafNode>
+                    #include <include/vpp/nat_protocol.xml.i>
+                    #include <include/generic-description.xml.i>
+                  </children>
+                </tagNode>
+              </children>
+            </node>
             <node name="timeout">
               <properties>
                 <help>Timeouts for CGNAT sessions</help>

--- a/op-mode-definitions/vpp_nat_cgnat.xml.in
+++ b/op-mode-definitions/vpp_nat_cgnat.xml.in
@@ -32,6 +32,12 @@
                     </properties>
                     <command>sudo ${vyos_op_scripts_dir}/vpp_nat_cgnat.py show_interfaces</command>
                   </node>
+                  <node name="exclude-rules">
+                    <properties>
+                      <help>Show VPP CGNAT exclude rules (identity mappings)</help>
+                    </properties>
+                    <command>sudo ${vyos_op_scripts_dir}/vpp_nat_cgnat.py show_exclude_rules</command>
+                  </node>
                 </children>
               </node>
             </children>

--- a/python/vyos/vpp/nat/det44.py
+++ b/python/vyos/vpp/nat/det44.py
@@ -16,6 +16,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from vyos.vpp import VPPControl
+from vyos.vpp.nat.nat44 import NAT_IS_NONE, NAT_IS_ADDR_ONLY
 
 
 class Det44:
@@ -118,3 +119,29 @@ class Det44:
             if iface.is_inside:
                 ifaces_inside.append(iface.sw_if_index)
         return ifaces_inside
+
+    def add_det44_identity_mapping(self, ip_address, protocol, port, tag=''):
+        """Add DET44 identity mapping (exclude rule)"""
+        flags = NAT_IS_ADDR_ONLY if not (protocol or port) else NAT_IS_NONE
+
+        self.vpp.api.det44_add_del_identity_mapping(
+            is_add=True,
+            addr=ip_address,
+            protocol=protocol,
+            port=port,
+            flags=flags,
+            tag=tag if tag else '',
+        )
+
+    def delete_det44_identity_mapping(self, ip_address, protocol, port, tag=''):
+        """Delete DET44 identity mapping (exclude rule)"""
+        flags = NAT_IS_ADDR_ONLY if not (protocol or port) else NAT_IS_NONE
+
+        self.vpp.api.det44_add_del_identity_mapping(
+            is_add=False,
+            addr=ip_address,
+            protocol=protocol,
+            port=port,
+            flags=flags,
+            tag=tag,
+        )

--- a/src/conf_mode/vpp_nat_cgnat.py
+++ b/src/conf_mode/vpp_nat_cgnat.py
@@ -26,6 +26,13 @@ from vyos.vpp.utils import vpp_iface_name_transform
 from vyos.vpp.nat.det44 import Det44
 from vyos.vpp.control_vpp import VPPControl
 
+protocol_map = {
+    'all': 0,
+    'icmp': 1,
+    'tcp': 6,
+    'udp': 17,
+}
+
 
 def get_config(config=None) -> dict:
     if config:
@@ -80,12 +87,22 @@ def get_config(config=None) -> dict:
         expand_nodes=Diff.DELETE | Diff.ADD,
     )
 
+    changed_exclude_rules = node_changed(
+        conf,
+        base + ['exclude', 'rule'],
+        key_mangling=('-', '_'),
+        recursive=True,
+        expand_nodes=Diff.DELETE | Diff.ADD,
+    )
+
     if not config_changed:
         changed_rules = list(config.get('rule', {}).keys())
+        changed_exclude_rules = list(config.get('exclude', {}).get('rule', {}).keys())
 
     config.update(
         {
             'changed_rules': changed_rules,
+            'changed_exclude_rules': changed_exclude_rules,
             'vpp_ifaces': cli_ifaces_list(conf),
         }
     )
@@ -140,6 +157,46 @@ def verify(config):
                 f'Please add: {", ".join(missing_keys).replace("_", "-")}'
             )
 
+    # Verify exclude rules (identity mappings)
+    if 'exclude' in config:
+        # Track identity mappings to detect duplicates
+        seen_mappings = {}
+
+        for rule, rule_config in config['exclude'].get('rule', {}).items():
+            error_msg = f'Exclude rule {rule}:'
+
+            if 'local_address' not in rule_config:
+                raise ConfigError(f'{error_msg} local-address must be specified')
+
+            has_protocol = (
+                'protocol' in rule_config and rule_config.get('protocol') != 'all'
+            )
+            has_port = 'local_port' in rule_config
+
+            # Either both protocol and local-port are set, or neither
+            if has_protocol != has_port:
+                raise ConfigError(
+                    f'{error_msg} protocol and local-port must either both be specified or both omitted'
+                )
+
+            # Check for duplicate identity mappings
+            # VPP identifies identity mappings by (address, protocol, port) tuple
+            local_addr = rule_config['local_address']
+            protocol = rule_config.get('protocol', 'all')
+            port = rule_config.get('local_port', 0)
+
+            mapping_key = (local_addr, protocol, port)
+
+            if mapping_key in seen_mappings:
+                duplicate_rule = seen_mappings[mapping_key]
+                raise ConfigError(
+                    f'{error_msg} duplicate identity mapping - '
+                    f'address {local_addr}, protocol {protocol}, port {port} '
+                    f'already configured in exclude rule {duplicate_rule}'
+                )
+
+            seen_mappings[mapping_key] = rule
+
 
 def generate(config):
     pass
@@ -175,6 +232,16 @@ def apply(config):
                     out_addr=out_addr,
                     out_plen=int(out_plen),
                 )
+        # Delete CGNAT exclude rules
+        for rule in config['changed_exclude_rules']:
+            if rule in remove_config.get('exclude', {}).get('rule', {}):
+                rule_config = remove_config['exclude']['rule'][rule]
+                cgnat.delete_det44_identity_mapping(
+                    ip_address=rule_config.get('local_address'),
+                    protocol=protocol_map[rule_config.get('protocol', 'all')],
+                    port=int(rule_config.get('local_port', 0)),
+                    tag=rule_config.get('description', ''),
+                )
 
     # Add DET44
     cgnat.enable_det44_plugin()
@@ -197,6 +264,16 @@ def apply(config):
                 in_plen=int(in_plen),
                 out_addr=out_addr,
                 out_plen=int(out_plen),
+            )
+    # Add CGNAT exclude rules
+    for rule in config['changed_exclude_rules']:
+        if rule in config.get('exclude', {}).get('rule', {}):
+            rule_config = config['exclude']['rule'][rule]
+            cgnat.add_det44_identity_mapping(
+                ip_address=rule_config.get('local_address'),
+                protocol=protocol_map[rule_config.get('protocol', 'all')],
+                port=int(rule_config.get('local_port', 0)),
+                tag=rule_config.get('description', ''),
             )
     # Set CGNAT timeouts
     cgnat.set_det44_timeouts(

--- a/src/op_mode/vpp_nat_cgnat.py
+++ b/src/op_mode/vpp_nat_cgnat.py
@@ -120,6 +120,44 @@ def show_interfaces(raw: bool):
 
 
 @_verify
+def show_exclude_rules(raw: bool):
+    """Show CGNAT exclude rules (identity mappings)"""
+    vpp = VPPControl()
+    identity_mappings_dump = vpp.api.det44_identity_mapping_dump()
+    mappings: list[dict] = _get_raw_output(identity_mappings_dump)
+
+    if raw:
+        return mappings
+
+    if not mappings:
+        return "No CGNAT exclude rules configured"
+
+    data_entries = []
+    for m in mappings:
+        proto_map = {0: 'all', 1: 'icmp', 6: 'tcp', 17: 'udp'}
+        proto_name = proto_map.get(m.get('protocol'), str(m.get('protocol')))
+        port_str = str(m.get('port')) if m.get('port') else 'any'
+
+        # Check if address-only (flag & 1)
+        if m.get('flags', 0) & 1:
+            proto_name = 'all'
+            port_str = 'any'
+
+        tag_raw = m.get('tag')
+        if isinstance(tag_raw, bytes):
+            tag = tag_raw.decode('utf-8', errors='replace').rstrip('\x00')
+        else:
+            tag = str(tag_raw) if tag_raw else ''
+
+        values = [m.get('addr'), proto_name, port_str, m.get('vrf_id', 0), tag]
+        data_entries.append(values)
+
+    headers = ['Address', 'Protocol', 'Port', 'VRF', 'Description']
+    out = sorted(data_entries, key=lambda x: x[0])
+    return tabulate(out, headers=headers, tablefmt='simple')
+
+
+@_verify
 def clear_session(address: str, port: str, ext_address: str, ext_port: str):
     vpp = VPPControl()
     vpp.api.det44_close_session_in(


### PR DESCRIPTION
Support added for VPP DET44 Identity Mappings via CGNAT exclude rule CLIs

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
CGNAT Exclude Rule config can be applied to exclude an IP and/or protocol-port from CGNAT translation
```
set vpp nat cgnat exclude rule 11 
Possible completions:
   description          Description
   local-address        IP address of the internal (local) device
   local-port           Port number used by connection on internal device
   protocol             Protocol (default: all)
 ``` 
   
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7513

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vpp/pull/45

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
Tested the Set and Show CLIs 

- SET EXCLUDE RULE IP ADDRESS
vyos@vyos# set vpp nat cgnat exclude rule 1 local-address 192.168.65.8
vyos@vyos# commit
vyos@vyos# show vpp nat cgnat exclude rule 1
 local-address 192.168.65.8

- SET DUPLICATE EXCLUDE RULE
vyos@vyos# set vpp nat cgnat exclude rule 2 local-address 192.168.65.8
vyos@vyos# commit
[ vpp nat cgnat ]
Exclude rule 2: duplicate identity mapping - address 192.168.65.8,
protocol all, port 0 already configured in exclude rule 1
[[vpp nat cgnat]] failed
Commit failed

- SET DESCRIPTION/TAG
vyos@vyos# set vpp nat cgnat exclude rule 1 description r1

- SHOW EXCLUDE RULES
vyos@vyos# set vpp nat cgnat exclude rule 2 local-address 192.168.65.10
vyos@vyos# commit
vyos@vyos# show vpp nat cgnat exclude rule
 rule 1 {
     description r1
     local-address 192.168.65.8
 }
 rule 2 {
     local-address 192.168.65.10
 }

- SET INVALID PORT NUMBER
 vyos@vyos# set vpp nat cgnat exclude rule 3 local-port 0
  Number is not in any of allowed ranges  
  Port number must be in range 1 to 65535
  Value validation failed
  Set failed

- SET ONLY PROTOCOL, NO PORT
vyos@vyos# set vpp nat cgnat exclude rule 3 protocol tcp
vyos@vyos# set vpp nat cgnat exclude rule 3 local-address 192.168.65.8
vyos@vyos# commit
[ vpp nat cgnat ]
Exclude rule 3: protocol and local-port must either both be specified or
both omitted
[[vpp nat cgnat]] failed
Commit failed


- DELETE EXISTENT AND NON-EXISTENT EXCLUDE RULES
vyos@vyos# del vpp nat cgnat exclude rule 
Possible completions:
 > 1                    
 > 2                   

vyos@vyos# del vpp nat cgnat exclude rule 1
vyos@vyos# del vpp nat cgnat exclude rule 2
vyos@vyos# del vpp nat cgnat exclude rule 3

  Nothing to delete (the specified node does not exist)

vyos@vyos# sho vpp nat cgnat exclude rule
Configuration under specified path is empty

```
Or provide the output of the smoketest
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_cgnat.py
test_cgnat (__main__.TestCGNAT.test_cgnat) ... ok
test_cgnat_sequence (__main__.TestCGNAT.test_cgnat_sequence) ... ok

----------------------------------------------------------------------
Ran 2 tests in 145.973s

OK
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
