### PR TITLE
wireless: T8528: Add module config code for mt7916 based cards

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_wireless.py
+++ b/smoketest/scripts/cli/test_interfaces_wireless.py
@@ -82,17 +82,6 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
 
         cls.cli_set(cls, wifi_cc_path + [country])
 
-    def tearDown(self):
-        # Remove mt7915e module configuration file after each test
-        mt7915e_conf = f'/etc/modprobe.d/mt7915e.conf'
-        if os.path.isfile(mt7915e_conf):
-            tmp = call(f'sudo rm -f {mt7915e_conf}')
-            # Fail the test if file cannot be removed
-            if tmp != 0:
-                self.fail(f'Failed to remove {mt7915e_conf}')
-        # Call tearDown method from super class...
-        super().tearDown()
-
     def test_wireless_add_single_ip_address(self):
         # derived method to check if member interfaces are enslaved properly
         super().test_add_single_ip_address()
@@ -229,9 +218,6 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         for key in vht_opt:
             self.cli_set(self._base_path + [interface, 'capabilities', 'vht'] + key.split())
 
-        # Load mt7915e to test module config generation
-        check_kmod('mt7915e')
-
         self.cli_commit()
 
         #
@@ -255,11 +241,6 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         tmp = get_config_value(interface, 'vht_capab')
         for key, value in vht_opt.items():
             self.assertIn(value, tmp)
-
-        # mt7916 card configuration
-        tmp = read_file(f'/etc/modprobe.d/mt7915e.conf')
-        self.assertIsNotNone(tmp)
-        self.assertEqual('options mt7915e enable_6ghz=0', tmp)
 
     def test_wireless_hostapd_vht_su_beamformer_config(self):
         # Single-User-Beamformer
@@ -306,9 +287,6 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         for key in vht_opt:
             self.cli_set(self._base_path + [interface, 'capabilities', 'vht'] + key.split())
 
-        # Load mt7915e to test module config generation
-        check_kmod('mt7915e')
-
         self.cli_commit()
 
         #
@@ -332,11 +310,6 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         tmp = get_config_value(interface, 'vht_capab')
         for key, value in vht_opt.items():
             self.assertIn(value, tmp)
-
-        # mt7916 card configuration
-        tmp = read_file(f'/etc/modprobe.d/mt7915e.conf')
-        self.assertIsNotNone(tmp)
-        self.assertEqual('options mt7915e enable_6ghz=0', tmp)
 
     def test_wireless_hostapd_he_2ghz_config(self):
         # Only set the hostapd (access-point) options - HE mode for 802.11ax at 2.4GHz
@@ -447,9 +420,6 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         self.cli_set(self._base_path + [interface, 'capabilities', 'he', 'beamform', 'multi-user-beamformer'])
         self.cli_set(self._base_path + [interface, 'capabilities', 'he', 'beamform', 'single-user-beamformer'])
 
-        # Load mt7915e to test module config generation
-        check_kmod('mt7915e')
-
         self.cli_commit()
 
         #
@@ -508,11 +478,6 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
 
         # Check for running process
         self.assertTrue(process_named_running('hostapd'))
-
-        # mt7916 card configuration
-        tmp = read_file(f'/etc/modprobe.d/mt7915e.conf')
-        self.assertIsNotNone(tmp)
-        self.assertEqual('options mt7915e enable_6ghz=1', tmp)
 
     def test_wireless_hostapd_wpa_config(self):
         # Only set the hostapd (access-point) options

--- a/smoketest/scripts/cli/test_interfaces_wireless.py
+++ b/smoketest/scripts/cli/test_interfaces_wireless.py
@@ -82,6 +82,17 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
 
         cls.cli_set(cls, wifi_cc_path + [country])
 
+    def tearDown(self):
+        # Remove mt7915e module configuration file after each test
+        mt7915e_conf = f'/etc/modprobe.d/mt7915e.conf'
+        if os.path.isfile(mt7915e_conf):
+            tmp = call(f'sudo rm -f {mt7915e_conf}')
+            # Fail the test if file cannot be removed
+            if tmp != 0:
+                self.fail(f'Failed to remove {mt7915e_conf}')
+        # Call tearDown method from super class...
+        super().tearDown()
+
     def test_wireless_add_single_ip_address(self):
         # derived method to check if member interfaces are enslaved properly
         super().test_add_single_ip_address()
@@ -218,6 +229,9 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         for key in vht_opt:
             self.cli_set(self._base_path + [interface, 'capabilities', 'vht'] + key.split())
 
+        # Load mt7915e to test module config generation
+        check_kmod('mt7915e')
+
         self.cli_commit()
 
         #
@@ -241,6 +255,11 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         tmp = get_config_value(interface, 'vht_capab')
         for key, value in vht_opt.items():
             self.assertIn(value, tmp)
+
+        # mt7916 card configuration
+        tmp = read_file(f'/etc/modprobe.d/mt7915e.conf')
+        self.assertIsNotNone(tmp)
+        self.assertEqual('options mt7915e enable_6ghz=0', tmp)
 
     def test_wireless_hostapd_vht_su_beamformer_config(self):
         # Single-User-Beamformer
@@ -287,6 +306,9 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         for key in vht_opt:
             self.cli_set(self._base_path + [interface, 'capabilities', 'vht'] + key.split())
 
+        # Load mt7915e to test module config generation
+        check_kmod('mt7915e')
+
         self.cli_commit()
 
         #
@@ -310,6 +332,11 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         tmp = get_config_value(interface, 'vht_capab')
         for key, value in vht_opt.items():
             self.assertIn(value, tmp)
+
+        # mt7916 card configuration
+        tmp = read_file(f'/etc/modprobe.d/mt7915e.conf')
+        self.assertIsNotNone(tmp)
+        self.assertEqual('options mt7915e enable_6ghz=0', tmp)
 
     def test_wireless_hostapd_he_2ghz_config(self):
         # Only set the hostapd (access-point) options - HE mode for 802.11ax at 2.4GHz
@@ -420,6 +447,9 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
         self.cli_set(self._base_path + [interface, 'capabilities', 'he', 'beamform', 'multi-user-beamformer'])
         self.cli_set(self._base_path + [interface, 'capabilities', 'he', 'beamform', 'single-user-beamformer'])
 
+        # Load mt7915e to test module config generation
+        check_kmod('mt7915e')
+
         self.cli_commit()
 
         #
@@ -478,6 +508,11 @@ class WirelessInterfaceTest(BasicInterfaceTest.TestCase):
 
         # Check for running process
         self.assertTrue(process_named_running('hostapd'))
+
+        # mt7916 card configuration
+        tmp = read_file(f'/etc/modprobe.d/mt7915e.conf')
+        self.assertIsNotNone(tmp)
+        self.assertEqual('options mt7915e enable_6ghz=1', tmp)
 
     def test_wireless_hostapd_wpa_config(self):
         # Only set the hostapd (access-point) options

--- a/src/conf_mode/interfaces_wireless.py
+++ b/src/conf_mode/interfaces_wireless.py
@@ -36,10 +36,14 @@ from vyos.ifconfig import WiFiIf
 from vyos.template import render
 from vyos.utils.dict import dict_search
 from vyos.utils.kernel import check_kmod
+from vyos.utils.kernel import is_module_loaded
+from vyos.utils.file import read_file
+from vyos.utils.file import write_file
 from vyos.utils.process import call
 from vyos.utils.process import is_systemd_service_active
 from vyos.utils.process import is_systemd_service_running
 from vyos.utils.network import interface_exists
+from vyos.base import Warning
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -232,7 +236,9 @@ def verify(wifi):
         phy = wifi['physical_device']
         if phy in wifi['station_interfaces']:
             if len(wifi['station_interfaces'][phy]) > 0:
-                raise ConfigError('Only one station per wireless physical interface possible!')
+                raise ConfigError(
+                    'Only one station per wireless physical interface possible!'
+                )
 
     verify_address(wifi)
     verify_vrf(wifi)
@@ -319,6 +325,59 @@ def apply(wifi):
     # Finally create the new interface
     w = WiFiIf(**wifi)
     w.update(wifi)
+
+    # Set up the mt7915e module according to new wifi configuration.
+    # For this card, the decision is made for the 5GHz/6GHz-capable phy:
+    # 5GHz uses VHT (802.11ac) op_modes and 6GHz uses HE (802.11ax)
+    # op_modes. The card does not support WiFi-7 (802.11be).
+    # There is a race condition in the order the two phys on that card
+    # are configured. Sometimes, the 5/6GHz phy is configured first and
+    # the 2.4GHz phy is configured last, which would overwrite the module
+    # parameter definition. Only the Wi-Fi configuration for the 5/6GHz phy
+    # must write the file!
+    # op_modes as configured in interfaces_wireless.xml.in
+    five_ghz_op_modes_vht = ['0', '1', '2', '3']
+    six_ghz_op_modes_he = ['131', '132', '133', '134', '135']
+    # Make sure to act only when VHT or HE modes are used
+    module_options = None
+    if 'capabilities' in wifi:
+        if 'he' in wifi['capabilities']:
+            if 'channel_set_width' in wifi['capabilities']['he']:
+                if wifi['capabilities']['he']['channel_set_width'] in six_ghz_op_modes_he:
+                    # 6GHz band required (802.11ax, WiFi-6e)
+                    module_options = 'options mt7915e enable_6ghz=1'
+        if 'vht' in wifi['capabilities']:
+            if 'channel_set_width' in wifi['capabilities']['vht']:
+                if wifi['capabilities']['vht']['channel_set_width'] in five_ghz_op_modes_vht:
+                    # 5GHz band required...
+                    module_options = 'options mt7915e enable_6ghz=0'
+        if module_options:
+            # Only if the mt7915e module is loaded (card present)...
+            if is_module_loaded('mt7915e'):
+                tmp = None
+                try:
+                    tmp = read_file(f'/etc/modprobe.d/mt7915e.conf')
+                except FileNotFoundError:
+                    # Module config does not exist yet.
+                    # Fail silently as it is written later in any case.
+                    pass
+                finally:
+                    # Write the module config in any case, so that there always is a
+                    # valid module config which is mandatory to load the mt7916 firmware.
+                    write_file(
+                        f'/etc/modprobe.d/mt7915e.conf',
+                        module_options,
+                        user='root',
+                        group='root',
+                        mode=0o644
+                    )
+                    # Issue a warning if module options have changed.
+                    # A warning is necessary even if this is the first time
+                    # this module is configured. The firmware must be reloaded.
+                    if tmp != module_options:
+                        Warning(
+                            'Change to firmware 5GHz/6GHz configuration detected. The system must be rebooted to correctly reload the mt7916 firmware. The card will not work otherwise!'
+                        )
 
     # Enable/Disable interface - interface is always placed in
     # administrative down state in WiFiIf class

--- a/src/conf_mode/interfaces_wireless.py
+++ b/src/conf_mode/interfaces_wireless.py
@@ -54,6 +54,8 @@ hostapd_conf = '/run/hostapd/{ifname}.conf'
 hostapd_accept_station_conf = '/run/hostapd/{ifname}_station_accept.conf'
 hostapd_deny_station_conf = '/run/hostapd/{ifname}_station_deny.conf'
 
+mt7915e_conf = f'/etc/modprobe.d/mt7915e.conf'
+
 country_code_path = ['system', 'wireless', 'country-code']
 
 def find_other_stations(conf, base, ifname):
@@ -335,49 +337,44 @@ def apply(wifi):
     # the 2.4GHz phy is configured last, which would overwrite the module
     # parameter definition. Only the Wi-Fi configuration for the 5/6GHz phy
     # must write the file!
-    # op_modes as configured in interfaces_wireless.xml.in
-    five_ghz_op_modes_vht = ['0', '1', '2', '3']
-    six_ghz_op_modes_he = ['131', '132', '133', '134', '135']
-    # Make sure to act only when VHT or HE modes are used
-    module_options = None
-    if 'capabilities' in wifi:
-        if 'he' in wifi['capabilities']:
-            if 'channel_set_width' in wifi['capabilities']['he']:
-                if wifi['capabilities']['he']['channel_set_width'] in six_ghz_op_modes_he:
-                    # 6GHz band required (802.11ax, WiFi-6e)
-                    module_options = 'options mt7915e enable_6ghz=1'
-        if 'vht' in wifi['capabilities']:
-            if 'channel_set_width' in wifi['capabilities']['vht']:
-                if wifi['capabilities']['vht']['channel_set_width'] in five_ghz_op_modes_vht:
-                    # 5GHz band required...
-                    module_options = 'options mt7915e enable_6ghz=0'
-        if module_options:
-            # Only if the mt7915e module is loaded (card present)...
-            if is_module_loaded('mt7915e'):
-                tmp = None
-                try:
-                    tmp = read_file(f'/etc/modprobe.d/mt7915e.conf')
-                except FileNotFoundError:
-                    # Module config does not exist yet.
-                    # Fail silently as it is written later in any case.
-                    pass
-                finally:
-                    # Write the module config in any case, so that there always is a
-                    # valid module config which is mandatory to load the mt7916 firmware.
-                    write_file(
-                        f'/etc/modprobe.d/mt7915e.conf',
-                        module_options,
-                        user='root',
-                        group='root',
-                        mode=0o644
-                    )
-                    # Issue a warning if module options have changed.
-                    # A warning is necessary even if this is the first time
-                    # this module is configured. The firmware must be reloaded.
-                    if tmp != module_options:
-                        Warning(
-                            'Change to firmware 5GHz/6GHz configuration detected. The system must be rebooted to correctly reload the mt7916 firmware. The card will not work otherwise!'
-                        )
+    #
+    # Only if the mt7915e module is loaded (card present)...
+    if is_module_loaded('mt7915e'):
+        # op_modes as configured in interfaces_wireless.xml.in
+        five_ghz_op_modes_vht = ['0', '1', '2', '3']
+        six_ghz_op_modes_he = ['131', '132', '133', '134', '135']
+        # Make sure to act only when VHT or HE modes are used
+        module_options = ''
+        if 'capabilities' in wifi:
+            mt7915e_options_string = 'options mt7915e'
+            if 'he' in wifi['capabilities']:
+                if 'channel_set_width' in wifi['capabilities']['he']:
+                    if wifi['capabilities']['he']['channel_set_width'] in six_ghz_op_modes_he:
+                        # 6GHz band required (802.11ax, WiFi-6e)
+                        module_options = f'{mt7915e_options_string} enable_6ghz=1'
+            if 'vht' in wifi['capabilities']:
+                if 'channel_set_width' in wifi['capabilities']['vht']:
+                    if wifi['capabilities']['vht']['channel_set_width'] in five_ghz_op_modes_vht:
+                        # 5GHz band required...
+                        module_options = f'{mt7915e_options_string} enable_6ghz=0'
+
+            tmp = None
+            if os.path.isfile(mt7915e_conf):
+                tmp = read_file(mt7915e_conf)
+
+            # Write the module config, so that there always is a valid module
+            # config which is mandatory to load the mt7916 firmware.
+            write_file(mt7915e_conf, module_options, mode=0o644)
+            # Issue warning if module options have changed. Warning is necessary
+            # even if this is the first time this module is configured,
+            # firmware must be reloaded.
+            if tmp != module_options:
+                Warning('Change to firmware 5GHz/6GHz configuration detected. '\
+                        'The system must be rebooted to correctly reload the ' \
+                        'mt7916 firmware. The card will not work otherwise!')
+                # Instead of reboot - can we unload and re-load the driver?
+    elif os.path.isfile(mt7915e_conf):
+        os.remove(mt7915e_conf)
 
     # Enable/Disable interface - interface is always placed in
     # administrative down state in WiFiIf class


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8528

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireless.py
test_add_multiple_ip_addresses (__main__.WirelessInterfaceTest.test_add_multiple_ip_addresses) ... ok
test_add_single_ip_address (__main__.WirelessInterfaceTest.test_add_single_ip_address) ... ok
test_add_to_invalid_vrf (__main__.WirelessInterfaceTest.test_add_to_invalid_vrf) ... ok
test_dhcp_client_options (__main__.WirelessInterfaceTest.test_dhcp_client_options) ... ok
test_dhcp_disable_interface (__main__.WirelessInterfaceTest.test_dhcp_disable_interface) ... ok
test_dhcp_vrf (__main__.WirelessInterfaceTest.test_dhcp_vrf) ... ok
test_dhcpv6_client_options (__main__.WirelessInterfaceTest.test_dhcpv6_client_options) ... ok
test_dhcpv6_vrf (__main__.WirelessInterfaceTest.test_dhcpv6_vrf) ... ok
test_dhcpv6pd_auto_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_auto_sla_id) ... ok
test_dhcpv6pd_manual_sla_id (__main__.WirelessInterfaceTest.test_dhcpv6pd_manual_sla_id) ... ok
test_eapol (__main__.WirelessInterfaceTest.test_eapol) ... skipped 'unsupported on interface family'
test_interface_description (__main__.WirelessInterfaceTest.test_interface_description) ... ok
test_interface_disable (__main__.WirelessInterfaceTest.test_interface_disable) ... ok
test_interface_ip_options (__main__.WirelessInterfaceTest.test_interface_ip_options) ... ok
test_interface_ipv6_options (__main__.WirelessInterfaceTest.test_interface_ipv6_options) ... skipped 'unsupported on interface family'
test_interface_mtu (__main__.WirelessInterfaceTest.test_interface_mtu) ... skipped 'unsupported on interface family'
test_ipv6_link_local_address (__main__.WirelessInterfaceTest.test_ipv6_link_local_address) ... skipped 'unsupported on interface family'
test_move_interface_between_vrf_instances (__main__.WirelessInterfaceTest.test_move_interface_between_vrf_instances) ... ok
test_mtu_1200_no_ipv6_interface (__main__.WirelessInterfaceTest.test_mtu_1200_no_ipv6_interface) ... skipped 'unsupported on interface family'
test_span_mirror (__main__.WirelessInterfaceTest.test_span_mirror) ... ok
test_vif_8021q_interfaces (__main__.WirelessInterfaceTest.test_vif_8021q_interfaces) ... skipped 'unsupported on interface family'
test_vif_8021q_lower_up_down (__main__.WirelessInterfaceTest.test_vif_8021q_lower_up_down) ... skipped 'unsupported on interface family'
test_vif_8021q_mtu_limits (__main__.WirelessInterfaceTest.test_vif_8021q_mtu_limits) ... skipped 'unsupported on interface family'
test_vif_8021q_qos_change (__main__.WirelessInterfaceTest.test_vif_8021q_qos_change) ... skipped 'unsupported on interface family'
test_vif_s_8021ad_vlan_interfaces (__main__.WirelessInterfaceTest.test_vif_s_8021ad_vlan_interfaces) ... skipped 'unsupported on interface family'
test_vif_s_protocol_change (__main__.WirelessInterfaceTest.test_vif_s_protocol_change) ... skipped 'unsupported on interface family'
test_wireless_access_point_bridge (__main__.WirelessInterfaceTest.test_wireless_access_point_bridge) ... ok
test_wireless_add_single_ip_address (__main__.WirelessInterfaceTest.test_wireless_add_single_ip_address) ... ok
test_wireless_hostapd_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_config) ... ok
test_wireless_hostapd_he_2ghz_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_he_2ghz_config) ... ok
test_wireless_hostapd_he_6ghz_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_he_6ghz_config) ... ok
test_wireless_hostapd_vht_mu_beamformer_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_vht_mu_beamformer_config) ... ok
test_wireless_hostapd_vht_su_beamformer_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_vht_su_beamformer_config) ... ok
test_wireless_hostapd_wpa_config (__main__.WirelessInterfaceTest.test_wireless_hostapd_wpa_config) ... ok
test_wireless_security_station_address (__main__.WirelessInterfaceTest.test_wireless_security_station_address) ... ok

----------------------------------------------------------------------
Ran 35 tests in 148.216s

OK (skipped=11)
vyos@vyos:~$
```

In addition, a real AsiaRF AW7916-NPD WiFi adapter with Mediatek MT7916AN chipset was used in a PC Engines APU3 for testing. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
