### PR TITLE
T8385: fix config key name in chap-secrets.config_dict.j2

### DIFF
--- a/data/templates/accel-ppp/chap-secrets.config_dict.j2
+++ b/data/templates/accel-ppp/chap-secrets.config_dict.j2
@@ -1,6 +1,6 @@
 # username  server  password  acceptable local IP addresses   shaper
 {% if authentication.local_users.username is vyos_defined %}
-{%     for user, user_config in authentication.local_users.username.items() if user_config.disabled is not vyos_defined %}
+{%     for user, user_config in authentication.local_users.username.items() if user_config.disable is not vyos_defined %}
 {%         if user_config.rate_limit is vyos_defined %}
 {{ "%-12s" | format(user) }} * {{ "%-16s" | format(user_config.password) }} {{ "%-16s" | format(user_config.static_ip) }} {{ user_config.rate_limit.download }}/{{ user_config.rate_limit.upload }}
 {%         else %}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->



There is a typo in the config key name: the template uses user_config.**disabled** instead of user_config.**disable**.
Because **disabled** never exists, the filter user_config.disabled is not vyos_defined is always true and disabled users are not excluded from chap-secrets:

```
{% for user, user_config in authentication.local_users.username.items() if user_config.disabled is not vyos_defined %}
```

disabled user is still in allowed list, new sessions from the user get established:

<img width="1100" height="259" alt="Screenshot 2026-03-15 at 16 13 17" src="https://github.com/user-attachments/assets/455b423b-a864-4b16-8726-7d4e00d70380" />


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8385

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set service pppoe-server authentication mode local
set service pppoe-server authentication local-users username foo password bar
set service pppoe-server authentication local-users username foo disable
set service pppoe-server client-ip-pool default range 10.0.0.2-10.0.0.254
set service pppoe-server default-pool default
set service pppoe-server gateway-address 10.0.0.1
set service pppoe-server interface eth0
commit
```
disabled user should not be present in chap-secrets list:
`sudo cat /run/accel-pppd/pppoe.chap-secrets`

sessions from disabled user should not be established

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
