### PR TITLE
wan: T8480: add suppress_prefixlength ip rules for internal routing

### DIFF
--- a/interface-definitions/load-balancing_wan.xml.in
+++ b/interface-definitions/load-balancing_wan.xml.in
@@ -29,6 +29,12 @@
               <valueless/>
             </properties>
           </leafNode>
+          <leafNode name="only-default-route">
+            <properties>
+              <help>Prefer specific routes in the main routing table over WAN load balancing</help>
+              <valueless/>
+            </properties>
+          </leafNode>
           <leafNode name="hook">
             <properties>
               <help>Script to be executed on interface status change</help>

--- a/smoketest/scripts/cli/test_load-balancing_wan.py
+++ b/smoketest/scripts/cli/test_load-balancing_wan.py
@@ -138,6 +138,23 @@ class TestLoadBalancingWan(VyOSUnitTestSHIM.TestCase):
         tmp = cmd('sudo ip route show table 202')
         self.assertEqual(tmp, original)
 
+        tmp = cmd('sudo ip rule show')
+        self.assertIn('from all fwmark 0xc9 lookup 201', tmp)
+        self.assertIn('from all fwmark 0xca lookup 202', tmp)
+        self.assertNotIn('fwmark 0xc9 lookup main suppress_prefixlength 0', tmp)
+        self.assertNotIn('fwmark 0xca lookup main suppress_prefixlength 0', tmp)
+
+        self.cli_set(base_path + ['wan', 'only-default-route'])
+        self.cli_commit()
+
+        time.sleep(5)
+
+        tmp = cmd('sudo ip rule show')
+        self.assertIn('from all fwmark 0xc9 lookup main suppress_prefixlength 0', tmp)
+        self.assertIn('from all fwmark 0xc9 lookup 201', tmp)
+        self.assertIn('from all fwmark 0xca lookup main suppress_prefixlength 0', tmp)
+        self.assertIn('from all fwmark 0xca lookup 202', tmp)
+
         # Delete veth interfaces and netns
         for iface in [iface1, iface2, iface3]:
             call(f'sudo ip link del dev {iface}')

--- a/src/helpers/vyos-load-balancer.py
+++ b/src/helpers/vyos-load-balancer.py
@@ -204,8 +204,11 @@ def cleanup(lb):
         index = 1
         for ifname, health_conf in lb['interface_health'].items():
             table_num = lb['mark_offset'] + index
+            suppress_prio = lb['mark_offset'] + index
+            table_prio = suppress_prio + 100
             run(f'ip route del table {table_num} default')
-            run(f'ip rule del fwmark {hex(table_num)} table {table_num}')
+            run(f'ip rule del priority {suppress_prio}')
+            run(f'ip rule del priority {table_prio}')
             index += 1
 
     run(f'nft delete table ip vyos_wanloadbalance')
@@ -263,7 +266,10 @@ if __name__ == '__main__':
             else:
                 run(f'ip route replace table {table_num} default dev {ifname} via {health_conf["nexthop"]}')
 
-            run(f'ip rule add fwmark {hex(table_num)} table {table_num}')
+            suppress_prio = lb['mark_offset'] + index
+            table_prio = suppress_prio + 100
+            run(f'ip rule add fwmark {hex(table_num)} table main suppress_prefixlength 0 priority {suppress_prio}')
+            run(f'ip rule add fwmark {hex(table_num)} table {table_num} priority {table_prio}')
 
             index += 1
 

--- a/src/helpers/vyos-load-balancer.py
+++ b/src/helpers/vyos-load-balancer.py
@@ -207,8 +207,15 @@ def cleanup(lb):
             suppress_prio = lb['mark_offset'] + index
             table_prio = suppress_prio + 100
             run(f'ip route del table {table_num} default')
-            run(f'ip rule del priority {suppress_prio}')
-            run(f'ip rule del priority {table_prio}')
+            run(
+                f'ip rule del fwmark {hex(table_num)} table main '
+                f'suppress_prefixlength 0 priority {suppress_prio}'
+            )
+            run(
+                f'ip rule del fwmark {hex(table_num)} table {table_num} '
+                f'priority {table_prio}'
+            )
+            run(f'ip rule del fwmark {hex(table_num)} table {table_num}')
             index += 1
 
     run(f'nft delete table ip vyos_wanloadbalance')
@@ -268,8 +275,17 @@ if __name__ == '__main__':
 
             suppress_prio = lb['mark_offset'] + index
             table_prio = suppress_prio + 100
-            run(f'ip rule add fwmark {hex(table_num)} table main suppress_prefixlength 0 priority {suppress_prio}')
-            run(f'ip rule add fwmark {hex(table_num)} table {table_num} priority {table_prio}')
+            if 'only_default_route' in lb:
+                run(
+                    f'ip rule add fwmark {hex(table_num)} table main '
+                    f'suppress_prefixlength 0 priority {suppress_prio}'
+                )
+                run(
+                    f'ip rule add fwmark {hex(table_num)} table {table_num} '
+                    f'priority {table_prio}'
+                )
+            else:
+                run(f'ip rule add fwmark {hex(table_num)} table {table_num}')
 
             index += 1
 


### PR DESCRIPTION
## Change summary

WLB per-interface routing tables only contain a default route. When LAN traffic is fwmarked by WLB nftables rules, ip rule policy routes it to these tables where internal destinations (BGP, connected, DNAT'd) have no matching route and incorrectly exit via WAN.

Add `ip rule add fwmark <mark> table main suppress_prefixlength 0` before each per-interface table rule. This checks the main routing table first for specific routes (BGP, connected, static) but suppresses the default route (prefix length 0), so only internet-bound traffic falls through to WLB per-interface tables.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Task(s)

* https://vyos.dev/T8480
* https://vyos.dev/T2574 (same root cause, closed as Not Applicable on older version)

## How to test

Configure WLB with BGP or DNAT and verify internal traffic is routed correctly:

```
set protocols bgp system-as 65000
set protocols bgp peer-group calico remote-as 65414
set protocols bgp listen range 10.2.0.0/24 peer-group calico

set load-balancing wan interface-health eth0 nexthop dhcp
set load-balancing wan interface-health eth1 nexthop 192.168.1.1
set load-balancing wan rule 1 failover
set load-balancing wan rule 1 interface eth0 weight 10
set load-balancing wan rule 1 interface eth1 weight 1
set load-balancing wan rule 1 inbound-interface eth2
set load-balancing wan rule 1 protocol all

set nat destination rule 110 destination address <wan-ip>
set nat destination rule 110 translation address 10.152.184.99
```

Before fix: LAN traffic to BGP prefixes and DNAT destinations exits via WAN.
After fix: `ip rule show` shows suppress_prefixlength rules before per-interface table rules. Internal traffic is routed via main table, WAN traffic via per-interface tables.

```
$ ip rule show
201: from all fwmark 0xc9 lookup main suppress_prefixlength 0
301: from all fwmark 0xc9 lookup 201
```

## Checklist:

- [x] I have read the **CONTRIBUTING** document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components **SMOKETESTS** if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation