### PR TITLE
T8587: fix XML data type from u32 to u64 where range exceeds uint32 max

### DIFF
--- a/interface-definitions/service_lldp.xml.in
+++ b/interface-definitions/service_lldp.xml.in
@@ -142,7 +142,7 @@
                     <properties>
                       <help>ECS ELIN (Emergency location identifier number)</help>
                       <valueHelp>
-                        <format>u32:0-9999999999</format>
+                        <format>u64:0-9999999999</format>
                         <description>Emergency Call Service ELIN number (between 10-25 numbers)</description>
                       </valueHelp>
                       <constraint>

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -129,7 +129,7 @@
                 <properties>
                   <help>Security Association byte count to expire</help>
                   <valueHelp>
-                    <format>u32:1024-26843545600000</format>
+                    <format>u64:1024-26843545600000</format>
                     <description>SA life in bytes</description>
                   </valueHelp>
                   <constraint>
@@ -141,7 +141,7 @@
                 <properties>
                   <help>Security Association packet count to expire</help>
                   <valueHelp>
-                    <format>u32:1000-26843545600000</format>
+                    <format>u64:1000-26843545600000</format>
                     <description>SA life in packets</description>
                   </valueHelp>
                   <constraint>


### PR DESCRIPTION
## Change summary
Fix XML data type definitions where `u32` was specified but range values exceed the uint32 maximum (4,294,967,295). Updated to `u64` to match actual value ranges.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Task(s)
- https://vyos.dev/T8587

## Related PR(s)
https://github.com/vyos/vyatta-cfg/pull/127

## How to test / Smoketest result
Verify the XML definitions now use `u64` for the affected nodes:
```
grep -n "u64:" interface-definitions/service_lldp.xml.in interface-definitions/vpn_ipsec.xml.in
```
Expected output:
```
interface-definitions/service_lldp.xml.in:145:                        <format>u64:0-9999999999</format>
interface-definitions/vpn_ipsec.xml.in:132:                    <format>u64:1024-26843545600000</format>
interface-definitions/vpn_ipsec.xml.in:144:                    <format>u64:1000-26843545600000</format>
```

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly