### PR TITLE
T8370: VPP cosmetic fix for verify buffers path

### DIFF
--- a/python/vyos/vpp/config_verify.py
+++ b/python/vyos/vpp/config_verify.py
@@ -34,7 +34,7 @@ def verify_vpp_remove_xconnect_interface(config: dict):
         if xconn_member == config.get('ifname'):
             raise ConfigError(
                 f'interface "{xconn_member}" is still in use within "interfaces vpp xconnect". '
-                f'Please remove it from "interface vpp xconnect {xconn_iface}" before proceeding.'
+                f'Please remove it from "interfaces vpp xconnect {xconn_iface}" before proceeding.'
             )
 
 
@@ -45,7 +45,7 @@ def verify_vpp_remove_bridge_interface(config: dict):
         if bridge_member == config.get('ifname'):
             raise ConfigError(
                 f'interface "{bridge_member}" is still in use within "interfaces vpp bridge". '
-                f'Please remove it from "interface vpp bridge {bridge_iface}" before proceeding.'
+                f'Please remove it from "interfaces vpp bridge {bridge_iface}" before proceeding.'
             )
 
 
@@ -339,5 +339,5 @@ def verify_vpp_buffers(settings: dict):
     if buffers_required > buffers_configured:
         raise ConfigError(
             'Not enough buffers to initialize RX/TX queues for interfaces. '
-            f'Set "vpp settings buffers buffers-per-numa" to {buffers_required} or higher'
+            f'Set "vpp settings resource-allocation buffers buffers-per-numa" to {buffers_required} or higher'
         )


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
VPP cosmetic fix for verify buffers path
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T8370

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
