### PR TITLE
bgp: T8589: Add ead, es and [1-5] to route-map match evpn route-type

### DIFF
--- a/interface-definitions/policy.xml.in
+++ b/interface-definitions/policy.xml.in
@@ -607,22 +607,50 @@
                         <properties>
                           <help>Match route-type</help>
                           <completionHelp>
-                            <list>macip multicast prefix</list>
+                            <list>1 2 3 4 5 ead macip multicast es prefix</list>
                           </completionHelp>
                           <valueHelp>
+                            <format>1</format>
+                            <description>EAD (Type-1) route</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>2</format>
+                            <description>MAC-IP (Type-2) route</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>3</format>
+                            <description>Multicast (Type-3) route</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>4</format>
+                            <description>Ethernet Segment (Type-4) route</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>5</format>
+                            <description>Prefix (Type-5) route</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>ead</format>
+                            <description>EAD (Type-1) route</description>
+                          </valueHelp>
+                          <valueHelp>
                             <format>macip</format>
-                            <description>mac-ip route</description>
+                            <description>MAC-IP (Type-2) route</description>
                           </valueHelp>
                           <valueHelp>
                             <format>multicast</format>
-                            <description>IMET route</description>
+                            <description>Multicast (Type-3) route</description>
+                          </valueHelp>
+                          <valueHelp>
+                            <format>es</format>
+                            <description>Ethernet Segment (Type-4) route</description>
                           </valueHelp>
                           <valueHelp>
                             <format>prefix</format>
-                            <description>Prefix route</description>
+                            <description>Prefix (Type-5) route</description>
                           </valueHelp>
                           <constraint>
-                            <regex>(macip|multicast|prefix)</regex>
+                            <regex>([1-5]|ead|macip|multicast|es|prefix)</regex>
                           </constraint>
                         </properties>
                       </leafNode>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
This PR adds `ead` (EVPN Ethernet Auto-Discovery, Route Type 1) and `es` (EVPN Ethernet Segment, Route Type 4) to route-map match evpn route-type.

It also adds the numeric indices as option to match FRR's behaviour (e.g. some people prefer RT5 over Prefix RT). Help texts are updated to match FRR's help texts.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T8589

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

FRR automatically canonicalizes the route-type
```
vyos@vyos-test01# set policy route-map test1 rule 1 match evpn route-type 4
[edit]
vyos@vyos-test01# commit
[edit]
vyos@vyos-test01# cat /etc/frr/frr.conf
frr version 10.5.2
frr defaults datacenter
hostname vyos-test01
log syslog notifications
log timestamp precision 3
no log unique-id
service integrated-vtysh-config
!
route-map test1 permit 1
 match evpn route-type es
exit
...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
