### PR TITLE
vpp: T8315: Add support for configuring unsupported NICs and update compatible list

### DIFF
--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -491,6 +491,12 @@
           <defaultValue>0</defaultValue>
         </leafNode>
         #include <include/vpp/iface_rx_mode.xml.i>
+        <leafNode name="allow-unsupported-nics">
+          <properties>
+            <help>Allow the attachment of unsupported NICs to VPP. This operation voids official support for the system</help>
+            <valueless/>
+          </properties>
+        </leafNode>
       </children>
     </node>
     <node name="sflow" owner="${vyos_conf_scripts_dir}/vpp_sflow.py">

--- a/python/vyos/vpp/config_verify.py
+++ b/python/vyos/vpp/config_verify.py
@@ -62,68 +62,6 @@ def verify_vpp_tunnel_source_address(config: dict):
     )
 
 
-def verify_dev_driver(driver_type: str, driver: str) -> bool:
-    # Lists of drivers compatible with DPDK and XDP
-    drivers_dpdk: list[str] = [
-        'atlantic',
-        'bnx2x',
-        'e1000',
-        'ena',
-        'gve',
-        'hv_netvsc',
-        'i40e',
-        'ice',
-        'igc',
-        'ixgbe',
-        'ixgbevf',
-        'liquidio',
-        'mlx4_core',
-        'mlx5_core',
-        'qede',
-        'sfc',
-        'tap',
-        'tun',
-        'virtio_net',
-        'vmxnet3',
-    ]
-
-    drivers_xdp: list[str] = [
-        'atlantic',
-        'ena',
-        'gve',
-        'hv_netvsc',
-        'i40e',
-        'ice',
-        'igb',
-        'igc',
-        'ixgbe',
-        'mlx4_core',
-        'mlx5_core',
-        'qede',
-        'sfc',
-        'tap',
-        'tun',
-        'virtio_net',
-        'vmxnet3',
-    ]
-
-    if driver_type == 'dpdk':
-        if driver in drivers_dpdk:
-            return True
-    # XDP support is intentionally disabled (T8202).
-    # XDP is no longer configurable via the CLI.
-    # This logic is kept commented out to make it easy
-    # to reintroduce XDP if there is a clear need in the future.
-    #
-    # elif driver_type == 'xdp':
-    #     if driver in drivers_xdp:
-    #         return True
-    else:
-        raise ConfigError(f'"Driver type {driver_type} is wrong')
-
-    return False
-
-
 def create_cpu_error_message(cpus_required: int, cpus_available: int = None) -> str:
     cpu_info = get_cpus()
     logical_cores = sum(

--- a/python/vyos/vpp/control_host.py
+++ b/python/vyos/vpp/control_host.py
@@ -313,6 +313,42 @@ def get_eth_driver(iface: str) -> str:
         raise Exception(f'Could not determine driver for "{iface}": {error}') from error
 
 
+def get_pci_id(iface: str) -> str | None:
+    """
+    Retrieves the PCI ID for a specified network interface.
+
+    Args:
+        iface (str): The name of the network interface (e.g., 'eth0').
+
+    Raises:
+        OSError: The interface cannot be resolved or PCI ID files cannot be read
+
+    Returns:
+        str: The PCI ID in the format 'vendor:device'.
+        None: In case a NIC is not on a PCI bus.
+    """
+    dev_id = get_dev_id(iface)
+
+    # Check if this device is on a PCI bus, return `None` if this is not a PCI device
+    pci_dev_path = Path(f'/sys/bus/pci/devices/{dev_id}')
+    if not pci_dev_path.exists():
+        return None
+
+    # Read vendor and device IDs
+    def _read_bus(file: str) -> str:
+        path = Path(f'/sys/bus/pci/devices/{dev_id}/{file}')
+        return path.read_text().removeprefix('0x').strip()
+
+    try:
+        device_id, vendor_id = _read_bus('device'), _read_bus('vendor')
+    except OSError as e:
+        # If we reached this exception, then something really weird happened,
+        # but it is still right to have it
+        raise OSError(f'PCI IDs for {iface} cannot be retrieved') from e
+
+    return f'{vendor_id}:{device_id}'.lower()
+
+
 def unsafe_noiommu_mode(status: bool) -> None:
     """Control unsafe_noiommu_mode parameter of vfio module
 

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -48,7 +48,6 @@ from vyos.vpp import VppNotRunningError
 from vyos.vpp.config_deps import deps_bridge_dict
 from vyos.vpp.config_deps import deps_xconnect_dict
 from vyos.vpp.config_verify import (
-    verify_dev_driver,
     verify_vpp_minimum_cpus,
     verify_vpp_minimum_memory,
     verify_vpp_cpu_cores,
@@ -111,6 +110,21 @@ drivers_support_interrupt: dict[str, list] = {
 
 # drivers that require changing channels (half the maximum number of RX/TX queues)
 ethtool_channels_change_drv: list[str] = ['ena', 'gve']
+
+# List of NICs where VPP activation is supported
+SUPPORTED_PCI_IDS = (
+    '15b3:1019',  # Mellanox Technologies MT28800 Family [ConnectX-5 Ex]
+    '15b3:101d',  # Mellanox Technologies MT2892 Family [ConnectX-6 Dx]
+    '15b3:101e',  # Mellanox Technologies ConnectX Family mlx5Gen Virtual Function
+    '8086:1592',  # Intel Corporation Ethernet Controller E810-C for QSFP
+    '1ae0:0042',  # Google, Inc. Compute Engine Virtual Ethernet [gVNIC]
+    '1af4:1000',  # Red Hat, Inc. Virtio network device (legacy ID)
+    '1af4:1041',  # Red Hat, Inc. Virtio network device (modern ID)
+    '1d0f:ec20',  # Amazon.com, Inc. Elastic Network Adapter (ENA)
+)
+SUPPORTED_DRIVERS = (
+    'hv_netvsc',  # Microsoft Hyper-V network interface card
+)
 
 
 def _load_module(module_name: str):
@@ -223,6 +237,29 @@ def _check_removed_interfaces(config: dict, feature_name: str, interfaces_config
                 f'Cannot remove interface {iface_name} - it is currently configured for {feature_name}. '
                 f'Remove it from {feature_name} configuration first.'
             )
+
+
+def _is_device_allowed(config: dict, iface: str):
+    """
+    Determines if a network interface device is allowed to be used
+    with VPP based on its PCI ID or driver.
+    """
+    if 'allow_unsupported_nics' in config['settings']:
+        return True
+
+    persist_config = config['persist_config'][iface]
+
+    pci_id = persist_config.get('pci_id')
+    # PCI ID is sufficient by itself, if presented
+    if pci_id is not None and pci_id in SUPPORTED_PCI_IDS:
+        return True
+
+    # If the PCI ID did not match or does not exist, fall back to a driver
+    original_driver = persist_config.get('original_driver')
+    if original_driver is not None and original_driver in SUPPORTED_DRIVERS:
+        return True
+
+    return False
 
 
 def get_config(config=None):
@@ -344,6 +381,7 @@ def get_config(config=None):
             }
             eth_ifaces_persist[iface]['bus_id'] = control_host.get_bus_name(iface)
             eth_ifaces_persist[iface]['dev_id'] = control_host.get_dev_id(iface)
+            eth_ifaces_persist[iface]['pci_id'] = control_host.get_pci_id(iface)
             eth_ifaces_persist[iface]['channels'] = control_host.get_eth_channels(iface)
 
     # Return to config dictionary
@@ -554,10 +592,13 @@ def verify(config):
             not in config.get('effective', {}).get('settings', {}).get('interface', {})
             or 'driver_changed' in iface_config
         ):
-            if not verify_dev_driver(iface_config['driver'], original_driver):
+            if not _is_device_allowed(config, iface):
                 raise ConfigError(
-                    f'Driver {iface_config["driver"]} is not compatible with interface {iface}!'
+                    f'NIC used by "{iface}" is not validated for VPP on VyOS. '
+                    'Using it is unsafe and unsupported and will void support for the entire system. '
+                    'To proceed at your own risk, enable: "set vpp settings allow-unsupported-nics".'
                 )
+
         if iface_config['driver'] == 'xdp' and 'xdp_options' in iface_config:
             if iface_config['xdp_options']['num_rx_queues'] != 'all':
                 rx_queues = iface_config['xdp_api_params']['rxq_num']


### PR DESCRIPTION
## Change summary
 - Update current compatible NICs list.
 - Introduce `set vpp settings allow-unsupported-nics` to permit VPP activation on hardware not present in the validated NIC list.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8315

## Related PR(s)
* https://github.com/vyos/vyos-documentation/pull/1792

## How to test / Smoketest result
### Manual test
```
vyos@vyos# set vpp settings interface eth0
[edit]
vyos@vyos# commit
[ vpp ]
NIC used by "eth0" is not validated for VPP on VyOS. Using it is unsafe
and unsupported and will void support for the entire system. To proceed
at your own risk, enable: "set vpp settings allow-unsupported-nics".
[[vpp]] failed
Commit failed
[edit]
vyos@vyos# lspci -nn | grep Ethernet
00:03.0 Ethernet controller [0200]: Red Hat, Inc. Virtio network device [1af4:1000]
00:04.0 Ethernet controller [0200]: Intel Corporation 82574L Gigabit Network Connection [8086:10d3]
00:05.0 Ethernet controller [0200]: Intel Corporation 82574L Gigabit Network Connection [8086:10d3]
[edit]
vyos@vyos# ethtool -i eth0
driver: e1000e
version: 6.6.128-vyos
firmware-version: 2.1-0
expansion-rom-version:
bus-info: 0000:00:04.0
...
[edit]
vyos@vyos# set vpp settings allow-unsupported-nics
[edit]
vyos@vyos# commit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly