### PR TITLE
vpp: T8286: Uninitialized interfaces raise errors when added to VPP

### DIFF
--- a/python/vyos/vpp/config_filter.py
+++ b/python/vyos/vpp/config_filter.py
@@ -15,6 +15,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+from vyos.base import Warning
 from vyos.config import Config
 
 
@@ -42,7 +43,10 @@ def iface_filter_eth(config: Config, iface: str) -> None:
         'vrf',
     ]
 
-    # get list of config nides in a session configuration
+    if not config._session_config.exists(['interfaces', 'ethernet', iface]):
+        return
+
+    # get list of config nodes in a session configuration
     iface_nodes = config._session_config.list_nodes(['interfaces', 'ethernet', iface])
 
     # clean cached session config
@@ -53,6 +57,6 @@ def iface_filter_eth(config: Config, iface: str) -> None:
     for cfg_node in iface_nodes:
         if cfg_node not in allowed_nodes:
             config._session_config.delete(['interfaces', 'ethernet', iface, cfg_node])
-            print(
-                f'WARNING: {cfg_node} option in {iface} settings is not supported by VPP interfaces. It will be ignored.'
+            Warning(
+                f'{cfg_node} option in {iface} settings is not supported by VPP interfaces. It will be ignored.'
             )


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8286
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# show vpp
 settings {
     allow-unsupported-nics
     interface eth0 {
     }
     interface eth1 {
     }
     poll-sleep-usec 222
 }
[edit]
vyos@vyos# show interfaces
 ethernet eth0 {
     hw-id 0c:9c:d0:3d:00:00
 }
 ethernet eth1 {
     hw-id 0c:9c:d0:3d:00:01
     offload {
         gro
     }
 }
 ethernet eth2 {
     hw-id 0c:9c:d0:3d:00:02
 }
 ethernet eth3 {
     address dhcp
     hw-id 0c:9c:d0:3d:00:03
 }
 loopback lo {
 }
[edit]
vyos@vyos# ip link show dev eth4
45: eth4: <BROADCAST,MULTICAST> mtu 1500 qdisc noop state DOWN mode DEFAULT group default qlen 1000
    link/ether 0c:9c:d0:3d:00:04 brd ff:ff:ff:ff:ff:ff
    altname enp0s7
    altname ens7
[edit]
vyos@vyos# set vpp settings interface eth4
[edit]
vyos@vyos# commit
[ vpp ]

WARNING: offload option in eth1 settings is not supported by VPP
interfaces. It will be ignored.


WARNING: Interface eth4 is not present in the current configuration


WARNING: NOTE: Current dataplane capacity (estimated): 2.1 M IPv4
routes. Exceeding these values will lead to a dataplane out-of-memory
condition and a crash. Extensive use of features like ACLs, NAT and
others may reduce the numbers above. Please read the documentation for
details: https://docs.vyos.io/


[edit]
vyos@vyos# run show interfaces vpp
Kernel    Dataplane    Type    IP Address    MAC                  MTU  State
--------  -----------  ------  ------------  -----------------  -----  -------
          eth0         dpdk                  0c:9c:d0:3d:00:00   1500  down
          eth1         dpdk                  0c:9c:d0:3d:00:01   1500  up
          eth4         dpdk                  0c:9c:d0:3d:00:04   9000  down
          local0       local                 00:00:00:00:00:00      0  down
eth0      tap4096      virtio                02:fe:a9:0e:a8:1d   1500  up
eth1      tap4097      virtio                02:fe:2d:e4:9f:c6   1500  up
eth4      tap4098      virtio                02:fe:3b:5e:2e:c3   9000  up
[edit]
vyos@vyos#
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
