### PR TITLE
vpp: T8416: Prevent interfaces from being assigned to xconnect and bridge/bonding at the same time

### DIFF
--- a/python/vyos/vpp/config_verify.py
+++ b/python/vyos/vpp/config_verify.py
@@ -62,6 +62,35 @@ def verify_vpp_tunnel_source_address(config: dict):
     )
 
 
+def verify_member_conflicts(iface, config, current_type):
+    """
+    Check that a member interface is not already used by another interface type.
+
+    Args:
+        iface (str): interface name to check
+        config (dict): configuration dictionary
+        current_type (str): the membership type being assigned
+            to the interface ('bridge', 'bond', or 'xconn')
+
+    Raises:
+        ConfigError: If the interface is already a member of a conflicting interface type.
+    """
+    iface_type_map = {
+        'bridge': 'bridge',
+        'bond': 'bonding',
+        'xconn': 'xconnect',
+    }
+    for iface_type, label in iface_type_map.items():
+        if iface_type == current_type:
+            continue
+        members = config.get(f'{iface_type}_members', {}).get(iface)
+        if members:
+            raise ConfigError(
+                f'Interface {iface} cannot be a member of {iface_type_map[current_type]} '
+                f'because it already belongs to {label} interface(s): {", ".join(members)}.'
+            )
+
+
 def create_cpu_error_message(cpus_required: int, cpus_available: int = None) -> str:
     cpu_info = get_cpus()
     logical_cores = sum(

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -543,6 +543,19 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.assertRegex(out, r'\s*eth1\s+\d+\s+\d+')
         self.assertRegex(out, r'\s*vxlan_tunnel23\s+\d+\s+\d+')
 
+        # Cannot add members of bridge interface to cross-connect
+        # expect raise ConfigError
+        self.cli_set(
+            interfaces_path + ['xconnect', 'vppxcon1', 'member', 'interface', interface]
+        )
+        self.cli_set(
+            interfaces_path
+            + ['xconnect', 'vppxcon1', 'member', 'interface', interface_vxlan]
+        )
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(interfaces_path + ['xconnect'])
+
         # Add Loopback BVI to the bridge
         self.cli_set(interfaces_path + ['loopback', f'vpplo{vni}'])
         self.cli_set(
@@ -652,6 +665,16 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         ]
         for required_string in required_str_list:
             self.assertIn(required_string, out)
+
+        # Cannot add members of cross-connect interface to bond/bridge
+        # expect raise ConfigError
+        self.cli_set(
+            interfaces_path
+            + ['bonding', 'vppbond1', 'member', 'interface', interface_vxlan]
+        )
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(interfaces_path + ['bonding'])
 
         # delete xconnect interface
         self.cli_delete(xconn_path + [interface_xconnect])

--- a/src/conf_mode/vpp_interfaces_bonding.py
+++ b/src/conf_mode/vpp_interfaces_bonding.py
@@ -27,6 +27,7 @@ from vyos.ifconfig.vpp import VPPBondInterface
 from vyos.vpp.config_deps import deps_bond_dict
 from vyos.vpp.config_deps import deps_bridge_dict
 from vyos.vpp.config_deps import deps_xconnect_dict
+from vyos.vpp.config_verify import verify_member_conflicts
 from vyos.vpp.config_verify import verify_vpp_remove_bridge_interface
 from vyos.vpp.config_verify import verify_vpp_remove_xconnect_interface
 from vyos.vpp.utils import cli_ifaces_list
@@ -166,13 +167,7 @@ def verify(config):
                 f'Interface {iface} cannot be a member of multiple bonding interfaces: {", ".join(bond_members)}'
             )
 
-        # Interface cannot be a member of a bridge and a bond at the same time
-        bridge_members = config['bridge_members'].get(iface)
-        if bridge_members:
-            raise ConfigError(
-                f'Interface {iface} cannot be a member of a bond because '
-                f'it already belongs to bridge interface: {", ".join(bridge_members)}.'
-            )
+        verify_member_conflicts(iface, config, 'bond')
 
     if 'mac' in config:
         mac = config['mac']

--- a/src/conf_mode/vpp_interfaces_bridge.py
+++ b/src/conf_mode/vpp_interfaces_bridge.py
@@ -24,6 +24,8 @@ from vyos.utils.process import is_systemd_service_active
 from vyos.ifconfig.vpp import VPPBridgeInterface
 from vyos.vpp.config_deps import deps_bond_dict
 from vyos.vpp.config_deps import deps_bridge_dict
+from vyos.vpp.config_deps import deps_xconnect_dict
+from vyos.vpp.config_verify import verify_member_conflicts
 
 
 def get_config(config=None) -> dict:
@@ -67,6 +69,7 @@ def get_config(config=None) -> dict:
 
     config['bond_members'] = deps_bond_dict(conf)
     config['bridge_members'] = deps_bridge_dict(conf)
+    config['xconn_members'] = deps_xconnect_dict(conf)
 
     return config
 
@@ -104,13 +107,7 @@ def verify(config):
                     f'Interface {member} is added to more than one bridge: {", ".join(bridge_members)}'
                 )
 
-            # Interface cannot be a member of a bridge and a bond at the same time
-            bond_members = config['bond_members'].get(member)
-            if bond_members:
-                raise ConfigError(
-                    f'Interface {member} cannot be a member of a bridge '
-                    f'because it already belongs to bonding interface: {", ".join(bond_members)}.'
-                )
+            verify_member_conflicts(member, config, 'bridge')
 
             # Check if BVI is already defined, only one BVI per bridge domain is allowed
             if 'bvi' in member_config:

--- a/src/conf_mode/vpp_interfaces_xconnect.py
+++ b/src/conf_mode/vpp_interfaces_xconnect.py
@@ -22,7 +22,10 @@ from vyos.configdict import get_interface_dict
 from vyos.utils.process import is_systemd_service_active
 
 from vyos.ifconfig.vpp import VPPXconnectInterface
+from vyos.vpp.config_deps import deps_bond_dict
+from vyos.vpp.config_deps import deps_bridge_dict
 from vyos.vpp.config_deps import deps_xconnect_dict
+from vyos.vpp.config_verify import verify_member_conflicts
 from vyos.vpp.utils import cli_ifaces_list
 
 
@@ -59,6 +62,8 @@ def get_config(config=None) -> dict:
     if effective_config:
         config.update({'effective': effective_config})
 
+    config['bond_members'] = deps_bond_dict(conf)
+    config['bridge_members'] = deps_bridge_dict(conf)
     config['xconn_members'] = deps_xconnect_dict(conf)
     config['vpp_ifaces'] = cli_ifaces_list(conf, 'candidate')
 
@@ -78,7 +83,7 @@ def verify(config):
     if len(config.get('member', {}).get('interface')) != 2:
         raise ConfigError('Cross connect requires 2 members')
 
-    not_allowed_prefixes = ('vppbond', 'vppbridge', 'vpplo')
+    not_allowed_prefixes = ('vppbond', 'vppbr', 'vpplo')
     for iface in config.get('member', {}).get('interface', []):
         # Ensure the interface is allowed as xconnect member
         if iface.startswith(not_allowed_prefixes):
@@ -93,6 +98,8 @@ def verify(config):
             raise ConfigError(
                 f'Interface {iface} added to more than one xconnect: {", ".join(xconn_members)}'
             )
+
+        verify_member_conflicts(iface, config, 'xconn')
 
 
 def generate(config):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8416
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set interfaces vpp bridge vppbr1 member interface eth1
set vpp settings interface eth1

vyos@vyos# set interfaces vpp xconnect vppxcon1 member interface vppbr1
[edit]
vyos@vyos# set interfaces vpp xconnect vppxcon1 member interface eth1
[edit]
vyos@vyos# commit
[ interfaces vpp xconnect vppxcon1 ]
Interface eth1 cannot be a member of xconnect because it already belongs
to bridge interface: vppbr1.

[[interfaces vpp xconnect vppxcon1]] failed
Commit failed
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
