### PR TITLE
T8397: macsec: fix source-interface change

### DIFF
--- a/src/conf_mode/interfaces_macsec.py
+++ b/src/conf_mode/interfaces_macsec.py
@@ -73,7 +73,7 @@ def get_config(config=None):
     if is_node_changed(conf, base + [ifname, 'security']):
         macsec.update({'shutdown_required': {}})
 
-    if is_node_changed(conf, base + [ifname, 'source_interface']):
+    if is_node_changed(conf, base + [ifname, 'source-interface']):
         macsec.update({'shutdown_required': {}})
 
     if 'source_interface' in macsec:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Changing source-interface commits successfully, but the MACsec interface does not move to the new port.
```
set interfaces macsec macsec0 address '10.0.0.1/24'
set interfaces macsec macsec0 security cipher 'gcm-aes-128'
set interfaces macsec macsec0 security encrypt
set interfaces macsec macsec0 security mka cak '0123456789abcdef0123456789abcdef'
set interfaces macsec macsec0 security mka ckn '0123456789abcdef0123456789abcdef'

set interfaces macsec macsec0 source-interface 'eth0'
commit

set interfaces macsec macsec0 source-interface 'eth1'
commit
```

macsec0 still using eth0:
```
vyos@vyos# ip link show macsec0
7: macsec0@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1460 qdisc noqueue state UP mode DEFAULT group defa0
    link/ether 0c:c1:a0:05:00:00 brd ff:ff:ff:ff:ff:ff
[edit]
```

The fix corrects the node name in is_node_changed() call:

`if is_node_changed(conf, base + [ifname, 'source_interface']):` -> `if is_node_changed(conf, base + [ifname, 'source-interface']):`

Required for sagitta and circinus as well

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8397

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set interfaces macsec macsec0 address '10.0.0.1/24'
set interfaces macsec macsec0 security cipher 'gcm-aes-128'
set interfaces macsec macsec0 security encrypt
set interfaces macsec macsec0 security mka cak '0123456789abcdef0123456789abcdef'
set interfaces macsec macsec0 security mka ckn '0123456789abcdef0123456789abcdef'

set interfaces macsec macsec0 source-interface 'eth0'
commit

set interfaces macsec macsec0 source-interface 'eth1'
commit
```

```
vyos@vyos# ip link show macsec0
7: macsec0@eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1460 qdisc noqueue state UP mode DEFAULT group defa0
    link/ether 0c:c1:a0:05:00:00 brd ff:ff:ff:ff:ff:ff
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
