### PR TITLE
T8457: BGP link-state address family

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -157,6 +157,8 @@
  address-family ipv6 flowspec
 {%         elif afi == 'l2vpn_evpn' %}
  address-family l2vpn evpn
+{%         elif afi == 'link_state' %}
+ address-family link-state
 {%         endif %}
 {%         if afi_config.addpath_tx_all is vyos_defined %}
   neighbor {{ neighbor }} addpath-tx-all-paths

--- a/interface-definitions/include/bgp/neighbor-afi-link-state.xml.i
+++ b/interface-definitions/include/bgp/neighbor-afi-link-state.xml.i
@@ -1,0 +1,10 @@
+<!-- include start from bgp/neighbor-afi-link-state.xml.i -->
+<node name="link-state">
+  <properties>
+    <help>Link State BGP settings</help>
+  </properties>
+  <children>
+    #include <include/bgp/afi-nexthop-self.xml.i>
+  </children>
+</node>
+<!-- include end -->

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -1056,6 +1056,7 @@
         #include <include/bgp/neighbor-afi-ipv4-multicast.xml.i>
         #include <include/bgp/neighbor-afi-ipv6-multicast.xml.i>
         #include <include/bgp/neighbor-afi-l2vpn-evpn.xml.i>
+        #include <include/bgp/neighbor-afi-link-state.xml.i>
       </children>
     </node>
     <leafNode name="advertisement-interval">
@@ -1708,6 +1709,7 @@
         #include <include/bgp/neighbor-afi-ipv6-labeled-unicast.xml.i>
         #include <include/bgp/neighbor-afi-ipv6-vpn.xml.i>
         #include <include/bgp/neighbor-afi-l2vpn-evpn.xml.i>
+        #include <include/bgp/neighbor-afi-link-state.xml.i>
       </children>
     </node>
     #include <include/generic-description.xml.i>

--- a/smoketest/configs/assert/bgp-small-link-state
+++ b/smoketest/configs/assert/bgp-small-link-state
@@ -1,0 +1,4 @@
+set protocols bgp neighbor 192.168.0.1 address-family link-state
+set protocols bgp parameters router-id '3.3.3.3'
+set protocols bgp system-as '65002'
+set protocols bgp neighbor 192.168.0.1 remote-as '65001'

--- a/smoketest/configs/bgp-small-link-state
+++ b/smoketest/configs/bgp-small-link-state
@@ -1,0 +1,104 @@
+interfaces {
+    dummy dum0 {
+        address "10.0.0.1/32"
+    }
+    ethernet eth0 {
+        address "dhcp"
+        offload {
+            gro
+            gso
+            sg
+            tso
+        }
+    }
+    ethernet eth1 {
+        address "10.1.0.1/30"
+        description "r1 -> r2"
+    }
+    loopback lo {
+    }
+}
+protocols {
+    bgp {
+        neighbor 192.168.0.1 {
+            address-family {
+                link-state {
+                }
+            }
+            remote-as "65001"
+        }
+        parameters {
+            router-id "3.3.3.3"
+        }
+        system-as "65002"
+    }
+}
+service {
+    lldp {
+        interface all {
+        }
+        interface eth0 {
+            mode "disable"
+        }
+    }
+    ntp {
+        allow-client {
+            address "0.0.0.0/0"
+            address "::/0"
+        }
+        server time1.vyos.net {
+        }
+        server time2.vyos.net {
+        }
+        server time3.vyos.net {
+        }
+    }
+    ssh {
+        disable-host-validation
+    }
+}
+system {
+    config-management {
+        commit-revisions "100"
+    }
+    conntrack {
+        modules {
+            ftp
+            h323
+            nfs
+            pptp
+            sip
+            sqlnet
+            tftp
+        }
+    }
+    host-name "r1"
+    login {
+        user vyos {
+            authentication {
+                encrypted-password "$6$MjV2YvKQ56q$QbL562qhRoyUu8OaqrXagicvcsNpF1HssCY06ZxxghDJkBCfSfTE/4FlFB41xZcd/HqYyVBuRt8Zyq3ozJ0dc."
+                plaintext-password ""
+                public-keys defaultkey {
+                    key "AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ=="
+                    type "ssh-rsa"
+                }
+            }
+        }
+    }
+    name-server "eth0"
+    syslog {
+        local {
+            facility all {
+                level "notice"
+            }
+            facility local7 {
+                level "debug"
+            }
+        }
+    }
+}
+
+
+// Warning: Do not remove the following line.
+// vyos-config-version: "bgp@6:broadcast-relay@1:cluster@2:config-management@1:conntrack@6:conntrack-sync@2:container@3:dhcp-relay@2:dhcp-server@11:dhcpv6-server@6:dns-dynamic@4:dns-forwarding@4:firewall@20:flow-accounting@3:https@7:ids@2:interfaces@34:ipoe-server@4:ipsec@14:isis@3:l2tp@9:lldp@3:mdns@1:monitoring@2:nat@8:nat66@3:nhrp@1:ntp@3:openconnect@3:openvpn@5:ospf@2:pim@1:policy@9:pppoe-server@12:pptp@5:qos@3:quagga@12:reverse-proxy@3:rip@1:rpki@2:salt@1:snmp@3:ssh@3:sstp@6:system@31:vpp@6:vrf@4:vrrp@4:vyos-accel-ppp@2:wanloadbalance@4:webproxy@2"
+// Release version: 1.5-rolling-202604141237

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -1749,5 +1749,21 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'bmp monitor ipv6 unicast loc-rib', frrconfig)
         self.assertIn(f'bmp connect {target_address} port {target_port} min-retry {min_retry} max-retry {max_retry}', frrconfig)
 
+    def test_bgp_100_link_state(self):
+        router_id = '127.0.0.1'
+        peer = '192.0.3.3'
+        peer_asn = '100'
+
+        self.cli_set(base_path + ['parameters', 'router-id', router_id])
+        self.cli_set(base_path + ['neighbor', peer, 'remote-as', peer_asn])
+
+        self.cli_set(base_path + ['neighbor', peer, 'address-family', 'link-state'])
+
+        self.cli_commit()
+
+        # Verify FRR bgpd configuration
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', stop_section='^exit')
+        self.assertIn(f' address-family link-state', frrconfig)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())


### PR DESCRIPTION
## Change summary

Add `link-state` address familty to BGP

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T8457

## Related PR(s)

* https://github.com/vyos/vyos-build/pull/1154

## How to test / Smoketest result

Use https://vyos.io/solutions/service-provider/segment-routing but replace Junos router with VyOS with configuration:

```
set system host-name 'P1' 
set interfaces ethernet eth1 address '10.100.1.3/24' 
set interfaces ethernet eth2 address '10.100.3.3/24' 
set interfaces ethernet eth3 address '10.100.10.3/24' 
set interfaces ethernet eth5 address '192.168.0.103/24' 
set interfaces loopback lo address '3.3.3.3/32' 
set protocols traffic-engineering admin-group BLUE bit-position '0' 
set protocols traffic-engineering interface eth1 admin-group 'BLUE' 
set protocols traffic-engineering interface eth1 max-bandwidth '10000' 
set protocols traffic-engineering interface eth1 max-reservable-bandwidth '10000' 
set protocols traffic-engineering interface eth2 admin-group 'BLUE' 
set protocols traffic-engineering interface eth2 max-bandwidth '10000' 
set protocols traffic-engineering interface eth2 max-reservable-bandwidth '10000' 
set protocols traffic-engineering interface eth3 max-bandwidth '10000' 
set protocols traffic-engineering interface eth3 max-reservable-bandwidth '10000' 
set protocols isis interface eth1 network point-to-point 
set protocols isis interface eth2 network point-to-point 
set protocols isis interface eth3 network point-to-point 
set protocols isis interface eth5 network point-to-point 
set protocols isis interface lo passive 
set protocols isis level 'level-2' 
set protocols isis lsp-mtu '1300' 
set protocols isis net '49.0003.0003.0003.00' 
set protocols isis segment-routing global-block high-label-value '865534' 
set protocols isis segment-routing global-block low-label-value '800000' 
set protocols isis segment-routing prefix 3.3.3.3/32 index value '3' 
set protocols isis traffic-engineering enable 
set protocols isis traffic-engineering export 
set protocols mpls interface 'eth1' 
set protocols mpls interface 'eth2' 
set protocols mpls interface 'eth3' 
set protocols mpls interface 'eth5' 
set protocols mpls interface 'lo' 
set protocols bgp neighbor 192.168.0.1 address-family link-state
set protocols bgp parameters router-id '3.3.3.3'
set protocols bgp system-as '65002'
set protocols bgp neighbor 192.168.0.1 remote-as '65001'
set protocols isis segment-routing maximum-label-depth 13
```

## Checklist:

- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
