### PR TITLE
T8465: Fix test_06_dhcp_default_route_for_vrf

### DIFF
--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -18,6 +18,7 @@ import pprint
 import re
 import unittest
 
+from math import ceil
 from time import sleep
 from typing import Type
 
@@ -414,6 +415,31 @@ class VyOSUnitTestSHIM:
                         matched = True
                         break
                 self.assertTrue(not matched if inverse else matched, msg=search)
+
+        @staticmethod
+        def wait_for_result(runnable, check, pause=1, timeout=10):
+            """
+            Run `runnable` each `pause` seconds till `timeout` seconds is over.
+            Each time compare return value with `check` if it is not callable, if
+            it is callable check if `check(result)` is True.
+
+            @returns tuple (check_result, last_return_value). check_result is True
+            if (last_return_value == check) for non-callable check or if (check(last_return_value))
+            is true.
+            """
+            tries = ceil(timeout / pause)
+            result = None
+            for i in range(tries):
+                result = runnable()
+                if callable(check):
+                    if check(result):
+                        return True, result
+                elif result == check:
+                    return True, result
+
+                sleep(pause)
+
+            return False, result
 
 # standard construction; typing suggestion: https://stackoverflow.com/a/70292317
 def ignore_warning(warning: Type[Warning]):

--- a/smoketest/scripts/cli/test_protocols_static.py
+++ b/smoketest/scripts/cli/test_protocols_static.py
@@ -648,16 +648,31 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
         self.cli_set(interface_path + ['vrf', vrf])
         self.cli_commit()
 
-        # Wait for dhclient to receive IP address and default gateway
-        sleep(5)
-
         router = get_dhcp_router(interface)
-        frrconfig = self.getFRRconfig(f'vrf {vrf}', stop_section='^exit-vrf')
-        self.assertIn(rf'ip route 0.0.0.0/0 {router} {interface} tag 210 {default_distance}', frrconfig)
+        route_str = (
+            rf'ip route 0.0.0.0/0 {router} {interface} tag 210 {default_distance}'
+        )
 
+        def check_default_route():
+            frrconfig = self.getFRRconfig(f'vrf {vrf}', stop_section='^exit-vrf')
+            if route_str in frrconfig:
+                return True
+            return frrconfig
+
+        result, config = self.wait_for_result(
+            check_default_route, True, pause=1, timeout=10
+        )
+
+        # First clean interfaces from VRF so that VRF can be deleted
         self.cli_delete(interface_path + ['address'])
         self.cli_delete(interface_path + ['vrf'])
         self.cli_commit()
+
+        # now we can assert
+        self.assertTrue(
+            result,
+            f"Expected '{route_str}' in FRR config, vrf section of FRR config:\n {config}",
+        )
 
         # Wait for dhclient to stop
         while process_named_running('dhclient', cmdline=interface, timeout=10):


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Fix test_06_dhcp_default_route_for_vrf

* Add wait_for_result function to VyOSUnitTestSHIM.
* Use it for periodic polling in test_06_dhcp_default_route_for_vrf
* Move interface removal from VRF before assert.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T8465

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_static.py -k test_06_dhcp_default_route_for_vrf
test_06_dhcp_default_route_for_vrf (__main__.TestProtocolsStatic.test_06_dhcp_default_route_for_vrf) ... ok
````

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
