### PR TITLE
T8405: fix noipv6 emitted when dhcpv6-options configured without ipv6 node

### DIFF
--- a/data/templates/pppoe/peer.j2
+++ b/data/templates/pppoe/peer.j2
@@ -59,7 +59,7 @@ mru {{ mru }}
 
 {{ "usepeerdns" if no_peer_dns is not vyos_defined }}
 
-{% if ipv6 is vyos_defined %}
++{% if ipv6 is vyos_defined or dhcpv6_options.pd is vyos_defined or (address is vyos_defined and 'dhcpv6' in address) %}
 +ipv6 {{ 'ipv6cp-use-ipaddr' if ipv6.address.autoconf is vyos_defined }}
 {% else %}
 noipv6

--- a/src/conf_mode/interfaces_pppoe.py
+++ b/src/conf_mode/interfaces_pppoe.py
@@ -49,9 +49,18 @@ def get_config(config=None):
     # We should only terminate the PPPoE session if critical parameters change.
     # All parameters that can be changed on-the-fly (like interface description)
     # should not lead to a reconnect!
-    for options in ['access-concentrator', 'connect-on-demand', 'service-name',
-                    'source-interface', 'vrf', 'no-default-route',
-                    'authentication', 'host_uniq']:
+    for options in [
+        'access-concentrator',
+        'connect-on-demand',
+        'service-name',
+        'source-interface',
+        'vrf',
+        'no-default-route',
+        'authentication',
+        'host-uniq',
+        'dhcpv6-options',
+        'ipv6',
+    ]:
         if is_node_changed(conf, base + [ifname, options]):
             pppoe.update({'shutdown_required': {}})
             # bail out early - no need to further process other nodes


### PR DESCRIPTION
## Change summary

When a PPPoE interface has dhcpv6-options (e.g. prefix delegation) configured but no explicit ipv6 node, the Jinja template writes noipv6 into the PPP peer configuration. This prevents IPv6CP negotiation, causing the ISP to silently ignore all DHCPv6 traffic. Extending the peer template to also check for dhcpv6_options before emitting noipv6, and add dhcpv6-options and ipv6 to the list of config nodes that trigger a PPPoE session restart so the change takes effect without manual disconnect/reconnect as it is not immediately clear that this is necessary

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->


<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T8405
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

  1. Configure a PPPoE interface with DHCPv6-PD but **no** `ipv6` node:
```
  set interfaces pppoe pppoe0 authentication username user
  set interfaces pppoe pppoe0 authentication password pass
  set interfaces pppoe pppoe0 source-interface eth0
  set interfaces pppoe pppoe0 dhcpv6-options pd 0 length 56
  set interfaces pppoe pppoe0 dhcpv6-options pd 0 interface eth1 sla-id 1
  commit
```

  2. Before fix: the generated peer config at 
 ```
  /etc/ppp/peers/pppoe0
```
contains
```
     noipv6 
```
preventing IPv6CP negotiation. 

DHCPv6 Solicit messages are sent but never receive a response from the BNG.

  5. After fix: peer config contains `+ipv6`, IPv6CP negotiates successfully, and DHCPv6-PD works as expected.

  ### Smoketest
  $ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_pppoe.py

  Existing `test_pppoe_dhcpv6pd` always sets `ipv6 address autoconf`
  alongside DHCPv6-PD (line 267), so it does not hit this bug but
  confirms the change does not regress the existing path.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
