### PR TITLE
conntrack-sync: T8189: Add conntrackd FTFW PurgeTimeout setting

### DIFF
--- a/data/templates/conntrackd/conntrackd.conf.j2
+++ b/data/templates/conntrackd/conntrackd.conf.j2
@@ -3,6 +3,7 @@
 # Synchronizer settings
 Sync {
     Mode FTFW {
+        PurgeTimeout {{ purge_timeout }}
         DisableExternalCache {{ 'on' if disable_external_cache is vyos_defined else 'off' }}
         StartupResync {{ 'on' if startup_resync is vyos_defined else 'off' }}
     }

--- a/interface-definitions/service_conntrack-sync.xml.in
+++ b/interface-definitions/service_conntrack-sync.xml.in
@@ -178,6 +178,19 @@
             </properties>
             <defaultValue>1</defaultValue>
           </leafNode>
+          <leafNode name="purge-timeout">
+            <properties>
+              <help>Timeout for purging synchronized entries on handover events</help>
+              <valueHelp>
+                <format>u32:1-2147483647</format>
+                <description>Purge timeout in seconds</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 1-2147483647"/>
+              </constraint>
+            </properties>
+            <defaultValue>60</defaultValue>
+          </leafNode>
         </children>
       </node>
     </children>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8189
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set high-availability vrrp group TEST address 10.9.1.1/24
set high-availability vrrp group TEST interface 'eth3'
set high-availability vrrp group TEST vrid '9'
set high-availability vrrp sync-group TEST-GROUP member TEST

set service conntrack-sync failover-mechanism vrrp sync-group TEST-GROUP
set service conntrack-sync interface eth3

vyos@vyos# sed -n '/^Sync {/,/^}/p' /run/conntrackd/conntrackd.conf
Sync {
    Mode FTFW {
        PurgeTimeout 60
        DisableExternalCache off
        StartupResync off
    }
    Multicast {
        IPv4_address 225.0.0.50
        Group 3780
        IPv4_interface 111.10.0.1
        Interface eth3
        SndSocketBuffer 1048576
        RcvSocketBuffer 1048576
        Checksum on
    }
}
[edit]
vyos@vyos# set service conntrack-sync purge-timeout 120
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# sed -n '/^Sync {/,/^}/p' /run/conntrackd/conntrackd.conf
Sync {
    Mode FTFW {
        PurgeTimeout 120
        DisableExternalCache off
        StartupResync off
    }
    Multicast {
        IPv4_address 225.0.0.50
        Group 3780
        IPv4_interface 111.10.0.1
        Interface eth3
        SndSocketBuffer 1048576
        RcvSocketBuffer 1048576
        Checksum on
    }
}
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
