### PR TITLE
ping: T8608: add TCP connect probe

### DIFF
--- a/op-mode-definitions/ping.xml.in
+++ b/op-mode-definitions/ping.xml.in
@@ -2,7 +2,7 @@
 <interfaceDefinition>
   <tagNode name="ping">
     <properties>
-      <help>Send Internet Control Message Protocol (ICMP) echo request</help>
+      <help>Send ICMP echo request or TCP connect probe</help>
       <completionHelp>
         <list>&lt;hostname&gt; &lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
       </completionHelp>

--- a/src/etc/sudoers.d/vyos
+++ b/src/etc/sudoers.d/vyos
@@ -42,6 +42,8 @@ Cmnd_Alias HWINFO   = /usr/bin/lspci
 Cmnd_Alias FORCE_CLUSTER = /usr/share/heartbeat/hb_takeover, \
                            /usr/share/heartbeat/hb_standby
 Cmnd_Alias DIAGNOSTICS = /bin/ip vrf exec * /bin/ping *,       \
+                         /usr/bin/nping *, \
+                         /bin/ip vrf exec * /usr/bin/nping *, \
                          /bin/ip vrf exec * /bin/traceroute *, \
                          /bin/ip vrf exec * /usr/bin/mtr *, \
                          /usr/libexec/vyos/op_mode/*

--- a/src/op_mode/ping.py
+++ b/src/op_mode/ping.py
@@ -15,8 +15,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+import re
 import socket
 import ipaddress
+import subprocess
 
 from vyos.utils.network import interface_list
 from vyos.utils.network import vrf_list
@@ -156,6 +158,33 @@ ping = {
     6: '/bin/ping6',
 }
 
+tcp_options = {
+    'count': {'type': '<requests>', 'help': 'Number of requests to send'},
+    'interface': {
+        'type': '<interface>',
+        'helpfunction': interface_list,
+        'help': 'Source interface',
+    },
+    'port': {'type': '<port>', 'help': 'Destination port'},
+    'source-address': {'type': '<x.x.x.x> <h:h:h:h:h:h:h:h>', 'help': 'Source address'},
+    'vrf': {
+        'type': '<vrf>',
+        'help': 'Use specified VRF table',
+        'helpfunction': vrf_list,
+        'dflt': 'default',
+    },
+}
+
+ping_options = options | {
+    'tcp': {'type': 'noarg', 'help': 'Use TCP connect probe'},
+}
+
+tcp_completion_options = {'tcp': ping_options['tcp']} | tcp_options
+
+NPING = '/usr/bin/nping'
+TCP_DELAY = '1s'
+SUCCESSFUL_CONNECTIONS_RE = re.compile(r'Successful connections:\s+(\d+)')
+
 
 class List(list):
     def first(self):
@@ -179,7 +208,7 @@ def completion_failure(option: str) -> None:
     sys.exit(1)
 
 
-def expension_failure(option, completions):
+def expansion_failure(option, completions):
     reason = 'Ambiguous' if completions else 'Invalid'
     sys.stderr.write(
         '\n\n  {} command: {} [{}]\n\n'.format(reason, ' '.join(sys.argv),
@@ -192,8 +221,12 @@ def expension_failure(option, completions):
     sys.exit(1)
 
 
-def complete(prefix):
-    return [o for o in options if o.startswith(prefix)]
+def complete(prefix, available_options=options):
+    return [o for o in available_options if o.startswith(prefix)]
+
+
+class UsageError(Exception):
+    pass
 
 
 def convert(command, args):
@@ -201,7 +234,7 @@ def convert(command, args):
         shortname = args.first()
         longnames = complete(shortname)
         if len(longnames) != 1:
-            expension_failure(shortname, longnames)
+            expansion_failure(shortname, longnames)
         longname = longnames[0]
         if options[longname]['type'] == 'noarg':
             command = options[longname]['ping'].format(
@@ -214,6 +247,249 @@ def convert(command, args):
     return command
 
 
+def option_value_help(option, available_options):
+    helplines = available_options[option]['type']
+    if 'helpfunction' in available_options[option]:
+        result = available_options[option]['helpfunction']()
+        if result:
+            helplines = '\n' + ' '.join(result)
+
+    return helplines
+
+
+def get_option_completion(args, available_options):
+    args.first()  # pop ping
+    args.first()  # pop IP
+    usedoptionslist = []
+    while args:
+        option = args.first()  # pop option
+        matched = complete(option, available_options)  # get option parameters
+        usedoptionslist.append(option)  # list of used options
+        # Select options
+        if not args:
+            # remove from Possible completions used options
+            for o in usedoptionslist:
+                if o in matched:
+                    matched.remove(o)
+            return ' '.join(matched)
+
+        if len(matched) > 1:
+            return ' '.join(matched)
+        # If option doesn't have value
+        if matched:
+            if available_options[matched[0]]['type'] == 'noarg':
+                continue
+        else:
+            # Unexpected option
+            completion_failure(option)
+
+        args.first()  # pop option's value
+        if not args:
+            matched = complete(option, available_options)
+            return option_value_help(matched[0], available_options)
+
+    return ''
+
+
+def get_icmp_completion(args):
+    return get_option_completion(args, ping_options)
+
+
+def get_tcp_completion(args):
+    return get_option_completion(args, tcp_completion_options)
+
+
+def has_tcp_option(args):
+    args = List(args[:])
+    args.first()  # pop ping
+    args.first()  # pop IP
+
+    while args:
+        shortname = args.first()
+        longnames = complete(shortname, ping_options)
+        if len(longnames) != 1:
+            continue
+
+        longname = longnames[0]
+        if longname == 'tcp':
+            return True
+
+        if ping_options[longname]['type'] != 'noarg':
+            args.first()
+
+    return False
+
+
+def get_completion(args):
+    if has_tcp_option(args):
+        return get_tcp_completion(args)
+
+    return get_icmp_completion(args)
+
+
+def tcp_usage(message):
+    sys.stderr.write(f'{message}\n')
+    return 2
+
+
+def parse_positive_int(value, option):
+    try:
+        number = int(value)
+    except ValueError:
+        raise UsageError(f'ping tcp: invalid {option}: {value}')
+
+    if number < 1:
+        raise UsageError(f'ping tcp: invalid {option}: {value}')
+
+    return number
+
+
+def parse_tcp_port(value):
+    port = parse_positive_int(value, 'port')
+    if port > 65535:
+        raise UsageError(f'ping tcp: invalid port: {value}')
+
+    return port
+
+
+def parse_tcp_args(argv):
+    args = List(argv)
+    host = args.first()
+    if not host:
+        raise UsageError('ping tcp: Missing host')
+
+    result = {
+        'host': host,
+        'port': None,
+        'count': None,
+        'interface': None,
+        'source_address': None,
+        'vrf': 'default',
+    }
+
+    while args:
+        shortname = args.first()
+        longnames = complete(shortname, tcp_completion_options)
+        if len(longnames) > 1:
+            raise UsageError(f'ping tcp: ambiguous option: {shortname}')
+        if not longnames:
+            raise UsageError(f'ping tcp: invalid option: {shortname}')
+
+        longname = longnames[0]
+        if longname == 'tcp':
+            continue
+
+        if not args:
+            raise UsageError(f'ping tcp: missing argument for {longname} option')
+
+        value = args.first()
+        if longname == 'port':
+            result['port'] = parse_tcp_port(value)
+        elif longname == 'count':
+            result['count'] = parse_positive_int(value, 'count')
+        elif longname == 'source-address':
+            try:
+                ipaddress.ip_address(value)
+            except ValueError:
+                raise UsageError(f'ping tcp: invalid source-address: {value}')
+            result['source_address'] = value
+        elif longname == 'interface':
+            result['interface'] = value
+        elif longname == 'vrf':
+            result['vrf'] = value
+
+    if result['port'] is None:
+        raise UsageError('ping tcp: missing port option')
+
+    return result
+
+
+def tcp_uses_ipv6(config):
+    addresses = [config['host'], config['source_address']]
+    for address in addresses:
+        if not address:
+            continue
+        try:
+            if ipaddress.ip_address(address).version == 6:
+                return True
+        except ValueError:
+            continue
+
+    return False
+
+
+def build_tcp_nping_command(config):
+    command = [
+        NPING,
+        '--tcp-connect',
+        '--dest-port',
+        str(config['port']),
+        '--count',
+        str(config['count'] if config['count'] is not None else 0),
+        '--delay',
+        TCP_DELAY,
+    ]
+
+    if tcp_uses_ipv6(config):
+        command.insert(1, '-6')
+
+    if config['interface']:
+        command.extend(['--interface', config['interface']])
+
+    if config['source_address']:
+        command.extend(['--source-ip', config['source_address']])
+
+    command.append(config['host'])
+
+    if config['vrf'] != 'default':
+        return ['sudo', '/bin/ip', 'vrf', 'exec', config['vrf']] + command
+
+    if config['interface'] or config['source_address']:
+        return ['sudo'] + command
+
+    return command
+
+
+def run_tcp_nping(command, popen=subprocess.Popen):
+    successful_connections = None
+    process = None
+
+    try:
+        process = popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        for line in process.stdout:
+            print(line, end='')
+            match = SUCCESSFUL_CONNECTIONS_RE.search(line)
+            if match:
+                successful_connections = int(match.group(1))
+        returncode = process.wait()
+    except FileNotFoundError:
+        raise UsageError('ping tcp: nping is not installed')
+    except KeyboardInterrupt:
+        if process:
+            process.terminate()
+            process.wait()
+        print()
+        return 130
+
+    if successful_connections is not None:
+        return 0 if successful_connections > 0 else 1
+
+    return returncode if returncode else 1
+
+
+def run_tcp_ping(argv):
+    try:
+        config = parse_tcp_args(argv)
+        return run_tcp_nping(build_tcp_nping_command(config))
+    except UsageError as err:
+        return tcp_usage(str(err))
+
+
 if __name__ == '__main__':
     args = List(sys.argv[1:])
     host = args.first()
@@ -222,44 +498,11 @@ if __name__ == '__main__':
         sys.exit("ping: Missing host")
 
     if host == '--get-options':
-        args.first()  # pop ping
-        args.first()  # pop IP
-        usedoptionslist = []
-        while args:
-            option = args.first()  # pop option
-            matched = complete(option)  # get option parameters
-            usedoptionslist.append(option)  # list of used options
-            # Select options
-            if not args:
-                # remove from Possible completions used options
-                for o in usedoptionslist:
-                    if o in matched:
-                        matched.remove(o)
-                sys.stdout.write(' '.join(matched))
-                sys.exit(0)
+        sys.stdout.write(get_completion(args))
+        sys.exit(0)
 
-            if len(matched) > 1:
-                sys.stdout.write(' '.join(matched))
-                sys.exit(0)
-            # If option doesn't have value
-            if matched:
-                if options[matched[0]]['type'] == 'noarg':
-                    continue
-            else:
-                # Unexpected option
-                completion_failure(option)
-
-            value = args.first()  # pop option's value
-            if not args:
-                matched = complete(option)
-                helplines = options[matched[0]]['type']
-                # Run helpfunction to get list of possible values
-                if 'helpfunction' in options[matched[0]]:
-                    result = options[matched[0]]['helpfunction']()
-                    if result:
-                        helplines = '\n' + ' '.join(result)
-                sys.stdout.write(helplines)
-                sys.exit(0)
+    if has_tcp_option(['ping', host] + args):
+        sys.exit(run_tcp_ping([host] + args))
 
     for name, option in options.items():
         if 'dflt' in option and name not in args:

--- a/src/tests/test_op_mode_ping.py
+++ b/src/tests/test_op_mode_ping.py
@@ -1,0 +1,313 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import contextlib
+import importlib.util
+import io
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+
+def load_ping_module():
+    module_path = Path(__file__).resolve().parents[1] / 'op_mode' / 'ping.py'
+    spec = importlib.util.spec_from_file_location('op_mode_ping', module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ping = load_ping_module()
+
+
+class FakeNpingProcess:
+    def __init__(self, lines, returncode=0):
+        self.stdout = iter(lines)
+        self.returncode = returncode
+        self.terminated = False
+
+    def wait(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+
+
+class TestVyOSOpModePingTcp(TestCase):
+    def test_parse_tcp_args(self):
+        config = ping.parse_tcp_args(
+            [
+                'example.com',
+                'tcp',
+                'port',
+                '443',
+                'count',
+                '3',
+                'interface',
+                'eth0',
+                'source-address',
+                '192.0.2.1',
+                'vrf',
+                'red',
+            ]
+        )
+
+        self.assertEqual(config['host'], 'example.com')
+        self.assertEqual(config['port'], 443)
+        self.assertEqual(config['count'], 3)
+        self.assertEqual(config['interface'], 'eth0')
+        self.assertEqual(config['source_address'], '192.0.2.1')
+        self.assertEqual(config['vrf'], 'red')
+
+    def test_parse_tcp_args_rejects_invalid_input(self):
+        cases = [
+            [],
+            ['example.com'],
+            ['example.com', 'tcp'],
+            ['example.com', 'tcp', 'port', '0'],
+            ['example.com', 'tcp', 'port', '65536'],
+            ['example.com', 'tcp', 'port', 'ssh'],
+            ['example.com', 'tcp', 'port', '443', 'count', '0'],
+            [
+                'example.com',
+                'tcp',
+                'port',
+                '443',
+                'source-address',
+                'not-an-address',
+            ],
+            ['example.com', 'tcp', 'port', '443', 'bogus', 'value'],
+        ]
+
+        for argv in cases:
+            with self.subTest(argv=argv):
+                with self.assertRaises(ping.UsageError):
+                    ping.parse_tcp_args(argv)
+
+    def test_tcp_completion(self):
+        icmp_options = (
+            'audible adaptive allow-broadcast bypass-route count deadline '
+            'do-not-fragment flood interface interval ipv4 ipv6 mark numeric '
+            'no-loopback pattern timestamp tos quiet record-route size '
+            'source-address ttl vrf verbose tcp'
+        )
+
+        self.assertEqual(
+            ping.get_completion(ping.List(['ping', '192.0.2.1', ''])),
+            icmp_options,
+        )
+        self.assertEqual(
+            ping.get_completion(ping.List(['ping', '192.0.2.1', 'tc'])), 'tcp'
+        )
+        self.assertEqual(
+            ping.get_completion(ping.List(['ping', '192.0.2.1', 'tcp', ''])),
+            'count interface port source-address vrf',
+        )
+        self.assertEqual(
+            ping.get_completion(ping.List(['ping', '192.0.2.1', 'tcp', 'p'])),
+            'port',
+        )
+        self.assertEqual(
+            ping.get_completion(ping.List(['ping', '192.0.2.1', 'tcp', 'port', ''])),
+            '<port>',
+        )
+
+        completions = ping.get_completion(
+            ping.List(['ping', '192.0.2.1', 'tcp', 'port', '443', ''])
+        )
+        self.assertIn('count', completions)
+        self.assertIn('interface', completions)
+        self.assertIn('source-address', completions)
+        self.assertIn('vrf', completions)
+        self.assertNotIn('port', completions)
+        self.assertNotIn('tcp', completions)
+
+    def test_has_tcp_option_respects_option_values(self):
+        self.assertTrue(ping.has_tcp_option(['ping', '192.0.2.1', 'tcp']))
+        self.assertTrue(ping.has_tcp_option(['ping', '192.0.2.1', 'tc']))
+        self.assertFalse(ping.has_tcp_option(['ping', '192.0.2.1', 't']))
+        self.assertFalse(ping.has_tcp_option(['ping', '192.0.2.1', 'pattern', 'tcp']))
+
+    def test_build_tcp_nping_command_defaults_to_continuous(self):
+        config = ping.parse_tcp_args(['example.com', 'tcp', 'port', '443'])
+
+        self.assertEqual(
+            ping.build_tcp_nping_command(config),
+            [
+                ping.NPING,
+                '--tcp-connect',
+                '--dest-port',
+                '443',
+                '--count',
+                '0',
+                '--delay',
+                ping.TCP_DELAY,
+                'example.com',
+            ],
+        )
+
+    def test_build_tcp_nping_command_includes_count(self):
+        config = ping.parse_tcp_args(
+            ['example.com', 'tcp', 'port', '443', 'count', '2']
+        )
+
+        command = ping.build_tcp_nping_command(config)
+
+        self.assertIn('--count', command)
+        self.assertEqual(command[command.index('--count') + 1], '2')
+
+    def test_build_tcp_nping_command_for_interface_uses_sudo(self):
+        config = ping.parse_tcp_args(
+            ['example.com', 'tcp', 'port', '443', 'interface', 'eth0']
+        )
+
+        self.assertEqual(
+            ping.build_tcp_nping_command(config),
+            [
+                'sudo',
+                ping.NPING,
+                '--tcp-connect',
+                '--dest-port',
+                '443',
+                '--count',
+                '0',
+                '--delay',
+                ping.TCP_DELAY,
+                '--interface',
+                'eth0',
+                'example.com',
+            ],
+        )
+
+    def test_build_tcp_nping_command_for_source_address_uses_sudo(self):
+        config = ping.parse_tcp_args(
+            ['example.com', 'tcp', 'port', '443', 'source-address', '192.0.2.1']
+        )
+
+        self.assertEqual(
+            ping.build_tcp_nping_command(config),
+            [
+                'sudo',
+                ping.NPING,
+                '--tcp-connect',
+                '--dest-port',
+                '443',
+                '--count',
+                '0',
+                '--delay',
+                ping.TCP_DELAY,
+                '--source-ip',
+                '192.0.2.1',
+                'example.com',
+            ],
+        )
+
+    def test_build_tcp_nping_command_for_vrf_uses_ip_vrf_exec(self):
+        config = ping.parse_tcp_args(
+            ['example.com', 'tcp', 'port', '443', 'vrf', 'red']
+        )
+
+        self.assertEqual(
+            ping.build_tcp_nping_command(config),
+            [
+                'sudo',
+                '/bin/ip',
+                'vrf',
+                'exec',
+                'red',
+                ping.NPING,
+                '--tcp-connect',
+                '--dest-port',
+                '443',
+                '--count',
+                '0',
+                '--delay',
+                ping.TCP_DELAY,
+                'example.com',
+            ],
+        )
+
+    def test_build_tcp_nping_command_for_ipv6_literal(self):
+        config = ping.parse_tcp_args(['2001:db8::1', 'tcp', 'port', '443'])
+
+        command = ping.build_tcp_nping_command(config)
+
+        self.assertIn('-6', command)
+
+    def test_run_tcp_nping_returns_success_when_any_connection_succeeds(self):
+        process = FakeNpingProcess(
+            [
+                'Starting Nping\n',
+                'Nping done: 1 IP address pinged in 1.02 seconds\n',
+                'Successful connections: 1\n',
+            ]
+        )
+
+        def popen(command, **kwargs):
+            self.assertEqual(command, [ping.NPING])
+            self.assertEqual(kwargs['stdout'], ping.subprocess.PIPE)
+            self.assertEqual(kwargs['stderr'], ping.subprocess.STDOUT)
+            self.assertTrue(kwargs['text'])
+            return process
+
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output):
+            rc = ping.run_tcp_nping([ping.NPING], popen=popen)
+
+        self.assertEqual(rc, 0)
+        self.assertIn('Successful connections: 1', output.getvalue())
+
+    def test_run_tcp_nping_returns_failure_when_no_connection_succeeds(self):
+        process = FakeNpingProcess(['Successful connections: 0\n'])
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = ping.run_tcp_nping([ping.NPING], popen=lambda *args, **kwargs: process)
+
+        self.assertEqual(rc, 1)
+
+    def test_run_tcp_nping_returns_setup_error_without_statistics(self):
+        process = FakeNpingProcess(['nping failed\n'], returncode=2)
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            rc = ping.run_tcp_nping([ping.NPING], popen=lambda *args, **kwargs: process)
+
+        self.assertEqual(rc, 2)
+
+    def test_run_tcp_ping_executes_nping(self):
+        with patch.object(ping, 'run_tcp_nping', return_value=7) as run_nping:
+            rc = ping.run_tcp_ping(['example.com', 'tcp', 'port', '443', 'count', '1'])
+
+        self.assertEqual(rc, 7)
+        run_nping.assert_called_once_with(
+            [
+                ping.NPING,
+                '--tcp-connect',
+                '--dest-port',
+                '443',
+                '--count',
+                '1',
+                '--delay',
+                ping.TCP_DELAY,
+                'example.com',
+            ]
+        )
+
+    def test_run_tcp_ping_returns_usage_error(self):
+        output = io.StringIO()
+
+        with contextlib.redirect_stderr(output):
+            rc = ping.run_tcp_ping(['example.com', 'tcp'])
+
+        self.assertEqual(rc, 2)
+        self.assertIn('missing port option', output.getvalue())


### PR DESCRIPTION
## Change summary

Add TCP connect probes to the existing `ping` operational command for cases where ICMP is filtered or a specific TCP service needs to be checked.

The new syntax is:

```text
ping tcp <host> port <port> [count <n>] [interface <ifname>] [vrf <name>] [source-address <address>]
```

The implementation uses Python sockets directly, supports IPv4/IPv6 resolution, keeps the existing ICMP ping path unchanged, and adds a sudoers allowance for VRF execution of the op-mode script.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T8608

## Related PR(s)

* Documentation PR: https://github.com/vyos/vyos-documentation/pull/1878

## How to test / Smoketest result

```text
$ PYTHONPATH=python/ python3 -m nose2 -v src.tests.test_op_mode_ping
Ran 10 tests in 0.091s
OK

$ visudo -cf src/etc/sudoers.d/vyos
src/etc/sudoers.d/vyos: parsed OK

$ make libvyosconfig interface_definitions test
Ran 93 tests in 3.717s
OK (skipped=1)

$ make op_mode_definitions
OK

$ darker -r origin/base --check --diff --color . && graylint -L "ruff check" --revision origin/base .
OK
```

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
