### PR TITLE
T8399: dhcpv6-server: move connectivity/overlap checks inside subnet loop

### DIFF
--- a/src/conf_mode/service_dhcpv6-server.py
+++ b/src/conf_mode/service_dhcpv6-server.py
@@ -241,22 +241,22 @@ def verify(dhcpv6):
 
             subnets.append(subnet)
 
-        # DHCPv6 requires at least one configured address range or one static mapping
-        # (FIXME: is not actually checked right now?)
+            # DHCPv6 requires at least one configured address range or one static mapping
+            # (FIXME: is not actually checked right now?)
 
-        # There must be one subnet connected to a listen interface if network is not disabled.
-        if 'disable' not in network_config:
-            if is_subnet_connected(subnet):
-                listen_ok = True
+            # There must be one subnet connected to a listen interface if network is not disabled.
+            if 'disable' not in network_config:
+                if is_subnet_connected(subnet):
+                    listen_ok = True
 
-            # DHCPv6 subnet must not overlap. ISC DHCP also complains about overlapping
-            # subnets: "Warning: subnet 2001:db8::/32 overlaps subnet 2001:db8:1::/32"
-            net = ip_network(subnet)
-            for n in subnets:
-                net2 = ip_network(n)
-                if (net != net2):
-                    if net.overlaps(net2):
-                        raise ConfigError('DHCPv6 conflicting subnet ranges: {0} overlaps {1}'.format(net, net2))
+                # DHCPv6 subnet must not overlap. ISC DHCP also complains about overlapping
+                # subnets: "Warning: subnet 2001:db8::/32 overlaps subnet 2001:db8:1::/32"
+                net = ip_network(subnet)
+                for n in subnets:
+                    net2 = ip_network(n)
+                    if (net != net2):
+                        if net.overlaps(net2):
+                            raise ConfigError('DHCPv6 conflicting subnet ranges: {0} overlaps {1}'.format(net, net2))
 
     if not listen_ok:
         raise ConfigError('None of the DHCPv6 subnets are connected to a subnet6 on '\


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
In service_dhcpv6-server verify(), the is_subnet_connected() and overlap checks run outside the subnet loop and check only the last subnet. The fix is to move connectivity/overlap checks inside subnet loop, required for circinus and sagitta as well

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8399

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
set interfaces ethernet eth0 address 2001:db8:f::1/64
set service dhcpv6-server shared-network-name LAN subnet 2001:db8:a::/48 subnet-id 1
set service dhcpv6-server shared-network-name LAN subnet 2001:db8:a::/48 interface eth0
set service dhcpv6-server shared-network-name LAN subnet 2001:db8:a::/48 range 0 start 2001:db8:a::100
set service dhcpv6-server shared-network-name LAN subnet 2001:db8:a::/48 range 0 stop 2001:db8:a:1::ffff
set service dhcpv6-server shared-network-name LAN subnet 2001:db8:a:1::/64 subnet-id 2
set service dhcpv6-server shared-network-name LAN subnet 2001:db8:a:1::/64 range 0 start 2001:db8:a:1::100
set service dhcpv6-server shared-network-name LAN subnet 2001:db8:a:1::/64 range 0 stop 2001:db8:a:1::200
set service dhcpv6-server shared-network-name LAN subnet 2001:db8:f::/64 subnet-id 3
set service dhcpv6-server shared-network-name LAN subnet 2001:db8:f::/64 range 0 start 2001:db8:f::100
set service dhcpv6-server shared-network-name LAN subnet 2001:db8:f::/64 range 0 stop 2001:db8:f::200
```

```
vyos@vyos# commit
[ service dhcpv6-server ]
DHCPv6 conflicting subnet ranges: 2001:db8:a::/48 overlaps
2001:db8:a:1::/64
[[service dhcpv6-server]] failed
Commit failed
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
