### PR TITLE
vpp: T8368: Features nat44 and cgnat should not use the same interfaces

### DIFF
--- a/python/vyos/vpp/config_verify.py
+++ b/python/vyos/vpp/config_verify.py
@@ -341,3 +341,27 @@ def verify_vpp_buffers(settings: dict):
             'Not enough buffers to initialize RX/TX queues for interfaces. '
             f'Set "vpp settings resource-allocation buffers buffers-per-numa" to {buffers_required} or higher'
         )
+
+
+def verify_nat_interfaces(config: dict, feature_name: str):
+    """
+    Verify that interfaces are not already used in the selected NAT feature.
+    Example:
+        verify_nat_interfaces(config, 'nat44')
+        verify_nat_interfaces(config, 'cgnat')
+    """
+    directions = ['inside', 'outside']
+    interfaces = config.get('interface', {})
+    nat_interfaces = config.get(f'{feature_name}_config', {}).get('interface', {})
+
+    for direction in directions:
+        for iface in interfaces.get(direction, []):
+            # Check if iface is used in any nat44/cgnat direction
+            nat_dir = next(
+                (d for d in directions if iface in nat_interfaces.get(d, [])), None
+            )
+            if nat_dir:
+                raise ConfigError(
+                    f'Cannot use {iface} as {direction} interface: '
+                    f'it is already configured as {nat_dir} interface in {feature_name.upper()}'
+                )

--- a/src/conf_mode/vpp_nat_cgnat.py
+++ b/src/conf_mode/vpp_nat_cgnat.py
@@ -25,6 +25,7 @@ from vyos.vpp.utils import vpp_iface_name_transform
 
 from vyos.vpp.nat.det44 import Det44
 from vyos.vpp.control_vpp import VPPControl
+from vyos.vpp.config_verify import verify_nat_interfaces
 
 protocol_map = {
     'all': 0,
@@ -107,6 +108,13 @@ def get_config(config=None) -> dict:
         }
     )
 
+    config['nat44_config'] = conf.get_config_dict(
+        ['vpp', 'nat', 'nat44'],
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+    )
+
     if effective_config:
         config.update({'effective': effective_config})
 
@@ -138,6 +146,8 @@ def verify(config):
             f'Interface cannot be both inside and outside. '
             f'Please choose a side for: {", ".join(conflict_ifaces)} '
         )
+
+    verify_nat_interfaces(config, 'nat44')
 
     vpp = VPPControl()
     for direction in ['inside', 'outside']:

--- a/src/conf_mode/vpp_nat_nat44.py
+++ b/src/conf_mode/vpp_nat_nat44.py
@@ -29,6 +29,7 @@ from vyos.vpp.utils import cli_ifaces_list
 from vyos.vpp.utils import vpp_iface_name_transform
 from vyos.vpp.nat.nat44 import Nat44
 from vyos.vpp.control_vpp import VPPControl
+from vyos.vpp.config_verify import verify_nat_interfaces
 
 
 protocol_map = {
@@ -113,6 +114,13 @@ def get_config(config=None) -> dict:
         }
     )
 
+    config['cgnat_config'] = conf.get_config_dict(
+        ['vpp', 'nat', 'cgnat'],
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+    )
+
     if effective_config:
         config.update({'effective': effective_config})
 
@@ -152,6 +160,8 @@ def verify(config):
         raise ConfigError(
             f'Both inside and outside interfaces must be configured. Please add: {", ".join(missing_keys)}'
         )
+
+    verify_nat_interfaces(config, 'cgnat')
 
     vpp = VPPControl()
     for direction in ['inside', 'outside']:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8368
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set interfaces vpp bonding vppbond1
set vpp nat cgnat interface inside 'eth0'
set vpp nat cgnat interface outside 'vppbond1'
set vpp nat cgnat rule 100 inside-prefix '100.64.0.0/24'
set vpp nat cgnat rule 100 outside-prefix '192.0.2.0/30'
set vpp settings interface eth0
set vpp settings interface eth1

set vpp nat nat44 address-pool translation address 192.0.2.0-192.0.2.2
set vpp nat nat44 interface inside eth1
set vpp nat nat44 interface outside eth0

vyos@vyos# commit
[ vpp nat nat44 ]
Cannot use eth0 as outside interface: it is already configured as inside
interface in CGNAT

[[vpp nat nat44]] failed
Commit failed
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
