### PR TITLE
dhcpv6: T8414: missing prefix-delegation interface constraint

### DIFF
--- a/interface-definitions/include/interface/dhcpv6-options.xml.i
+++ b/interface-definitions/include/interface/dhcpv6-options.xml.i
@@ -54,6 +54,13 @@
             <completionHelp>
               <script>${vyos_completion_dir}/list_interfaces --broadcast</script>
             </completionHelp>
+            <valueHelp>
+              <format>txt</format>
+              <description>Interface name</description>
+            </valueHelp>
+            <constraint>
+              #include <include/constraint/interface-name.xml.i>
+            </constraint>
           </properties>
           <children>
             <leafNode name="address">


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

```
vyos@vyos# show interfaces pppoe
 pppoe pppoe111 {
     address dhcpv6
     authentication {
         password vyos
         username vyos
     }
+    dhcpv6-options {
+        pd 0 {
+            interface dum0 {
+            }
+            interface dumL {
+            }
+        }
+    }
     source-interface eth1
 }
[edit]
vyos@vyos# commit
vyos@vyos#
```
```
vyos@vyos# set interfaces dummy dumL

  Dummy interface must be named dumN
  Value validation failed
  Set failed
``` 
It must not be allowed to define interface dumL on the CLI

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8414

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
See summary

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
