### PR TITLE
T8404: pppoe: fix TypeError when ipv6 address node exists without autoconf

### DIFF
--- a/python/vyos/ifconfig/pppoe.py
+++ b/python/vyos/ifconfig/pppoe.py
@@ -142,5 +142,5 @@ class PPPoEIf(Interface):
                 self._cmd(f'vtysh -c "conf t" {vrf} -c "ipv6 route ::/0 {self.ifname} tag 210 {distance}"')
 
         # kick RS when IPv6 is up.
-        if 'autoconf' in dict_search('ipv6.address', config):
+        if dict_search('ipv6.address.autoconf', config) is not None:
             self._cmd(f'rdisc6 --single --retry 3 {self.ifname}')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
in ppp/pppoe interfaces, dict_search('ipv6.address', config) returns None when the ipv6 address node is empty (e.g. after deleting autoconf), causing a TypeError on the 'in' membership test. Update dict_search('ipv6.address.autoconf', config) which safely returns None for any missing path segment.


<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
[T8404](https://vyos.dev/T8404)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

```
admin@core1# delete interfaces pppoe pppoe0 ipv6
[edit]
admin@core1# commit
[ interfaces pppoe pppoe0 ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 157, in run_script
    script.apply(c)
  File "/usr/libexec/vyos/conf_mode/interfaces_pppoe.py", line 132, in apply
    p.update(pppoe)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/pppoe.py", line 145, in update
    if 'autoconf' in dict_search('ipv6.address', config):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
[[interfaces pppoe pppoe0]] failed
Commit failed
[edit]
```

change line 145 in  /usr/lib/python3/dist-packages/vyos/ifconfig/pppoe.py from 

```
if 'autoconf' in dict_search('ipv6.address', config):
```
to

```
if dict_search('ipv6.address', config) and 'autoconf' in dict_search('ipv6.address', config)
```

the commit does work now


Existing `test_pppoe_dhcpv6pd` in
  `smoketest/scripts/cli/test_interfaces_pppoe.py` covers the working
  DHCPv6-PD + autoconf path. The fix changes no behavior when autoconf
  is present. It only prevents the crash when the node is absent.


<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics

```
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
