### PR TITLE
openvpn: T8304: fix migration for des, bf128 or bf256 cipher; use 3des instead

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_openvpn.py
+++ b/smoketest/scripts/cli/test_interfaces_openvpn.py
@@ -642,6 +642,12 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
             self.cli_commit()
         self.cli_set(path + ['shared-secret-key', 'ovpn_test'])
 
+        # check validate() - Must define "encryption cipher" or "encryption
+        # data-ciphers-fallback" for site-to-site encryption
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(path + ['encryption', 'cipher', '3des'])
+
         self.cli_commit()
 
     def test_openvpn_options(self):

--- a/src/conf_mode/interfaces_openvpn.py
+++ b/src/conf_mode/interfaces_openvpn.py
@@ -367,6 +367,11 @@ def verify(openvpn):
         if dict_search('encryption.data_ciphers', openvpn):
             raise ConfigError('Cipher negotiation can only be used in client or server mode')
 
+        if not dict_search('encryption.cipher', openvpn) and \
+           not dict_search('encryption.data_ciphers_fallback', openvpn):
+            raise ConfigError('Must define "encryption cipher" or "encryption ' \
+                              'data-ciphers-fallback" for site-to-site encryption!')
+
     else:
         # checks for client-server or site-to-site bridged
         if 'local_address' in openvpn or 'remote_address' in openvpn:

--- a/src/migration-scripts/openvpn/0-to-1
+++ b/src/migration-scripts/openvpn/0-to-1
@@ -17,6 +17,8 @@
 
 from vyos.configtree import ConfigTree
 
+updated_cipher='3des'
+
 def migrate(config: ConfigTree) -> None:
     if not config.exists(['interfaces', 'openvpn']):
         # Nothing to do
@@ -25,6 +27,7 @@ def migrate(config: ConfigTree) -> None:
     ovpn_intfs = config.list_nodes(['interfaces', 'openvpn'])
     for	i in ovpn_intfs:
         # Remove DES and Blowfish from 'encryption cipher'
+        # Support for these insecure ciphers will be removed in OpenVPN 2.6.
         cipher_path = ['interfaces', 'openvpn', i, 'encryption', 'cipher']
         if config.exists(cipher_path):
             cipher = config.return_value(cipher_path)
@@ -41,3 +44,11 @@ def migrate(config: ConfigTree) -> None:
         if config.exists(['interfaces', 'openvpn', i, 'encryption']) and \
            (config.list_nodes(['interfaces', 'openvpn', i, 'encryption']) == []):
             config.delete(['interfaces', 'openvpn', i, 'encryption'])
+
+        # We need to take care about site-to-site tunnels which had an implicit
+        # OpenVPN default cipher (BF-CBC) with block size less than 128 bit (64 bit).
+        mode_path = ['interfaces', 'openvpn', i, 'mode']
+        if config.exists(mode_path) and config.return_value(mode_path) == 'site-to-site':
+            # if no explicit cipher is defined, we will "upgrade" to 3DES at least
+            if not config.exists(cipher_path):
+                config.set(cipher_path, value=updated_cipher)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

This extends the CLI migration from commit 941c5adfaca2c7 (`openvpn: T5634: Remove support for insecure DES and Blowfish ciphers`) by not only deleting insecure DES and Blowfish ciphers, but providing an alternative (3DES).

If no cipher is defined, this will result in OpenVPN service not starting at all, as the implicit defined BF-CBC cipher is no longer supported by OpenSSL 3.0.0.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8304

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-1x/pull/2353

## How to test / Smoketest result

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_openvpn.py
test_openvpn_client_interfaces (__main__.TestInterfacesOpenVPN.test_openvpn_client_interfaces) ... ok
test_openvpn_client_ip_version (__main__.TestInterfacesOpenVPN.test_openvpn_client_ip_version) ... ok
test_openvpn_client_verify (__main__.TestInterfacesOpenVPN.test_openvpn_client_verify) ... ok
test_openvpn_options (__main__.TestInterfacesOpenVPN.test_openvpn_options) ... ok
test_openvpn_server_ip_version (__main__.TestInterfacesOpenVPN.test_openvpn_server_ip_version) ... ok
test_openvpn_server_server_bridge (__main__.TestInterfacesOpenVPN.test_openvpn_server_server_bridge) ... ok
test_openvpn_server_subnet_topology (__main__.TestInterfacesOpenVPN.test_openvpn_server_subnet_topology) ... ok
test_openvpn_server_verify (__main__.TestInterfacesOpenVPN.test_openvpn_server_verify) ... ok
test_openvpn_site2site_interfaces_tun (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_interfaces_tun) ... ok
test_openvpn_site2site_ip_version (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_ip_version) ... ok
test_openvpn_site2site_verify (__main__.TestInterfacesOpenVPN.test_openvpn_site2site_verify) ... ok
test_site2site_data_ciphers_fallback (__main__.TestInterfacesOpenVPN.test_site2site_data_ciphers_fallback) ... ok

----------------------------------------------------------------------
Ran 12 tests in 88.983s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
