### PR TITLE
vpp: T8342: Add verification of members for bond and bridge interfaces

### DIFF
--- a/python/vyos/vpp/config_deps.py
+++ b/python/vyos/vpp/config_deps.py
@@ -74,3 +74,33 @@ def deps_bridge_dict(conf) -> dict[str, list[str]]:
             bridge_members_dict.update({member_name: bridge_ifaces_list})
 
     return bridge_members_dict
+
+
+def deps_bond_dict(conf) -> dict[str, list[str]]:
+    """Get a dict of all bonding interface members:
+
+        keys: members
+
+        values: bridge interfaces
+
+    Args:
+        conf (config): VyOS config object
+
+    Returns:
+        dict[str, list[str]]: dict of members
+    """
+    bond_members_dict: dict[str, list[str]] = {}
+    config = conf.get_config_dict(
+        ['interfaces', 'vpp', 'bonding'],
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+    )
+
+    for bond_name, bond_config in config.items():
+        for member_name in bond_config.get('member', {}).get('interface', []):
+            bond_ifaces_list = bond_members_dict.get(member_name, [])
+            bond_ifaces_list.append(bond_name)
+            bond_members_dict.update({member_name: bond_ifaces_list})
+
+    return bond_members_dict

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -45,6 +45,7 @@ from vyos.utils.process import is_systemd_service_active
 from vyos.vpp import VPPControl
 from vyos.vpp import control_host
 from vyos.vpp import VppNotRunningError
+from vyos.vpp.config_deps import deps_bond_dict
 from vyos.vpp.config_deps import deps_bridge_dict
 from vyos.vpp.config_deps import deps_xconnect_dict
 from vyos.vpp.config_verify import (
@@ -254,6 +255,7 @@ def get_config(config=None):
 
     xconn_members = deps_xconnect_dict(conf)
     bridge_members = deps_bridge_dict(conf)
+    bond_members = deps_bond_dict(conf)
 
     removed_ifaces = []
     tmp = node_changed(conf, base_settings + ['interface'])
@@ -295,6 +297,7 @@ def get_config(config=None):
             'removed_ifaces': removed_ifaces,
             'xconn_members': xconn_members,
             'bridge_members': bridge_members,
+            'bond_members': bond_members,
             'persist_config': eth_ifaces_persist,
             'interfaces_vpp': interfaces_config,
             'remove': {},
@@ -435,6 +438,7 @@ def get_config(config=None):
         config['removed_ifaces'] = removed_ifaces
         config['xconn_members'] = xconn_members
         config['bridge_members'] = bridge_members
+        config['bond_members'] = bond_members
 
     config['interfaces_vpp'] = interfaces_config
 
@@ -597,7 +601,7 @@ def verify(config):
                     f'RX mode {rx_mode} is not supported for interface {iface}'
                 )
 
-    # Check if deleted interfaces are not xconnect members or not bridge members
+    # Check if deleted interfaces are not xconnect/bridge/bond members
     for iface_config in config.get('removed_ifaces', []):
         if iface_config['iface_name'] in config.get('xconn_members', {}):
             raise ConfigError(
@@ -606,6 +610,10 @@ def verify(config):
         if iface_config['iface_name'] in config.get('bridge_members', {}):
             raise ConfigError(
                 f'Interface {iface_config["iface_name"]} is a bridge member and cannot be removed'
+            )
+        if iface_config['iface_name'] in config.get('bond_members', {}):
+            raise ConfigError(
+                f'Interface {iface_config["iface_name"]} is a bond member and cannot be removed'
             )
 
     verify_routes_count(config['settings'])

--- a/src/conf_mode/vpp_interfaces_bonding.py
+++ b/src/conf_mode/vpp_interfaces_bonding.py
@@ -24,6 +24,7 @@ from vyos.utils.assertion import assert_mac
 from vyos.utils.process import is_systemd_service_active
 
 from vyos.ifconfig.vpp import VPPBondInterface
+from vyos.vpp.config_deps import deps_bond_dict
 from vyos.vpp.config_deps import deps_bridge_dict
 from vyos.vpp.config_deps import deps_xconnect_dict
 from vyos.vpp.config_verify import verify_vpp_remove_bridge_interface
@@ -92,6 +93,8 @@ def get_config(config=None) -> dict:
         no_tag_node_value_mangle=True,
     )
 
+    config['bond_members'] = deps_bond_dict(conf)
+
     # Dependency
     config['xconn_members'] = deps_xconnect_dict(conf)
     if ifname in config['xconn_members']:
@@ -139,6 +142,21 @@ def verify(config):
     for iface in config.get('member', {}).get('interface', []):
         if iface not in config['vpp_ifaces']:
             raise ConfigError(f'{iface} must be a VPP interface for bonding')
+
+        # Each interface can belong only to one bond
+        bond_members = config['bond_members'][iface]
+        if len(bond_members) > 1:
+            raise ConfigError(
+                f'Interface {iface} cannot be a member of multiple bonding interfaces: {", ".join(bond_members)}'
+            )
+
+        # Interface cannot be a member of a bridge and a bond at the same time
+        bridge_members = config['bridge_members'].get(iface)
+        if bridge_members:
+            raise ConfigError(
+                f'Interface {iface} cannot be a member of a bond because '
+                f'it already belongs to bridge interface: {", ".join(bridge_members)}.'
+            )
 
     if 'mac' in config:
         mac = config['mac']

--- a/src/conf_mode/vpp_interfaces_bridge.py
+++ b/src/conf_mode/vpp_interfaces_bridge.py
@@ -22,6 +22,8 @@ from vyos import ConfigError
 from vyos.utils.process import is_systemd_service_active
 
 from vyos.ifconfig.vpp import VPPBridgeInterface
+from vyos.vpp.config_deps import deps_bond_dict
+from vyos.vpp.config_deps import deps_bridge_dict
 
 
 def get_config(config=None) -> dict:
@@ -63,6 +65,9 @@ def get_config(config=None) -> dict:
         with_recursive_defaults=True,
     )
 
+    config['bond_members'] = deps_bond_dict(conf)
+    config['bridge_members'] = deps_bridge_dict(conf)
+
     return config
 
 
@@ -90,6 +95,21 @@ def verify(config):
             ):
                 raise ConfigError(
                     f"Interface '{member}' not found in 'vpp settings interface' or does not start with allowed prefixes {allowed_prefixes}"
+                )
+
+            # Each interface can belong only to one bridge
+            bridge_members = config['bridge_members'][member]
+            if len(bridge_members) > 1:
+                raise ConfigError(
+                    f'Interface {member} is added to more than one bridge: {", ".join(bridge_members)}'
+                )
+
+            # Interface cannot be a member of a bridge and a bond at the same time
+            bond_members = config['bond_members'].get(member)
+            if bond_members:
+                raise ConfigError(
+                    f'Interface {member} cannot be a member of a bridge '
+                    f'because it already belongs to bonding interface: {", ".join(bond_members)}.'
                 )
 
             # Check if BVI is already defined, only one BVI per bridge domain is allowed


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8342
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# run show configuration commands | grep bond
set interfaces vpp bonding vppbond1 address '100.64.111.1/24'
set interfaces vpp bonding vppbond1 member interface 'eth1'
set interfaces vpp bonding vppbond1 member interface 'eth2'
set interfaces vpp bonding vppbond1 mode '802.3ad'
[edit]
vyos@vyos# set interfaces vpp bonding vppbond2 member interface eth1
[edit]
vyos@vyos# commit
[ interfaces vpp bonding vppbond2 ]
Interface eth1 cannot be a member of multiple bonding interfaces:
vppbond1, vppbond2

[[interfaces vpp bonding vppbond2]] failed
Commit failed
[edit]

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
