### PR TITLE
T8371: VPP add op-mode command show runtime

### DIFF
--- a/op-mode-definitions/show_vpp_runtime.xml.in
+++ b/op-mode-definitions/show_vpp_runtime.xml.in
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<interfaceDefinition>
+  <node name="show">
+    <children>
+      <node name="vpp">
+        <children>
+          <node name="runtime">
+            <properties>
+              <help>Show VPP runtime statistics</help>
+            </properties>
+            <command>sudo ${vyos_op_scripts_dir}/vpp.py show_runtime</command>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
+</interfaceDefinition>

--- a/src/op_mode/vpp.py
+++ b/src/op_mode/vpp.py
@@ -344,6 +344,22 @@ class VPPShow:
 
         return data.reply
 
+    # -----------------------------
+    # Runtime table
+    # -----------------------------
+    def _get_runtime_raw(self):
+        # VPP does not have API call to get this data
+        data = self.vpp.cli_cmd('show runtime')
+        return [data.reply]
+
+    def _show_runtime_formatted(self) -> str:
+        data = self.vpp.cli_cmd('show runtime')
+        return data.reply
+
+    def runtime(self, raw: bool):
+        data = self._get_runtime_raw()
+        return data if raw else self._show_runtime_formatted()
+
 
 # -----------------------------
 # VyOS IPFIX op-mode entries
@@ -381,6 +397,14 @@ def show_bridge(raw: bool, ifname: typing.Optional[str] = None):
 @vyos.opmode.verify_cli_exists(['interfaces', 'vpp', 'bridge'])
 def show_bridge_details(raw: bool, ifname: typing.Optional[str] = None):
     return VPPShow().bridge_domain_details(raw, ifname)
+
+# -----------------------------
+# show runtime
+# -----------------------------
+@vyos.opmode.verify_cli_exists(['vpp'])
+def show_runtime(raw: bool):
+    return VPPShow().runtime(raw)
+
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
VPP add op-mode command `show vpp runtime`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T8371

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
vyos@r14:~$ show vpp runtime | head -16
Time 2550.6, 10 sec internal node vector rate 1.05 loops/sec 432.85
  vector rates in 5.9897e0, out 4.9816e0, drop 1.0100e0, punt 8.3413e-4
             Name                 State         Calls          Vectors        Suspends         Clocks       Vectors/Call  
acl-plugin-fa-cleaner-process "event wait"               0               0               1          4.19e4            0.00
admin-up-down-process         "event wait"               0               0               1          1.82e4            0.00
api-rx-from-ring                "running"                0               0             189          4.86e5            0.00
arp-input                        active                  9              11               0          1.73e3            1.22
arp-reply                        active                  6               7               0          6.46e4            1.17
avf-process                   "event wait"               0               0               1          1.40e4            0.00
bfd-process                   "event wait"               0               0               1          5.43e3            0.00
bond-process                  "event wait"               0               0               1          6.21e3            0.00
deleted-503                   "not started               1               0               0          2.13e4            0.00
dhcp-client-process            "any wait"                0               0               3          2.01e4            0.00
dhcp6-client-cp-process        "any wait"                0               0               1          7.06e3            0.00
dhcp6-pd-client-cp-process     "any wait"                0               0               1          6.69e3            0.00
dhcp6-pd-reply-publisher-proce"event wait"               0               0               1          7.47e3            0.00
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
