### PR TITLE
opmode: T8343: implement common verify_cli_exists() helper

### DIFF
--- a/python/vyos/opmode.py
+++ b/python/vyos/opmode.py
@@ -16,8 +16,9 @@
 import re
 import sys
 import typing
-from humps import decamelize
 
+from humps import decamelize
+from vyos.configquery import ConfigTreeQuery
 
 class Error(Exception):
     """Any error that makes requested operation impossible to complete
@@ -327,3 +328,28 @@ def run(module):
         # Other functions should not return anything,
         # although they may print their own warnings or status messages
         func(**args)
+
+def verify_cli_exists(cli_path: list, error_msg: str=''):
+    """Decorator checks if CLI config exists using a dynamic path and error message"""
+    def decorator(func):
+        from functools import wraps
+
+        @wraps(func)
+        def _wrapper(*args, **kwargs):
+            config = ConfigTreeQuery()
+            interface = kwargs.get('intf_name')
+
+            # Combine the base CLI path with the specific interface name
+            path = cli_path + [interface] if interface else cli_path
+
+            if not config.exists(path):
+                if not error_msg:
+                    unconf_message = f'CLI path [{" ".join(cli_path)}] unconfigured!'
+                else:
+                    # Format the error message dynamically to allow {interface} injection
+                    unconf_message = error_msg.format(interface=interface)
+                raise UnconfiguredSubsystem(unconf_message)
+            return func(*args, **kwargs)
+
+        return _wrapper
+    return decorator

--- a/src/op_mode/interfaces_wireguard.py
+++ b/src/op_mode/interfaces_wireguard.py
@@ -18,30 +18,12 @@ import sys
 import vyos.opmode
 
 from vyos.ifconfig import WireGuardIf
-from vyos.configquery import ConfigTreeQuery
 
-
-def _verify(func):
-    """Decorator checks if WireGuard interface config exists"""
-    from functools import wraps
-
-    @wraps(func)
-    def _wrapper(*args, **kwargs):
-        config = ConfigTreeQuery()
-        interface = kwargs.get('intf_name')
-        if not config.exists(['interfaces', 'wireguard', interface]):
-            unconf_message = f'WireGuard interface {interface} is not configured'
-            raise vyos.opmode.UnconfiguredSubsystem(unconf_message)
-        return func(*args, **kwargs)
-
-    return _wrapper
-
-
-@_verify
+@vyos.opmode.verify_cli_exists(['interfaces', 'wireguard'],
+    'WireGuard interface {interface} is not configured!')
 def show_summary(raw: bool, intf_name: str):
     intf = WireGuardIf(intf_name, create=False, debug=False)
     return intf.operational.show_interface()
-
 
 if __name__ == '__main__':
     try:

--- a/src/op_mode/interfaces_wireless.py
+++ b/src/op_mode/interfaces_wireless.py
@@ -23,18 +23,9 @@ from tabulate import tabulate
 from vyos.utils.process import popen
 from vyos.configquery import ConfigTreeQuery
 
-def _verify(func):
-    """Decorator checks if Wireless LAN config exists"""
-    from functools import wraps
-
-    @wraps(func)
-    def _wrapper(*args, **kwargs):
-        config = ConfigTreeQuery()
-        if not config.exists(['interfaces', 'wireless']):
-            unconf_message = 'No Wireless interfaces configured'
-            raise vyos.opmode.UnconfiguredSubsystem(unconf_message)
-        return func(*args, **kwargs)
-    return _wrapper
+verify_path = ['interfaces', 'wireless']
+verify_error = 'Wireless/WiFi subsystem unconfigured!'
+verify_interface_error = 'Wireless interface {interface} is not configured!'
 
 def _get_raw_info_data():
     output_data = []
@@ -156,7 +147,7 @@ def _format_station_data(raw_data):
     headers = ["Station", "Signal", "RX bytes", "RX packets", "TX bytes", "TX packets"]
     return tabulate(output, headers, numalign="left")
 
-@_verify
+@vyos.opmode.verify_cli_exists(verify_path, verify_error)
 def show_info(raw: bool):
     info_data = _get_raw_info_data()
     if raw:
@@ -169,7 +160,7 @@ def show_scan(raw: bool, intf_name: str):
         return data
     return _format_scan_data(data)
 
-@_verify
+@vyos.opmode.verify_cli_exists(verify_path, verify_interface_error)
 def show_stations(raw: bool, intf_name: str):
     data = _get_raw_station_data(intf_name)
     if raw:

--- a/src/op_mode/reset_wireguard.py
+++ b/src/op_mode/reset_wireguard.py
@@ -16,34 +16,15 @@
 
 import sys
 import typing
-
 import vyos.opmode
 
 from vyos.ifconfig import WireGuardIf
-from vyos.configquery import ConfigTreeQuery
 
-
-def _verify(func):
-    """Decorator checks if WireGuard interface config exists"""
-    from functools import wraps
-
-    @wraps(func)
-    def _wrapper(*args, **kwargs):
-        config = ConfigTreeQuery()
-        interface = kwargs.get('interface')
-        if not config.exists(['interfaces', 'wireguard', interface]):
-            unconf_message = f'WireGuard interface {interface} is not configured'
-            raise vyos.opmode.UnconfiguredSubsystem(unconf_message)
-        return func(*args, **kwargs)
-
-    return _wrapper
-
-
-@_verify
+@vyos.opmode.verify_cli_exists(['interfaces', 'wireguard'],
+    'WireGuard interface {interface} is not configured!')
 def reset_peer(interface: str, peer: typing.Optional[str] = None):
     intf = WireGuardIf(interface, create=False, debug=False)
     return intf.operational.reset_peer(peer)
-
 
 if __name__ == '__main__':
     try:

--- a/src/op_mode/vpp.py
+++ b/src/op_mode/vpp.py
@@ -23,30 +23,7 @@ from vyos.vpp import VPPControl
 from vyos.configquery import ConfigTreeQuery
 import vyos.opmode
 
-
 NO_INDEX = 0xFFFFFFFF
-
-
-def _verify(target: typing.Optional[str]):
-    """Decorator checks if config for VPP feature exists"""
-    from functools import wraps
-
-    path = target.split() if target else []
-
-    def _verify_target(func):
-        @wraps(func)
-        def _wrapper(*args, **kwargs):
-            config = ConfigTreeQuery()
-            if not config.exists(path):
-                raise vyos.opmode.UnconfiguredSubsystem(
-                    f'"{" ".join(path)}" is not configured'
-                )
-            return func(*args, **kwargs)
-
-        return _wrapper
-
-    return _verify_target
-
 
 class VPPShow:
     RX_STATES = {
@@ -361,6 +338,7 @@ class VPPShow:
         cmd_command = f'show bridge-domain {bd_id} detail'
         data = self.vpp.cli_cmd(cmd_command)
 
+
         if raw:
             return [data.reply]
 
@@ -370,46 +348,39 @@ class VPPShow:
 # -----------------------------
 # VyOS IPFIX op-mode entries
 # -----------------------------
-@_verify('vpp ipfix interface')
+@vyos.opmode.verify_cli_exists(['vpp', 'ipfix', 'interface'])
 def show_ipfix_interfaces(raw: bool):
     return VPPShow().ipfix_interfaces(raw)
 
-
-@_verify('vpp ipfix collector')
+@vyos.opmode.verify_cli_exists(['vpp', 'ipfix', 'collector'])
 def show_ipfix_collectors(raw: bool):
     return VPPShow().ipfix_collectors(raw)
 
-
-@_verify('vpp ipfix')
+@vyos.opmode.verify_cli_exists(['vpp', 'ipfix'])
 def show_ipfix_table(raw: bool):
     return VPPShow().ipfix_table(raw)
-
 
 # -----------------------------
 # VPP LACP information
 # -----------------------------
-@_verify('interfaces vpp bonding')
+@vyos.opmode.verify_cli_exists(['interfaces', 'vpp', 'bonding'])
 def show_lacp(raw: bool, ifname: typing.Optional[str]):
     return VPPShow().lacp_info(raw, ifname)
 
-
-@_verify('interfaces vpp bonding')
+@vyos.opmode.verify_cli_exists(['interfaces', 'vpp', 'bonding'])
 def show_lacp_details(raw: bool, ifname: typing.Optional[str]):
     return VPPShow().lacp_details(raw, ifname)
 
-
 # -----------------------------
-# Bridge op-mode entries
+# Bridge op-mode entrie
 # -----------------------------
-@_verify('interfaces vpp bridge')
+@vyos.opmode.verify_cli_exists(['interfaces', 'vpp', 'bridge'])
 def show_bridge(raw: bool, ifname: typing.Optional[str] = None):
     return VPPShow().bridge_domain(raw, ifname)
 
-
-@_verify('interfaces vpp bridge')
+@vyos.opmode.verify_cli_exists(['interfaces', 'vpp', 'bridge'])
 def show_bridge_details(raw: bool, ifname: typing.Optional[str] = None):
     return VPPShow().bridge_domain_details(raw, ifname)
-
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Instead of re-defining a per module helper which verifies that a given CLI path exists during execution, rather create a generic representation which takes a CLI path (list) as argument with an optional error message to display on the CLI.

This is the initial implementation of the generic helper with some migrations for VPP, WireGuard and Wireless interfaces. More opmode scripts should follow.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8343

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
vyos@vyos:~$ show interfaces wireguard wg0 summary
WireGuard interface wg0 is not configured
```

```
vyos@vyos:~$ show interfaces wireless wlan0 stations
Wireless interface wlan0 is not configured!
```

```
vyos@vyos:~$ show vpp bridge
CLI path [interfaces vpp bridge] unconfigured!
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
