### PR TITLE
T8389: fix domain-password md5 for isisd/fabricd

### DIFF
--- a/data/templates/frr/fabricd.frr.j2
+++ b/data/templates/frr/fabricd.frr.j2
@@ -39,7 +39,7 @@ exit
 router openfabric {{ name }}
  net {{ net }}
 {%     if router_config.domain_password.md5 is vyos_defined %}
- domain-password md5 {{ router_config.domain_password.plaintext_password }}
+ domain-password md5 {{ router_config.domain_password.md5 }}
 {%     elif router_config.domain_password.plaintext_password is vyos_defined %}
  domain-password clear {{ router_config.domain_password.plaintext_password }}
 {%     endif %}

--- a/data/templates/frr/isisd.frr.j2
+++ b/data/templates/frr/isisd.frr.j2
@@ -107,7 +107,7 @@ advertise-passive-only
  metric-style {{ metric_style }}
 {% endif %}
 {% if domain_password.md5 is vyos_defined %}
- domain-password md5 {{ domain_password.plaintext_password }}
+ domain-password md5 {{ domain_password.md5 }}
 {% elif domain_password.plaintext_password is vyos_defined %}
  domain-password clear {{ domain_password.plaintext_password }}
 {% endif %}

--- a/smoketest/scripts/cli/test_protocols_isis.py
+++ b/smoketest/scripts/cli/test_protocols_isis.py
@@ -167,6 +167,7 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
 
     def test_isis_05_password(self):
         password = 'foo'
+        md5_password = 'secret_md5_hash'
 
         self.cli_set(base_path + ['net', net])
         for interface in self._interfaces:
@@ -199,6 +200,29 @@ class TestProtocolsISIS(VyOSUnitTestSHIM.TestCase):
         for interface in self._interfaces:
             tmp = self.getFRRconfig(f'interface {interface}', stop_section='^exit')
             self.assertIn(f' isis password clear {password}-{interface}', tmp)
+
+        # Switch to MD5 passwords - delete plaintext passwords first
+        self.cli_delete(base_path + ['area-password', 'plaintext-password'])
+        self.cli_delete(base_path + ['domain-password', 'plaintext-password'])
+        for interface in self._interfaces:
+            self.cli_delete(base_path + ['interface', interface, 'password', 'plaintext-password'])
+
+        self.cli_set(base_path + ['domain-password', 'md5', md5_password])
+        self.cli_set(base_path + ['area-password', 'md5', md5_password])
+        for interface in self._interfaces:
+            self.cli_set(base_path + ['interface', interface, 'password', 'md5', md5_password])
+
+        # Commit all changes
+        self.cli_commit()
+
+        # Verify all changes
+        tmp = self.getFRRconfig(f'router isis {domain}', stop_section='exit')
+        self.assertIn(f' domain-password md5 {md5_password}', tmp)
+        self.assertIn(f' area-password md5 {md5_password}', tmp)
+
+        for interface in self._interfaces:
+            tmp = self.getFRRconfig(f'interface {interface}', stop_section='^exit')
+            self.assertIn(f' isis password md5 {md5_password}', tmp)
 
     def test_isis_06_spf_delay_bfd(self):
         network = 'point-to-point'

--- a/smoketest/scripts/cli/test_protocols_openfabric.py
+++ b/smoketest/scripts/cli/test_protocols_openfabric.py
@@ -117,6 +117,7 @@ class TestProtocolsOpenFabric(VyOSUnitTestSHIM.TestCase):
 
     def test_openfabric_03_password(self):
         password = 'foo'
+        md5_password = 'secret_md5_hash'
 
         self.openfabric_base_config()
 
@@ -146,6 +147,23 @@ class TestProtocolsOpenFabric(VyOSUnitTestSHIM.TestCase):
 
         tmp = self.getFRRconfig(f'interface {dummy_if}', stop_section='^exit')
         self.assertIn(f' openfabric password clear {password}-{dummy_if}', tmp)
+
+        # Switch to MD5 passwords - delete plaintext passwords first
+        self.cli_delete(path + ['domain-password', 'plaintext-password'])
+        self.cli_delete(path + ['interface', dummy_if, 'password', 'plaintext-password'])
+
+        self.cli_set(path + ['domain-password', 'md5', md5_password])
+        self.cli_set(path + ['interface', dummy_if, 'password', 'md5', md5_password])
+
+        # Commit all changes
+        self.cli_commit()
+
+        # Verify all changes
+        tmp = self.getFRRconfig(f'router openfabric {domain}', stop_section='^exit')
+        self.assertIn(f' domain-password md5 {md5_password}', tmp)
+
+        tmp = self.getFRRconfig(f'interface {dummy_if}', stop_section='^exit')
+        self.assertIn(f' openfabric password md5 {md5_password}', tmp)
 
     def test_openfabric_multiple_domains(self):
         domain_2 = 'VyOS_2'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
When `domain_password.md5` is defined, both templates output `domain-password md5 {{ domain_password.plaintext_password }}`. The MD5 branch should use the hash: `domain_password.md5`, not `plaintext_password`.
This fix is required for sagitta and circinus


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8389

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
configs are applied with no commit error
```
set protocols isis net 49.0001.0000.0000.0001.00
set protocols isis interface eth0
set protocols isis domain-password md5 0123456789abcdef0123456789abcdef
```

```
set protocols openfabric net 49.0001.0000.0000.0001.00
set protocols openfabric domain VyOS interface eth0 address-family ipv4
set protocols openfabric domain VyOS domain-password md5 0123456789abcdef0123456789abcdef
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
