### PR TITLE
wan: T8481: scope flush-connections to WLB interfaces only

### DIFF
--- a/src/helpers/vyos-load-balancer.py
+++ b/src/helpers/vyos-load-balancer.py
@@ -278,8 +278,8 @@ if __name__ == '__main__':
         run('ip route flush cache')
 
         if 'flush_connections' in lb:
-            run('conntrack --delete')
-            run('conntrack -F expect')
+            for _state in lb['health_state'].values():
+                run(f'conntrack --delete --mark {_state["table_number"]}')
 
         with open(wlb_status_file, 'w') as f:
             f.write(json.dumps(lb['health_state']))

--- a/src/helpers/vyos-load-balancer.py
+++ b/src/helpers/vyos-load-balancer.py
@@ -204,8 +204,11 @@ def cleanup(lb):
         index = 1
         for ifname, health_conf in lb['interface_health'].items():
             table_num = lb['mark_offset'] + index
+            suppress_prio = lb['mark_offset'] + index
+            table_prio = suppress_prio + 100
             run(f'ip route del table {table_num} default')
-            run(f'ip rule del fwmark {hex(table_num)} table {table_num}')
+            run(f'ip rule del priority {suppress_prio}')
+            run(f'ip rule del priority {table_prio}')
             index += 1
 
     run(f'nft delete table ip vyos_wanloadbalance')
@@ -263,7 +266,10 @@ if __name__ == '__main__':
             else:
                 run(f'ip route replace table {table_num} default dev {ifname} via {health_conf["nexthop"]}')
 
-            run(f'ip rule add fwmark {hex(table_num)} table {table_num}')
+            suppress_prio = lb['mark_offset'] + index
+            table_prio = suppress_prio + 100
+            run(f'ip rule add fwmark {hex(table_num)} table main suppress_prefixlength 0 priority {suppress_prio}')
+            run(f'ip rule add fwmark {hex(table_num)} table {table_num} priority {table_prio}')
 
             index += 1
 


### PR DESCRIPTION
## Change summary

`flush-connections` runs `conntrack --delete` which destroys all conntrack entries system-wide, including unrelated NAT translations (hairpin SNAT, DNAT port forwards) and established connections that have nothing to do with WLB.

WLB tags every connection it manages with a conntrack mark via the `wlb_mangle_isp_<ifname>` chain (`ct mark set 0xc9`, `0xca`, etc.). Scope the flush to these marks using `conntrack -D -m <mark>` so only WLB-managed connections are affected.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Task(s)

* https://vyos.dev/T8481
* https://vyos.dev/T1311 (related: conntrack flush hanging with conntrackd, resolved)

## How to test

1. Enable WLB with `set load-balancing wan flush-connections`
2. Establish a long-lived TCP connection on a non-WLB path (e.g. SSH from LAN to LAN host)
3. Trigger a WLB state change (fail a health check)
4. Before fix: all connections drop. After fix: only connections marked by WLB are flushed.

## Checklist:

- [x] I have read the **CONTRIBUTING** document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components **SMOKETESTS** if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation