### PR TITLE
op-mode: T8483: fix /show_sensors.py: No such file or directory

### DIFF
--- a/op-mode-definitions/show-environment.xml.in
+++ b/op-mode-definitions/show-environment.xml.in
@@ -11,8 +11,7 @@
             <properties>
               <help>Show hardware monitoring results</help>
             </properties>
-            <!-- Linux always adds "hypervisor" to CPU flags -->
-	    <command>bash -c 'if ! grep -q hypervisor /proc/cpuinfo; then ${vyos_op_scripts_dir}/show_sensors.py; else echo "VyOS running under hypervisor, no sensors available"; fi'</command>
+	          <command>${vyos_op_scripts_dir}/show_sensors.py</command>
           </leafNode>
         </children>
       </node>

--- a/src/op_mode/show_sensors.py
+++ b/src/op_mode/show_sensors.py
@@ -17,8 +17,16 @@
 
 import re
 import sys
+
+from vyos.utils.file import read_file
 from vyos.utils.process import popen
 from vyos.utils.process import DEVNULL
+
+cpu_info = read_file('/proc/cpuinfo')
+# Linux always adds "hypervisor" to CPU flags
+if 'hypervisor' in cpu_info:
+    print('VyOS running under hypervisor, no sensors available!')
+    sys.exit(1)
 
 output,retcode = popen("sensors --no-adapter",  stderr=DEVNULL)
 if retcode == 0:

--- a/src/op_mode/show_sensors.py
+++ b/src/op_mode/show_sensors.py
@@ -28,22 +28,22 @@ if 'hypervisor' in cpu_info:
     print('VyOS running under hypervisor, no sensors available!')
     sys.exit(1)
 
-output,retcode = popen("sensors --no-adapter",  stderr=DEVNULL)
+output, retcode = popen("sensors --no-adapter", stderr=DEVNULL)
 if retcode == 0:
     print (output)
     sys.exit(0)
 else:
-    output,retcode = popen("sensors-detect --auto",stderr=DEVNULL)
-    match = re.search(r'#----cut here----(.*)#----cut here----',output, re.DOTALL)
+    output, retcode = popen("sensors-detect --auto", stderr=DEVNULL)
+    match = re.search(r'#----cut here----(.*)#----cut here----', output,
+                      re.DOTALL)
     if match:
         for module in match.group(0).split('\n'):
             if not module.startswith("#"):
                 popen("modprobe {}".format(module.strip()))
-                output,retcode = popen("sensors --no-adapter",  stderr=DEVNULL)
+                output, retcode = popen("sensors --no-adapter", stderr=DEVNULL)
                 if retcode == 0:
-                    print (output)
+                    print(output)
                     sys.exit(0)
 
-
-print ("No sensors found")
+print("No sensors found")
 sys.exit(1)

--- a/src/op_mode/show_sensors.py
+++ b/src/op_mode/show_sensors.py
@@ -18,15 +18,8 @@
 import re
 import sys
 
-from vyos.utils.file import read_file
 from vyos.utils.process import popen
 from vyos.utils.process import DEVNULL
-
-cpu_info = read_file('/proc/cpuinfo')
-# Linux always adds "hypervisor" to CPU flags
-if 'hypervisor' in cpu_info:
-    print('VyOS running under hypervisor, no sensors available!')
-    sys.exit(1)
 
 output, retcode = popen("sensors --no-adapter", stderr=DEVNULL)
 if retcode == 0:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

After rewriting the op-mode handlind code and introducing `<virtualTagNodes>` for op-mode, also all `<command>` statements will be executed by a runner. Executing `bash -c ''` code within that runner lacks the proper environment.

This can be verified by adding `env` into the `bash -c ''` executions string.

Solve this issue by moving the hypervisor detection code to `show_sensors.py`.

No backport for `circinus` needed as this code only lives in `current`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8483

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
vyos@vyos:~$ show environment sensors
No sensors found
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
