### PR TITLE
kea: T8408: Fixes to enable dhcp option 67

### DIFF
--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -47,7 +47,7 @@ kea4_options = {
     'captive_portal': 'v4-captive-portal',
     'capwap_controller': 'capwap-ac-v4',
     'interface_mtu': 'interface-mtu',
-    'bootfile_name': 'boot-file-name'
+    'bootfile_name': 'boot-file-name',
 }
 
 kea6_options = {

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -165,7 +165,7 @@ def kea_parse_subnet(subnet, config):
 
         if 'bootfile_name' in config['option']:
             out['boot-file-name'] = config['option']['bootfile_name']
-            out['option-data'].append({"name": "boot-file-name", "data": config['option']['bootfile_name']})
+            out['option-data'].append({'name': 'boot-file-name', 'data': config['option']['bootfile_name']})
 
         if 'bootfile_server' in config['option']:
             out['next-server'] = config['option']['bootfile_server']
@@ -196,8 +196,8 @@ def kea_parse_subnet(subnet, config):
                     pool['boot-file-name'] = range_config['option']['bootfile_name']
                     pool['option-data'].append(
                         {
-                            "name": "boot-file-name",
-                            "data": range_config['option']['bootfile_name']
+                            'name': 'boot-file-name',
+                            'data': range_config['option']['bootfile_name']
                         }
                     )
 
@@ -238,8 +238,8 @@ def kea_parse_subnet(subnet, config):
                     ]
                     reservation['option-data'].append(
                         {
-                            "name": "boot-file-name",
-                            "data": host_config['option']['bootfile_name']
+                            'name': 'boot-file-name',
+                            'data': host_config['option']['bootfile_name']
                         }
                     )
 

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -165,6 +165,7 @@ def kea_parse_subnet(subnet, config):
 
         if 'bootfile_name' in config['option']:
             out['boot-file-name'] = config['option']['bootfile_name']
+            out['option-data'].append({"name": "boot-file-name", "data": config['option']['bootfile_name']})
 
         if 'bootfile_server' in config['option']:
             out['next-server'] = config['option']['bootfile_server']
@@ -193,6 +194,12 @@ def kea_parse_subnet(subnet, config):
 
                 if 'bootfile_name' in range_config['option']:
                     pool['boot-file-name'] = range_config['option']['bootfile_name']
+                    pool['option-data'].append(
+                        {
+                            "name": "boot-file-name",
+                            "data": range_config['option']['bootfile_name']
+                        }
+                    )
 
                 if 'bootfile_server' in range_config['option']:
                     pool['next-server'] = range_config['option']['bootfile_server']
@@ -229,6 +236,12 @@ def kea_parse_subnet(subnet, config):
                     reservation['boot-file-name'] = host_config['option'][
                         'bootfile_name'
                     ]
+                    reservation['option-data'].append(
+                        {
+                            "name": "boot-file-name",
+                            "data": host_config['option']['bootfile_name']
+                        }
+                    )
 
                 if 'bootfile_server' in host_config['option']:
                     reservation['next-server'] = host_config['option'][

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -47,6 +47,7 @@ kea4_options = {
     'captive_portal': 'v4-captive-portal',
     'capwap_controller': 'capwap-ac-v4',
     'interface_mtu': 'interface-mtu',
+    'bootfile_name': 'boot-file-name'
 }
 
 kea6_options = {
@@ -165,7 +166,6 @@ def kea_parse_subnet(subnet, config):
 
         if 'bootfile_name' in config['option']:
             out['boot-file-name'] = config['option']['bootfile_name']
-            out['option-data'].append({'name': 'boot-file-name', 'data': config['option']['bootfile_name']})
 
         if 'bootfile_server' in config['option']:
             out['next-server'] = config['option']['bootfile_server']
@@ -194,12 +194,6 @@ def kea_parse_subnet(subnet, config):
 
                 if 'bootfile_name' in range_config['option']:
                     pool['boot-file-name'] = range_config['option']['bootfile_name']
-                    pool['option-data'].append(
-                        {
-                            'name': 'boot-file-name',
-                            'data': range_config['option']['bootfile_name']
-                        }
-                    )
 
                 if 'bootfile_server' in range_config['option']:
                     pool['next-server'] = range_config['option']['bootfile_server']
@@ -236,12 +230,6 @@ def kea_parse_subnet(subnet, config):
                     reservation['boot-file-name'] = host_config['option'][
                         'bootfile_name'
                     ]
-                    reservation['option-data'].append(
-                        {
-                            'name': 'boot-file-name',
-                            'data': host_config['option']['bootfile_name']
-                        }
-                    )
 
                 if 'bootfile_server' in host_config['option']:
                     reservation['next-server'] = host_config['option'][

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -1031,6 +1031,7 @@ def kea_shared_network_json(shared_networks):
 
             if 'bootfile_name' in config['option']:
                 network['boot-file-name'] = config['option']['bootfile_name']
+                network['option-data'].append({"name": "boot-file-name", "data": config['option']['bootfile_name']})
 
             if 'bootfile_server' in config['option']:
                 network['next-server'] = config['option']['bootfile_server']

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -1031,7 +1031,7 @@ def kea_shared_network_json(shared_networks):
 
             if 'bootfile_name' in config['option']:
                 network['boot-file-name'] = config['option']['bootfile_name']
-                network['option-data'].append({"name": "boot-file-name", "data": config['option']['bootfile_name']})
+                network['option-data'].append({'name': 'boot-file-name', 'data': config['option']['bootfile_name']})
 
             if 'bootfile_server' in config['option']:
                 network['next-server'] = config['option']['bootfile_server']

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -1031,7 +1031,6 @@ def kea_shared_network_json(shared_networks):
 
             if 'bootfile_name' in config['option']:
                 network['boot-file-name'] = config['option']['bootfile_name']
-                network['option-data'].append({'name': 'boot-file-name', 'data': config['option']['bootfile_name']})
 
             if 'bootfile_server' in config['option']:
                 network['next-server'] = config['option']['bootfile_server']

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -384,6 +384,11 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.verify_config_object(
             obj,
             ['Dhcp4', 'shared-networks', 0, 'subnet4', 0, 'option-data'],
+            {'name': 'boot-file-name', 'data': bootfile_name},
+        )
+        self.verify_config_object(
+            obj,
+            ['Dhcp4', 'shared-networks', 0, 'subnet4', 0, 'option-data'],
             {'name': 'domain-name', 'data': domain_name},
         )
         self.verify_config_object(


### PR DESCRIPTION
## Change summary

Kea overloads the meaning of the boot-file-name option.  When used on its own, it represents the legacy bootp filename option.  When option 67 is needed, boot-file-name must be included in an options block.

This change copies the bootfile-name into the kea options, setting both as specified.

Another option would be to introduce a new config option specific to option 67.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T8408

## Related PR(s)

## How to test / Smoketest result
given the following vyos config:
```
vyos@vyos-lab# show | commands | grep shared-network-name
set service dhcp-server shared-network-name workInt authoritative
set service dhcp-server shared-network-name workInt description 'test'
set service dhcp-server shared-network-name workInt subnet 192.168.128.0/22 option bootfile-name 'http://this-is-the-bootfile-name.local'
set service dhcp-server shared-network-name workInt subnet 192.168.128.0/22 option default-router '192.168.128.1'
set service dhcp-server shared-network-name workInt subnet 192.168.128.0/22 option name-server '192.168.128.1'
set service dhcp-server shared-network-name workInt subnet 192.168.128.0/22 option time-server '192.168.128.1'
set service dhcp-server shared-network-name workInt subnet 192.168.128.0/22 range main start '192.168.128.100'
set service dhcp-server shared-network-name workInt subnet 192.168.128.0/22 range main stop '192.168.131.100'
set service dhcp-server shared-network-name workInt subnet 192.168.128.0/22 subnet-id '128'
```

the currently generated kea configuration in `/var/run/kea-dhcp4.conf`
```
    {
        "name": "workInt",
        "authoritative": true,
        "subnet4": [
            {
                "subnet": "192.168.128.0/22",
                "id": 128,
                "user-context": {
                    "enable-ping-check": false
                },
                "option-data": [
                    {
                        "name": "domain-name-servers",
                        "data": "192.168.128.1"
                    },
                    {
                        "name": "time-servers",
                        "data": "192.168.128.1"
                    },
                    {
                        "name": "routers",
                        "data": "192.168.128.1"
                    }
                ],
                "boot-file-name": "http://this-is-the-bootfile-name.local",
                "valid-lifetime": 86400,
                "max-valid-lifetime": 86400,
                "pools": [
                    {
                        "pool": "192.168.128.100 - 192.168.131.100"
                    }
                ]
            }
        ],
        "user-context": {
            "enable-ping-check": false
        }
    }
```

this change adds the following block to the `option-data` section:
```
                    {
                        "name": "boot-file-name",
                        "data": "http://this-is-the-bootfile-name.local"
                    }
```

Packet captures on the wire of dhcp offers show option 67 being included

## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
