### PR TITLE
op-mode: T8305: Fix completion for "show isis neighbor <system-id>" command

### DIFF
--- a/op-mode-definitions/include/isis-common.xml.i
+++ b/op-mode-definitions/include/isis-common.xml.i
@@ -106,7 +106,7 @@
       <properties>
         <help>Show specific IS-IS neighbor adjacency </help>
         <completionHelp>
-          <list>system-id</list>
+          <script>vtysh -c "show isis hostname" | awk 'NR>2 &amp;&amp; $1 != "*" {print $NF}' | sort -u</script>
         </completionHelp>
       </properties>
       <command>${vyos_op_scripts_dir}/vtysh_wrapper.sh $@</command>


### PR DESCRIPTION
Problem: The completion helper for `show isis neighbor` showed `system-id` as a literal keyword suggestion,
leading users to type exactly `system-id` instead of an actual neighbor name. Doing so returned
`Invalid system id system-id`. In reality, FRR accepts any real system-id (e.g. vyos01)
and returns correct per-neighbor details — the issue was purely in the completion hint misguiding the user.
Fix: Replaced the static `system-id` placeholder in the completion helper with a dynamic script that queries
`vtysh -c "show isis hostname"` and offers real neighbor names as tab-completion suggestions.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8305
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# run show isis neighbor 
Possible completions:
  <Enter>               Execute the current command
  detail                Detailed information
  vyos                  Show specific IS-IS neighbor adjacency

      
[edit]
vyos@vyos# run show isis neighbor vyos 
Area VyOS:
 vyos                
    Interface: eth1, Level: 1, State: Up, Expires in 27s
    Adjacency flaps: 1, Last: 14s ago
    Circuit type: L1L2, Speaks: IPv4, IPv6
    SNPA: 0c57.235c.0001, LAN id: 1921.6825.5255.03
    LAN Priority: 64, is not DIS, DIS flaps: 1, Last: 14s ago
    Area Address(es):
      49.0001
    IPv4 Address(es):
      192.0.2.2
    IPv6 Address(es):
      fe80::e57:23ff:fe5c:1

 vyos                
    Interface: eth1, Level: 2, State: Up, Expires in 30s
    Adjacency flaps: 1, Last: 14s ago
    Circuit type: L1L2, Speaks: IPv4, IPv6
    SNPA: 0c57.235c.0001, LAN id: 1921.6825.5255.03
    LAN Priority: 64, is not DIS, DIS flaps: 1, Last: 14s ago
    Area Address(es):
      49.0001
    IPv4 Address(es):
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
