### PR TITLE
dhcp: T8493: Fix sort ordering for remaining time display

### DIFF
--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -661,7 +661,7 @@ def kea_get_server_leases(config, inet, vrf_name, pools=[], state=[], origin=Non
         if lease['valid-lft'] > 0 and lease['expire_time'] > now:
             # subtraction gives us a timedelta object which can't be formatted
             # with strftime so we use str(), split gets rid of the microseconds
-            data_lease['remaining'] = str(lease['expire_time'] - now).split('.')[0]
+            data_lease['remaining'] = (lease['expire_time'].replace(microsecond=0) - now.replace(microsecond=0))
 
         # Do not add old leases
         if (

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -88,6 +88,7 @@ def _find_list_of_dict_index(lst, key='ip', value=''):
     idx = next((index for (index, d) in enumerate(lst) if d[key] == value), None)
     return idx
 
+
 def kea_test_config(process: str, config_path: str) -> tuple[bool, str]:
     result, output = rc_cmd(f'{process} -t {config_path}')
 
@@ -96,6 +97,7 @@ def kea_test_config(process: str, config_path: str) -> tuple[bool, str]:
 
     find = re.search(r'Error encountered:\s([^\n$]+)', output)
     return (False, find[1] if find else None)
+
 
 def kea_parse_options(config):
     options = []
@@ -159,7 +161,11 @@ def kea_parse_options(config):
 
 
 def kea_parse_subnet(subnet, config):
-    out = {'subnet': subnet, 'id': int(config['subnet_id']), 'user-context': {'enable-ping-check': False}}
+    out = {
+        'subnet': subnet,
+        'id': int(config['subnet_id']),
+        'user-context': {'enable-ping-check': False},
+    }
 
     if 'option' in config:
         out['option-data'] = kea_parse_options(config['option'])
@@ -371,6 +377,7 @@ def kea6_parse_subnet(subnet, config):
 
     return out
 
+
 def kea_parse_tsig_algo(algo_spec):
     translate = {
         'md5': 'HMAC-MD5',
@@ -378,14 +385,16 @@ def kea_parse_tsig_algo(algo_spec):
         'sha224': 'HMAC-SHA224',
         'sha256': 'HMAC-SHA256',
         'sha384': 'HMAC-SHA384',
-        'sha512': 'HMAC-SHA512'
+        'sha512': 'HMAC-SHA512',
     }
     if algo_spec not in translate:
         raise ConfigError(f'Unsupported TSIG algorithm: {algo_spec}')
     return translate[algo_spec]
 
+
 def kea_parse_enable_disable(value):
     return True if value == 'enable' else False
+
 
 def kea_parse_ddns_settings(config):
     data = {}
@@ -394,7 +403,9 @@ def kea_parse_ddns_settings(config):
         data['ddns-send-updates'] = kea_parse_enable_disable(send_updates)
 
     if override_client_update := config.get('override_client_update'):
-        data['ddns-override-client-update'] = kea_parse_enable_disable(override_client_update)
+        data['ddns-override-client-update'] = kea_parse_enable_disable(
+            override_client_update
+        )
 
     if override_no_update := config.get('override_no_update'):
         data['ddns-override-no-update'] = kea_parse_enable_disable(override_no_update)
@@ -403,7 +414,9 @@ def kea_parse_ddns_settings(config):
         data['ddns-update-on-renew'] = kea_parse_enable_disable(update_on_renew)
 
     if conflict_resolution := config.get('conflict_resolution'):
-        data['ddns-use-conflict-resolution'] = kea_parse_enable_disable(conflict_resolution)
+        data['ddns-use-conflict-resolution'] = kea_parse_enable_disable(
+            conflict_resolution
+        )
 
     if 'replace_client_name' in config:
         data['ddns-replace-client-name'] = config['replace_client_name']
@@ -419,6 +432,7 @@ def kea_parse_ddns_settings(config):
         data['hostname-char-replacement'] = config['hostname_char_replacement']
 
     return data
+
 
 def _ctrl_socket_command(inet, vrf_name, command, args=None):
     if vrf_name:
@@ -603,7 +617,9 @@ def kea_get_static_mappings(config, inet, pools=[]) -> list:
     return mappings
 
 
-def kea_get_server_leases(config, inet, vrf_name, pools=[], state=[], origin=None) -> list:
+def kea_get_server_leases(
+    config, inet, vrf_name, pools=[], state=[], origin=None
+) -> list:
     """
     Get DHCP server leases from active Kea DHCPv4 or DHCPv6 configuration
     :return list
@@ -659,9 +675,10 @@ def kea_get_server_leases(config, inet, vrf_name, pools=[], state=[], origin=Non
 
         now = datetime.now(timezone.utc)
         if lease['valid-lft'] > 0 and lease['expire_time'] > now:
-            # subtraction gives us a timedelta object which can't be formatted
-            # with strftime so we use str(), split gets rid of the microseconds
-            data_lease['remaining'] = (lease['expire_time'].replace(microsecond=0) - now.replace(microsecond=0))
+            # clear the microseconds before subtraction for visual clarity
+            data_lease['remaining'] = lease['expire_time'].replace(
+                microsecond=0
+            ) - now.replace(microsecond=0)
 
         # Do not add old leases
         if (
@@ -685,21 +702,31 @@ def kea_get_server_leases(config, inet, vrf_name, pools=[], state=[], origin=Non
 
     return data
 
+
 def _build_relay_hex_condition(sub_option_index, value):
-    if value.startswith("0x"):
-        return f"relay4[{sub_option_index}].hex == {value}"
+    if value.startswith('0x'):
+        return f'relay4[{sub_option_index}].hex == {value}'
     else:
-        return f"relay4[{sub_option_index}].hex == 0x{value.encode().hex().lower()}"
+        return f'relay4[{sub_option_index}].hex == 0x{value.encode().hex().lower()}'
+
 
 def kea_build_client_class_test(config):
     conditions = []
 
-    if "relay_agent_information" in config:
-        if "circuit_id" in config["relay_agent_information"]:
-            conditions.append(_build_relay_hex_condition(1, config["relay_agent_information"]["circuit_id"]))
-        if "remote_id" in config["relay_agent_information"]:
-            conditions.append(_build_relay_hex_condition(2, config["relay_agent_information"]["remote_id"]))
+    if 'relay_agent_information' in config:
+        if 'circuit_id' in config['relay_agent_information']:
+            conditions.append(
+                _build_relay_hex_condition(
+                    1, config['relay_agent_information']['circuit_id']
+                )
+            )
+        if 'remote_id' in config['relay_agent_information']:
+            conditions.append(
+                _build_relay_hex_condition(
+                    2, config['relay_agent_information']['remote_id']
+                )
+            )
 
-    test = " and ".join(conditions)
+    test = ' and '.join(conditions)
 
     return test


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Op mode command `show dhcp server leases sort remaining` should sort leases by remaining time in timedelta form, not string form.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8493

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Current output of `show dhcp server leases sort remaining` (incorrect - before fix):
```
IP Address     MAC address        State    Lease start                Lease expiration           Remaining    Pool    Hostname            Origin
-------------  -----------------  -------  -------------------------  -------------------------  -----------  ------  ------------------  --------
192.168.28.82   aa:bb:50:e4:84:xx  active   2026-04-13 16:32:29+00:00  2026-04-14 16:32:29+00:00  12:36:50     FOO     redacted            local
192.168.17.1    aa:bb:c6:ad:f4:xx  active   2026-04-13 17:02:50+00:00  2026-04-14 17:02:50+00:00  13:07:11     FOO     redacted            local
192.168.19.200  aa:bb:f9:c6:28:xx  active   2026-04-13 17:02:57+00:00  2026-04-14 17:02:57+00:00  13:07:18     FOO     redacted            local
192.168.17.9    aa:bb:4e:ca:35:xx  active   2026-04-14 02:13:24+00:00  2026-04-15 02:13:24+00:00  22:17:45     FOO     redacted            local
192.168.60.11   aa:bb:d4:7d:57:xx  active   2026-04-13 22:47:09+00:00  2026-04-14 06:47:09+00:00  2:51:30      FOO     redacted            local
192.168.44.4    aa:bb:5c:a8:1c:xx  active   2026-04-13 23:28:36+00:00  2026-04-14 07:28:36+00:00  3:32:57      FOO     redacted            local
192.168.44.86   aa:bb:03:55:a4:xx  active   2026-04-13 23:43:10+00:00  2026-04-14 07:43:10+00:00  3:47:31      FOO     redacted            local
192.168.44.91   aa:bb:85:dd:3b:xx  active   2026-04-13 23:59:27+00:00  2026-04-14 07:59:27+00:00  4:03:48      FOO     redacted            local
192.168.44.89   aa:bb:85:dd:3b:xx  active   2026-04-14 00:15:21+00:00  2026-04-14 08:15:21+00:00  4:19:42      FOO     redacted            local

```

Expected output of `show dhcp server leases sort remaining` (correct - after fix):
```
IP Address     MAC address        State    Lease start                Lease expiration           Remaining    Pool    Hostname            Origin
-------------  -----------------  -------  -------------------------  -------------------------  -----------  ------  ------------------  --------
192.168.60.11   aa:bb:d4:7d:57:xx  active   2026-04-13 22:47:09+00:00  2026-04-14 06:47:09+00:00  2:51:30      FOO     redacted            local
192.168.44.4    aa:bb:5c:a8:1c:xx  active   2026-04-13 23:28:36+00:00  2026-04-14 07:28:36+00:00  3:32:57      FOO     redacted            local
192.168.44.86   aa:bb:03:55:a4:xx  active   2026-04-13 23:43:10+00:00  2026-04-14 07:43:10+00:00  3:47:31      FOO     redacted            local
192.168.44.91   aa:bb:85:dd:3b:xx  active   2026-04-13 23:59:27+00:00  2026-04-14 07:59:27+00:00  4:03:48      FOO     redacted            local
192.168.44.89   aa:bb:85:dd:3b:xx  active   2026-04-14 00:15:21+00:00  2026-04-14 08:15:21+00:00  4:19:42      FOO     redacted            local
192.168.28.82   aa:bb:50:e4:84:xx  active   2026-04-13 16:32:29+00:00  2026-04-14 16:32:29+00:00  12:36:50     FOO     redacted            local
192.168.17.1    aa:bb:c6:ad:f4:xx  active   2026-04-13 17:02:50+00:00  2026-04-14 17:02:50+00:00  13:07:11     FOO     redacted            local
192.168.19.200  aa:bb:f9:c6:28:xx  active   2026-04-13 17:02:57+00:00  2026-04-14 17:02:57+00:00  13:07:18     FOO     redacted            local
192.168.17.9    aa:bb:4e:ca:35:xx  active   2026-04-14 02:13:24+00:00  2026-04-15 02:13:24+00:00  22:17:45     FOO     redacted            local

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
