### PR TITLE
dhcp-relay: T8760: Remove redundant deprecation warning for legacy interface option

### DIFF
--- a/src/conf_mode/service_dhcp-relay.py
+++ b/src/conf_mode/service_dhcp-relay.py
@@ -21,7 +21,6 @@ from sys import exit
 from vyos.base import Warning
 from vyos.config import Config
 from vyos.template import render
-from vyos.base import Warning
 from vyos.utils.process import call
 from vyos.utils.dict import dict_search
 from vyos import ConfigError
@@ -61,9 +60,6 @@ def verify(relay):
         Warning('DHCP relay interface is DEPRECATED - please use upstream-interface and listen-interface instead!')
         if 'upstream_interface' in relay or 'listen_interface' in relay:
             raise ConfigError('<interface> configuration is not compatible with upstream/listen interface')
-        else:
-            Warning('<interface> is going to be deprecated.\n'  \
-                    'Please use <listen-interface> and <upstream-interface>')
 
     if 'upstream_interface' in relay and 'listen_interface' not in relay:
         raise ConfigError('No listen-interface configured')


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->
Before the fix:
```
vyos@r10# set service dhcp-relay interface eth0
[edit]
vyos@r10# commit
[ service dhcp-relay ]

WARNING: DHCP relay interface is DEPRECATED - please use upstream-
interface and listen-interface instead!


WARNING: <interface> is going to be deprecated.
Please use <listen-interface> and <upstream-interface>


[edit]
```
## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8760
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set service dhcp-relay interface eth1
set service dhcp-relay server 10.0.0.2

vyos@r10# commit
[ service dhcp-relay ]

WARNING: DHCP relay interface is DEPRECATED - please use upstream-
interface and listen-interface instead!


[edit]
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
