### PR TITLE
openvpn: T6478: Skip restart service when only client config changed

### DIFF
--- a/src/conf_mode/interfaces_openvpn.py
+++ b/src/conf_mode/interfaces_openvpn.py
@@ -78,6 +78,28 @@ otp_file = '/config/auth/openvpn/{ifname}-otp-secrets'
 secret_chars = list('ABCDEFGHIJKLMNOPQRSTUVWXYZ234567')
 service_file = '/run/systemd/system/openvpn@{ifname}.service.d/20-override.conf'
 
+def _only_client_config_changed(conf, base, ifname):
+    """
+    Return True when the sole diff under this interface is a change to
+    `server.client` entries (i.e. CCD files).
+    """
+
+    iface_path = base + [ifname]
+    diff = get_config_diff(conf)
+
+    def _has_only_changes(path, node):
+        changes = diff.node_changed_children(path)
+        return len(changes) == 1 and changes[0] == node
+
+    # Something outside of 'server' also changed - not a CCD-only change
+    if _has_only_changes(iface_path, 'server'):
+        # Something outside of 'server.client' also changed - not a CCD-only change
+        if _has_only_changes(iface_path + ['server'], 'client'):
+            return True
+
+    return False
+
+
 def get_config(config=None):
     """
     Retrieve CLI config as dictionary. Dictionary can never be empty, as at least the
@@ -116,6 +138,12 @@ def get_config(config=None):
         openvpn.update({'restart_required': {}})
     if is_node_changed(conf, base + [ifname, 'enable-dco']):
         openvpn.update({'restart_required': {}})
+
+    # Detect changes that are limited to per-client CCD entries (T6478).
+    # OpenVPN reads client-config-dir files at connect time, so adding or
+    # updating them requires neither a SIGHUP nor a service restart.
+    if 'restart_required' not in openvpn and openvpn['mode'] == 'server':
+        openvpn['client_only_changed'] = _only_client_config_changed(conf, base, ifname)
 
     # We have to get the dict using 'get_config_dict' instead of 'get_interface_dict'
     # as 'get_interface_dict' merges the defaults in, so we can not check for defaults in there.
@@ -818,7 +846,7 @@ def apply(openvpn):
     # No matching OpenVPN process running - maybe it got killed or none
     # existed - nevertheless, spawn new OpenVPN process
 
-    if not openvpn.get('no_restart_crl'):
+    if not openvpn.get('no_restart_crl') and not openvpn.get('client_only_changed'):
         action = 'reload-or-restart'
         if 'restart_required' in openvpn:
             action = 'restart'


### PR DESCRIPTION
## Change summary
OpenVPN server reads per-client files from `--client-config-dir` at connect time. When only `interfaces openvpn vtunN server client <client>` entries are modified there is no need to send SIGHUP or restart the service - the new [CCD](https://openvpn.net/community-docs/configuring-client-specific-rules-and-access-policies.html) files written by `generate()` will be picked up automatically on the next client connection.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T6478

## How to test / Smoketest result

### Manual test
1. Configure OpenVPN server (vyos1):
```
conf
run generate pki ca install ca-1
run generate pki certificate sign ca-1 install srv-1
run generate pki dh install dh-1
run generate pki certificate sign ca-1 install client1

set interfaces openvpn vtun0 mode 'server'
set interfaces openvpn vtun0 protocol 'udp'
set interfaces openvpn vtun0 local-port '1194'
set interfaces openvpn vtun0 persistent-tunnel
set interfaces openvpn vtun0 tls ca-certificate 'ca-1'
set interfaces openvpn vtun0 tls certificate 'srv-1'
set interfaces openvpn vtun0 tls dh-params 'dh-1'
set interfaces openvpn vtun0 server subnet '10.8.0.0/24'
set interfaces openvpn vtun0 server topology 'subnet'
set interfaces openvpn vtun0 server push-route '192.168.1.0/24'
set interfaces openvpn vtun0 server client client1 ip '10.8.0.10'
set interfaces openvpn vtun0 encryption data-ciphers 'aes256gcm'
set interfaces openvpn vtun0 hash 'sha256'
set protocols static route 10.8.0.0/24 interface vtun0
commit
```

2. Configure OpenVPN client (vyos2) using generated certificates from the server:
```
conf
set pki ca ca-1 certificate 'MIIDnT...GO8='
set pki certificate client1 certificate 'MIIDs...2Vg=='
set pki certificate client1 private key 'MIIEv...ztQ=='

set interfaces openvpn vtun0 mode 'client'
set interfaces openvpn vtun0 protocol 'udp'
set interfaces openvpn vtun0 persistent-tunnel
set interfaces openvpn vtun0 remote-host '192.168.50.1'
set interfaces openvpn vtun0 remote-port '1194'
set interfaces openvpn vtun0 tls ca-certificate 'ca-1'
set interfaces openvpn vtun0 tls certificate 'client1'
set interfaces openvpn vtun0 encryption data-ciphers 'aes256gcm'
set interfaces openvpn vtun0 hash 'sha256'
set protocols static route 10.8.0.0/24 interface eth1
commit
```

3. Make sure the client is connected:
```
vyos@vyos2# ping 10.8.0.1
PING 10.8.0.1 (10.8.0.1) 56(84) bytes of data.
64 bytes from 10.8.0.1: icmp_seq=1 ttl=64 time=1.66 ms
64 bytes from 10.8.0.1: icmp_seq=2 ttl=64 time=1.65 ms
...
```

4. Generate the second certificate for the next client:
```
run generate pki certificate sign ca-1 install client2
set interfaces openvpn vtun0 server client client2 ip '10.8.0.20'
commit
```

5. The first client and the server should be connected:
```
vyos@vyos1# ping 10.8.0.10
PING 10.8.0.10 (10.8.0.10) 56(84) bytes of data.
64 bytes from 10.8.0.10: icmp_seq=1 ttl=64 time=1.66 ms
64 bytes from 10.8.0.10: icmp_seq=2 ttl=64 time=1.85 ms
...
vyos@vyos2# ping 10.8.0.1
PING 10.8.0.1 (10.8.0.1) 56(84) bytes of data.
64 bytes from 10.8.0.1: icmp_seq=1 ttl=64 time=1.42 ms
64 bytes from 10.8.0.1: icmp_seq=2 ttl=64 time=1.63 ms
...
```

6. The third client should also be ready to connect:
```
vyos@vyos1# ping 10.8.0.20
PING 10.8.0.20 (10.8.0.20) 56(84) bytes of data.
64 bytes from 10.8.0.20: icmp_seq=1 ttl=64 time=1.70 ms
64 bytes from 10.8.0.20: icmp_seq=2 ttl=64 time=1.63 ms
...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly