### PR TITLE
vpp: T8452: fix typo in variable name

### DIFF
--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -420,11 +420,11 @@ def get_config(config=None):
                     if 'dpdk_options' not in iface_config:
                         iface_config['dpdk_options'] = {}
                     # Check in a persistent config first
-                    id_from_persisten_conf = eth_ifaces_persist.get(iface, {}).get(
+                    id_from_persistent_conf = eth_ifaces_persist.get(iface, {}).get(
                         'dev_id'
                     )
-                    if id_from_persisten_conf:
-                        iface_config['dpdk_options']['dev_id'] = id_from_persisten_conf
+                    if id_from_persistent_conf:
+                        iface_config['dpdk_options']['dev_id'] = id_from_persistent_conf
                     else:
                         try:
                             iface_to_search = iface


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
Fix typo in variable name `id_from_persisten_conf` → `id_from_persistent_conf` in `src/conf_mode/vpp.py`.

##

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8452

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
none

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
This is a variable rename only (no functional change). Verified by grep that zero references to the old name remain:

`$ grep -r 'persisten_conf' src/`
`(no output)`


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
