### PR TITLE
T7513: CGNAT show exclude rules - all protocol value fix

### DIFF
--- a/src/op_mode/vpp_nat_cgnat.py
+++ b/src/op_mode/vpp_nat_cgnat.py
@@ -134,7 +134,7 @@ def show_exclude_rules(raw: bool):
 
     data_entries = []
     for m in mappings:
-        proto_map = {0: 'all', 1: 'icmp', 6: 'tcp', 17: 'udp'}
+        proto_map = {0: 'all', 1: 'icmp', 6: 'tcp', 17: 'udp', 255: 'all'}
         proto_name = proto_map.get(m.get('protocol'), str(m.get('protocol')))
         port_str = str(m.get('port')) if m.get('port') else 'any'
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
In  op-mode cmd for show cgnat exclude rules, the default protocol value for the case of all protocols should be printed as 'all' instead of 255. Added a fix to print the value as 'all'

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T7513

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vpp/pull/45

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# set vpp nat cgnat exclude rule 1 local-address 192.168.65.8
vyos@vyos#  set vpp nat cgnat exclude rule 1 local-port 53
vyos@vyos# set vpp nat cgnat exclude rule 1 protocol udp
vyos@vyos# set vpp nat cgnat exclude rule 2 local-address  100.64.0.10
vyos@vyos# commit

vyos@vyos# sho  vpp nat cgnat exclude rule
 rule 1 {
     local-address 192.168.65.8
     local-port 53
     protocol udp
 }
 rule 2 {
     local-address 100.64.0.10
 }

vyos@vyos# exit
vyos@vyos:~$ show vpp nat cgnat exclude-rules
Address       Protocol    Port      VRF  Description
------------  ----------  ------  -----  -------------
100.64.0.10   all         any         0
192.168.65.8  udp         53          0


```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
