### PR TITLE
configverify: T8413: fix issue in duplex shaping (redirect to input interface)

### DIFF
--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -180,8 +180,13 @@ def verify_mirror_redirect(config):
 
     It makes no sense to mirror traffic back at yourself!
     """
-    if {'mirror', 'redirect'} <= set(config):
+    if 'mirror' in config and 'redirect' in config:
         raise ConfigError('Mirror and redirect can not be enabled at the same time!')
+
+    if 'mirror' in config and 'qos' in config:
+        # XXX: support combination of limiting and mirror - this is an artificial
+        # limitation from the past
+        raise ConfigError('Can not use QoS together with mirror!')
 
     if 'mirror' in config:
         for direction, mirror_interface in config['mirror'].items():
@@ -198,11 +203,6 @@ def verify_mirror_redirect(config):
         if not interface_exists(redirect_ifname):
             raise ConfigError(f'Requested redirect interface "{redirect_ifname}" '\
                                'does not exist!')
-
-    if 'qos' in config and ('mirror' in config or 'redirect' in config):
-        # XXX: support combination of limiting and redirect/mirror - this is an
-        # artificial limitation
-        raise ConfigError('Can not use QoS together with mirror/redirect!')
 
 def verify_authentication(config):
     """


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

After commit 6eafdbf1a8 (`configdict: T8358: rename internal representation from traffic_policy to qos`) we uncovered a bug/added a feature in supporting QoS and redirect on an interface.

The code in VyOS stream 2026.02 is:

`if ('mirror' in config or 'redirect' in config) and dict_search('traffic_policy.in', config) is not None:`
and this got changed to:
`if 'qos' in config and ('mirror' in config or 'redirect' in config):`
in the commit mentioned above

When looking at the code in 2026.02 release
```
# git describe --tags
2026.02

# git grep traffic_policy
python/vyos/configdict.py:        dict.update({'traffic_policy': {}})
python/vyos/configdict.py:            dict['vif'][vif].update({'traffic_policy': {}})
python/vyos/configdict.py:            dict['vif_s'][vif_s].update({'traffic_policy': {}})
python/vyos/configdict.py:                dict['vif_s'][vif_s]['vif_c'][vif_c].update({'traffic_policy': {}})
python/vyos/configverify.py:    if ('mirror' in config or 'redirect' in config) and dict_search('traffic_policy.in', config) is not None:
python/vyos/ifconfig/interface.py:        if not 'traffic_policy' in self.config:
```
I never see `traffic_policy.in` set, so the check seems to have never worked in the past at all

During the QoS rewrite from 1.3 -> 1.4 CLI `traffic-policy` was renamed by me to `qos` but we kept that synthetic key in the Python code. That is the root cause. So it should have never worked (CLI wise) but during that bug it started to work as expected, and even the Python code stated in a comment: 

```
if 'qos' in config and ('mirror' in config or 'redirect' in config):
    # XXX: support combination of limiting and redirect/mirror - this is an artificial limitation
    raise ConfigError('Can not use QoS together with mirror/redirect!')
```

So we have enabled this feature for a long time by accident already.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8413

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/5036

## How to test / Smoketest result
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_qos.py
test_01_cake (__main__.TestQoS.test_01_cake) ... ok
test_02_drop_tail (__main__.TestQoS.test_02_drop_tail) ... ok
test_03_fair_queue (__main__.TestQoS.test_03_fair_queue) ... ok
test_04_fq_codel (__main__.TestQoS.test_04_fq_codel) ... ok
test_05_limiter (__main__.TestQoS.test_05_limiter) ... ok
test_06_network_emulator (__main__.TestQoS.test_06_network_emulator) ... ok
test_07_priority_queue (__main__.TestQoS.test_07_priority_queue) ... ok
test_08_random_detect (__main__.TestQoS.test_08_random_detect) ... ok
test_09_rate_control (__main__.TestQoS.test_09_rate_control) ... ok
test_10_round_robin (__main__.TestQoS.test_10_round_robin) ... ok
test_11_shaper (__main__.TestQoS.test_11_shaper) ... ok
test_12_shaper_with_red_queue (__main__.TestQoS.test_12_shaper_with_red_queue) ... ok
test_13_shaper_delete_only_rule (__main__.TestQoS.test_13_shaper_delete_only_rule) ... ok
test_14_policy_limiter_marked_traffic (__main__.TestQoS.test_14_policy_limiter_marked_traffic) ... ok
test_15_traffic_match_group (__main__.TestQoS.test_15_traffic_match_group) ... ok
test_16_wrong_traffic_match_group (__main__.TestQoS.test_16_wrong_traffic_match_group) ... ok
test_17_cake_updates (__main__.TestQoS.test_17_cake_updates) ... ok
test_18_priority_queue_default (__main__.TestQoS.test_18_priority_queue_default) ... ok
test_19_priority_queue_default_random_detect (__main__.TestQoS.test_19_priority_queue_default_random_detect) ... ok
test_20_round_robin_policy_default (__main__.TestQoS.test_20_round_robin_policy_default) ... ok
test_21_shaper_hfsc (__main__.TestQoS.test_21_shaper_hfsc) ... ok
test_22_rate_control_default (__main__.TestQoS.test_22_rate_control_default) ... ok
test_23_policy_limiter_iif_filter (__main__.TestQoS.test_23_policy_limiter_iif_filter) ... ok
test_24_policy_shaper_match_ether (__main__.TestQoS.test_24_policy_shaper_match_ether) ... ok

----------------------------------------------------------------------
Ran 24 tests in 87.333s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
