### PR TITLE
serial: T8211: fix symlink collisions for multi-port USB serial adapters

### DIFF
--- a/src/etc/udev/rules.d/90-vyos-serial.rules
+++ b/src/etc/udev/rules.d/90-vyos-serial.rules
@@ -22,8 +22,9 @@ IMPORT{builtin}="path_id", IMPORT{builtin}="usb_id"
 #   (tr -d -) does the replacement
 # - Replace the first group after ":" to represent the bus relation (sed -e 0,/:/s//b/) indicated by "b"
 # - Replace the next group after ":" to represent the port relation (sed -e 0,/:/s//p/) indicated by "p"
-ENV{ID_PATH}=="?*", ENV{.ID_PORT}=="",  PROGRAM="/bin/sh -c 'echo $env{ID_PATH} | cut -d- -f3- | tr -d - | sed -e 0,/:/s//b/ | sed -e 0,/:/s//p/'", SYMLINK+="serial/by-bus/$result"
-ENV{ID_PATH}=="?*", ENV{.ID_PORT}=="0", PROGRAM="/bin/sh -c 'echo $env{ID_PATH} | cut -d- -f3- | tr -d - | sed -e 0,/:/s//b/ | sed -e 0,/:/s//p/'", SYMLINK+="serial/by-bus/$result"
-ENV{ID_PATH}=="?*", ENV{.ID_PORT}=="?*", ENV{.ID_PORT}!="0", PROGRAM="/bin/sh -c 'echo $env{ID_PATH} | cut -d- -f3- | tr -d - | sed -e 0,/:/s//b/ | sed -e 0,/:/s//p/'", SYMLINK+="serial/by-bus/%cp%E{.ID_PORT}"
+ENV{ID_PATH}=="?*", PROGRAM="/bin/sh -c 'echo $env{ID_PATH} | cut -d- -f3- | tr -d - | sed -e 0,/:/s//b/ | sed -e 0,/:/s//p/'", ENV{.BY_BUS}="%c"
+ENV{.BY_BUS}=="?*", ENV{.ID_PORT}=="",  SYMLINK+="serial/by-bus/%E{.BY_BUS}"
+ENV{.BY_BUS}=="?*", ENV{.ID_PORT}=="0", SYMLINK+="serial/by-bus/%E{.BY_BUS}"
+ENV{.BY_BUS}=="?*", ENV{.ID_PORT}=="?*", ENV{.ID_PORT}!="0", SYMLINK+="serial/by-bus/%E{.BY_BUS}p%E{.ID_PORT}"
 
 LABEL="serial_end"

--- a/src/etc/udev/rules.d/90-vyos-serial.rules
+++ b/src/etc/udev/rules.d/90-vyos-serial.rules
@@ -22,7 +22,8 @@ IMPORT{builtin}="path_id", IMPORT{builtin}="usb_id"
 #   (tr -d -) does the replacement
 # - Replace the first group after ":" to represent the bus relation (sed -e 0,/:/s//b/) indicated by "b"
 # - Replace the next group after ":" to represent the port relation (sed -e 0,/:/s//p/) indicated by "p"
-ENV{ID_PATH}=="?*", ENV{.ID_PORT}=="",   PROGRAM="/bin/sh -c 'echo $env{ID_PATH} | cut -d- -f3- | tr -d - | sed -e 0,/:/s//b/ | sed -e 0,/:/s//p/'", SYMLINK+="serial/by-bus/$result"
-ENV{ID_PATH}=="?*", ENV{.ID_PORT}=="?*", PROGRAM="/bin/sh -c 'echo $env{ID_PATH} | cut -d- -f3- | tr -d - | sed -e 0,/:/s//b/ | sed -e 0,/:/s//p/'", SYMLINK+="serial/by-bus/$result"
+ENV{ID_PATH}=="?*", ENV{.ID_PORT}=="",  PROGRAM="/bin/sh -c 'echo $env{ID_PATH} | cut -d- -f3- | tr -d - | sed -e 0,/:/s//b/ | sed -e 0,/:/s//p/'", SYMLINK+="serial/by-bus/$result"
+ENV{ID_PATH}=="?*", ENV{.ID_PORT}=="0", PROGRAM="/bin/sh -c 'echo $env{ID_PATH} | cut -d- -f3- | tr -d - | sed -e 0,/:/s//b/ | sed -e 0,/:/s//p/'", SYMLINK+="serial/by-bus/$result"
+ENV{ID_PATH}=="?*", ENV{.ID_PORT}=="?*", ENV{.ID_PORT}!="0", PROGRAM="/bin/sh -c 'echo $env{ID_PATH} | cut -d- -f3- | tr -d - | sed -e 0,/:/s//b/ | sed -e 0,/:/s//p/'", SYMLINK+="serial/by-bus/%cp%E{.ID_PORT}"
 
 LABEL="serial_end"


### PR DESCRIPTION
## Change summary

Multi-port USB serial adapters where all ports share the same USB
`ID_PATH` (e.g., MosChip MCS7840) create identical symlink names in
`/dev/serial/by-bus/`, so only the last-enumerated port is accessible.

The existing udev rule captures `.ID_PORT` but never includes it in the
symlink name. This splits the catch-all `.ID_PORT` rule into two cases:
- **Port 0**: keeps the base symlink name (backward compatible)
- **Port 1+**: appends `pN` suffix following the existing naming scheme

Adapters where each port is a separate USB interface with a unique
`ID_PATH` (e.g., FTDI FT4232H) and single-port devices are unaffected.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T8211

## Related PR(s)

N/A

## How to test / Smoketest result

Tested on VyOS 2026.02 (circinus) with:
- MosChip MCS7840 8-port adapter (2× 4-port chips)
- FTDI FT4232H 4-port adapter
- Single-port USB serial adapters

Before (MCS7840 — only 1 symlink per 4-port chip):
```
usb0b1.4.1p1.0 -> ../../ttyUSB7
usb0b1.4.2p1.0 -> ../../ttyUSB11
```

After (all 8 ports visible):
```
usb0b1.4.1p1.0   -> ../../ttyUSB6
usb0b1.4.1p1.0p1 -> ../../ttyUSB7
usb0b1.4.1p1.0p2 -> ../../ttyUSB8
usb0b1.4.1p1.0p3 -> ../../ttyUSB9
usb0b1.4.2p1.0   -> ../../ttyUSB11
usb0b1.4.2p1.0p1 -> ../../ttyUSB12
usb0b1.4.2p1.0p2 -> ../../ttyUSB13
usb0b1.4.2p1.0p3 -> ../../ttyUSB14
```

FTDI FT4232H and single-port devices unchanged. No applicable smoketest exists for udev rules.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly