### PR TITLE
serial: T8375: call update_serial_console() only once for default tty

### DIFF
--- a/src/conf_mode/system_console.py
+++ b/src/conf_mode/system_console.py
@@ -30,8 +30,6 @@ airbag.enable()
 
 by_bus_dir = '/dev/serial/by-bus'
 
-default_tty_console = ('tty', '0', '')
-
 def get_config(config=None):
     if config:
         conf = config
@@ -89,6 +87,8 @@ def generate(console):
             if 'serial-getty' in basename:
                 os.unlink(os.path.join(root, basename))
 
+    # Define a default console on a tty framebuffer
+    default_tty_console = ('tty', '0', '')
     if not console or 'device' not in console:
         grub_util.update_serial_console(*default_tty_console)
         return None
@@ -110,7 +110,6 @@ def generate(console):
             else:
                 raise ConfigError(f'Device {device} does not support being used as tty')
 
-    use_serial_console = False
     for device, device_config in console['device'].items():
         # Do not render getty configuration if specified device is not a TTY.
         if not is_tty(device):
@@ -126,12 +125,9 @@ def generate(console):
             # get console type ("ttyS" or "ttyAMA") from device (e.g. "ttyS0")
             console_type = device.rstrip('0123456789')
             console_num = device[len(console_type):]
-            grub_util.update_serial_console(console_type, console_num, device_config['speed'])
-            use_serial_console = True
+            default_tty_console = (console_type, console_num, device_config['speed'])
 
-        if not use_serial_console:
-            grub_util.update_serial_console(*default_tty_console)
-
+    grub_util.update_serial_console(*default_tty_console)
     return None
 
 def apply(console):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

When there are multiple serial consoles defined; but either none or the last used the 'kernel' CLI option to disply Kernel messages, the GRUB code was called multiple times.

By moving the call to the GRUB helpers outside the for loop we gain a single execution of the code path, not that it matters performance wise - but messing with the bootloader should be reduced to a minimum.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8375

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/5092

## How to test / Smoketest result
Checked via `print` that the code is executed only once

```
cpo@LR1.wue3# show system console
+device ttyS0 {
+}
+device ttyS1 {
+}
+device ttyS2 {
+    kernel
+}
+device ttyS3 {
+}
[edit]
cpo@LR1.wue3# commit
[ system console ]

WARNING: Device "ttyS2" used for console is not a TTY!


WARNING: Device "ttyS3" used for console is not a TTY!

grub.update_serial_console()

[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
