### PR TITLE
T8382: Stats monitoring support for VPP via Prometheus

### DIFF
--- a/data/templates/prometheus/vpp_exporter.service.j2
+++ b/data/templates/prometheus/vpp_exporter.service.j2
@@ -1,0 +1,15 @@
+{% set vrf_command = 'ip vrf exec ' ~ vrf ~ ' ' if vrf is vyos_defined else '' %}
+[Unit]
+Description=VPP Prometheus Exporter
+After=network.target vpp.service
+Wants=vpp.service
+PartOf=vpp.service
+BindsTo=vpp.service
+
+[Service]
+ExecStart={{ vrf_command }}/usr/bin/vpp_prometheus_export v2 socket-name /run/vpp/stats.sock port {{ port }} {{ patterns | join(' ') }}
+Restart=always
+RestartSec=2s
+
+[Install]
+WantedBy=vpp.service

--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -134,6 +134,9 @@ linux-nl {
 
 {% if resource_allocation.memory.stats is vyos_defined %}
 statseg {
+{%     if resource_allocation.memory.stats.per_node_counters is vyos_defined %}
+    per-node-counters on
+{%     endif %}
 {%     if resource_allocation.memory.stats.size is vyos_defined %}
     size {{ resource_allocation.memory.stats.size }}
 {%     endif %}

--- a/interface-definitions/service_monitoring_prometheus.xml.in
+++ b/interface-definitions/service_monitoring_prometheus.xml.in
@@ -125,6 +125,62 @@
                   </node>
                 </children>
               </node>
+              <node name="vpp-exporter">
+                <properties>
+                  <help>Prometheus exporter for VPP metrics</help>
+                </properties>
+                <children>
+                  #include <include/port-number.xml.i>
+                  <leafNode name="port">
+                    <defaultValue>9482</defaultValue>
+                  </leafNode>
+                  #include <include/interface/vrf.xml.i>
+                  <leafNode name="stat-group">
+                    <properties>
+                      <help>VPP stat groups to be exported</help>
+                      <valueHelp>
+                        <format>interfaces</format>
+                        <description>Interface counters</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>err</format>
+                        <description>Error counters</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>buffer-pools</format>
+                        <description>Buffer pool counters</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>sys</format>
+                        <description>System counters</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>workers</format>
+                        <description>Worker counters</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>nodes</format>
+                        <description>Node counters</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>mem</format>
+                        <description>Memory counters</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>(interfaces|err|buffer-pools|sys|workers|nodes|mem)</regex>
+                      </constraint>
+                      <constraintErrorMessage>Invalid stat-group. Allowed values: interfaces, err, buffer-pools, sys, workers, nodes, mem</constraintErrorMessage>
+                      <multi/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="stat-pattern">
+                    <properties>
+                      <help>Regex pattern to export filtered VPP stats. Examples: ^/interfaces, ^/interfaces/.*/rx$ </help>
+                      <multi/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
             </children>
           </node>
         </children>

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -323,6 +323,12 @@
                       <help>Stats settings</help>
                     </properties>
                     <children>
+                      <leafNode name="per-node-counters">
+                        <properties>
+                          <help>Enable per-node counters in stats segment</help>
+                          <valueless/>
+                        </properties>
+                      </leafNode>
                       <leafNode name="size">
                         <properties>
                           <help>Size of stats segment</help>

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -38,11 +38,14 @@ from vyos.vpp.utils import vpp_iface_name_transform
 from vyos.vpp.config_resource_checks.resource_defaults import default_resource_map
 
 PROCESS_NAME = 'vpp_main'
+VPP_EXPORTER_PROCESS_NAME = 'vpp_prometheus_export'
 VPP_CONF = '/run/vpp/vpp.conf'
 base_path = ['vpp']
+prometheus_base_path = ['service', 'monitoring', 'prometheus']
 resource_path = base_path + ['settings', 'resource-allocation']
 interfaces_path = ['interfaces', 'vpp']
 interface = 'eth1'
+vpp_exporter_service_file = '/etc/systemd/system/vpp_exporter.service'
 
 
 def get_vpp_config():
@@ -119,6 +122,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
             # Ensure these cleanup operations always run
             self.cli_delete(base_path)
             self.cli_delete(interfaces_path)
+            self.cli_delete(prometheus_base_path)
             self.cli_commit()
 
             # delete address for Ethernet interface
@@ -753,6 +757,13 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
             conf = get_vpp_config()
             self.assertEqual(conf['memory']['main-heap-page-size'], size)
 
+    def test_11_4_statseg_per_node_counters(self):
+        self.cli_set(resource_path + ['memory', 'stats', 'per-node-counters'])
+        self.cli_commit()
+
+        conf = get_vpp_config()
+        self.assertEqual(conf['statseg']['per-node-counters'], 'on')
+
     def test_12_vpp_ipsec_xfrm_nl(self):
         rx_buffer_zise = default_resource_map.get('netlink_rx_buffer_size')
 
@@ -1377,6 +1388,45 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
 
         # Ensure that VPP process is active
         self.assertTrue(process_named_running(PROCESS_NAME))
+
+    def test_22_vpp_exporter(self):
+        self.cli_set(prometheus_base_path + ['vpp-exporter'])
+
+        # commit changes
+        self.cli_commit()
+
+        file_content = read_file(vpp_exporter_service_file)
+        self.assertIn('port 9482', file_content)
+        self.assertIn('socket-name /run/vpp/stats.sock', file_content)
+        self.assertIn('^/interfaces', file_content)
+        self.assertIn('^/err', file_content)
+        self.assertIn('^/buffer-pools', file_content)
+        self.assertIn('^/sys', file_content)
+        self.assertIn('^/workers', file_content)
+        self.assertIn('^/mem', file_content)
+        self.assertIn('PartOf=vpp.service', file_content)
+        self.assertIn('BindsTo=vpp.service', file_content)
+        self.assertIn('WantedBy=vpp.service', file_content)
+
+        # Check for running process
+        self.assertTrue(process_named_running(VPP_EXPORTER_PROCESS_NAME))
+
+    def test_23_vpp_exporter_group_and_custom_patterns(self):
+        self.cli_set(prometheus_base_path + ['vpp-exporter'])
+        self.cli_set(
+            prometheus_base_path + ['vpp-exporter', 'stat-group', 'interfaces']
+        )
+        self.cli_set(prometheus_base_path + ['vpp-exporter', 'stat-pattern', '^/sys'])
+
+        # commit changes
+        self.cli_commit()
+
+        file_content = read_file(vpp_exporter_service_file)
+        self.assertIn('^/interfaces', file_content)
+        self.assertIn('^/sys', file_content)
+
+        # Check for running process
+        self.assertTrue(process_named_running(VPP_EXPORTER_PROCESS_NAME))
 
 
 if __name__ == '__main__':

--- a/src/conf_mode/service_monitoring_prometheus.py
+++ b/src/conf_mode/service_monitoring_prometheus.py
@@ -16,6 +16,7 @@
 
 import os
 
+from time import sleep
 from sys import exit
 
 from vyos.config import Config
@@ -24,6 +25,10 @@ from vyos.configverify import verify_vrf
 from vyos.template import render
 from vyos.utils.process import call
 from vyos.utils.process import is_systemd_service_active
+from vyos.utils.process import is_systemd_service_running
+from vyos.utils.network import check_port_availability
+from vyos.utils.network import is_listen_port_bind_service
+from vyos.base import Warning
 from vyos import ConfigError
 from vyos import airbag
 
@@ -38,6 +43,51 @@ frr_exporter_systemd_service = 'frr_exporter.service'
 
 blackbox_exporter_service_file = '/etc/systemd/system/blackbox_exporter.service'
 blackbox_exporter_systemd_service = 'blackbox_exporter.service'
+
+vpp_exporter_service_file = '/etc/systemd/system/vpp_exporter.service'
+vpp_exporter_systemd_service = 'vpp_exporter.service'
+vpp_exporter_process_name = 'vpp_prometheus_export'
+
+vpp_stat_group_patterns = {
+    'interfaces': '^/interfaces',
+    'err': '^/err',
+    'buffer-pools': '^/buffer-pools',
+    'sys': '^/sys',
+    'workers': '^/workers',
+    'nodes': '^/nodes',
+    'mem': '^/mem',
+}
+vpp_default_stat_groups = ['interfaces', 'err', 'buffer-pools', 'sys', 'workers', 'mem']
+
+
+def get_node_values(node):
+    if node is None:
+        return []
+    if isinstance(node, dict):
+        return list(node.keys())
+    if isinstance(node, list):
+        return node
+    return [node]
+
+
+def build_vpp_stat_patterns(vpp_exporter):
+    selected_groups = get_node_values(vpp_exporter.get('stat_group'))
+    custom_patterns = get_node_values(vpp_exporter.get('stat_pattern'))
+
+    if not selected_groups and not custom_patterns:
+        selected_groups = vpp_default_stat_groups
+
+    patterns = []
+    selected_groups_set = set(selected_groups)
+    for group_name, pattern in vpp_stat_group_patterns.items():
+        if group_name in selected_groups_set:
+            patterns.append(pattern)
+
+    for pattern in custom_patterns:
+        if pattern not in patterns:
+            patterns.append(pattern)
+
+    return patterns
 
 
 def get_config(config=None):
@@ -54,6 +104,7 @@ def get_config(config=None):
         'node_exporter': base + ['node-exporter'],
         'frr_exporter': base + ['frr-exporter'],
         'blackbox_exporter': base + ['blackbox-exporter'],
+        'vpp_exporter': base + ['vpp-exporter'],
     }
 
     for exporter_name, exporter_base in exporters.items():
@@ -64,20 +115,48 @@ def get_config(config=None):
                 get_first_key=True,
                 with_recursive_defaults=True,
             )
+            if exporter_name == 'vpp_exporter':
+                monitoring[exporter_name]['patterns'] = build_vpp_stat_patterns(
+                    monitoring[exporter_name]
+                )
+                monitoring[exporter_name]['vpp_per_node_counters_enabled'] = (
+                    conf.exists(
+                        [
+                            'vpp',
+                            'settings',
+                            'resource-allocation',
+                            'memory',
+                            'stats',
+                            'per-node-counters',
+                        ]
+                    )
+                )
+                monitoring[exporter_name]['vpp_configured'] = conf.exists(['vpp'])
 
-    tmp = is_node_changed(conf, base + ['node-exporter', 'vrf'])
-    if tmp:
-        monitoring.update({'node_exporter_restart_required': {}})
+                configured_groups = conf.return_values(exporter_base + ['stat-group'])
+                configured_patterns = conf.return_values(
+                    exporter_base + ['stat-pattern']
+                )
 
-    tmp = is_node_changed(conf, base + ['frr-exporter', 'vrf'])
-    if tmp:
-        monitoring.update({'frr_exporter_restart_required': {}})
+                effective_groups = conf.return_effective_values(
+                    exporter_base + ['stat-group']
+                )
+                effective_patterns = conf.return_effective_values(
+                    exporter_base + ['stat-pattern']
+                )
 
-    tmp = False
-    for node in ['vrf', 'config-file']:
-        tmp = tmp or is_node_changed(conf, base + ['blackbox-exporter', node])
-    if tmp:
-        monitoring.update({'blackbox_exporter_restart_required': {}})
+                nodes_requested = 'nodes' in configured_groups or any(
+                    pattern.startswith('^/nodes') for pattern in configured_patterns
+                )
+                nodes_requested_effective = 'nodes' in effective_groups or any(
+                    pattern.startswith('^/nodes') for pattern in effective_patterns
+                )
+
+                monitoring[exporter_name]['nodes_selection_newly_enabled'] = (
+                    nodes_requested and not nodes_requested_effective
+                )
+            if is_node_changed(conf, exporter_base):
+                monitoring.update({f'{exporter_name}_restart_required': {}})
 
     return monitoring
 
@@ -108,6 +187,43 @@ def verify(monitoring):
                         f'query name not specified in dns module {mod_name}'
                     )
 
+    if 'vpp_exporter' in monitoring:
+        verify_vrf(monitoring['vpp_exporter'])
+
+        port = int(monitoring['vpp_exporter']['port'])
+        if check_port_availability(
+            None, port, 'tcp'
+        ) is not True and not is_listen_port_bind_service(
+            port, vpp_exporter_process_name
+        ):
+            raise ConfigError(f'TCP port "{port}" is used by another service!')
+
+        if not monitoring['vpp_exporter'].get('vpp_configured'):
+            raise ConfigError(
+                'No VPP configuration exists. Configure VPP before configuring VPP-exporter.'
+            )
+
+        if 'stat_group' in monitoring['vpp_exporter']:
+            for group_name in get_node_values(monitoring['vpp_exporter']['stat_group']):
+                if group_name not in vpp_stat_group_patterns:
+                    raise ConfigError(f'Invalid stat-group "{group_name}"')
+
+        if 'stat_pattern' in monitoring['vpp_exporter']:
+            for pattern in get_node_values(monitoring['vpp_exporter']['stat_pattern']):
+                if not pattern or not pattern.startswith('^/'):
+                    raise ConfigError(
+                        f'Invalid stat-pattern "{pattern}". Pattern must start with "^/"'
+                    )
+
+        if monitoring['vpp_exporter'].get(
+            'nodes_selection_newly_enabled'
+        ) and not monitoring['vpp_exporter'].get('vpp_per_node_counters_enabled'):
+            Warning(
+                'VPP node metrics requested but per-node-counters setting is not enabled.'
+                'Enable it using below cmd for "nodes" metrics to be available:\n'
+                '"set vpp settings resource-allocation memory stats per-node-counters".'
+            )
+
     return None
 
 
@@ -126,6 +242,11 @@ def generate(monitoring):
         # Delete systemd files
         if os.path.isfile(blackbox_exporter_service_file):
             os.unlink(blackbox_exporter_service_file)
+
+    if not monitoring or 'vpp_exporter' not in monitoring:
+        # Delete systemd files
+        if os.path.isfile(vpp_exporter_service_file):
+            os.unlink(vpp_exporter_service_file)
 
     if not monitoring:
         return None
@@ -167,48 +288,92 @@ def generate(monitoring):
             monitoring['blackbox_exporter'],
         )
 
+    if 'vpp_exporter' in monitoring:
+        # Render vpp_exporter service_file
+        render(
+            vpp_exporter_service_file,
+            'prometheus/vpp_exporter.service.j2',
+            monitoring['vpp_exporter'],
+        )
+
     return None
 
 
 def apply(monitoring):
+    def run_systemctl(action, service=None, verify_running=False):
+        command = f'systemctl {action}'
+        if service:
+            command = f'{command} {service}'
+
+        rc = call(command)
+        if rc != 0:
+            if service:
+                raise ConfigError(
+                    f'Failed to {action} {service}. Check "journalctl -xe" for details.'
+                )
+            raise ConfigError(
+                f'Failed to run "systemctl {action}". Check "journalctl -xe" for details.'
+            )
+
+        if verify_running and service:
+            for _ in range(6):
+                if is_systemd_service_running(service):
+                    return
+                sleep(0.5)
+            raise ConfigError(
+                f'{service} failed to reach running state after {action}. Check "journalctl -xe" for details.'
+            )
+
     # Reload systemd manager configuration
-    call('systemctl daemon-reload')
+    run_systemctl('daemon-reload')
     if not monitoring or 'node_exporter' not in monitoring:
         if is_systemd_service_active(node_exporter_systemd_service):
-            call(f'systemctl stop {node_exporter_systemd_service}')
+            run_systemctl('stop', node_exporter_systemd_service)
     if not monitoring or 'frr_exporter' not in monitoring:
         if is_systemd_service_active(frr_exporter_systemd_service):
-            call(f'systemctl stop {frr_exporter_systemd_service}')
+            run_systemctl('stop', frr_exporter_systemd_service)
     if not monitoring or 'blackbox_exporter' not in monitoring:
         if is_systemd_service_active(blackbox_exporter_systemd_service):
-            call(f'systemctl stop {blackbox_exporter_systemd_service}')
+            run_systemctl('stop', blackbox_exporter_systemd_service)
+    if not monitoring or 'vpp_exporter' not in monitoring:
+        if is_systemd_service_active(vpp_exporter_systemd_service):
+            run_systemctl('stop', vpp_exporter_systemd_service)
+        if os.path.isfile(vpp_exporter_service_file):
+            run_systemctl('disable', vpp_exporter_systemd_service)
 
     if not monitoring:
         return
 
     if 'node_exporter' in monitoring:
-        # we need to restart the service if e.g. the VRF name changed
-        systemd_action = 'reload-or-restart'
-        if 'node_exporter_restart_required' in monitoring:
-            systemd_action = 'restart'
-
-        call(f'systemctl {systemd_action} {node_exporter_systemd_service}')
+        if (
+            'node_exporter_restart_required' in monitoring
+            or not is_systemd_service_active(node_exporter_systemd_service)
+        ):
+            run_systemctl('restart', node_exporter_systemd_service, verify_running=True)
 
     if 'frr_exporter' in monitoring:
-        # we need to restart the service if e.g. the VRF name changed
-        systemd_action = 'reload-or-restart'
-        if 'frr_exporter_restart_required' in monitoring:
-            systemd_action = 'restart'
-
-        call(f'systemctl {systemd_action} {frr_exporter_systemd_service}')
+        if (
+            'frr_exporter_restart_required' in monitoring
+            or not is_systemd_service_active(frr_exporter_systemd_service)
+        ):
+            run_systemctl('restart', frr_exporter_systemd_service, verify_running=True)
 
     if 'blackbox_exporter' in monitoring:
-        # we need to restart the service if e.g. the VRF name changed
-        systemd_action = 'reload-or-restart'
-        if 'blackbox_exporter_restart_required' in monitoring:
-            systemd_action = 'restart'
+        if (
+            'blackbox_exporter_restart_required' in monitoring
+            or not is_systemd_service_active(blackbox_exporter_systemd_service)
+        ):
+            run_systemctl(
+                'restart', blackbox_exporter_systemd_service, verify_running=True
+            )
 
-        call(f'systemctl {systemd_action} {blackbox_exporter_systemd_service}')
+    if 'vpp_exporter' in monitoring:
+        run_systemctl('enable', vpp_exporter_systemd_service)
+        if (
+            'vpp_exporter_restart_required' in monitoring
+            or not is_systemd_service_active(vpp_exporter_systemd_service)
+        ):
+            run_systemctl('restart', vpp_exporter_systemd_service, verify_running=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Vyos VPP exporter implementation added to facilitate the VPP stats/metrics to be available via Prometheus. Vyos VPP exporter integrates with the VPP-exposed prometheus exporter binary and can be configured using the Vyos CLIs to fetch the stats/metrics selectively from VPP. 

Following functionalities have been implemented:
- Stat-groups stats are available on Prometheus web UI
- Regex pattern based filtered stats are available on Prometheus web UI
- vpp-exporter service restarts automatically upon:
	any change in vpp-exporter config
	VPP service restart
	system reboot	
- vpp-exporter service cannot be started until VPP service exists
- vpp-exporter service stops if VPP service becomes unavailable
- vpp-exporter service can co-exist with node-exporter (both independently) to provide VPP and kernel stats respectively.
- Added CLI support for enabling VPP per-node-counters, which is required to export node-level statistics.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8382 

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Testing done:
- Verified stat-group stats and regex pattern based filtered stats on Prometheus web UI against the VPP CLI output
- Verified VPP service restarts automatically upon below actions and correct/updated stats are available again on Prometheus. 
	any change in vpp-exporter config
	VPP service restart
	system reboot	

- Verified changing the node_exporter config only restarts node_exporter. Same for vpp_exporter.
- Verified vpp-exporter vrf endpoint option

CONFIGURE METRICS FOR BUFFER-POOL AND SYS GROUPS & CUSTOM STAT-PATTERN FOR INTERFACES
```
vyos@vyos# set service monitoring prometheus vpp-exporter stat-group buffer-pools 
vyos@vyos# commit
vyos@vyos#  set service monitoring prometheus vpp-exporter stat-group sys
vyos@vyos# commit
vyos@vyos#  set service monitoring prometheus vpp-exporter stat-pattern ^/interfaces/.*/rx$
vyos@vyos# commit

a@Mac vyos-build % curl -fsS http://192.168.65.18:9482/metrics
sys_heartbeat 2694.00
sys_last_stats_clear 0.00
sys_boottime 1773122098.00
sys_uptime 44219.00
sys_vector_rate 0.00
sys_vector_rate_per_worker{index="0",thread="0"} 0
sys_vector_rate_per_worker{index="1",thread="0"} 0
sys_loops_per_worker{index="0",thread="0"} 777854
sys_loops_per_worker{index="1",thread="0"} 0
buffer_pools_cached{pool="default-numa-0"} 344.00
buffer_pools_used{pool="default-numa-0"} 712.00
buffer_pools_available{pool="default-numa-0"} 15728.00
sys_num_worker_threads 0.00
sys_last_update 44220.00
sys_input_rate 0.00
interfaces_rx_packets{interface="local0",index="0",thread="0"} 0
interfaces_rx_bytes{interface="local0",index="0",thread="0"} 0
interfaces_rx_packets{interface="eth1",index="0",thread="0"} 585
interfaces_rx_bytes{interface="eth1",index="0",thread="0"} 139158
interfaces_rx_packets{interface="tap4096",index="0",thread="0"} 12
interfaces_rx_bytes{interface="tap4096",index="0",thread="0"} 1196

vyos@vyos:~$ sudo vpp_get_stats dump '^/buffer-pools'
344.00 /buffer-pools/default-numa-0/cached
712.00 /buffer-pools/default-numa-0/used
15728.00 /buffer-pools/default-numa-0/available

vyos@vyos:~$ sudo vpp_get_stats dump '^/sys'
2694.00 /sys/heartbeat
0.00 /sys/last_stats_clear
1773122098.00 /sys/boottime
0.00 /sys/vector_rate
[0 @ 0]: 0 packets /sys/vector_rate_per_worker
[1 @ 0]: 0 packets /sys/vector_rate_per_worker
[0 @ 0]: 777854 packets /sys/loops_per_worker
[1 @ 0]: 0 packets /sys/loops_per_worker
0.00 /sys/num_worker_threads
44220.00 /sys/last_update
0.00 /sys/input_rate

vyos@vyos:~$ sudo vpp_get_stats dump '^/interfaces/.*/rx$'
[0 @ 0]: 0 packets, 0 bytes /interfaces/local0/rx
[0 @ 0]: 585 packets, 139158 bytes /interfaces/eth1/rx
[0 @ 0]: 12 packets, 1196 bytes /interfaces/tap4096/rx
```

VRF TESTING
```
set interfaces ethernet eth2 address 100.64.0.8/24
set vrf name TEST table 1001
set interfaces ethernet eth2 vrf TEST
set ser moni prom vpp vrf TEST
commit

vyos@vyos:~$ sudo ip vrf exec TEST curl -s http://127.0.0.1:9482/metrics |head
sys_heartbeat 168.00
sys_last_stats_clear 0.00
sys_boottime 1773260614.00
sys_uptime 6183.00
sys_vector_rate 0.00
sys_vector_rate_per_worker{index="0",thread="0"} 0
sys_vector_rate_per_worker{index="1",thread="0"} 0
sys_loops_per_worker{index="0",thread="0"} 1135441
sys_loops_per_worker{index="1",thread="0"} 0
buffer_pools_cached{pool="default-numa-0"} 206.00
vyos@vyos:~$ 
vyos@vyos:~$ sudo ip vrf exec TEST curl -s http://100.64.0.8:9482/metrics |head
sys_heartbeat 173.00
sys_last_stats_clear 0.00
sys_boottime 1773260614.00
sys_uptime 6241.00
sys_vector_rate 0.00
sys_vector_rate_per_worker{index="0",thread="0"} 0
sys_vector_rate_per_worker{index="1",thread="0"} 0
sys_loops_per_worker{index="0",thread="0"} 1166346
sys_loops_per_worker{index="1",thread="0"} 0
buffer_pools_cached{pool="default-numa-0"} 207.00
```
CLI VALIDATION
- No VPP
```
vyos@vyos# set serv moni prom vpp stat-group nodes
[edit]
vyos@vyos# commit
[ service monitoring prometheus ]
No VPP configuration exists!  Configure VPP before VPP-exporter
configuration.
[[service monitoring prometheus]] failed
Commit failed
```
- Invalid Stat-group
```
vyos@vyos# set service monitoring prometheus vpp-exporter stat-group abd

  
  
  Invalid stat-group. Allowed values: interfaces, err, buffer-pools, sys, workers, nodes, mem
  Value validation failed
  Set failed
```
- Invalid regex pattern
```
vyos@vyos# set service monitoring prometheus vpp-exporter stat-pattern mem
[edit]
vyos@vyos# commit
[ service monitoring prometheus ]
Invalid stat-pattern "mem". Pattern must start with "^/"

[[service monitoring prometheus]] failed
Commit failed
```
- Per-node-counters not enabled triggers a one-time warning while configuring nodes stats
```
vyos@vyos# set serv moni prom vpp stat-group nodes
[edit]
vyos@vyos# commit
[ service monitoring prometheus ]

WARNING: VPP node metrics requested but per-node-counters setting is
not enabled. Enable it using below cmd for "nodes" metrics to be 
available:
"set vpp settings resource-allocation memory stats per-node-counters".
```


SMOKETESTS:
```
vyos@vyos:~$ sudo /usr/libexec/vyos/tests/smoke/cli/test_vpp.py TestVPP.test_11_4_statseg_per_node_counters
test_11_4_statseg_per_node_counters (__main__.TestVPP.test_11_4_statseg_per_node_counters) ... ok

----------------------------------------------------------------------
Ran 1 test in 89.569s

OK
vyos@vyos:~$  sudo /usr/libexec/vyos/tests/smoke/cli/test_service_monitoring_prometheus.py 
test_01_node_exporter (__main__.TestMonitoringPrometheus.test_01_node_exporter) ... ok
test_02_frr_exporter (__main__.TestMonitoringPrometheus.test_02_frr_exporter) ... ok
test_03_blackbox_exporter (__main__.TestMonitoringPrometheus.test_03_blackbox_exporter) ... ok
test_04_blackbox_exporter_with_config (__main__.TestMonitoringPrometheus.test_04_blackbox_exporter_with_config) ... ok
test_05_vpp_exporter (__main__.TestMonitoringPrometheus.test_05_vpp_exporter) ... ok
test_06_vpp_exporter_group_and_custom_patterns (__main__.TestMonitoringPrometheus.test_06_vpp_exporter_group_and_custom_patterns) ... ok

----------------------------------------------------------------------
Ran 6 tests in 159.910s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
