### PR TITLE
T8396: VPP op-mode "show interfaces vpp" missing ipv6 address

### DIFF
--- a/python/vyos/vpp/utils.py
+++ b/python/vyos/vpp/utils.py
@@ -167,18 +167,19 @@ def vpp_ifaces_list(vpp_api) -> list[dict]:
     return ifaces_list
 
 
-def vpp_ip_addresses_by_index(vpp_api, index: str) -> list[str]:
+def vpp_ip_addresses_by_index(vpp_api, index: int, is_ipv6: bool = False) -> list[str]:
     """List of IP addresses for interface by its index in VPP
 
     Args:
         vpp_api (_type_): VPP API object
-        index (str): interface index in vpp
+        index (int): interface index in vpp
+        is_ipv6 (bool, optional): If True, return IPv6 addresses. Defaults to False.
 
     Returns:
-        list[str]: list of IP addresses
+        list[str]: list of IP addresses (e.g. '192.0.2.1/24', '2001:db8::1/64')
     """
-    ip_addresses_list: list[dict] = []
-    ip_address_dump = vpp_api.ip_address_dump(sw_if_index=index)
+    ip_addresses_list: list[str] = []
+    ip_address_dump = vpp_api.ip_address_dump(sw_if_index=index, is_ipv6=is_ipv6)
     while ip_address_dump:
         ip_address_details = ip_address_dump.pop()
         ip_addresses_list.append(str(ip_address_details._asdict().get('prefix')))

--- a/src/op_mode/show_vpp_interfaces.py
+++ b/src/op_mode/show_vpp_interfaces.py
@@ -158,7 +158,10 @@ def show_interfaces_dataplane(interfaces_list: list, filter_type: str = 'all') -
         dp_ip_addresses = vpp_ip_addresses_by_index(
             vpp.api, interface.get('sw_if_index')
         )
-        ip_addresses = '\n'.join(dp_ip_addresses)
+        dp_ipv6_addresses = vpp_ip_addresses_by_index(
+            vpp.api, interface.get('sw_if_index'), is_ipv6=True
+        )
+        ip_addresses = '\n'.join(dp_ip_addresses + dp_ipv6_addresses)
 
         mac = str(interface.get('l2_address', 'n/a'))
         mtu = interface.get('mtu', [])[0]


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8396
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# run show interfaces vpp
Kernel        Dataplane          Type      IP Address          MAC                  MTU  State
------------  -----------------  --------  ------------------  -----------------  -----  -------
              BondEthernet1      bond      2001:db8:1::1/64    36:5c:ff:62:ce:ab   9000  up
              BondEthernet1.100  bond      2001:db8:200::1/64  00:00:00:00:00:00   9000  up
              eth0               dpdk                          0c:9c:d0:3d:00:00   1500  down
              eth1               dpdk      100.64.0.1/24       0c:9c:d0:3d:00:01   1500  up
                                           100.0.0.1/24
              eth1.10            dpdk                          00:00:00:00:00:00   1500  up
              eth1.20            dpdk                          00:00:00:00:00:00   1500  up
              local0             local                         00:00:00:00:00:00      0  down
              loop0              Loopback  10.255.0.1/32       46:fd:f0:9b:c9:a4   9000  up
                                           2001:db8:2::1/64
eth0          tap4096            virtio                        02:fe:52:5e:6f:e9   1500  up
eth1          tap4097            virtio                        02:fe:80:68:ef:14   1500  up
eth1.10       tap4097.10         virtio                        00:00:00:00:00:00   1500  up
eth1.20       tap4097.20         virtio                        00:00:00:00:00:00   1500  up
vppbond1      tap4098            virtio                        02:fe:90:5c:01:aa   9000  up
vppbond1.100  tap4098.100        virtio                        00:00:00:00:00:00      0  up
vpplo0        tap4099            virtio                        02:fe:74:2b:45:b0   9000  up
[edit]
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
