### PR TITLE
pseudo-ethernet: T8434: source-interface does not show bridge or bond interfaces

### DIFF
--- a/interface-definitions/include/source-interface-broadcast.xml.i
+++ b/interface-definitions/include/source-interface-broadcast.xml.i
@@ -1,4 +1,4 @@
-<!-- include start from source-interface-ethernet.xml.i -->
+<!-- include start from source-interface-broadcast.xml.i -->
 <leafNode name="source-interface">
   <properties>
     <help>Physical interface the traffic will go through</help>
@@ -7,7 +7,7 @@
       <description>Interface name</description>
     </valueHelp>
     <completionHelp>
-      <script>${vyos_completion_dir}/list_interfaces --type ethernet</script>
+      <script>${vyos_completion_dir}/list_interfaces --broadcast</script>
     </completionHelp>
   </properties>
 </leafNode>

--- a/interface-definitions/interfaces_pseudo-ethernet.xml.in
+++ b/interface-definitions/interfaces_pseudo-ethernet.xml.in
@@ -26,7 +26,7 @@
           #include <include/interface/ipv4-options.xml.i>
           #include <include/interface/ipv6-options.xml.i>
           #include <include/interface/ipv6-options-with-nd.xml.i>
-          #include <include/source-interface-ethernet.xml.i>
+          #include <include/source-interface-broadcast.xml.i>
           #include <include/interface/mac.xml.i>
           #include <include/interface/mirror.xml.i>
           <leafNode name="mode">


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

We can create pseudo-ethernet (peth, macvlan) interfaces from bond or bridge interfaces as the unddelraying parent, so the completion helper should honor it.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8434

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

```
set interfaces bonding bond0 member interface 'eth1'
set interfaces bridge br0 member interface eth2
set interfaces pseudo-ethernet peth0 source-interface 'bond0'
set interfaces pseudo-ethernet peth1 source-interface 'br0'
```

```
vyos@vyos# set interfaces pseudo-ethernet peth0 source-interface
Possible completions:
   interface            Interface name
   bond0
   br0
   eth0
   eth1
   eth2
   eth3
```

```
13: peth0@bond0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 7a:62:e1:37:3f:64 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::7862:e1ff:fe37:3f64/64 scope link
       valid_lft forever preferred_lft forever

14: peth1@br0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether d2:ff:7e:57:69:d4 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::d0ff:7eff:fe57:69d4/64 scope link
       valid_lft forever preferred_lft forever
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
