### PR TITLE
validators: T8384: ipv6-eui64-prefix: unhandled exception on eui-64 address validation

### DIFF
--- a/src/validators/ipv6-eui64-prefix
+++ b/src/validators/ipv6-eui64-prefix
@@ -2,6 +2,8 @@
 
 # Validator used to check if given IPv6 prefix is of size /64 required by EUI64
 
+import ipaddress
+
 from sys import argv
 from sys import exit
 
@@ -10,7 +12,14 @@ if __name__ == '__main__':
         exit(1)
 
     prefix = argv[1]
-    if prefix.split('/')[1] == '64':
-        exit(0)
+
+    try:
+        network = ipaddress.ip_network(prefix)
+        if network.prefixlen == 64:
+            exit(0)
+    except ValueError:
+        print(
+            'EUI64 prefix must be a valid IPv6 prefix in CIDR notation (e.g., 2001:db8::/64)'
+        )
 
     exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8384
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Before the fix:
```
vyos@vyos# set interfaces ethernet eth0 ipv6 address eui64 2001:db8::

  Traceback (most recent call last):
    File "/usr/libexec/vyos/validators/ipv6-eui64-prefix", line 13, in <module>
      if prefix.split('/')[1] == '64':
         ~~~~~~~~~~~~~~~~~^^^
  IndexError: list index out of range



  EUI64 prefix length must be 64
  Value validation failed
  Set failed

[edit]
```
After the fix:
```
vyos@vyos# set interfaces ethernet eth0 ipv6 address eui64 2001:db8::




  EUI64 prefix length must be 64
  Value validation failed
  Set failed

[edit]
vyos@vyos# set interfaces ethernet eth0 ipv6 address eui64 2001:db8::/64
[edit]
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
