### PR TITLE
bgp: T7338: Add support for "parameters as-notation <asdot|asdot+>"

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -259,7 +259,7 @@
 {# j2lint: disable=jinja-statements-delimeter #}
 {%- endmacro -%}
 !
-router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }}
+router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }} {{ 'as-notation ' ~ parameters.as_notation | replace('as', '') if parameters.as_notation is vyos_defined }}
 {% if parameters.ebgp_requires_policy is vyos_defined %}
  bgp ebgp-requires-policy
 {% else %}

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -1153,6 +1153,25 @@
     <help>BGP parameters</help>
   </properties>
   <children>
+    <leafNode name="as-notation">
+      <properties>
+        <help>BGP AS-notation output format</help>
+        <completionHelp>
+          <list>asdot asdot+</list>
+        </completionHelp>
+        <valueHelp>
+          <format>asdot</format>
+          <description>Use asdot notation only for 4 byte AS numbers</description>
+        </valueHelp>
+        <valueHelp>
+          <format>asdot+</format>
+          <description>Use asdot notation for all AS numbers</description>
+        </valueHelp>
+        <constraint>
+          <regex>(asdot\+|asdot)</regex>
+        </constraint>
+      </properties>
+    </leafNode>
     <leafNode name="allow-martian-nexthop">
       <properties>
         <help>Allow Martian nexthops to be received in the NLRI from a peer</help>

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -1638,6 +1638,57 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f' bgp router-id {router_id}', frr_vrf_config)
 
 
+    def test_bgp_31_as_notation(self):
+        # Test BGP AS-notation output format for both global and VRF BGP instances.
+        # Verify all three notation types render correctly on the router bgp line.
+        router_id = '127.0.0.4'
+        vrf = 'red'
+
+        for vrf in ['', 'red']:
+            vrf_base = ['vrf', 'name', vrf] if vrf else []
+            vrf_frr_bit = f' vrf {vrf}' if vrf else ''
+            bgp_path = vrf_base + base_path
+
+            if vrf_base:
+                self.cli_set(vrf_base + ['table', '2000'])
+
+            self.cli_set(bgp_path + ['system-as', ASN])
+            self.cli_set(bgp_path + ['parameters', 'router-id', router_id])
+
+            for notation in ['asdot', 'asdot+']:
+                self.cli_set(bgp_path + ['parameters', 'as-notation', notation])
+                self.cli_commit()
+
+                # our config options are called 'asdot' and 'asdot+' as in
+                # RFC 5396
+                # but FRR calls them 'dot' and 'dot+' in the router bgp line
+                # e.g. router bgp 12345 as-notation dot
+                # or
+                # router bgp 12345 vrf red as-notation dot
+                router_str = f'router bgp {ASN}{vrf_frr_bit} as-notation {notation.replace("as", "")}'
+                # getFRRConfig interprets the arguments as regex, so escape '+' if present
+                frrconfig = self.getFRRconfig(
+                    router_str.replace('+', r'\+'), stop_section='^exit'
+                )
+                self.assertIn(router_str, frrconfig)
+
+            # Verify removing as-notation works
+            self.cli_delete(bgp_path + ['parameters', 'as-notation'])
+            self.cli_commit()
+
+            router_str = f'router bgp {ASN}{vrf_frr_bit}'
+
+            frrconfig = self.getFRRconfig(router_str, stop_section='^exit')
+            self.assertIn(router_str, frrconfig)
+            self.assertNotIn('as-notation', frrconfig.splitlines()[0])
+
+            # Cleanup
+            self.cli_delete(bgp_path)
+            if vrf_base:
+                self.cli_delete(vrf_base)
+
+            self.cli_commit()
+
     def test_bgp_99_bmp(self):
         target_name = 'instance-bmp'
         target_address = '127.0.0.1'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary

This PR adds support in BGP for `parameters as-notation <asdot|asdot+|plain>` 

With this option the user can control how FRR prints AS Numbers, which can be particularly useful in datacenter scenarios with lots very large of 4-byte AS numbers, as the reserved range starts at 4200000000.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7338

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
DEBUG - test_bgp_28_peer_group_member_all_internal_or_external (__main__.TestProtocolsBGP.test_bgp_28_peer_group_member_all_internal_or_external) ... ok
DEBUG - test_bgp_29_peer_group_remote_as_equal_local_as (__main__.TestProtocolsBGP.test_bgp_29_peer_group_remote_as_equal_local_as) ... ok
DEBUG - test_bgp_30_import_vrf_routemap (__main__.TestProtocolsBGP.test_bgp_30_import_vrf_routemap) ... ok
DEBUG - test_bgp_31_as_notation (__main__.TestProtocolsBGP.test_bgp_31_as_notation) ... ok
DEBUG - test_bgp_99_bmp (__main__.TestProtocolsBGP.test_bgp_99_bmp) ... ok


DEBUG - 
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 31 tests in 120.663s
DEBUG - 
DEBUG - OK
```
+ some manual tests, looked fine.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
