### PR TITLE
T8535: Remove next-hop-self for BGP link state

### DIFF
--- a/interface-definitions/include/bgp/neighbor-afi-link-state.xml.i
+++ b/interface-definitions/include/bgp/neighbor-afi-link-state.xml.i
@@ -1,10 +1,8 @@
 <!-- include start from bgp/neighbor-afi-link-state.xml.i -->
-<node name="link-state">
+<leafNode name="link-state">
   <properties>
-    <help>Link State BGP settings</help>
+    <help>Link State BGP address family</help>
+    <valueless/>
   </properties>
-  <children>
-    #include <include/bgp/afi-nexthop-self.xml.i>
-  </children>
-</node>
+</leafNode>
 <!-- include end -->


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary

BGP link-state doesn't support next-hop-self, so remove it.

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T8535

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

As described in task:

```
configure
set protocols bgp neighbor 3.3.3.3 address-family link-state
set protocols bgp neighbor 3.3.3.3 remote-as '65002'
set protocols bgp neighbor 3.3.3.3 update-source '1.1.1.1'
set protocols bgp parameters router-id '1.1.1.1'
set protocols bgp system-as '65001'
commit
```

Before PR

```
set protocols bgp neighbor 3.3.3.3 address-family link-state nexthop-self 
commit
```

leads to FRR error. After PR this command is unavailable.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation (as there is no BGP-LS documentation yet)
- [ ] I have updated the documentation accordingly