### PR TITLE
vpp: T8505: Switch PPPoE bindings retrieval from CLI parsing to API call

### DIFF
--- a/python/vyos/vpp/control_vpp.py
+++ b/python/vyos/vpp/control_vpp.py
@@ -472,73 +472,39 @@ class VPPControl:
         """
         vpp_pair = self.lcp_pair_find(kernel_name=ifname)
         if vpp_pair:
-            vpp_iface_name = vpp_pair['vpp_name_hw']
-            vpp_pair_name = vpp_pair['vpp_name_kernel']
+            vpp_iface_index = vpp_pair['vpp_index_hw']
+            vpp_pair_index = vpp_pair['vpp_index_kernel']
             self.__vpp_api_client.api.pppoe_add_del_cp(
-                dp_sw_if_index=self.get_sw_if_index(vpp_iface_name),
-                cp_sw_if_index=self.get_sw_if_index(vpp_pair_name),
+                dp_sw_if_index=vpp_iface_index,
+                cp_sw_if_index=vpp_pair_index,
                 is_add=True,
             )
 
     @_Decorators.api_call
     def get_pppoe_interface_mapping(self) -> dict:
         """
-        Parse the output of 'show pppoe control-plane binding' to build a mapping
-        between data-plane and control-plane interfaces.
+        Build a mapping between data-plane and control-plane interfaces.
 
         Returns:
-            dict: Mapping of data-plane interface names/indices to control-plane interface names/indices.
+            dict: Mapping of data-plane interface indices to control-plane interface indices.
         """
-        reply = self.cli_cmd('show pppoe control-plane binding').reply
         result = {}
-
-        deleted_re = re.compile(r'DELETED\s*\((\d+)\)')
-
-        lines = reply.strip().splitlines()
-
-        # If there are less than 2 lines, assume no PPPoE configured
-        if len(lines) < 2:
-            return result
-
-        # Skip header lines (first 2 lines)
-        for line in lines[2:]:
-            line = line.strip()
-            if not line:
-                continue
-
-            # Split into two columns by 2+ spaces
-            cols = re.split(r'\s{2,}', line, maxsplit=1)
-            if len(cols) != 2:
-                continue
-
-            # Determine key/value depending on which column has "DELETED (index)"
-            col_a, col_b = cols
-
-            match_a = deleted_re.search(col_a)
-            match_b = deleted_re.search(col_b)
-
-            key = int(match_a.group(1)) if match_a else col_a
-            value = int(match_b.group(1)) if match_b else col_b
-
-            result[key] = value
+        for binding in self.__vpp_api_client.api.pppoe_cp_binding_dump():
+            dp_index = binding.dp_sw_if_index
+            cp_index = binding.cp_sw_if_index
+            result[dp_index] = cp_index
 
         return result
 
     @_Decorators.api_call
-    def delete_pppoe_mapping(self, dp_iface: str | int, cp_iface: str | int) -> None:
+    def delete_pppoe_mapping(self, dp_index: int, cp_index: int) -> None:
         """
         Delete PPPoE mapping between data-plane and control-plane interfaces.
 
         Args:
-            dp_iface (str|int): Name or index of an interface in data-plane.
-            cp_iface (str|int): Name or index of an interface in control plane.
+            dp_index (int): Index of an interface in data-plane.
+            cp_index (int): Index of an interface in control plane.
         """
-        dp_index = dp_iface
-        if isinstance(dp_iface, str):
-            dp_index = self.get_sw_if_index(dp_iface)
-        cp_index = cp_iface
-        if isinstance(cp_iface, str):
-            cp_index = self.get_sw_if_index(cp_iface)
         self.__vpp_api_client.api.pppoe_add_del_cp(
             dp_sw_if_index=dp_index,
             cp_sw_if_index=cp_index,

--- a/src/conf_mode/service_pppoe-server.py
+++ b/src/conf_mode/service_pppoe-server.py
@@ -219,8 +219,8 @@ def apply(pppoe):
     if 'vpp_ifaces' in pppoe:
         vpp = VPPControl()
         mapping = vpp.get_pppoe_interface_mapping()
-        for dp_iface, cp_iface in mapping.items():
-            vpp.delete_pppoe_mapping(dp_iface, cp_iface)
+        for dp_index, cp_index in mapping.items():
+            vpp.delete_pppoe_mapping(dp_index, cp_index)
 
     if 'remove' in pppoe:
         call(f'systemctl stop {systemd_service}')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Replaced fragile CLI output parsing in `get_pppoe_interface_mapping()` with a direct VPP API call (`pppoe_cp_binding_dump`).
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8505
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
