### PR TITLE
T8269: add option to silence individual validator output

### DIFF
--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -1036,6 +1036,8 @@
       <validator name="ip-address"/>
       #include <include/constraint/interface-name.xml.i>
     </constraint>
+    <constraintSilenceOutput/>
+    <constraintErrorMessage>BGP neighbor must be one of: IP address, IPv6 address, or interface name</constraintErrorMessage>
   </properties>
   <children>
     <node name="address-family">

--- a/schema/interface_definition.rnc
+++ b/schema/interface_definition.rnc
@@ -96,6 +96,7 @@ properties = element properties
     constraintGroup* &
     valueHelp* &
     (element constraintErrorMessage { text })? &
+    (element constraintSilenceOutput { empty })? &
     completionHelp* &
     
     # "docs" is used to store documentation for a node in a structured format

--- a/schema/interface_definition.rng
+++ b/schema/interface_definition.rng
@@ -174,6 +174,11 @@
             <text/>
           </element>
         </optional>
+        <optional>
+          <element name="constraintSilenceOutput">
+            <empty/>
+          </element>
+        </optional>
         <zeroOrMore>
           <ref name="completionHelp"/>
         </zeroOrMore>

--- a/scripts/build-command-templates
+++ b/scripts/build-command-templates
@@ -177,9 +177,11 @@ def get_properties(p, default=None):
         for vcg in vcge:
             group_validator_string = group_validator_string + " --grp " + collect_validators(vcg)
 
+    silent = " --silent" if p.findall("constraintSilenceOutput") else ""
+
     if vce is not None or len(vcge):
         validator_script = '${vyos_libexec_dir}/validate-value'
-        validator_string = "exec \"{0} {1} {2} --value \\\'$VAR(@)\\\'\"; \"{3}\"".format(validator_script, distinct_validator_string, group_validator_string, error_msg)
+        validator_string = "exec \"{0} {1} {2} --value \\\'$VAR(@)\\\'{3}\"; \"{4}\"".format(validator_script, distinct_validator_string, group_validator_string, silent, error_msg)
 
         props["constraint"] = validator_string
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

DRAFT until merge of:
https://github.com/vyos/vyos-utils/pull/51
https://github.com/vyos/vyos1x-config/pull/67
AND update of vyos1x-config commit hash: until then, integration will fail.

NOTE that this will need a manual backport after manual backport of above PR for vyos1x-config.

Add option to silence individual validator output, in cases where it is misleading; for example (from task):

```
vyos@vyos# set protocols bgp neighbor 172.18.20

  Incorrect path /sys/class/net/172.18.20: no such file or directory

  Error: 172.18.20 is not a valid IP address

  Invalid value
  Value validation failed
  Set failed

```

After these PRs, one may make the following adjustment to the interface definition:

```
diff --git a/interface-definitions/include/bgp/protocol-common-config.xml.i b/interface-definitions/include/bgp/protocol-common-config.xml.i
index e859fe804..f4bcf1509 100644
--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -1036,6 +1036,8 @@
       <validator name="ip-address"/>
       #include <include/constraint/interface-name.xml.i>
     </constraint>
+    <constraintSilenceOutput/>
+    <constraintErrorMessage>BGP neighbor must be one of: IP address, IPv6 address, or interface name</constraintErrorMessage>
   </properties>
   <children>
     <node name="address-family">
```

resulting in:

```
vyos@vyos# set protocols bgp neighbor 172.18.20

  BGP neighbor must be one of: IP address, IPv6 address, or interface name
  Value validation failed
  Set failed

```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): add element to optionally silence individual validator output

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/vyos-utils/pull/51
https://github.com/vyos/vyos1x-config/pull/67

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Described in summary, above.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
