### PR TITLE
T7880: Add NTP hardware timestamp receive-filter compatibility check

### DIFF
--- a/python/vyos/ethtool.py
+++ b/python/vyos/ethtool.py
@@ -20,6 +20,7 @@ from json import loads
 from vyos.utils.network import interface_exists
 from vyos.utils.process import popen
 from vyos.netlink import coalesce
+from vyos.netlink import timestamp
 
 # These drivers do not support using ethtool to change the speed, duplex, or
 # flow control settings
@@ -68,6 +69,7 @@ class Ethtool:
     _flow_control = None
     _channels = ''
     _coalesce = None
+    _hw_timestamp_filters = None
 
     def __init__(self, ifname):
         # Get driver used for interface
@@ -128,6 +130,10 @@ class Ethtool:
         # Get information about NIC coalesce settings
         with contextlib.suppress(coalesce.CoalesceError, coalesce.GeneralNetlinkError):
             self._coalesce = coalesce.get_coalesce(ifname)
+
+        # Get supported hardware timestamp receive filters
+        with contextlib.suppress(timestamp.TsInfoError, timestamp.GeneralNetlinkError):
+            self._hw_timestamp_filters = timestamp.get_hw_timestamp_filters(ifname)
 
     def check_auto_negotiation_supported(self):
         """ Check if the NIC supports changing auto-negotiation """
@@ -255,3 +261,7 @@ class Ethtool:
         """Get all 'coalesce' parameters for the interface"""
 
         return self._coalesce.copy() if self._coalesce else {}
+
+    def get_hw_timestamp_filters(self):
+        """Get supported hardware timestamp receive filter names"""
+        return self._hw_timestamp_filters or set()

--- a/python/vyos/netlink/timestamp.py
+++ b/python/vyos/netlink/timestamp.py
@@ -1,0 +1,204 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+from pyroute2.netlink import genlmsg
+from pyroute2.netlink import nla
+from pyroute2.netlink import NLM_F_REQUEST
+from pyroute2.netlink.exceptions import NetlinkError
+from pyroute2.netlink.generic import GenericNetlinkSocket
+from pyroute2.netlink.generic.ethtool import ETHTOOL_GENL_NAME
+from pyroute2.netlink.generic.ethtool import ETHTOOL_GENL_VERSION
+from pyroute2.netlink.generic.ethtool import ethtoolheader
+
+# Netlink message type for tsinfo (from Linux kernel uapi/linux/ethtool_netlink.h)
+ETHTOOL_MSG_TSINFO_GET = 0x19
+
+# Operation not supported error code from the kernel (95 decimal)
+EOPNOTSUPP = 0x5F
+
+# HWTSTAMP_FILTER_* types from <linux/net_tstamp.h>
+# Each enum value N maps to bit (1 << N) in the rx_filters bitmask.
+# 'ptp' is a combined mask of all PTP-related filter variants.
+HWTSTAMP_FILTER = {
+    'all': 1 << 1,  # HWTSTAMP_FILTER_ALL
+    'ntp': 1 << 15,  # HWTSTAMP_FILTER_NTP_ALL
+    'ptp': (1 << 3)  # HWTSTAMP_FILTER_PTP_V1_L4_EVENT
+    | (1 << 4)  # HWTSTAMP_FILTER_PTP_V1_L4_SYNC
+    | (1 << 5)  # HWTSTAMP_FILTER_PTP_V1_L4_DELAY_REQ
+    | (1 << 6)  # HWTSTAMP_FILTER_PTP_V2_L4_EVENT
+    | (1 << 7)  # HWTSTAMP_FILTER_PTP_V2_L4_SYNC
+    | (1 << 8)  # HWTSTAMP_FILTER_PTP_V2_L4_DELAY_REQ
+    | (1 << 9)  # HWTSTAMP_FILTER_PTP_V2_L2_EVENT
+    | (1 << 10)  # HWTSTAMP_FILTER_PTP_V2_L2_SYNC
+    | (1 << 11)  # HWTSTAMP_FILTER_PTP_V2_L2_DELAY_REQ
+    | (1 << 12)  # HWTSTAMP_FILTER_PTP_V2_EVENT
+    | (1 << 13)  # HWTSTAMP_FILTER_PTP_V2_SYNC
+    | (1 << 14),  # HWTSTAMP_FILTER_PTP_V2_DELAY_REQ
+}
+
+
+class ethtool_bitset_bit(nla):
+    """Single bit entry inside a verbose ethtool bitset."""
+
+    nla_map = (
+        ('ETHTOOL_A_BITSET_BIT_UNSPEC', 'none'),
+        ('ETHTOOL_A_BITSET_BIT_INDEX', 'uint32'),
+        ('ETHTOOL_A_BITSET_BIT_NAME', 'asciiz'),
+        ('ETHTOOL_A_BITSET_BIT_VALUE', 'flag'),
+    )
+
+
+class ethtool_bitset_bits(nla):
+    """Container layer for nesting bit entries in a verbose ethtool bitset."""
+
+    ethtool_bitset_bit = ethtool_bitset_bit
+    nla_map = (
+        ('ETHTOOL_A_BITSET_BIT_UNSPEC', 'none'),
+        ('ETHTOOL_A_BITSET_BIT', 'ethtool_bitset_bit'),
+    )
+
+
+class ethtool_bitset(nla):
+    """Ethtool verbose bitset NLA structure.
+
+    The kernel returns the verbose form by default (ETHTOOL_A_BITSET_BITS nested entries).
+    ETHTOOL_A_BITSET_VALUE and ETHTOOL_A_BITSET_MASK are listed for positional completeness
+    only — they are not read by this implementation.
+    """
+
+    ethtool_bitset_bits = ethtool_bitset_bits
+    nla_map = (
+        ('ETHTOOL_A_BITSET_UNSPEC', 'none'),
+        ('ETHTOOL_A_BITSET_NOMASK', 'flag'),
+        ('ETHTOOL_A_BITSET_SIZE', 'uint32'),
+        ('ETHTOOL_A_BITSET_BITS', 'ethtool_bitset_bits'),
+        ('ETHTOOL_A_BITSET_VALUE', 'binary'),
+        ('ETHTOOL_A_BITSET_MASK', 'binary'),
+    )
+
+
+class ethtool_tsinfo_msg(genlmsg):
+    """Netlink message structure for ETHTOOL_MSG_TSINFO_GET.
+
+    nla_map indices are strictly positional — all attributes up to the last needed index must be
+    listed. Intermediate unused attributes are typed 'hex' to skip full NLA decoding.
+    Reference: https://docs.kernel.org/networking/ethtool-netlink.html#tsinfo-get
+    """
+
+    ethtoolheader = ethtoolheader
+    ethtool_bitset = ethtool_bitset
+    nla_map = (
+        ('ETHTOOL_A_TSINFO_UNSPEC', 'none'),
+        ('ETHTOOL_A_TSINFO_HEADER', 'ethtoolheader'),
+        ('ETHTOOL_A_TSINFO_TIMESTAMPING', 'hex'),
+        ('ETHTOOL_A_TSINFO_TX_TYPES', 'hex'),
+        ('ETHTOOL_A_TSINFO_RX_FILTERS', 'ethtool_bitset'),
+    )
+
+
+GeneralNetlinkError = NetlinkError
+
+
+class TsInfoError(Exception):
+    """Custom exception for timestamp info retrieval errors."""
+
+    pass
+
+
+def _bitset_to_int(attr) -> int:
+    """Reconstruct an integer bitmask from a verbose ethtool_bitset NLA."""
+    if attr is None:
+        return 0
+    bits_attr = attr.get_attr('ETHTOOL_A_BITSET_BITS')
+    if bits_attr is None:
+        return 0
+    bitmask = 0
+    for bit in bits_attr.get_attrs('ETHTOOL_A_BITSET_BIT'):
+        index = bit.get_attr('ETHTOOL_A_BITSET_BIT_INDEX')
+        if index is not None:
+            bitmask |= 1 << index
+    return bitmask
+
+
+class TsInfoNetlink(GenericNetlinkSocket):
+    """Hardware timestamp info queries using pyroute2 with netlink support."""
+
+    def __init__(self, ifname: str):
+        super().__init__()
+        self._bound = False
+        self._ifname = ifname
+
+    def _ensure_bound(self):
+        """Bind netlink socket to the generic ethtool family structure if not already active."""
+        if not self._bound:
+            self.bind(ETHTOOL_GENL_NAME, ethtool_tsinfo_msg)
+            self._bound = True
+
+    def get_rx_filters(self) -> set:
+        """
+        Query supported hardware timestamp receive filters for the interface.
+
+        Returns:
+            A set of supported filter names ('all', 'ntp', 'ptp'), or an empty set
+            if the driver or interface lacks hardware timestamping support.
+
+        Example:
+            >>> with TsInfoNetlink('eth0') as ts:
+            ...     print(ts.get_rx_filters())
+            {'ptp'}
+        """
+        self._ensure_bound()
+
+        msg = ethtool_tsinfo_msg()
+        msg['cmd'] = ETHTOOL_MSG_TSINFO_GET
+        msg['version'] = ETHTOOL_GENL_VERSION
+        msg['attrs'].append(
+            (
+                'ETHTOOL_A_TSINFO_HEADER',
+                {'attrs': [['ETHTOOL_A_HEADER_DEV_NAME', self._ifname]]},
+            )
+        )
+
+        try:
+            response = self.nlm_request(
+                msg, msg_type=self.prid, msg_flags=NLM_F_REQUEST
+            )
+        except NetlinkError as e:
+            if e.code == EOPNOTSUPP:
+                return set()
+            raise
+
+        if not response:
+            return set()
+
+        bitmask = _bitset_to_int(response[0].get_attr('ETHTOOL_A_TSINFO_RX_FILTERS'))
+        return {name for name, mask in HWTSTAMP_FILTER.items() if bitmask & mask}
+
+
+def get_hw_timestamp_filters(ifname: str) -> set:
+    """
+    Get supported hardware timestamp receive filter names for an interface.
+
+    Args:
+        ifname: Target network interface string (e.g., 'eth0').
+
+    Returns:
+        A set of supported human-readable filters, or an empty set on error/lack of support.
+    """
+    try:
+        with TsInfoNetlink(ifname) as ts:
+            return ts.get_rx_filters()
+    except (NetlinkError, OSError):
+        return set()

--- a/src/conf_mode/service_ntp.py
+++ b/src/conf_mode/service_ntp.py
@@ -21,6 +21,7 @@ from vyos.config import config_dict_merge
 from vyos.configdict import is_node_changed
 from vyos.configverify import verify_vrf
 from vyos.configverify import verify_interface_exists
+from vyos.netlink import timestamp
 from vyos.utils.process import call
 from vyos.utils.permission import chmod_750
 from vyos.utils.network import get_interface_config
@@ -104,6 +105,35 @@ def verify(ntp):
                                       f'before it can be used for server "{host}"')
                 else:
                     break
+
+    if 'timestamp' in ntp:
+        for iface, iface_config in ntp['timestamp'].get('interface', {}).items():
+            rx_filter = iface_config.get('receive_filter')
+            if iface != 'all':
+                verify_interface_exists(ntp, iface)
+            if rx_filter and rx_filter != 'none':
+                if iface == 'all':
+                    any_supported = False
+                    for real_iface in os.listdir('/sys/class/net'):
+                        supported = timestamp.get_hw_timestamp_filters(real_iface)
+                        if rx_filter in supported or 'all' in supported:
+                            any_supported = True
+                            break
+                    if not any_supported:
+                        raise ConfigError(
+                            f'No interface supports hardware timestamp receive-filter "{rx_filter}"'
+                        )
+                else:
+                    supported = timestamp.get_hw_timestamp_filters(iface)
+                    if not supported:
+                        raise ConfigError(
+                            f'Interface "{iface}" does not support hardware timestamping'
+                        )
+                    if rx_filter not in supported and 'all' not in supported:
+                        raise ConfigError(
+                            f'Interface "{iface}" does not support hardware timestamp '
+                            f'receive-filter "{rx_filter}", supported: {", ".join(sorted(supported))}'
+                        )
 
     return None
 


### PR DESCRIPTION
Add a check to determine whether the NIC supports hardware
timestamp receive filters required for NTP timestamping.
Implement the query in a new python/vyos/netlink/timestamp.py module
using pyroute2 generic netlink ETHTOOL_MSG_TSINFO_GET,
avoiding ethtool output parsing.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7880
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@r10# ethtool -T eth0
Time stamping parameters for eth0:
Capabilities:
	hardware-transmit
	software-transmit
	hardware-receive
	software-receive
	software-system-clock
	hardware-raw-clock
PTP Hardware Clock: 0
Hardware Transmit Timestamp Modes:
	off
	on
Hardware Receive Filter Modes:
	none
	ptpv1-l4-sync
	ptpv1-l4-delay-req
	ptpv2-event
[edit]
vyos@r10# set service ntp timestamp interface eth0 receive-filter all
[edit]
vyos@r10# commit
[ service ntp ]
Interface "eth0" does not support hardware timestamp receive-filter
"all", supported: ptp
[[service ntp]] failed
Commit failed
[edit]
vyos@r10# set service ntp timestamp interface eth0 receive-filter ptp 
[edit]
vyos@r10# commit
[edit]
vyos@r10# systemctl status chrony
● chrony.service - chrony, an NTP client/server
     Loaded: loaded (/lib/systemd/system/chrony.service; disabled; preset: enab>
    Drop-In: /run/systemd/system/chrony.service.d
             └─override.conf
     Active: active (running) since Mon 2026-05-04 08:32:27 UTC; 17s ago
       Docs: man:chronyd(8)
             man:chronyc(1)
             man:chrony.conf(5)
    Process: 5091 ExecStart=/usr/sbin/chronyd -F 1 -f /run/chrony/chrony.conf (>
   Main PID: 5095 (chronyd)
      Tasks: 2 (limit: 9487)
     Memory: 1.6M
        CPU: 97ms
     CGroup: /system.slice/chrony.service
             ├─5095 /usr/sbin/chronyd -F 1 -f /run/chrony/chrony.conf
             └─5096 /usr/sbin/chronyd -F 1 -f /run/chrony/chrony.conf

May 04 08:32:27 r10 chronyd[5095]: chronyd version 4.3 starting (+CMDMON +NTP +>
May 04 08:32:27 r10 chronyd[5095]: Enabled HW timestamping on eth0
May 04 08:32:27 r10 chronyd[5095]: Frequency -90.375 +/- 0.204 ppm read from /r>
May 04 08:32:27 r10 chronyd[5095]: Using right/UTC timezone to obtain leap seco>
May 04 08:32:27 r10 chronyd[5095]: Loaded seccomp filter (level 1)
May 04 08:32:27 r10 systemd[1]: Started chrony, an NTP client/server.
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
