### PR TITLE
login: T8415: show Warning() if default password is used when adding user

### DIFF
--- a/smoketest/scripts/cli/test_system_login.py
+++ b/smoketest/scripts/cli/test_system_login.py
@@ -31,6 +31,7 @@ from subprocess import PIPE
 
 from vyos.configsession import ConfigSessionError
 from vyos.configquery import ConfigTreeQuery
+from vyos.utils.auth import DEFAULT_PASSWORD
 from vyos.utils.auth import get_current_user
 from vyos.utils.auth import get_local_passwd_entries
 from vyos.utils.process import cmd
@@ -235,14 +236,22 @@ class TestSystemLogin(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'{locked_user} P ', tmp)
 
     def test_system_login_weak_password_warning(self):
+        username = weak_passwd_user[0]
         self.cli_set(base_path + [
-            'user', weak_passwd_user[0], 'authentication',
+            'user', username, 'authentication',
             'plaintext-password', weak_passwd_user[1]
         ])
 
         out = self.cli_commit().strip()
+        self.assertIn(f'WARNING: User "{username}" - The password complexity is too low', out)
 
-        self.assertIn('WARNING: The password complexity is too low', out)
+        self.cli_set(base_path + [
+            'user', username, 'authentication',
+            'plaintext-password', DEFAULT_PASSWORD])
+
+        out = self.cli_commit().strip()
+        self.assertIn(f'WARNING: Default password used for user "{username}"', out)
+
         self.cli_delete(base_path + ['user', weak_passwd_user[0]])
 
     def test_system_login_otp(self):

--- a/src/conf_mode/system_login.py
+++ b/src/conf_mode/system_login.py
@@ -33,6 +33,7 @@ from vyos.configverify import verify_vrf
 from vyos.defaults import SSH_DSA_DEPRECATION_WARNING
 from vyos.template import render
 from vyos.template import is_ipv4
+from vyos.utils.auth import DEFAULT_PASSWORD
 from vyos.utils.auth import EPasswdStrength
 from vyos.utils.auth import evaluate_strength
 from vyos.utils.auth import get_current_user
@@ -143,20 +144,21 @@ def verify(login):
                 if s_user.pw_name == user and s_user.pw_uid < MIN_USER_UID:
                     raise ConfigError(f'User "{user}" can not be created, conflict with local system account!')
 
+            plaintext_password = dict_search('authentication.plaintext_password', user_config)
+            if plaintext_password == DEFAULT_PASSWORD:
+                Warning(f'Default password used for user "{user}" - consider changing it')
+
             # T6353: Check password for complexity using cracklib.
             # A user password should be sufficiently complex
-            plaintext_password = dict_search(
-                path='authentication.plaintext_password',
-                dict_object=user_config
-            ) or None
-
             failed_check_status = [EPasswdStrength.WEAK, EPasswdStrength.ERROR]
-            if plaintext_password is not None:
+            if plaintext_password and len(plaintext_password) > 0:
                 result = evaluate_strength(plaintext_password)
                 if result['strength'] in failed_check_status:
-                    Warning(result['error'])
+                    tmp = result['error']
+                    Warning(f'User "{user}" - {tmp}')
 
-            for pubkey, pubkey_options in (dict_search('authentication.public_keys', user_config) or {}).items():
+            for pubkey, pubkey_options in dict_search('authentication.public_keys', user_config,
+                                                      default={}).items():
                 if 'type' not in pubkey_options:
                     raise ConfigError(f'Missing type for public-key "{pubkey}"!')
                 if 'key' not in pubkey_options:

--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -49,19 +49,17 @@ from vyos.system import raid
 from vyos.system import SYSTEM_CFG_VER
 from vyos.system import grub_util
 from vyos.template import render
-from vyos.utils.auth import (
-    DEFAULT_PASSWORD,
-    EPasswdStrength,
-    evaluate_strength
-)
+from vyos.utils.auth import DEFAULT_PASSWORD
+from vyos.utils.auth import EPasswdStrength
+from vyos.utils.auth import evaluate_strength
+from vyos.utils.auth import get_local_users
+from vyos.utils.auth import get_user_home_dir
 from vyos.utils.dict import dict_search
 from vyos.utils.io import ask_input, ask_yes_no, select_entry
 from vyos.utils.file import chmod_2775
 from vyos.utils.file import read_file
 from vyos.utils.file import write_file
 from vyos.utils.process import cmd, run, rc_cmd
-from vyos.utils.auth import get_local_users
-from vyos.utils.auth import get_user_home_dir
 from vyos.version import get_version_data
 from vyos.config_mgmt import unsaved_commits
 


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

When performing an image installation and the user chooses vyos as the default password, a warning is emitted.

The combination vyos/vyos is used in brute force lists and have been seen multiple times in the wild. When adding the user via: `set system login user vyos authentication plaintext-password vyos` a warning should be shown!

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8415

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
set system login user vyos authentication plaintext-password vyos
commit
```

```
WARNING: Default password used for user "vyos" - consider changing it

WARNING: User "vyos" - The password complexity is too low - it should not be too short
```

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_system_login.py -k test_system_login_weak_password_warning
test_system_login_weak_password_warning (__main__.TestSystemLogin.test_system_login_weak_password_warning) ... ok

----------------------------------------------------------------------
Ran 1 test in 6.728s

OK
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
