### PR TITLE
nat64: T8456: add constraint for translation port range

### DIFF
--- a/smoketest/scripts/cli/test_nat64.py
+++ b/smoketest/scripts/cli/test_nat64.py
@@ -20,6 +20,9 @@ import unittest
 
 from base_vyostest_shim import VyOSUnitTestSHIM
 
+from vyos.configsession import ConfigSessionError
+from vyos.utils.system import sysctl_read
+
 base_path = ['nat64']
 src_path = base_path + ['source']
 
@@ -48,15 +51,25 @@ class TestNAT64(VyOSUnitTestSHIM.TestCase):
         pool = '192.0.2.10'
         pool_port = '1-65535'
 
-        self.cli_set(src_path + ['rule', rule, 'source', 'prefix', prefix_v6])
-        self.cli_set(
-            src_path
-            + ['rule', rule, 'translation', 'pool', translation_rule, 'address', pool]
-        )
-        self.cli_set(
-            src_path
-            + ['rule', rule, 'translation', 'pool', translation_rule, 'port', pool_port]
-        )
+        rule_path = src_path + ['rule', rule]
+        self.cli_set(rule_path + ['source', 'prefix', prefix_v6])
+        self.cli_set(rule_path + ['translation', 'pool', translation_rule,
+                                  'address', pool])
+        self.cli_set(rule_path + ['translation', 'pool', translation_rule,
+                                  'port', pool_port])
+
+        # pool_port overlaps with the Linux Kernel ephemeral port range
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        # https://nicmx.github.io/Jool/en/usr-flags-pool4.html#port-range
+        # Jool is incapable of ensuring pool4 does not intersect with other defined
+        # port ranges; this validation is the operator’s responsibility.
+        tmp = sysctl_read('net.ipv4.ip_local_port_range')
+        _, ephemeral_port_max = map(int, tmp.split())
+        pool_port = f'{ephemeral_port_max +1}-{ephemeral_port_max +1000}'
+        self.cli_set(rule_path + ['translation', 'pool', translation_rule,
+                                  'port', pool_port])
         self.cli_commit()
 
         # Load the JSON file

--- a/src/conf_mode/nat64.py
+++ b/src/conf_mode/nat64.py
@@ -14,8 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=empty-docstring,missing-module-docstring
-
 import csv
 import os
 import re
@@ -57,8 +55,6 @@ def get_config(config: Config | None = None) -> ConfigDict:
 
 
 def verify(nat64) -> None:
-    # pylint: disable=too-many-branches
-
     config_diff = getattr(nat64, 'config_diff')
 
     check_kmod(['jool'])
@@ -139,13 +135,11 @@ def verify(nat64) -> None:
 
 
 def generate(nat64) -> None:
-    # pylint: disable=too-many-branches
     if not nat64:
         return
 
     os.makedirs(JOOL_CONFIG_DIR, exist_ok=True)
 
-    # pylint: disable=too-many-nested-blocks
     if dict_search('source.rule', nat64):
         for rule, instance in nat64['source']['rule'].items():
             if 'deleted' in instance:

--- a/src/conf_mode/nat64.py
+++ b/src/conf_mode/nat64.py
@@ -19,7 +19,8 @@ import os
 import re
 import sys
 
-from ipaddress import IPv6Network, IPv6Address
+from ipaddress import IPv6Network
+from ipaddress import IPv6Address
 from json import dumps as json_write
 
 from vyos import ConfigError
@@ -38,14 +39,14 @@ airbag.enable()
 
 INSTANCE_REGEX = re.compile(r'instance-(\d+)')
 JOOL_CONFIG_DIR = '/run/jool'
-
+base = ['nat64']
 
 def get_config(config: Config | None = None) -> ConfigDict:
     if config is None:
         config = Config()
 
-    base = ['nat64']
-    nat64 = config.get_config_dict(base, key_mangling=('-', '_'), get_first_key=True)
+    nat64 = config.get_config_dict(base, key_mangling=('-', '_'),
+                                   get_first_key=True)
 
     config_diff = get_config_diff(config)
     # get_config_dict returns an instance of ConfigDict
@@ -55,10 +56,10 @@ def get_config(config: Config | None = None) -> ConfigDict:
 
 
 def verify(nat64) -> None:
+    check_kmod(['jool'])
     config_diff = getattr(nat64, 'config_diff')
 
-    check_kmod(['jool'])
-    base_src = ['nat64', 'source', 'rule']
+    base_rule = base + ['source', 'rule']
 
     # Load in existing instances so we can destroy any unknown
     lines = cmd('jool instance display --csv').splitlines()
@@ -77,13 +78,13 @@ def verify(nat64) -> None:
 
         # If the user changes the mode, recreate the instance else Jool fails with:
         # Jool error: Sorry; you can't change an instance's framework for now.
-        if config_diff.is_node_changed(base_src + [f'instance-{num}', 'mode']):
+        if config_diff.is_node_changed(base_rule + [f'instance-{num}', 'mode']):
             rules[num]['recreate'] = True
 
         # If the user changes the pool6, recreate the instance else Jool fails with:
         # Jool error: Sorry; you can't change a NAT64 instance's pool6 for now.
         if dict_search('source.prefix', rules[num]) and config_diff.is_node_changed(
-            base_src + [num, 'source', 'prefix'],
+            base_rule + [num, 'source', 'prefix'],
         ):
             rules[num]['recreate'] = True
 

--- a/src/conf_mode/nat64.py
+++ b/src/conf_mode/nat64.py
@@ -34,6 +34,7 @@ from vyos.utils.kernel import check_kmod
 from vyos.utils.kernel import unload_kmod
 from vyos.utils.process import cmd
 from vyos.utils.process import run
+from vyos.utils.system import sysctl_read
 
 airbag.enable()
 
@@ -92,6 +93,12 @@ def verify(nat64) -> None:
         # nothing left to do
         return
 
+    # https://nicmx.github.io/Jool/en/usr-flags-pool4.html#port-range
+    # Jool is incapable of ensuring pool4 does not intersect with other defined
+    # port ranges; this validation is the operator’s responsibility.
+    tmp = sysctl_read('net.ipv4.ip_local_port_range')
+    ephemeral_port_min, ephemeral_port_max = map(int, tmp.split())
+
     if dict_search('source.rule', nat64):
         # Ensure only 1 netfilter instance per namespace
         nf_rules = filter(
@@ -123,17 +130,28 @@ def verify(nat64) -> None:
             pools = dict_search('translation.pool', instance)
             if pools:
                 for num, pool in pools.items():
+                    error_msg = f'Source NAT64 rule {rule} translation pool {num}'
                     if 'address' not in pool:
-                        raise ConfigError(
-                            f'Source NAT64 rule {rule} translation pool '
-                            f'{num} missing address/prefix'
-                        )
+                        raise ConfigError(f'{error_msg} missing address/prefix')
                     if 'port' not in pool:
-                        raise ConfigError(
-                            f'Source NAT64 rule {rule} translation pool '
-                            f'{num} missing port(-range)'
-                        )
+                        raise ConfigError(f'{error_msg} missing port(-range)')
+                    # Split the provided ports, it's either a single port or start-end
+                    tmp = pool['port'].split('-')
+                    if len(tmp) == 1: # single port
+                        pool_min = pool_max = int(tmp[0])
+                    elif len(tmp) == 2: # port range with start-stop
+                        pool_min, pool_max = map(int, tmp)
+                    else:
+                        raise ConfigError('Invalid port range, this should not happen!')
 
+                    # Inclusive overlap check between nat64 translation ports and
+                    # the Linux Kernel ephemeral port range
+                    # overlap if pool_min <= ephemeral_port_max and ephemeral_port_min <= pool_max
+                    if pool_min <= ephemeral_port_max and ephemeral_port_min <= pool_max:
+                        raise ConfigError(
+                            f'{error_msg} port range {pool_min}-{pool_max} overlaps with '
+                            f'local ephemeral range {ephemeral_port_min}-{ephemeral_port_max}'
+                        )
 
 def generate(nat64) -> None:
     if not nat64:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

NAT64 requires dedicated transport address space for translation, similar to exclusive port ownership during socket binding. If a local process and Jool translation both use the same transport tuple (for example, 192.0.2.1:5000), traffic conflicts can occur.

Jool does not prevent pool4 from overlapping with other port allocations, so avoiding conflicts is an operator responsibility.

In addition to service ports already in use, account for Linux ephemeral range (`net.ipv4.ip_local_port_range`), which defaults to 32768-60999. This default is why, when pool4 is empty, Jool uses 61001-65535 on the node's primary global addresses.

One can adjust the ephemeral range via sysctl, and Jools translation range via pool4 add/remove.

```
vyos@vyos:~$ sysctl net.ipv4.ip_local_port_range
net.ipv4.ip_local_port_range = 32768    60999
```

VyOS now uses `verify()` in NAT64 to check that the supplied tranlation port range does not overlap with the Kernels ephemeral port range.

Change is required in order to update the Jool Kernel Module

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8456

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-build/pull/1153

## How to test / Smoketest result
```
cpo@LR1.wue3:~$ /usr/libexec/vyos/tests/smoke/cli/test_nat64.py
test_snat64 (__main__.TestNAT64.test_snat64) ... ok

----------------------------------------------------------------------
Ran 1 test in 4.131s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
