### PR TITLE
T8293: Add ability to set timeout for high-availability health-check

### DIFF
--- a/data/templates/high-availability/keepalived.conf.j2
+++ b/data/templates/high-availability/keepalived.conf.j2
@@ -47,6 +47,9 @@ vrrp_script healthcheck_sg_{{ name }} {
     script "/usr/bin/ping -c1 {{ sync_group_config.health_check.ping }}"
 {%             endif %}
     interval {{ sync_group_config.health_check.interval }}
+{%             if sync_group_config.health_check.timeout is vyos_defined %}
+    timeout {{ sync_group_config.health_check.timeout }}
+{%             endif %}
     fall {{ sync_group_config.health_check.failure_count }}
     rise 1
 }
@@ -64,6 +67,9 @@ vrrp_script healthcheck_{{ name }} {
     script "/usr/bin/ping -c1 {{ group_config.health_check.ping }}"
 {%             endif %}
     interval {{ group_config.health_check.interval }}
+{%             if group_config.health_check.timeout is vyos_defined %}
+    timeout {{ group_config.health_check.timeout }}
+{%             endif %}
     fall {{ group_config.health_check.failure_count }}
     rise 1
 }

--- a/interface-definitions/high-availability.xml.in
+++ b/interface-definitions/high-availability.xml.in
@@ -170,6 +170,18 @@
                       </constraint>
                     </properties>
                   </leafNode>
+                  <leafNode name="timeout">
+                    <properties>
+                      <help>Health check script timeout in seconds</help>
+                      <valueHelp>
+                        <format>u32</format>
+                        <description>Timeout in seconds</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--positive"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
                 </children>
               </node>
               <leafNode name="hello-source-address">
@@ -390,6 +402,18 @@
                       <help>Health check script file</help>
                       <constraint>
                         <validator name="script"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="timeout">
+                    <properties>
+                      <help>Health check script timeout in seconds</help>
+                      <valueHelp>
+                        <format>u32</format>
+                        <description>Timeout in seconds</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="numeric" argument="--positive"/>
                       </constraint>
                     </properties>
                   </leafNode>

--- a/smoketest/scripts/cli/test_high-availability_vrrp.py
+++ b/smoketest/scripts/cli/test_high-availability_vrrp.py
@@ -279,6 +279,7 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
 
     def test_check_health_script(self):
         sync_group = 'VyOS'
+        timeout = '100'
 
         for group in groups:
             vlan_id = group.lstrip('VLAN')
@@ -328,6 +329,16 @@ class TestVRRP(VyOSUnitTestSHIM.TestCase):
 
         config = getConfig(f'vrrp_sync_group {sync_group}')
         self.assertIn(f'track_script', config)
+
+        self.cli_set(
+            base_path
+            + ['vrrp', 'sync-group', sync_group, 'health-check', 'timeout', timeout]
+        )
+        # commit changes
+        self.cli_commit()
+
+        config = getConfig(f'vrrp_script healthcheck_sg_{sync_group}')
+        self.assertIn(f'timeout {timeout}', config)
 
 
 if __name__ == '__main__':

--- a/src/conf_mode/high-availability.py
+++ b/src/conf_mode/high-availability.py
@@ -188,6 +188,15 @@ def _validate_health_check(group, group_config):
         # to avoid generating useless config statements in keepalived.conf
         del group_config["health_check"]
 
+    if 'timeout' in group_config.get('health_check', {}):
+        interval = int(group_config['health_check']['interval'])
+        timeout = int(group_config['health_check']['timeout'])
+        if timeout < interval:
+            Warning(
+                f'Health check timeout ({timeout}s) is less than interval ({interval}s) '
+                f'for VRRP group "{group}", script may be killed before completion'
+            )
+
 
 def generate(ha):
     if not ha or 'disable' in ha:


### PR DESCRIPTION
Setting a timeout allows VRRP health-check scripts to run longer than the set interval. Without timeout, keepalived considers the script as failed after interval seconds. With timeout set higher than interval, the script has more time to complete before being marked as failed and transitioning VRRP to FAULT state.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8293
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-documentation/pull/1861
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set high-availability vrrp group Foo address 192.168.1.1/24
set high-availability vrrp group Foo health-check interval '20'
set high-availability vrrp group Foo health-check script '/home/vyos/test'
set high-availability vrrp group Foo health-check timeout '30'
set high-availability vrrp group Foo interface 'eth1'
set high-availability vrrp group Foo priority '200'
set high-availability vrrp group Foo vrid '10'


vyos@vyos# cat /run/keepalived/keepalived.conf 
# Autogenerated by VyOS
# Do not edit this file, all your changes will be lost
# on next commit or reboot

# Global definitions configuration block
global_defs {
    dynamic_interfaces
    script_user root
    notify_fifo /run/keepalived/keepalived_notify_fifo
    notify_fifo_script /usr/libexec/vyos/system/keepalived-fifo.py
}


vrrp_script healthcheck_Foo {
    script "/home/vyos/test"
    interval 20
    timeout 30
    fall 3
    rise 1
}
vrrp_instance Foo {
    state BACKUP
    interface eth1
    virtual_router_id 10
    priority 200
    advert_int 1
    preempt_delay 0
    virtual_ipaddress {
        192.168.1.1/24
    }
    track_script {
        healthcheck_Foo
    }
}
[edit]

vyos@vyos#  /usr/libexec/vyos/tests/smoke/cli/test_high-availability_vrrp.py -k test_check_health_script
test_check_health_script (__main__.TestVRRP.test_check_health_script) ... ok

----------------------------------------------------------------------
Ran 1 test in 38.422s

OK
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
