### PR TITLE
frr: T8606: add watchfrr timeout option

### DIFF
--- a/data/templates/frr/daemons.frr.tmpl
+++ b/data/templates/frr/daemons.frr.tmpl
@@ -103,7 +103,7 @@ vtysh_enable=yes
 watchfrr_enable=yes
 valgrind_enable=no
 
-#watchfrr_options=""
+watchfrr_options="--timeout={{ watchfrr_timeout }}"
 
 frr_profile="{{ profile }}"
 

--- a/interface-definitions/system_frr.xml.in
+++ b/interface-definitions/system_frr.xml.in
@@ -35,6 +35,20 @@
               <valueless/>
             </properties>
           </leafNode>
+          <leafNode name="watchfrr-timeout">
+            <properties>
+              <help>Set watchfrr daemon timeout</help>
+              <valueHelp>
+                <format>u32:60-600</format>
+                <description>Timeout in seconds</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 60-600"/>
+              </constraint>
+              <constraintErrorMessage>Timeout must be in range 60 to 600 seconds</constraintErrorMessage>
+            </properties>
+            <defaultValue>90</defaultValue>
+          </leafNode>
           <leafNode name="profile">
             <properties>
               <help>Select configuration profile to adapt different defaults</help>

--- a/smoketest/scripts/cli/test_system_frr.py
+++ b/smoketest/scripts/cli/test_system_frr.py
@@ -196,5 +196,29 @@ class TestSystemFRR(VyOSUnitTestSHIM.TestCase):
         daemons_config = read_file(config_file)
         self.assertIn(f'MAX_FDS={default_descriptors}', daemons_config)
 
+    def test_frr_watchfrr_timeout(self):
+        default_watchfrr_timeout = default_value(base_path + ['watchfrr-timeout'])
+        watchfrr_timeout = '120'
+
+        self.cli_set(base_path + ['watchfrr-timeout', watchfrr_timeout])
+        self.cli_commit()
+
+        # read the config file and check content
+        daemons_config = read_file(config_file)
+        self.assertIn(
+            f'watchfrr_options="--timeout={watchfrr_timeout}"', daemons_config
+        )
+
+        # test remove of watchfrr-timeout
+        self.cli_delete(base_path)
+        self.cli_commit()
+
+        # read the config file and check content
+        daemons_config = read_file(config_file)
+        self.assertIn(
+            f'watchfrr_options="--timeout={default_watchfrr_timeout}"', daemons_config
+        )
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())


### PR DESCRIPTION
﻿## Change summary
Add `set system frr watchfrr-timeout <seconds>` so operators can configure the FRR watchfrr timeout through VyOS config instead of editing `/etc/frr/daemons` manually.

When set, the generated daemons file now includes:

```text
watchfrr_options="--timeout=<seconds>"
```

A focused FRR CLI smoketest assertion was added for the generated `watchfrr_options` line and removal behavior.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T8606

## Related PR(s)
None.

## How to test / Smoketest result
Local validation:

```text
git diff --check -- interface-definitions/system_frr.xml.in data/templates/frr/daemons.frr.tmpl smoketest/scripts/cli/test_system_frr.py
python -m py_compile src/conf_mode/system_frr.py smoketest/scripts/cli/test_system_frr.py
powershell.exe -NoProfile -ExecutionPolicy Bypass -File C:\Users\Brian\Downloads\VyOS\scripts\Invoke-VyOS1xTests.ps1 -Repo C:\Users\Brian\Downloads\VyOS\src\vyos-1x
```

The containerized VyOS 1x validation ran `make libvyosconfig interface_definitions test` and completed successfully:

```text
Ran 83 tests in 5.415s
OK (skipped=1)
```

I also validated the FRR daemons Jinja template renders `watchfrr_options="--timeout=120"` when configured and leaves `#watchfrr_options=""` when unset.

The live CLI smoketest is covered by the added `test_frr_watchfrr_timeout` case and should run in the package smoketest CI.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
