### PR TITLE
T8386: fix locat_ts rendering in remote_access.j2

### DIFF
--- a/data/templates/ipsec/swanctl/remote_access.j2
+++ b/data/templates/ipsec/swanctl/remote_access.j2
@@ -79,7 +79,7 @@
 {% endif %}
 {% set local_prefix = rw_conf.local.prefix if rw_conf.local.prefix is vyos_defined else ['0.0.0.0/0', '::/0'] %}
 {% set local_port = rw_conf.local.port if rw_conf.local.port is vyos_defined else '' %}
-{% set local_suffix = '[%any/{1}]'.format(local_port) if local_port else '' %}
+{% set local_suffix = '[%any/{port}]'.format(port=local_port) if local_port else '' %}
                 local_ts = {{ local_prefix | join(local_suffix + ",") }}{{ local_suffix }}
 {% if rw_conf.bind is vyos_defined %}
 {#     The key defaults to 0 and will match any policies which similarly do not have a lookup key configuration. #}


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Commit fails applying `set vpn ipsec remote-access connection RA local port 4500`

```
  File "/usr/share/vyos/templates/ipsec/swanctl/remote_access.j2", line 78, in template
    {% set local_suffix = '[%any/{1}]'.format(local_port) if local_port else '' %}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
IndexError: Replacement index 1 out of range for positional args tuple
```

In '[%any/{1}]'.format(local_port), {1} selects the second argument but only local_port is passed (index 0). This fix is required for circinus and sagitta branches as well

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8386

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set vpn ipsec ike-group IKE key-exchange ikev2
set vpn ipsec ike-group IKE lifetime 3600
set vpn ipsec ike-group IKE proposal 1 encryption aes256
set vpn ipsec ike-group IKE proposal 1 hash sha256
set vpn ipsec ike-group IKE proposal 1 dh-group 14
set vpn ipsec esp-group ESP lifetime 3600
set vpn ipsec esp-group ESP proposal 1 encryption aes256
set vpn ipsec esp-group ESP proposal 1 hash sha256
set vpn ipsec remote-access pool POOL prefix 10.99.0.0/24
set vpn ipsec remote-access connection RA authentication local-users username vpnuser password secret123
set vpn ipsec remote-access connection RA authentication server-mode pre-shared-secret
set vpn ipsec remote-access connection RA authentication pre-shared-secret mysecretkey123
set vpn ipsec remote-access connection RA esp-group ESP
set vpn ipsec remote-access connection RA ike-group IKE
set vpn ipsec remote-access connection RA local-address 192.168.1.1
set vpn ipsec remote-access connection RA pool POOL
set vpn ipsec remote-access connection RA local port 4500
commit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
