### PR TITLE
vpp: T8422: Resolve inconsistent behavior with `allow-unsupported-nics` configuration option

### DIFF
--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -39,6 +39,7 @@ from vyos.logger import getLogger
 from vyos.template import render
 from vyos.utils.boot import boot_configuration_complete
 from vyos.utils.cpu import get_available_cpus
+from vyos.utils.dict import dict_search
 from vyos.utils.kernel import check_kmod
 from vyos.utils.kernel import unload_kmod
 from vyos.utils.kernel import list_loaded_modules
@@ -251,7 +252,7 @@ def _is_device_allowed(config: dict, iface: str):
     if 'allow_unsupported_nics' in config['settings']:
         return True
 
-    persist_config = config['persist_config'][iface]
+    persist_config = dict_search('persist_config.iface', config)
 
     pci_id = persist_config.get('pci_id')
     # PCI ID is sufficient by itself, if presented
@@ -602,20 +603,12 @@ def verify(config):
 
     # ensure DPDK/XDP settings are properly configured
     for iface, iface_config in config['settings']['interface'].items():
-        # check if selected driver is supported, but only for new interfaces
-        # or if driver was changed
-        original_driver = config['persist_config'][iface]['original_driver']
-        if (
-            iface
-            not in config.get('effective', {}).get('settings', {}).get('interface', {})
-            or 'driver_changed' in iface_config
-        ):
-            if not _is_device_allowed(config, iface):
-                raise ConfigError(
-                    f'NIC used by "{iface}" is not validated for VPP on VyOS. '
-                    'Using it is unsafe and unsupported and will void support for the entire system. '
-                    'To proceed at your own risk, enable: "set vpp settings allow-unsupported-nics".'
-                )
+        if not _is_device_allowed(config, iface):
+            raise ConfigError(
+                f'NIC used by "{iface}" is not validated for VPP on VyOS. '
+                'Using it is unsafe and unsupported and will void support for the entire system. '
+                'To proceed at your own risk, enable: "set vpp settings allow-unsupported-nics".'
+            )
 
         if iface_config['driver'] == 'xdp' and 'xdp_options' in iface_config:
             if iface_config['xdp_options']['num_rx_queues'] != 'all':


### PR DESCRIPTION
## Change summary
Prevents attachments of unsupported NICs when the `allow-unsupported-nics` option is removed.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8422

## How to test / Smoketest result
### Manual test
```
vyos@vyos# set vpp settings interface eth3
vyos@vyos# commit
[ vpp ]
NIC used by "eth3" is not validated for VPP on VyOS. Using it is unsafe
and unsupported and will void support for the entire system. To proceed
at your own risk, enable: "set vpp settings allow-unsupported-nics".
[[vpp]] failed
Commit failed
vyos@vyos# set vpp settings allow-unsupported-nics
vyos@vyos# commit

vyos@vyos# del vpp settings allow-unsupported-nics
vyos@vyos# commit
[ vpp ]
NIC used by "eth3" is not validated for VPP on VyOS. Using it is unsafe
and unsupported and will void support for the entire system. To proceed
at your own risk, enable: "set vpp settings allow-unsupported-nics".
[[vpp]] failed
Commit failed
vyos@vyos# comp
[vpp settings]
- allow-unsupported-nics
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly