### PR TITLE
vpp: T8432: Fix AttributeError for enabling vpp interface

### DIFF
--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -252,7 +252,7 @@ def _is_device_allowed(config: dict, iface: str):
     if 'allow_unsupported_nics' in config['settings']:
         return True
 
-    persist_config = dict_search('persist_config.iface', config)
+    persist_config = dict_search(f'persist_config.{iface}', config, default={})
 
     pci_id = persist_config.get('pci_id')
     # PCI ID is sufficient by itself, if presented


### PR DESCRIPTION
## Change summary
Fix AttributeError in `_is_device_allowed` by using iface parameter for `persist_config` lookup.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8432

## Related PR(s)
* https://github.com/vyos/vyos-1x/pull/5085

## How to test / Smoketest result
### Manual test
```
vyos@vyos# set vpp settings interface eth3
vyos@vyos# commit
[ vpp ]
NIC used by "eth3" is not validated for VPP on VyOS. Using it is unsafe
and unsupported and will void support for the entire system. To proceed
at your own risk, enable: "set vpp settings allow-unsupported-nics".
[[vpp]] failed
Commit failed
vyos@vyos# set vpp settings allow-unsupported-nics
vyos@vyos# commit

vyos@vyos# del vpp settings allow-unsupported-nics
vyos@vyos# commit
[ vpp ]
NIC used by "eth3" is not validated for VPP on VyOS. Using it is unsafe
and unsupported and will void support for the entire system. To proceed
at your own risk, enable: "set vpp settings allow-unsupported-nics".
[[vpp]] failed
Commit failed
vyos@vyos# comp
[vpp settings]
- allow-unsupported-nics
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly