### PR TITLE
T8448: add an option to enable SNMP traps in VRRP

### DIFF
--- a/data/templates/high-availability/keepalived.conf.j2
+++ b/data/templates/high-availability/keepalived.conf.j2
@@ -5,6 +5,9 @@
 # Global definitions configuration block
 global_defs {
     dynamic_interfaces
+{% if vrrp.snmp.trap is vyos_defined %}
+    enable_traps
+{% endif %}
     script_user root
 {% if vrrp.global_parameters.startup_delay is vyos_defined %}
     vrrp_startup_delay {{ vrrp.global_parameters.startup_delay }}

--- a/interface-definitions/high-availability.xml.in
+++ b/interface-definitions/high-availability.xml.in
@@ -12,12 +12,19 @@
           <help>Virtual Router Redundancy Protocol settings</help>
         </properties>
         <children>
-          <leafNode name="snmp">
+          <node name="snmp">
             <properties>
-              <valueless/>
               <help>Enable SNMP</help>
             </properties>
-          </leafNode>
+            <children>
+              <leafNode name="trap">
+                <properties>
+                  <valueless/>
+                  <help>Enable SNMP traps</help>
+                </properties>
+              </leafNode>
+            </children>
+          </node>
           <node name="global-parameters">
             <properties>
               <help>VRRP global parameters</help>

--- a/smoketest/scripts/cli/test_high-availability_vrrp.py
+++ b/smoketest/scripts/cli/test_high-availability_vrrp.py
@@ -137,6 +137,9 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
         self.cli_set(global_param_base + ['garp', 'master-refresh-repeat', f'{garp_master_refresh_repeat}'])
         self.cli_set(global_param_base + ['version', vrrp_version])
 
+        # SNMP
+        self.cli_set(base_path + ['vrrp', 'snmp', 'trap'])
+
         # commit changes
         self.cli_commit()
 
@@ -149,6 +152,7 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'vrrp_garp_master_refresh {garp_master_refresh}', config)
         self.assertIn(f'vrrp_garp_master_refresh_repeat {garp_master_refresh_repeat}', config)
         self.assertIn(f'vrrp_version {vrrp_version}', config)
+        self.assertIn('enable_traps', config)
 
         for group in groups:
             vlan_id = group.lstrip('VLAN')
@@ -173,6 +177,14 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f'garp_master_delay {group_garp_master_delay}', config)
             self.assertIn(f'garp_master_refresh {group_garp_master_refresh}', config)
             self.assertIn(f'garp_master_repeat {group_garp_master_repeat}', config)
+
+        # Remove SNMP traps
+        self.cli_delete(base_path + ['vrrp', 'snmp', 'trap'])
+
+        # commit changes
+        self.cli_commit()
+        config = getConfig(f'global_defs')
+        self.assertNotIn('enable_traps', config)
 
     def test_03_sync_group(self):
         sync_group = 'VyOS'

--- a/src/conf_mode/high-availability.py
+++ b/src/conf_mode/high-availability.py
@@ -25,7 +25,7 @@ from ipaddress import IPv6Interface
 
 from vyos.base import Warning
 from vyos.config import Config
-from vyos.configdict import leaf_node_changed
+from vyos.configdict import node_changed
 from vyos.ifconfig.vrrp import VRRP
 from vyos.template import render
 from vyos.template import is_ipv4
@@ -59,7 +59,7 @@ def get_config(config=None):
     if conf.exists(conntrack_path):
         ha['conntrack_sync_group'] = conf.return_value(conntrack_path)
 
-    if leaf_node_changed(conf, base + ['vrrp', 'snmp']):
+    if node_changed(conf, base + ['vrrp', 'snmp']):
         ha.update({'restart_required': {}})
 
     return ha


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Allow to configure Keepalived VRRP traps
 - set high-availability vrrp snmp trap

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8448

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
set high-availability vrrp group GRP-01 address 192.0.2.1
set high-availability vrrp group GRP-01 interface 'eth1'
set high-availability vrrp group GRP-01 vrid '1'
set high-availability vrrp snmp trap
```
Check config, expected option  `enable_traps` in the `global_defs`

```
vyos@r14# cat /run/keepalived/keepalived.conf 
# Autogenerated by VyOS
# Do not edit this file, all your changes will be lost
# on next commit or reboot

# Global definitions configuration block
global_defs {
    dynamic_interfaces
    enable_traps
    script_user root
    notify_fifo /run/keepalived/keepalived_notify_fifo
    notify_fifo_script /usr/libexec/vyos/system/keepalived-fifo.py
}


vrrp_instance GRP-01 {
    state BACKUP
    interface eth1
    virtual_router_id 1
    priority 100
    advert_int 1
    preempt_delay 0
    virtual_ipaddress {
        192.0.2.1
    }
}

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
