### PR TITLE
vyos-netlinkd: T8486: fix high-cpu utilisation due to excessive CLI calls

### DIFF
--- a/src/services/vyos-netlinkd
+++ b/src/services/vyos-netlinkd
@@ -50,7 +50,7 @@ def sigterm_handler(signo, frame):
     sig = signal.Signals(signo)
     syslog.syslog(syslog.LOG_INFO, f'Received signal {sig.name} - shutting down...')
 
-def _handle_dhcp_events(config_dict: dict, operstate: Optional[str], ifname: str) -> None:
+def _handle_dhcp_events(operstate: Optional[str], ifname: str) -> None:
     systemdV4_service = f'dhclient@{ifname}.service'
     systemdV6_service = f'dhcp6c@{ifname}.service'
 
@@ -70,6 +70,11 @@ def _handle_dhcp_events(config_dict: dict, operstate: Optional[str], ifname: str
     elif operstate == 'UP':
         v6_restart = False
         interface_path = Section.get_config_path(ifname, delimiter='.')
+
+        config_dict = op_mode_config_dict(
+            ['interfaces'], key_mangling=('-', '_'), get_first_key=True
+        )
+
         if tmp := dict_search(f'{interface_path}.address', config_dict):
             # Always (re-)start the DHCP(v6) client service. If the DHCP(v6) client
             # is already running - which could happen if the interface is re-
@@ -123,10 +128,6 @@ def main():
                 while commit_in_progress():
                     sleep(0.250)
 
-                config_dict = op_mode_config_dict(['interfaces'],
-                                            key_mangling=('-', '_'),
-                                            get_first_key=True)
-
                 # Parse NETLINK message
                 match message['event']:
                     # Message received during interface creation or modification
@@ -146,7 +147,7 @@ def main():
                         if not match_iface(ifname):
                             continue
 
-                        _handle_dhcp_events(config_dict, operstate, ifname)
+                        _handle_dhcp_events(operstate, ifname)
 
                     # Deletion of a network link which has been previously added to the kernel
                     case 'RTM_DELLINK':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

```
strace: Process 16362 attached
[pid 16362] execve("/bin/cli-shell-api", ["/bin/cli-shell-api", "--show-active-only", "showConfig", "interfaces"], ...) = 0 [pid 16362] +++ exited with 0 +++
--- SIGCHLD ...

strace: Process 16363 attached
[pid 16363] execve("/bin/cli-shell-api", ["/bin/cli-shell-api", "--show-active-only", "showConfig", "interfaces"], ...) = 0 [pid 16363] +++ exited with 0 +++
--- SIGCHLD ...
```

This would appear to be due to vyos-netlinkd calling `op_mode_config_dict()` more than is necessary: it can be called only when it may be applicable (this patch).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8486

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/4872

## How to test / Smoketest result

```
set interfaces ethernet eth0 vif 10 address 'dhcp'
set interfaces ethernet eth0 vif 10 vrf 'MGMT'
set vrf name MGMT table '1000'
```

Wait for interface to get a DHCP lease

`sudo ip link set dev eth0.10 down`

followed by

`sudo ip link set dev eth0.10 up`

`vyos-netlink` detects the interface change from DOWN -> UP and restarts dhcp client. All can be viewed via `monitor log` command.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
