### PR TITLE
T8352: VPP add op-mode commands to show bonding interfaces

### DIFF
--- a/op-mode-definitions/show_vpp_interfaces.xml.in
+++ b/op-mode-definitions/show_vpp_interfaces.xml.in
@@ -63,7 +63,23 @@
                 <properties>
                   <help>Show VPP bonding information</help>
                 </properties>
+                <command>${vyos_op_scripts_dir}/vpp.py show_bond</command>
                 <children>
+                  <virtualTagNode>
+                    <properties>
+                      <help>Show bonding information for a specific interface</help>
+                      <completionHelp>
+                        <path>interfaces vpp bonding</path>
+                      </completionHelp>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/vpp.py show_bond --ifname=$5</command>
+                  </virtualTagNode>
+                  <leafNode name="detail">
+                    <properties>
+                      <help>Show detailed bonding information</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/vpp.py show_bond_details</command>
+                  </leafNode>
                   <node name="lacp">
                     <properties>
                       <help>Show VPP LACP information</help>

--- a/src/conf_mode/vpp_interfaces_bonding.py
+++ b/src/conf_mode/vpp_interfaces_bonding.py
@@ -53,7 +53,7 @@ def _get_bond_lb(lb_name: str) -> int:
         'layer3+4': 1,
     }
 
-    return lb_mapping.get(lb_name, 5)
+    return lb_mapping.get(lb_name, 0)
 
 
 def get_config(config=None) -> dict:

--- a/src/op_mode/vpp.py
+++ b/src/op_mode/vpp.py
@@ -20,6 +20,7 @@ import typing
 
 from tabulate import tabulate
 from vyos.vpp import VPPControl
+from vyos.vpp.utils import vpp_iface_name_transform
 from vyos.configquery import ConfigTreeQuery
 import vyos.opmode
 
@@ -42,6 +43,21 @@ class VPPShow:
         3: 'COLLECTING_DISTRIBUTING',
     }
     PTX_STATES = {0: 'NO_PERIODIC', 1: 'FAST', 2: 'SLOW', 3: 'PERIODIC_TX'}
+    BOND_MODE = {
+        1: 'round-robin',
+        2: 'active-backup',
+        3: 'xor',
+        4: 'broadcast',
+        5: 'lacp',
+    }
+    BOND_LB = {
+        0: 'layer2',
+        1: 'layer3+4',
+        2: 'layer2+3',
+        3: 'round-robin',
+        4: 'broadcast',
+        5: 'active-backup',
+    }
 
     def __init__(self):
         self.config = ConfigTreeQuery()
@@ -159,7 +175,7 @@ class VPPShow:
         return data if raw else self._show_ipfix_table_formatted()
 
     # -----------------------------
-    # LACP information
+    # Bonding information
     # -----------------------------
     def _get_raw_output(self, data_dump: typing.List[dict]) -> list[dict]:
         data = [json.loads(json.dumps(d._asdict(), default=str)) for d in data_dump]
@@ -226,6 +242,47 @@ class VPPShow:
                 f'PTX-state: {self.PTX_STATES[d["ptx_state"]]}'
             )
 
+    def _get_bond_raw(self, index: typing.Optional[str]) -> list[dict]:
+        bond_dump = self.vpp.api.sw_bond_interface_dump(sw_if_index=index)
+
+        result = []
+        for bond in bond_dump:
+            bond_info = {
+                'interface_name': bond.interface_name,
+                'sw_if_index': bond.sw_if_index,
+                'mode': self.BOND_MODE[bond.mode],
+                'hash_policy': self.BOND_LB[bond.lb],
+                'active_members': bond.active_members,
+                'members': {},
+            }
+            members = self.vpp.api.sw_member_interface_dump(
+                sw_if_index=bond.sw_if_index
+            )
+            for member in members:
+                bond_info['members'][member.interface_name] = {
+                    'sw_if_index': member.sw_if_index,
+                    'is_passive': member.is_passive,
+                    'is_long_timeout': member.is_long_timeout,
+                    'is_local_numa': member.is_local_numa,
+                    'weight': member.weight,
+                }
+            result.append(bond_info)
+
+        return result
+
+    def _show_bond_info_formatted(self, data: typing.List[dict]) -> str:
+        table_data = [
+            {
+                'Interface': d['interface_name'],
+                'Mode': d['mode'],
+                'Hash': d['hash_policy'],
+                'Members': '\n'.join(sorted(d['members'].keys())),
+                'Active members': d['active_members'],
+            }
+            for d in data
+        ]
+        return tabulate(table_data, headers='keys', tablefmt='simple', numalign='left')
+
     def lacp_info(self, raw: bool, ifname: typing.Optional[str]):
         data = self._get_lacp_raw(ifname)
 
@@ -251,6 +308,31 @@ class VPPShow:
             return [data.reply]
 
         return data.reply
+
+    def bond_info(self, raw: bool, ifname: typing.Optional[str]) -> str:
+        index = NO_INDEX
+        if ifname:
+            if not ifname.startswith('vppbond') or not ifname[7:].isdigit():
+                raise vyos.opmode.IncorrectValue(
+                    f'"{ifname}" is not a valid bonding interface name (expected vppbondN)'
+                )
+
+            ifname_vpp = vpp_iface_name_transform(ifname)
+            index = self.vpp.get_sw_if_index(ifname_vpp)
+            if index is None:
+                raise vyos.opmode.IncorrectValue(
+                    f'Bonding interface {ifname} does not exist in VPP'
+                )
+
+        data = self._get_bond_raw(index)
+
+        return data if raw else self._show_bond_info_formatted(data)
+
+    def bond_details(self, raw: bool) -> str:
+        # VPP API call is not so informative -> use CLI command
+        cmd_command = 'show bond details'
+        data = self.vpp.cli_cmd(cmd_command)
+        return [data.reply] if raw else data.reply
 
     # -----------------------------
     # Bridge-domain information
@@ -343,7 +425,6 @@ class VPPShow:
         cmd_command = f'show bridge-domain {bd_id} detail'
         data = self.vpp.cli_cmd(cmd_command)
 
-
         if raw:
             return [data.reply]
 
@@ -382,7 +463,7 @@ def show_ipfix_table(raw: bool):
     return VPPShow().ipfix_table(raw)
 
 # -----------------------------
-# VPP LACP information
+# VPP Bonding information
 # -----------------------------
 @vyos.opmode.verify_cli_exists(['interfaces', 'vpp', 'bonding'])
 def show_lacp(raw: bool, ifname: typing.Optional[str]):
@@ -391,6 +472,14 @@ def show_lacp(raw: bool, ifname: typing.Optional[str]):
 @vyos.opmode.verify_cli_exists(['interfaces', 'vpp', 'bonding'])
 def show_lacp_details(raw: bool, ifname: typing.Optional[str]):
     return VPPShow().lacp_details(raw, ifname)
+
+@vyos.opmode.verify_cli_exists(['interfaces', 'vpp', 'bonding'])
+def show_bond(raw: bool, ifname: typing.Optional[str]):
+    return VPPShow().bond_info(raw, ifname)
+
+@vyos.opmode.verify_cli_exists(['interfaces', 'vpp', 'bonding'])
+def show_bond_details(raw: bool):
+    return VPPShow().bond_details(raw)
 
 # -----------------------------
 # Bridge op-mode entrie


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8352
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# run show interfaces vpp bonding
Interface      Mode           Hash           Members    Active members
-------------  -------------  -------------  ---------  ----------------
BondEthernet1  lacp           layer2         eth1       0
BondEthernet2  xor            layer2+3       eth0       0
BondEthernet3  active-backup  active-backup             0
[edit]
vyos@vyos# run show interfaces vpp bonding detail
BondEthernet1
  mode: lacp
  load balance: l2
  number of active members: 0
  number of members: 1
    eth1
  device instance: 0
  interface id: 1
  sw_if_index: 9
  hw_if_index: 5
BondEthernet2
  mode: xor
  load balance: l23
  number of active members: 0
  number of members: 1
    eth0
  device instance: 1
  interface id: 2
  sw_if_index: 11
  hw_if_index: 7
BondEthernet3
  mode: active-backup
  load balance: active-backup
  number of active members: 0
  number of members: 0
  device instance: 2
  interface id: 3
  sw_if_index: 13
  hw_if_index: 9

[edit]
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
