### PR TITLE
T8302: Add Router Advertisement (RA) base-interface support for IPv6 wildcard prefix derivation.

### DIFF
--- a/data/templates/router-advert/radvd.conf.j2
+++ b/data/templates/router-advert/radvd.conf.j2
@@ -84,6 +84,9 @@ interface {{ iface }} {
         AdvPreferredLifetime {{ prefix_options.preferred_lifetime }};
         DeprecatePrefix {{ 'on' if prefix_options.deprecate_prefix is vyos_defined else 'off' }};
         DecrementLifetimes {{ 'on' if prefix_options.decrement_lifetime is vyos_defined else 'off' }};
+{%                 if prefix_options.base_interface is vyos_defined %}
+        Base6Interface {{ prefix_options.base_interface }};
+{%                 endif %}
     };
 {%             endfor %}
 {%         endif %}

--- a/interface-definitions/service_router-advert.xml.in
+++ b/interface-definitions/service_router-advert.xml.in
@@ -305,6 +305,21 @@
                       <valueless/>
                     </properties>
                   </leafNode>
+                  <leafNode name="base-interface">
+                    <properties>
+                      <help>Prefix will be combined with IPv6 address of specified interface</help>
+                      <completionHelp>
+                        <script>${vyos_completion_dir}/list_interfaces</script>
+                      </completionHelp>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Interface name</description>
+                      </valueHelp>
+                      <constraint>
+                        #include <include/constraint/interface-name.xml.i>
+                      </constraint>
+                    </properties>
+                  </leafNode>
                   <leafNode name="preferred-lifetime">
                     <properties>
                       <help>Time in seconds that the prefix will remain preferred</help>

--- a/smoketest/scripts/cli/test_service_router-advert.py
+++ b/smoketest/scripts/cli/test_service_router-advert.py
@@ -376,5 +376,19 @@ class TestServiceRADVD(VyOSUnitTestSHIM.TestCase):
         tmp = f'autoignoreprefixes' + ' {'
         self.assertNotIn(tmp, config)
 
+    def test_base_interface(self):
+        self.cli_set(base_path + ['prefix', '::/64'])
+        self.cli_set(base_path + ['prefix', '::/64', 'base-interface', 'eth0'])
+        self.cli_commit()
+
+        config = read_file(RADVD_CONF)
+        self.assertIn('Base6Interface eth0;', config)
+
+        self.cli_set(base_path + ['prefix', '2001:db8:1234::/64'])
+        self.cli_set(
+            base_path + ['prefix', '2001:db8:1234::/64', 'base-interface', 'eth0']
+        )
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/src/conf_mode/service_router-advert.py
+++ b/src/conf_mode/service_router-advert.py
@@ -64,6 +64,9 @@ def verify(rtradv):
                 if not (int(valid_lifetime) >= int(preferred_lifetime)):
                     raise ConfigError('Prefix valid-lifetime must be greater then or equal to preferred-lifetime')
 
+                if 'base_interface' in prefix_config and prefix != '::/64':
+                    raise ConfigError('Prefix base-interface can only be used together with the wildcard prefix "::/64"')
+
         if 'nat64prefix' in interface_config:
             nat64_supported_lengths = [32, 40, 48, 56, 64, 96]
             for prefix, prefix_config in interface_config['nat64prefix'].items():


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Included changes:
- Add `base-interface` under:
  - `service router-advert interface <lan-if> prefix ::/64 base-interface <wan-if>`
- Render `Base6Interface <wan-if>;` in `radvd.conf` when configured.
- Add validation guard:
  - `base-interface` is only allowed with wildcard prefix `::/64`.
- Extend smoketests:
  - Positive case: `::/64` + `base-interface` commits and renders correctly.
  - Negative case: non-`::/64` prefix with `base-interface` fails commit.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8302
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-1x/pull/5004
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
