### PR TITLE
firewall: T8275: Resolve migration issue for 'weekdays' option from 1.3.8

### DIFF
--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -662,6 +662,19 @@ def parse_tcp_flags(flags):
     exclude = list(flags['not']) if 'not' in flags else []
     return f'tcp flags & ({"|".join(include + exclude)}) == {"|".join(include) if include else "0x0"}'
 
+def expand_weekday(abbrev: str) -> str:
+    mapping = {
+        'mon': 'monday',
+        'tue': 'tuesday',
+        'wed': 'wednesday',
+        'thu': 'thursday',
+        'fri': 'friday',
+        'sat': 'saturday',
+        'sun': 'sunday',
+    }
+    return mapping.get(abbrev.lower(), abbrev).lower()
+
+
 def parse_time(time):
     out = []
     if 'startdate' in time:
@@ -679,7 +692,7 @@ def parse_time(time):
     if 'stoptime' in time and 'stopdate' not in time:
         out.append(f'hour < "{time["stoptime"]}"')
     if 'weekdays' in time:
-        days = time['weekdays'].split(",")
-        out_days = [f'"{day}"' for day in days if day[0] != '!']
+        days = [day.strip() for day in time['weekdays'].split(",") if day]
+        out_days = [f'"{expand_weekday(day).title()}"' for day in days if day[0] != '!']
         out.append(f'day {{{",".join(out_days)}}}')
     return " ".join(out)

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -292,6 +292,33 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         self.verify_nftables(nftables_search, 'ip vyos_filter')
 
+    def test_ipv4_time_weekdays(self):
+        name = 'v4-time-weekdays-test'
+        rule_base = ['firewall', 'ipv4', 'name', name, 'rule', '10']
+
+        self.cli_set(rule_base + ['action', 'accept'])
+        self.cli_set(rule_base + ['time', 'weekdays', 'mon,friday'])
+
+        self.cli_commit()
+
+        nftables_search = [
+            [f'chain NAME_{name}'],
+            ['meta day { "Monday", "Friday" }'],
+        ]
+
+        self.verify_nftables(nftables_search, 'ip vyos_filter')
+
+        self.cli_set(rule_base + ['time', 'weekdays', 'Monday, Sat'])
+
+        self.cli_commit()
+
+        nftables_search = [
+            [f'chain NAME_{name}'],
+            ['meta day { "Monday", "Saturday" }'],
+        ]
+
+        self.verify_nftables(nftables_search, 'ip vyos_filter')
+
     def test_ipv4_advanced(self):
         name = 'smoketest-adv'
         name2 = 'smoketest-adv2'
@@ -536,6 +563,33 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['ct state established', 'accept'],
             ['ct state invalid', 'drop'],
             ['ct state related', 'accept']
+        ]
+
+        self.verify_nftables(nftables_search, 'ip6 vyos_filter')
+
+    def test_ipv6_time_weekdays(self):
+        name = 'v6-time-weekdays-test'
+        rule_base = ['firewall', 'ipv6', 'name', name, 'rule', '10']
+
+        self.cli_set(rule_base + ['action', 'accept'])
+        self.cli_set(rule_base + ['time', 'weekdays', 'mon,friday'])
+
+        self.cli_commit()
+
+        nftables_search = [
+            [f'chain NAME6_{name}'],
+            ['meta day { "Monday", "Friday" }'],
+        ]
+
+        self.verify_nftables(nftables_search, 'ip6 vyos_filter')
+
+        self.cli_set(rule_base + ['time', 'weekdays', 'Monday, Sat'])
+
+        self.cli_commit()
+
+        nftables_search = [
+            [f'chain NAME6_{name}'],
+            ['meta day { "Monday", "Saturday" }'],
         ]
 
         self.verify_nftables(nftables_search, 'ip6 vyos_filter')


### PR DESCRIPTION
## Change summary
Contrary to what is stated in the nftables wiki, nftables does not support lowercase or abbreviated names for weekdays. This results in an error: "Could not parse Day of week of packet reception" for inputs like `meta day { "sunday", "wed" }`.

To circumvent this issue, ensure that use capitalized weekday names.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8275

## How to test / Smoketest result
### Manual test
```
vyos@vyos# set firewall name TEST rule 10 action 'accept'
vyos@vyos# set firewall ipv4 name TEST rule 10 time weekdays 'mon,friday'
vyos@vyos# commit
vyos@vyos# sudo nft list ruleset | grep -C 2 day
        chain NAME_TEST {
                meta day { "Monday", "Friday" } counter packets 0 bytes 0 accept comment "ipv4-NAM-TEST-10"
                counter packets 0 bytes 0 accept comment "NAM-TEST default-action accept"
        }
vyos@vyos# set firewall ipv4 name TEST rule 10 time weekdays 'mon,Sat'
vyos@vyos# commit
vyos@vyos# sudo nft list ruleset | grep -C 2 day
        chain NAME_TEST {
                meta day { "Monday", "Saturday" } counter packets 0 bytes 0 accept comment "ipv4-NAM-TEST-10"
                counter packets 0 bytes 0 accept comment "NAM-TEST default-action accept"
        }
[edit]
```

### Smoketest
```
vyos@vyos# sudo /usr/libexec/vyos/tests/smoke/cli/test_firewall.py -k weekdays
test_ipv4_time_weekdays (__main__.TestFirewall.test_ipv4_time_weekdays) ... ok
test_ipv6_time_weekdays (__main__.TestFirewall.test_ipv6_time_weekdays) ... ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly