### PR TITLE
vpp: T8356: Fix traceback when adding a VPP bridge without members

### DIFF
--- a/python/vyos/ifconfig/vpp/bridge.py
+++ b/python/vyos/ifconfig/vpp/bridge.py
@@ -16,6 +16,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from vyos.ifconfig.vpp.interface import VPPInterface
+from vyos.utils.dict import dict_search
 from vyos.vpp.utils import iftunnel_transform
 
 
@@ -123,9 +124,9 @@ class VPPBridgeInterface(VPPInterface):
         self.add()
 
         # Add members to bridge
-        for member, member_config in (
-            config.get('member', {}).get('interface', []).items()
-        ):
+        for member, member_config in dict_search(
+            'member.interface', config, {}
+        ).items():
             member = member.removeprefix('vpp')
             if member.startswith('vxlan'):
                 member = iftunnel_transform(member)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe): 
## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8356
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Before the fix:
```
vyos@vyos# set interfaces vpp bridge vppbr10
[edit]
vyos@vyos# commit
[ interfaces vpp bridge vppbr10 ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 157, in run_script
    script.apply(c)
  File "/usr/libexec/vyos/conf_mode/vpp_interfaces_bridge.py", line 131, in apply
    bridge.update(config)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/vpp/bridge.py", line 127, in update
    config.get('member', {}).get('interface', []).items()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'items'

[[interfaces vpp bridge vppbr10]] failed
Commit failed
[edit]
```
After:
```
vyos@vyos# commit
[edit]
vyos@vyos# run show vpp bridge
BD-ID    Age(min)    Learning    U-Forwrd    UU-Flood    Flooding    ARP-Term    arp-ufwd    BVI-Intf
-------  ----------  ----------  ----------  ----------  ----------  ----------  ----------  ----------
10       off         on          on          flood       on          off         off         N/A
[edit]
vyos@vyos#
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
