### PR TITLE
config: T8858: fix mutable default argument in config API methods

### DIFF
--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -480,21 +480,24 @@ class Config(object):
         else:
             return(value)
 
-    def return_values(self, path, default=[]):
+    def return_values(self, path, default=None):
         """
         Retrieve all values of a multi-value leaf node in the running or proposed config
 
         Args:
             path (str): Configuration tree path
+            default (list): Value returned (as a copy) when the node does not exist or has no values. Defaults to an empty list.
 
         Returns:
             str list: Node values, if it has any
-            []: if node does not exist
+            default.copy(): if node does not exist or has no values
 
         Note:
             This function cannot be used outside a configuration session.
             In operational mode scripts, use ``return_effective_values``.
         """
+        if default is None:
+            default = []
         if self._session_config:
             try:
                 values = self._session_config.return_values(self._make_path(path))
@@ -508,17 +511,20 @@ class Config(object):
         else:
             return(values)
 
-    def list_nodes(self, path, default=[]):
+    def list_nodes(self, path, default=None):
         """
         Retrieve names of all children of a tag node in the running or proposed config
 
         Args:
             path (str): Configuration tree path
+            default (list): Value returned (as a copy) when the tag node does not exist or has no children. Defaults to an empty list.
 
         Returns:
-            string list: child node names
+            string list: child node names, or default.copy() if the node does not exist or has no children
 
         """
+        if default is None:
+            default = []
         if self._session_config:
             try:
                 nodes = self._session_config.list_nodes(self._make_path(path))
@@ -596,16 +602,19 @@ class Config(object):
         else:
             return(value)
 
-    def return_effective_values(self, path, default=[]):
+    def return_effective_values(self, path, default=None):
         """
         Retrieve all values of a multi-value node in a running (effective) config
 
         Args:
             path (str): Configuration tree path
+            default (list): Value returned (as a copy) when the node does not exist or has no values. Defaults to an empty list.
 
         Returns:
-            str list: A list of values
+            str list: A list of values, or default.copy() if the node does not exist or has no values
         """
+        if default is None:
+            default = []
         if self._running_config:
             try:
                 values = self._running_config.return_values(self._make_path(path))
@@ -619,16 +628,19 @@ class Config(object):
         else:
             return(values)
 
-    def list_effective_nodes(self, path, default=[]):
+    def list_effective_nodes(self, path, default=None):
         """
         Retrieve names of all children of a tag node in the running config
 
         Args:
             path (str): Configuration tree path
+            default (list): Value returned (as a copy) when the tag node does not exist or has no children. Defaults to an empty list.
 
         Returns:
-            str list: child node names
+            str list: child node names, or default.copy() if the node does not exist or has no children
         """
+        if default is None:
+            default = []
         if self._running_config:
             try:
                 nodes = self._running_config.list_nodes(self._make_path(path))

--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -480,7 +480,7 @@ class Config(object):
         else:
             return(value)
 
-    def return_values(self, path, default=[]):
+    def return_values(self, path, default=None):
         """
         Retrieve all values of a multi-value leaf node in the running or proposed config
 
@@ -495,6 +495,8 @@ class Config(object):
             This function cannot be used outside a configuration session.
             In operational mode scripts, use ``return_effective_values``.
         """
+        if default is None:
+            default = []
         if self._session_config:
             try:
                 values = self._session_config.return_values(self._make_path(path))
@@ -508,7 +510,7 @@ class Config(object):
         else:
             return(values)
 
-    def list_nodes(self, path, default=[]):
+    def list_nodes(self, path, default=None):
         """
         Retrieve names of all children of a tag node in the running or proposed config
 
@@ -519,6 +521,8 @@ class Config(object):
             string list: child node names
 
         """
+        if default is None:
+            default = []
         if self._session_config:
             try:
                 nodes = self._session_config.list_nodes(self._make_path(path))
@@ -596,7 +600,7 @@ class Config(object):
         else:
             return(value)
 
-    def return_effective_values(self, path, default=[]):
+    def return_effective_values(self, path, default=None):
         """
         Retrieve all values of a multi-value node in a running (effective) config
 
@@ -606,6 +610,8 @@ class Config(object):
         Returns:
             str list: A list of values
         """
+        if default is None:
+            default = []
         if self._running_config:
             try:
                 values = self._running_config.return_values(self._make_path(path))
@@ -619,7 +625,7 @@ class Config(object):
         else:
             return(values)
 
-    def list_effective_nodes(self, path, default=[]):
+    def list_effective_nodes(self, path, default=None):
         """
         Retrieve names of all children of a tag node in the running config
 
@@ -629,6 +635,8 @@ class Config(object):
         Returns:
             str list: child node names
         """
+        if default is None:
+            default = []
         if self._running_config:
             try:
                 nodes = self._running_config.list_nodes(self._make_path(path))


### PR DESCRIPTION
Tracked in Phorge [T8858](https://vyos.dev/T8858).

## Summary

- Change `default=[]` to `default=None` with an explicit `if default is None: default = []` guard inside the body, in four `Config` methods: `return_values`, `list_nodes`, `return_effective_values`, `list_effective_nodes`.
- Document the `default` parameter in each method's `Args:` section and clarify the `Returns:` clause to spell out the `default.copy()` fallback semantics when the node does not exist or is empty.

## Why this is a safeguard, not a bug fix

As [dmbaturin pointed out](https://github.com/vyos/vyos-1x/pull/5075#pullrequestreview-4280564088), the actual mutable-default footgun is mitigated by `_make_path` in `python/vyos/config.py` returning `(self._level + path)` — `+` creates a fresh list, so callers passing the default through these methods never reach a `.append()` site that would mutate it. The change is preserved as a defensive safeguard against future code paths that might mutate `default` directly.

## Scope (intentionally narrow)

`get_config_dict` and `get_config_defaults` accept `path=[]` too and would benefit from the same treatment, but their internal use of `path` flows through recursion and key-mangling logic where the `+`-semantics safety net does not apply cleanly. Auditing those properly warrants its own task — this PR stays scoped to the four list-returning helpers where the safeguard is trivially correct.

## Test plan

- [ ] Verify callers passing no `default` argument still receive an empty list as before.
- [ ] Verify callers passing an explicit `default` value still receive that value when the node is missing.
- [ ] Existing unit / integration tests pass without regressions.

🤖 Generated by [robots](https://vyos.io)