### PR TITLE
T8383: fix extra space in nftables ipv6 output chain template

### DIFF
--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -281,7 +281,7 @@ table ip6 vyos_filter {
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
         {{ rule_conf | nft_rule('OUT', prior, rule_id, 'ip6') }}
 {%                     if rule_conf.recent is vyos_defined %}
-{%                         set ns.sets = ns.sets + ['OUT_ ' + prior + '_' + rule_id] %}
+{%                         set ns.sets = ns.sets + ['OUT_' + prior + '_' + rule_id] %}
 {%                     endif %}
 {%                 endfor %}
 {%             endif %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
config:
```
set firewall ipv6 output filter default-action accept
set firewall ipv6 output filter rule 100 action drop
set firewall ipv6 output filter rule 100 recent count 10
set firewall ipv6 output filter rule 100 recent time minute
```

commit error:
```
[ firewall ]
Fail to apply firewall Error found on: firewall ipv6 output filter rule
100         Error message: syntax error, unexpected string, expecting '{'
[[firewall]] failed
Commit failed
```
Extra space in 'OUT_ ' creates invalid set name

```
{%                     if rule_conf.recent is vyos_defined %}
{%                         set ns.sets = ns.sets + ['OUT_ ' + prior + '_' + rule_id] %}
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8383

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set firewall ipv6 output filter default-action accept
set firewall ipv6 output filter rule 100 action drop
set firewall ipv6 output filter rule 100 recent count 10
set firewall ipv6 output filter rule 100 recent time minute
commit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
