### PR TITLE
vrf: T8320: only allow alpha numerical characters, - and _ as VRF name

### DIFF
--- a/interface-definitions/include/constraint/vrf.xml.i
+++ b/interface-definitions/include/constraint/vrf.xml.i
@@ -2,5 +2,5 @@
 <constraint>
   <validator name="vrf-name"/>
 </constraint>
-<constraintErrorMessage>VRF instance name must be 15 characters or less and can not\nbe named as regular network interfaces.\nA name must starts from a letter.\n</constraintErrorMessage>
+<constraintErrorMessage>VRF instance name must be 15 characters or less and can not be named as a\nregular network interfaces. VRF name must start with a letter.\n</constraintErrorMessage>
 <!-- include end -->

--- a/src/validators/vrf-name
+++ b/src/validators/vrf-name
@@ -24,7 +24,13 @@ if __name__ == '__main__':
     vrf = argv[1]
     length = len(vrf)
 
+    # must not exceed Linux Kernel IFNAMSIZ definition
     if length not in range(1, 16):
+        exit(1)
+
+    # allow only alpha numerical characters, - and _
+    pattern = r'^[A-Za-z0-9_-]+$'
+    if not re.match(pattern, vrf):
         exit(1)
 
     # Treat loopback interface "lo" explicitly. Adding "lo" explicitly to the
@@ -33,6 +39,7 @@ if __name__ == '__main__':
     if vrf == "lo":
         exit(1)
 
+    # VRF name must not conflict with local interface type prefix
     pattern = r'^(?!(bond|br|dum|eth|lan|eno|ens|enp|enx|gnv|ipoe|l2tp|l2tpeth|\
        vtun|ppp|pppoe|peth|tun|vti|vxlan|wg|wlan|wwan|\d)\d*(\.\d+)?(v.+)?).*$'
     if not re.match(pattern, vrf):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
   

This prevents the Kernel to error out. VRF names are limited within the Linux  Kernal as any other network interface name. See `net/core/dev.c:dev_valid_name()!`

```
vyos@vyos# set vrf name MGM>T table 1000
vyos@vyos# commit
[ vrf ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 157, in run_script
    script.apply(c)
  File "/usr/libexec/vyos/conf_mode/vrf.py", line 317, in apply
    vrf_if.add_addr('127.0.0.1/8')
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 1294, in add_addr
    elif not is_intf_addr_assigned(self.ifname, addr, netns=netns):
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/utils/network.py", line 444, in is_intf_addr_assigned
    json_out = json.loads(out)
               ^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

[[vrf]] failed
Commit failed
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8320

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
vyos@vyos# set vrf name MGM>T

VRF instance name must be 15 characters or less and can not be named as a
regular network interfaces. Name must start with a letter.
Value validation failed
Set failed
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
