### PR TITLE
T8357: Allow prefix vpp for show interfaces

### DIFF
--- a/python/vyos/ifconfig/section.py
+++ b/python/vyos/ifconfig/section.py
@@ -97,7 +97,9 @@ class Section:
 
         for ifname in interfaces:
             ifsection = cls.section(ifname)
-            if not ifsection and not ifname.startswith('vrrp'):
+            if not ifsection and not (
+                ifname.startswith('vrrp') or ifname.startswith('vpp')
+            ):
                 continue
 
             if section and ifsection != section:


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add prefix `vpp` for the op-mode output of `show interfaces`
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T8357

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Add some VPP tunnels/interfaces and check the output of `show interfaces`
config:
```
set interfaces ethernet eth1 address '100.64.0.1/24'
set interfaces vpp gre vppgre1 remote '192.0.2.25'
set interfaces vpp gre vppgre1 source-address '100.64.0.1'
set interfaces vpp ipip vppipip2 address '10.0.0.1/32'
set interfaces vpp ipip vppipip2 remote '192.0.2.85'
set interfaces vpp ipip vppipip2 source-address '100.64.0.1'
set interfaces vpp vxlan vppvxlan3 remote '192.0.2.33'
set interfaces vpp vxlan vppvxlan3 source-address '100.64.0.1'
set interfaces vpp vxlan vppvxlan3 vni '33333'
set vpp settings interface eth0
set vpp settings interface eth1
set vpp settings logging default-level 'info'
set vpp settings poll-sleep-usec '2222'
set vpp settings resource-allocation cpu-cores '1'
```
Before feature, we cannot see interfaces with the prefix `vpp`
```
vyos@r14# run show int
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address         MAC                VRF        MTU  S/L    Description
-----------  -----------------  -----------------  -------  -----  -----  -------------
eth0         192.168.122.14/24  52:54:00:8d:67:6e  default   1500  u/u
eth1         100.64.0.1/24      52:54:00:f4:d5:cd  default   1500  u/u
eth2         -                  52:54:00:b5:3a:46  default   1500  u/u
eth3         -                  52:54:00:6c:c4:3e  default   1500  u/u
lo           127.0.0.1/8        00:00:00:00:00:00  default  65536  u/u
             ::1/128
[edit]
vyos@r14# 
```
After implementation, expected `vpp` prefix in the output:
```
vyos@r14# run show interfaces 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address         MAC                VRF        MTU  S/L    Description
-----------  -----------------  -----------------  -------  -----  -----  -------------
eth0         192.168.122.14/24  52:54:00:8d:67:6e  default   1500  u/u
eth1         100.64.0.1/24      52:54:00:f4:d5:cd  default   1500  u/u
eth2         -                  52:54:00:b5:3a:46  default   1500  u/u
eth3         -                  52:54:00:6c:c4:3e  default   1500  u/u
lo           127.0.0.1/8        00:00:00:00:00:00  default  65536  u/u
             ::1/128
vppgre1      -                  n/a                default   9000  u/u
vppipip2     10.0.0.1/32        n/a                default   9000  u/u
vppvxlan3    -                  02:fe:28:41:b6:d7  default   9000  u/u
[edit]
vyos@r14# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
