### PR TITLE
migration: T8280: Fix auth file read for interfaces on first boot of new image

### DIFF
--- a/src/migration-scripts/interfaces/25-to-26
+++ b/src/migration-scripts/interfaces/25-to-26
@@ -29,6 +29,7 @@ from vyos.pki import encode_dh_parameters
 from vyos.pki import encode_private_key
 from vyos.pki import verify_crl
 from vyos.utils.process import run
+from vyos.utils.file import read_file
 
 def wrapped_pem_to_config_value(pem):
     out = []
@@ -38,20 +39,28 @@ def wrapped_pem_to_config_value(pem):
         out.append(line)
     return "".join(out)
 
-def read_file_for_pki(config_auth_path):
-    full_path = os.path.join(AUTH_DIR, config_auth_path)
-    output = None
+def read_auth_file(config_auth_path):
+    full_path = os.path.normpath(os.path.join(AUTH_DIR, config_auth_path))
+
+    # If the file is not found under `/config/auth`, it may be because the `/config`
+    # partition has not been bind-mounted yet during early boot migration execution.
+    # Fall back to the equivalent path under `/opt/vyatta/etc/config/auth` which
+    # is accessible at all boot stages.
+    if not os.path.isfile(full_path) and full_path.startswith(f'{AUTH_DIR}/'):
+        full_path = AUTH_DIR_FALLBACK + full_path[len(AUTH_DIR): ]
 
     if os.path.isfile(full_path):
         if not os.access(full_path, os.R_OK):
-            run(f'sudo chmod 644 {full_path}')
+            run(['sudo', 'chmod', '644', full_path])
 
-        with open(full_path, 'r') as f:
-            output = f.read()
+        return read_file(full_path)
 
-    return output
+    return None
+
 
 AUTH_DIR = '/config/auth'
+AUTH_DIR_FALLBACK = '/opt/vyatta/etc/config/auth'
+
 pki_base = ['pki']
 
 def migrate(config: ConfigTree) -> None:
@@ -69,7 +78,7 @@ def migrate(config: ConfigTree) -> None:
                     config.set_tag(pki_base + ['openvpn', 'shared-secret'])
 
                 key_file = config.return_value(base + [interface, 'shared-secret-key-file'])
-                key = read_file_for_pki(key_file)
+                key = read_auth_file(key_file)
                 key_pki_name = f'{pki_name}_shared'
 
                 if key:
@@ -107,7 +116,7 @@ def migrate(config: ConfigTree) -> None:
                     config.set_tag(pki_base + ['openvpn', 'shared-secret'])
 
                 key_file = config.return_value(base + [interface, 'tls', 'auth-file'])
-                key = read_file_for_pki(key_file)
+                key = read_auth_file(key_file)
                 key_pki_name = f'{pki_name}_auth'
 
                 if key:
@@ -142,7 +151,7 @@ def migrate(config: ConfigTree) -> None:
                     config.set_tag(pki_base + ['openvpn', 'shared-secret'])
 
                 key_file = config.return_value(base + [interface, 'tls', 'crypt-file'])
-                key = read_file_for_pki(key_file)
+                key = read_auth_file(key_file)
                 key_pki_name = f'{pki_name}_crypt'
 
                 if key:
@@ -179,46 +188,41 @@ def migrate(config: ConfigTree) -> None:
                     config.set_tag(pki_base + ['ca'])
 
                 cert_file = config.return_value(x509_base + ['ca-cert-file'])
-                cert_path = os.path.join(AUTH_DIR, cert_file)
+                certs_str = read_auth_file(cert_file)
 
-                if os.path.isfile(cert_path):
-                    if not os.access(cert_path, os.R_OK):
-                        run(f'sudo chmod 644 {cert_path}')
+                if certs_str:
+                    certs_data = certs_str.split(CERT_BEGIN)
+                    index = 1
+                    for cert_data in certs_data[1:]:
+                        cert = load_certificate(CERT_BEGIN + cert_data, wrap_tags=False)
 
-                    with open(cert_path, 'r') as f:
-                        certs_str = f.read()
-                        certs_data = certs_str.split(CERT_BEGIN)
-                        index = 1
-                        for cert_data in certs_data[1:]:
-                            cert = load_certificate(CERT_BEGIN + cert_data, wrap_tags=False)
+                        if cert:
+                            ca_certs[f'{pki_name}_{index}'] = cert
+                            cert_pem = encode_certificate(cert)
 
-                            if cert:
-                                ca_certs[f'{pki_name}_{index}'] = cert
-                                cert_pem = encode_certificate(cert)
+                            # Check if CA already exists - no need to check node existence as
+                            # it is always created above when entering this context
+                            ca_exists = None
+                            for ca_name in config.list_nodes(pki_base + ['ca']):
+                                ca_cert_path = pki_base + ['ca', ca_name, 'certificate']
+                                if not config.exists(ca_cert_path):
+                                    continue
 
-                                # Check if CA already exists - no need to check node existence as
-                                # it is always created above when entering this context
-                                ca_exists = None
-                                for ca_name in config.list_nodes(pki_base + ['ca']):
-                                    ca_cert_path = pki_base + ['ca', ca_name, 'certificate']
-                                    if not config.exists(ca_cert_path):
-                                        continue
+                                ca_base64 = config.return_value(ca_cert_path)
+                                # Check for duplicate cert/key - and re-use if possible
+                                if ca_base64 == wrapped_pem_to_config_value(cert_pem):
+                                    ca_exists = ca_name
+                                    break
 
-                                    ca_base64 = config.return_value(ca_cert_path)
-                                    # Check for duplicate cert/key - and re-use if possible
-                                    if ca_base64 == wrapped_pem_to_config_value(cert_pem):
-                                        ca_exists = ca_name
-                                        break
-
-                                if ca_exists:
-                                    config.set(x509_base + ['ca-certificate'], value=ca_exists, replace=False)
-                                else:
-                                    config.set(pki_base + ['ca', f'{pki_name}_{index}', 'certificate'], value=wrapped_pem_to_config_value(cert_pem))
-                                    config.set(x509_base + ['ca-certificate'], value=f'{pki_name}_{index}', replace=False)
+                            if ca_exists:
+                                config.set(x509_base + ['ca-certificate'], value=ca_exists, replace=False)
                             else:
-                                print(f'Failed to migrate CA certificate on openvpn interface {interface}')
+                                config.set(pki_base + ['ca', f'{pki_name}_{index}', 'certificate'], value=wrapped_pem_to_config_value(cert_pem))
+                                config.set(x509_base + ['ca-certificate'], value=f'{pki_name}_{index}', replace=False)
+                        else:
+                            print(f'Failed to migrate CA certificate on openvpn interface {interface}')
 
-                            index += 1
+                        index += 1
                 else:
                     print(f'Failed to migrate CA certificate on openvpn interface {interface}')
 
@@ -230,24 +234,18 @@ def migrate(config: ConfigTree) -> None:
                     config.set_tag(pki_base + ['ca'])
 
                 crl_file = config.return_value(x509_base + ['crl-file'])
-                crl_path = os.path.join(AUTH_DIR, crl_file)
-                crl = None
+                crl_data = read_auth_file(crl_file)
+
+                crl = load_crl(crl_data, wrap_tags=False) if crl_data else None
                 crl_ca_name = None
 
-                if os.path.isfile(crl_path):
-                    if not os.access(crl_path, os.R_OK):
-                        run(f'sudo chmod 644 {crl_path}')
+                if crl:
+                    for ca_name, ca_cert in ca_certs.items():
+                        if verify_crl(crl, ca_cert):
+                            crl_ca_name = ca_name
+                            break
 
-                    with open(crl_path, 'r') as f:
-                        crl_data = f.read()
-                        crl = load_crl(crl_data, wrap_tags=False)
-
-                        for ca_name, ca_cert in ca_certs.items():
-                            if verify_crl(crl, ca_cert):
-                                crl_ca_name = ca_name
-                                break
-
-                if crl and crl_ca_name:
+                if crl_ca_name:
                     crl_pem = encode_certificate(crl)
 
                     # Check if CRL already exists - no need to check node
@@ -277,16 +275,9 @@ def migrate(config: ConfigTree) -> None:
                     config.set_tag(pki_base + ['certificate'])
 
                 cert_file = config.return_value(x509_base + ['cert-file'])
-                cert_path = os.path.join(AUTH_DIR, cert_file)
-                cert = None
+                cert_data = read_auth_file(cert_file)
 
-                if os.path.isfile(cert_path):
-                    if not os.access(cert_path, os.R_OK):
-                        run(f'sudo chmod 644 {cert_path}')
-
-                    with open(cert_path, 'r') as f:
-                        cert_data = f.read()
-                        cert = load_certificate(cert_data, wrap_tags=False)
+                cert = load_certificate(cert_data, wrap_tags=False) if cert_data else None
 
                 if cert:
                     cert_pem = encode_certificate(cert)
@@ -316,16 +307,9 @@ def migrate(config: ConfigTree) -> None:
 
             if config.exists(x509_base + ['key-file']):
                 key_file = config.return_value(x509_base + ['key-file'])
-                key_path = os.path.join(AUTH_DIR, key_file)
-                key = None
+                key_data = read_auth_file(key_file)
 
-                if os.path.isfile(key_path):
-                    if not os.access(key_path, os.R_OK):
-                        run(f'sudo chmod 644 {key_path}')
-
-                    with open(key_path, 'r') as f:
-                        key_data = f.read()
-                        key = load_private_key(key_data, passphrase=None, wrap_tags=False)
+                key = load_private_key(key_data, passphrase=None, wrap_tags=False) if key_data else None
 
                 if key:
                     key_pem = encode_private_key(key, passphrase=None)
@@ -356,16 +340,9 @@ def migrate(config: ConfigTree) -> None:
                     config.set_tag(pki_base + ['dh'])
 
                 dh_file = config.return_value(x509_base + ['dh-file'])
-                dh_path = os.path.join(AUTH_DIR, dh_file)
-                dh = None
+                dh_data = read_auth_file(dh_file)
 
-                if os.path.isfile(dh_path):
-                    if not os.access(dh_path, os.R_OK):
-                        run(f'sudo chmod 644 {dh_path}')
-
-                    with open(dh_path, 'r') as f:
-                        dh_data = f.read()
-                        dh = load_dh_parameters(dh_data, wrap_tags=False)
+                dh = load_dh_parameters(dh_data, wrap_tags=False) if dh_data else None
 
                 if dh:
                     dh_pem = encode_dh_parameters(dh)
@@ -405,15 +382,15 @@ def migrate(config: ConfigTree) -> None:
             if config.exists(private_key_path):
                 key_file = config.return_value(private_key_path)
 
-            full_key_path = f'/config/auth/wireguard/{key_file}/private.key'
+            full_key_path = f'{AUTH_DIR}/wireguard/{key_file}/private.key'
+            key_data = read_auth_file(full_key_path)
 
-            if not os.path.exists(full_key_path):
+            if not key_data:
                 print(f'Could not find wireguard private key for migration on interface "{interface}"')
                 continue
 
-            with open(full_key_path, 'r') as f:
-                key_data = f.read().strip()
-                config.set(private_key_path, value=key_data)
+            key_data = key_data.strip()
+            config.set(private_key_path, value=key_data)
 
             for peer in config.list_nodes(base + [interface, 'peer']):
                 config.rename(base + [interface, 'peer', peer, 'pubkey'], 'public-key')
@@ -435,16 +412,9 @@ def migrate(config: ConfigTree) -> None:
                     config.set_tag(pki_base + ['ca'])
 
                 cert_file = config.return_value(x509_base + ['ca-cert-file'])
-                cert_path = os.path.join(AUTH_DIR, cert_file)
-                cert = None
+                cert_data = read_auth_file(cert_file)
 
-                if os.path.isfile(cert_path):
-                    if not os.access(cert_path, os.R_OK):
-                        run(f'sudo chmod 644 {cert_path}')
-
-                    with open(cert_path, 'r') as f:
-                        cert_data = f.read()
-                        cert = load_certificate(cert_data, wrap_tags=False)
+                cert = load_certificate(cert_data, wrap_tags=False) if cert_data else None
 
                 if cert:
                     cert_pem = encode_certificate(cert)
@@ -461,16 +431,9 @@ def migrate(config: ConfigTree) -> None:
                     config.set_tag(pki_base + ['certificate'])
 
                 cert_file = config.return_value(x509_base + ['cert-file'])
-                cert_path = os.path.join(AUTH_DIR, cert_file)
-                cert = None
+                cert_data = read_auth_file(cert_file)
 
-                if os.path.isfile(cert_path):
-                    if not os.access(cert_path, os.R_OK):
-                        run(f'sudo chmod 644 {cert_path}')
-
-                    with open(cert_path, 'r') as f:
-                        cert_data = f.read()
-                        cert = load_certificate(cert_data, wrap_tags=False)
+                cert = load_certificate(cert_data, wrap_tags=False) if cert_data else None
 
                 if cert:
                     cert_pem = encode_certificate(cert)
@@ -483,16 +446,9 @@ def migrate(config: ConfigTree) -> None:
 
             if config.exists(x509_base + ['key-file']):
                 key_file = config.return_value(x509_base + ['key-file'])
-                key_path = os.path.join(AUTH_DIR, key_file)
-                key = None
+                key_data = read_auth_file(key_file)
 
-                if os.path.isfile(key_path):
-                    if not os.access(key_path, os.R_OK):
-                        run(f'sudo chmod 644 {key_path}')
-
-                    with open(key_path, 'r') as f:
-                        key_data = f.read()
-                        key = load_private_key(key_data, passphrase=None, wrap_tags=False)
+                key = load_private_key(key_data, passphrase=None, wrap_tags=False) if key_data else None
 
                 if key:
                     key_pem = encode_private_key(key, passphrase=None)


### PR DESCRIPTION
## Change summary
During first boot after installing a new VyOS image, migrations are executed before the filesystem is fully initialized.
At this point `/config` is not yet bind-mounted, causing auth files (certificates, keys, credentials) for OpenVPN, WireGuard and Ethernet EAPoL interfaces under `/config/auth` to be inaccessible even though they exist under the underlying `/opt/vyatta/etc/config/auth` path which is available at all boot stages.

Add fallback logic to `read_auth_file()` to retry the file lookup under `/opt/vyatta/etc/config/auth` when the file is not found under `/config/auth`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8280

## How to test / Smoketest result

### Manual test

1. Configure lab using 1.3.8
```
vyos@vyos3:~$ show version | match Version
Version:          VyOS 1.3.8
```

2. Generate dummy CA key + self-signed certs
```
openssl genrsa -out /config/auth/ca.key 2048
openssl req -new -x509 -days 365 -key /config/auth/ca.key -subj "/CN=DummyCA" -out /config/auth/ca.crt

openssl genrsa -out /config/auth/server.key 2048
openssl req -new -key /config/auth/server.key -subj "/CN=DummyServer" -out /config/auth/server.csr
openssl x509 -req -days 365 -in /config/auth/server.csr -CA /config/auth/ca.crt -CAkey /config/auth/ca.key -CAcreateserial -out /config/auth/server.crt

rm /config/auth/ca.key /config/auth/server.csr /config/auth/ca.srl
```

3. Configure OpenVPN interface using generated before certificates
```
set interfaces openvpn vtun1 local-address 10.255.1.1
set interfaces openvpn vtun1 local-port '1195'
set interfaces openvpn vtun1 mode 'site-to-site'
set interfaces openvpn vtun1 persistent-tunnel
set interfaces openvpn vtun1 protocol 'udp'
set interfaces openvpn vtun1 remote-address '10.255.1.2'
set interfaces openvpn vtun1 remote-host '203.0.113.11'
set interfaces openvpn vtun1 remote-port '1195'
set interfaces openvpn vtun1 tls ca-cert-file '/config/auth/ca.crt'
set interfaces openvpn vtun1 tls cert-file '/config/auth/server.crt'
set interfaces openvpn vtun1 tls key-file '/config/auth/server.key'
set interfaces openvpn vtun1 tls role 'active'
commit
save
```

4. Install the new image with current configuration and reboot the system
```
vyos@vyos3:~$ add system image vyos-999.202604241427-generic-amd64.iso
Checking SHA256 checksums of files on the ISO image... OK.
Done!
What would you like to name this image? [999.202604241427]:
OK.  This image will be named: 999.202604241427
Installing "999.202604241427" image.
Copying new release files...
Would you like to save the current configuration
directory and config file? (Yes/No) [Yes]:
Copying current configuration...
Would you like to save the SSH host keys from your
current configuration? (Yes/No) [Yes]:
Copying SSH keys...
Running post-install script...
Setting up grub configuration...
Done.
vyos@vyos3:~$ sudo reboot now
```

5. Verify the result after reboot
```
...
[   26.092738] vyos-router[1122]: Starting VyOS router.
[   32.153303] vyos-router[1122]: Waiting for NICs to settle down: settled in 5sec..
[   37.637889] vyos-router[1122]: Mounting VyOS Config...done.
[   50.529771] vyos-router[1122]:  migrate activate configure.
[   51.095469] vyos-config[1128]: Configuration success
...
vyos@vyos3:~$ show configuration commands | match cert
set interfaces openvpn vtun1 tls ca-certificate 'openvpn_vtun1_1'
set interfaces openvpn vtun1 tls certificate 'openvpn_vtun1'
set pki ca openvpn_vtun1_1 certificate 'MIIDIzCCA...N7Upbct'
set pki certificate openvpn_vtun1 certificate 'MIICz...IsA=='
set pki certificate openvpn_vtun1 private key 'MIIEvwIB...1XOM9Lg=='
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly