### PR TITLE
ntp: T8601: add local stratum option

### DIFF
--- a/data/templates/chrony/chrony.conf.j2
+++ b/data/templates/chrony/chrony.conf.j2
@@ -46,6 +46,11 @@ user {{ user }}
 {%     endfor %}
 {% endif %}
 
+{% if local_stratum is vyos_defined %}
+# Enable local reference mode
+local stratum {{ local_stratum }}
+{% endif %}
+
 # Allowed clients configuration
 {% if allow_client.address is vyos_defined %}
 {%     for address in allow_client.address %}

--- a/interface-definitions/service_ntp.xml.in
+++ b/interface-definitions/service_ntp.xml.in
@@ -109,6 +109,18 @@
             </properties>
             <defaultValue>timezone</defaultValue>
           </leafNode>
+          <leafNode name="local-stratum">
+            <properties>
+              <help>Local reference stratum</help>
+              <valueHelp>
+                <format>u32:1-15</format>
+                <description>Local reference stratum</description>
+              </valueHelp>
+              <constraint>
+                <validator name="numeric" argument="--range 1-15"/>
+              </constraint>
+            </properties>
+          </leafNode>
           <tagNode name="server">
             <properties>
               <help>Network Time Protocol (NTP) server</help>

--- a/smoketest/scripts/cli/test_service_ntp.py
+++ b/smoketest/scripts/cli/test_service_ntp.py
@@ -79,6 +79,18 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
         for pool in pools:
             self.assertIn(f'pool {pool} iburst', config)
 
+    def test_local_stratum_without_upstream_server(self):
+        stratum = '10'
+        network = '192.0.2.0/24'
+
+        self.cli_set(base_path + ['local-stratum', stratum])
+        self.cli_set(base_path + ['allow-client', 'address', network])
+        self.cli_commit()
+
+        config = cmd(f'sudo cat {NTP_CONF}')
+        self.assertIn(f'local stratum {stratum}', config)
+        self.assertIn(f'allow {network}', config)
+
     def test_clients(self):
         # Test the allowed-networks statement
         listen_address = ['127.0.0.1', '::1']
@@ -88,14 +100,6 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
         networks = ['192.0.2.0/24', '2001:db8:1000::/64', '100.64.0.0', '2001:db8::ffff']
         for network in networks:
             self.cli_set(base_path + ['allow-client', 'address', network])
-
-        # Verify "NTP server not configured" verify() statement
-        with self.assertRaises(ConfigSessionError):
-            self.cli_commit()
-
-        servers = ['192.0.2.1', '192.0.2.2']
-        for server in servers:
-            self.cli_set(base_path + ['server', server])
 
         self.cli_commit()
 

--- a/smoketest/scripts/cli/test_service_ntp.py
+++ b/smoketest/scripts/cli/test_service_ntp.py
@@ -19,6 +19,7 @@ import unittest
 from base_vyostest_shim import VyOSUnitTestSHIM
 
 from vyos.configsession import ConfigSessionError
+from vyos.utils.file import read_file
 from vyos.utils.process import cmd
 from vyos.utils.process import process_named_running
 from vyos.xml_ref import default_value
@@ -64,7 +65,7 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
 
         # Check generated configuration
         # this file must be read with higher permissions
-        config = cmd(f'sudo cat {NTP_CONF}')
+        config = read_file(NTP_CONF, sudo=True)
         self.assertIn('driftfile /run/chrony/drift', config)
         self.assertIn('dumpdir /run/chrony', config)
         self.assertIn('ntsdumpdir /run/chrony', config)
@@ -87,7 +88,7 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['allow-client', 'address', network])
         self.cli_commit()
 
-        config = cmd(f'sudo cat {NTP_CONF}')
+        config = read_file(NTP_CONF, sudo=True)
         self.assertIn(f'local stratum {stratum}', config)
         self.assertIn(f'allow {network}', config)
 
@@ -104,8 +105,7 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Check generated client address configuration
-        # this file must be read with higher permissions
-        config = cmd(f'sudo cat {NTP_CONF}')
+        config = read_file(NTP_CONF, sudo=True)
         for network in networks:
             self.assertIn(f'allow {network}', config)
 
@@ -125,8 +125,7 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Check generated client address configuration
-        # this file must be read with higher permissions
-        config = cmd(f'sudo cat {NTP_CONF}')
+        config = read_file(NTP_CONF, sudo=True)
         for interface in interfaces:
             self.assertIn(f'binddevice {interface}', config)
 
@@ -156,14 +155,13 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Check generated client address configuration
-        # this file must be read with higher permissions
-        config = cmd(f'sudo cat {NTP_CONF}')
+        config = read_file(NTP_CONF, sudo=True)
         self.assertIn('leapsectz right/UTC', config) # CLI default
 
         for mode in ['ignore', 'system', 'smear']:
             self.cli_set(base_path + ['leap-second', mode])
             self.cli_commit()
-            config = cmd(f'sudo cat {NTP_CONF}')
+            config = read_file(NTP_CONF, sudo=True)
             if mode != 'smear':
                 self.assertIn(f'leapsecmode {mode}', config)
             else:
@@ -186,8 +184,7 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Check generated configuration
-        # this file must be read with higher permissions
-        config = cmd(f'sudo cat {NTP_CONF}')
+        config = read_file(NTP_CONF, sudo=True)
         self.assertIn('driftfile /run/chrony/drift', config)
         self.assertIn('dumpdir /run/chrony', config)
         self.assertIn('ntsdumpdir /run/chrony', config)
@@ -214,8 +211,7 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Check generated configuration
-        # this file must be read with higher permissions
-        config = cmd(f'sudo cat {NTP_CONF}')
+        config = read_file(NTP_CONF, sudo=True)
         self.assertIn('driftfile /run/chrony/drift', config)
         self.assertIn('dumpdir /run/chrony', config)
         self.assertIn('ntsdumpdir /run/chrony', config)
@@ -250,8 +246,7 @@ class TestSystemNTP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Check generated configuration
-        # this file must be read with higher permissions
-        config = cmd(f'sudo cat {NTP_CONF}')
+        config = read_file(NTP_CONF, sudo=True)
         self.assertIn('driftfile /run/chrony/drift', config)
         self.assertIn('dumpdir /run/chrony', config)
         self.assertIn('ntsdumpdir /run/chrony', config)

--- a/src/conf_mode/service_ntp.py
+++ b/src/conf_mode/service_ntp.py
@@ -66,9 +66,6 @@ def verify(ntp):
     if not ntp:
         return None
 
-    if 'server' not in ntp:
-        raise ConfigError('NTP server not configured')
-
     verify_vrf(ntp)
 
     if 'interface' in ntp:


### PR DESCRIPTION
## Summary
- Add `service ntp local-stratum <1-15>`.
- Render Chrony `local stratum <value>` in `/run/chrony/chrony.conf`.
- Allow `service ntp` to commit without upstream `server` entries when `local-stratum` is configured.

## Testing
- `git diff --check`
- `python -m compileall src\conf_mode\service_ntp.py smoketest\scripts\cli\test_service_ntp.py`
- Direct Chrony template render assertion with `local_stratum=10`
- `powershell -ExecutionPolicy Bypass -File C:\Users\Brian\Downloads\VyOS\scripts\Invoke-VyOS1xTests.ps1 -Repo C:\Users\Brian\Downloads\VyOS\src\vyos-1x -Bash "apt-get update >/dev/null && apt-get install -y procps make >/dev/null && sysctl -w net.ipv4.conf.lo.forwarding=1 >/dev/null || true; make libvyosconfig interface_definitions test"`

Task: https://vyos.dev/T8601
