### PR TITLE
op-mode: T8362: "compare" command lacks catch_broken_pipe decorator

### DIFF
--- a/python/vyos/config_mgmt.py
+++ b/python/vyos/config_mgmt.py
@@ -43,6 +43,7 @@ from vyos.load_config import LoadConfigError
 from vyos.defaults import directories
 from vyos.version import get_full_version_data
 from vyos.utils.io import ask_yes_no
+from vyos.utils.io import catch_broken_pipe
 from vyos.utils.boot import boot_configuration_complete
 from vyos.utils.process import is_systemd_service_active
 from vyos.utils.process import rc_cmd
@@ -560,6 +561,7 @@ Proceed ?"""
         ret = tabulate(res_l, tablefmt='plain')
         return ret
 
+    @catch_broken_pipe
     def show_commit_diff(
         self, rev: int, rev2: Optional[int] = None, commands: bool = False
     ) -> str:
@@ -800,6 +802,7 @@ Proceed ?"""
 
 # entry_point for console script
 #
+@catch_broken_pipe
 def run():
     from argparse import ArgumentParser, REMAINDER
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

When compare calculation is still in progress and it should be abourted by Ctrl+C, prevent a backtrace and catch the KeyboardInterrupt.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8362

## How to test / Smoketest result
```
vyos@vyos# compare
Ctrl+C
:...skipping...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
