### PR TITLE
firewall: T8277: Resolve migration issue when using `port-group` with protocol `all`

### DIFF
--- a/src/migration-scripts/firewall/6-to-7
+++ b/src/migration-scripts/firewall/6-to-7
@@ -194,8 +194,14 @@ def migrate(config: ConfigTree) -> None:
 
                         pg_base = base + ['name', name, 'rule', rule, direction, 'group', 'port-group']
                         proto_base = base + ['name', name, 'rule', rule, 'protocol']
-                        if config.exists(pg_base) and not config.exists(proto_base):
-                            config.set(proto_base, value='tcp_udp')
+                        if config.exists(pg_base):
+                            if config.exists(proto_base):
+                                proto_name = config.return_value(proto_base)
+                                set_as_tcp_udp = proto_name == 'all'
+                            else:
+                                set_as_tcp_udp = False
+                            if set_as_tcp_udp:
+                                config.set(proto_base, value='tcp_udp')
 
             if '+' in name:
                 replacement_string = "_"
@@ -291,8 +297,14 @@ def migrate(config: ConfigTree) -> None:
 
                         pg_base = base + ['ipv6-name', name, 'rule', rule, direction, 'group', 'port-group']
                         proto_base = base + ['ipv6-name', name, 'rule', rule, 'protocol']
-                        if config.exists(pg_base) and not config.exists(proto_base):
-                            config.set(proto_base, value='tcp_udp')
+                        if config.exists(pg_base):
+                            if config.exists(proto_base):
+                                proto_name = config.return_value(proto_base)
+                                set_as_tcp_udp = proto_name == 'all'
+                            else:
+                                set_as_tcp_udp = False
+                            if set_as_tcp_udp:
+                                config.set(proto_base, value='tcp_udp')
 
             if '+' in name:
                 replacement_string = "_"


### PR DESCRIPTION
## Change summary
Updated the migration script to ensure that when migrating firewall rules, if a `port-group` exists, the protocol will be set to `tcp_udp` only when its previous value is `all`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8277

## How to test / Smoketest result
### Manual test
Generate configuration using VyOS 1.3.8:
```
set firewall group port-group TESTPORTGROUP port '22'
set firewall name TEST rule 20 action 'accept'
set firewall name TEST rule 20 protocol 'all'
set firewall name TEST rule 20 source group port-group 'TESTPORTGROUP'
```

Use the generated config for loading:
```
vyos@vyos# load /tmp/config.boot
Load complete. Use 'commit' to make changes effective.
[edit]
vyos@vyos# comp commands | match firewall
set firewall group port-group TESTPORTGROUP port '22'
set firewall ipv4 name TEST rule 20 action 'return'
set firewall ipv4 name TEST rule 20 protocol 'tcp_udp'
set firewall ipv4 name TEST rule 20 source group port-group 'TESTPORTGROUP'
vyos@vyos# commit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly