### PR TITLE
bgp: T8535: Fix FRR rendering for BGP-LS with next-hop-self

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -160,6 +160,7 @@
 {%         elif afi == 'link_state' %}
  address-family link-state
 {%         endif %}
+  neighbor {{ neighbor }} activate
 {%         if afi_config.addpath_tx_all is vyos_defined %}
   neighbor {{ neighbor }} addpath-tx-all-paths
 {%         endif %}
@@ -252,8 +253,13 @@
 {%         if afi_config.disable_send_community.standard is vyos_defined %}
   no neighbor {{ neighbor }} send-community standard
 {%         endif %}
-  neighbor {{ neighbor }} activate
+{#         Workaround: FRR's link-state SAFI parser rejects    #}
+{#         'exit-address-family' when 'next-hop-self' is set   #}
+{#         in the same block. It is optional when followed by  #}
+{#         '!', so omit it. Remove once fixed upstream.        #}
+{%         if not (afi == 'link_state' and afi_config.nexthop_self is vyos_defined) %}
  exit-address-family
+{%         endif %}
  !
 {# j2lint: disable=jinja-statements-delimeter #}
 {%     endfor %}


### PR DESCRIPTION
When a BGP neighbor has 'next-hop-self' configured under 'address-family link-state', the rendered FRR config is rejected by frr-reload.py with:

  % Unknown command:  exit-address-family

FRR's link-state SAFI parser accepts 'next-hop-self' inside the AF block but does not recognize 'exit-address-family' after it. Since 'exit-address-family' is optional when the block is followed by '!', we omit it in this specific case.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8535
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
