### PR TITLE
firewall: T8761: Reintroduce VRF-interface names in generated config

### DIFF
--- a/data/config-mode-dependencies/vyos-1x.json
+++ b/data/config-mode-dependencies/vyos-1x.json
@@ -9,41 +9,71 @@
     },
     "interfaces_bonding": {
         "ethernet": ["interfaces_ethernet"],
+        "firewall": ["firewall"],
         "static_arp": ["protocols_static_arp"]
     },
     "interfaces_bridge": {
         "vxlan": ["interfaces_vxlan"],
         "wlan": ["interfaces_wireless"],
+        "firewall": ["firewall"],
         "static_arp": ["protocols_static_arp"]
     },
+    "interfaces_dummy": {
+        "firewall": ["firewall"]
+    },
     "interfaces_ethernet": {
+        "firewall": ["firewall"],
         "static_arp": ["protocols_static_arp"]
     },
     "interfaces_geneve": {
+        "firewall": ["firewall"],
         "static_arp": ["protocols_static_arp"]
     },
     "interfaces_l2tpv3": {
+        "firewall": ["firewall"],
         "static_arp": ["protocols_static_arp"]
     },
     "interfaces_macsec": {
+        "firewall": ["firewall"],
         "static_arp": ["protocols_static_arp"]
+    },
+    "interfaces_openvpn": {
+        "firewall": ["firewall"]
+    },
+    "interfaces_pppoe": {
+        "firewall": ["firewall"]
     },
     "interfaces_pseudo_ethernet": {
+        "firewall": ["firewall"],
         "static_arp": ["protocols_static_arp"]
+    },
+    "interfaces_sstpc": {
+        "firewall": ["firewall"]
+    },
+    "interfaces_tunnel": {
+        "firewall": ["firewall"]
     },
     "interfaces_virtual_ethernet": {
+        "firewall": ["firewall"],
         "static_arp": ["protocols_static_arp"]
     },
+    "interfaces_vti": {
+        "firewall": ["firewall"]
+    },
     "interfaces_vxlan": {
+        "firewall": ["firewall"],
         "static_arp": ["protocols_static_arp"]
     },
     "interfaces_wireless": {
+        "firewall": ["firewall"],
         "static_arp": ["protocols_static_arp"]
     },
     "interfaces_wwan": {
+        "firewall": ["firewall"],
         "static_arp": ["protocols_static_arp"]
     },
     "interfaces_wireguard": {
+        "firewall": ["firewall"],
         "vxlan": ["interfaces_vxlan"]
     },
     "load_balancing_wan": {

--- a/data/templates/firewall/nftables-zone.j2
+++ b/data/templates/firewall/nftables-zone.j2
@@ -9,9 +9,14 @@
 {% for zone_name, zone_conf in zone.items() %}
 {%     if 'local_zone' not in zone_conf %}
 {%         if 'interface' in zone_conf.member %}
-        oifname { {{ zone_conf.member.interface | quoted_join(',') }} } counter jump VZONE_{{ zone_name }}
+        oifname { {{ zone_conf.member.interface | quoted_join(",") }} } counter jump VZONE_{{ zone_name }}
 {%         endif %}
 {%         if 'vrf' in zone_conf.member %}
+{%             for vrf_name in zone_conf.member.vrf %}
+{%                 if zone_conf.vrf_interfaces[vrf_name] | length > 0 %}
+        oifname { {{ zone_conf.vrf_interfaces[vrf_name] | quoted_join(",") }} } counter jump VZONE_{{ zone_name }}
+{%                 endif %}
+{%             endfor %}
         oifname { {{ zone_conf.member.vrf | quoted_join(",") }} } counter jump VZONE_{{ zone_name }}
 {%         endif %}
 {%     endif %}
@@ -71,6 +76,12 @@
         oifname { {{ zone[from_zone].member.interface | quoted_join(",") }} } counter return
 {%                 endif %}
 {%                 if 'vrf' in zone[from_zone].member %}
+{%                     for vrf_name in zone[from_zone].member.vrf %}
+{%                         if zone[from_zone]['vrf_interfaces'][vrf_name] | length > 0 %}
+        oifname { {{ zone[from_zone].vrf_interfaces[vrf_name] | quoted_join(",") }} } counter jump NAME{{ suffix }}_{{ from_conf.firewall[fw_name] }}
+        oifname { {{ zone[from_zone].vrf_interfaces[vrf_name] | quoted_join(",") }} } counter return
+{%                         endif %}
+{%                     endfor %}
         oifname { {{ zone[from_zone].member.vrf | quoted_join(",") }} } counter jump NAME{{ suffix }}_{{ from_conf.firewall[fw_name] }}
         oifname { {{ zone[from_zone].member.vrf | quoted_join(",") }} } counter return
 {%                 endif %}
@@ -84,9 +95,13 @@
 {%                 endif %}
 {%                 if 'vrf' in zone[from_zone].member %}
 {%                     for vrf_name in zone[from_zone].member.vrf %}
-        oifname { "{{ zone[from_zone]['vrf_interfaces'][vrf_name] }}" } counter jump NAME{{ suffix }}_{{ from_conf[fw_name] }}
-        oifname { "{{ zone[from_zone]['vrf_interfaces'][vrf_name] }}" } counter return
+{%                         if zone[from_zone]['vrf_interfaces'][vrf_name] | length > 0 %}
+        oifname { {{ zone[from_zone].vrf_interfaces[vrf_name] | quoted_join(",") }} } counter jump NAME{{ suffix }}_{{ from_conf[fw_name] }}
+        oifname { {{ zone[from_zone].vrf_interfaces[vrf_name] | quoted_join(",") }} } counter return
+{%                         endif %}
 {%                     endfor %}
+        oifname { {{ zone[from_zone].member.vrf | quoted_join(",") }} } counter jump NAME{{ suffix }}_{{ from_conf.firewall[fw_name] }}
+        oifname { {{ zone[from_zone].member.vrf | quoted_join(",") }} } counter return
 {%                 endif %}
 {%             endfor %}
 {%         endif %}

--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -19,6 +19,7 @@ A library for retrieving value dicts from VyOS configs in a declarative fashion.
 import os
 import json
 
+from vyos.config import Config
 from vyos.utils.dict import dict_search
 from vyos.utils.process import cmd
 
@@ -299,6 +300,34 @@ def has_vrf_configured(conf, intf):
 
     conf.set_level(old_level)
     return ret
+
+def is_vrf_changed(conf : Config, intf) -> bool:
+    """
+    Checks if interface has a VRF changed.
+
+    Returns True if interface has VRF changed, False if it doesn't.
+    """
+    from vyos.ifconfig import Section
+
+    # set default path for this interface
+    intfpath = ['interfaces', Section.section(intf), intf]
+
+    # Check top-level interface
+    if is_node_changed(conf, intfpath + ['vrf']):
+        return True
+
+    # check sub interfaces
+    for vif in conf.list_nodes(intfpath + ['vif']):
+        if is_node_changed(conf, intfpath + ['vif', vif, 'vrf']):
+            return True
+    for vif_s in conf.list_nodes(intfpath + ['vif-s']):
+        if is_node_changed(conf, intfpath + ['vif-s', vif_s, 'vrf']):
+            return True
+        for vif_c in conf.list_nodes(intfpath + ['vif-s', vif_s, 'vif-c']):
+            if is_node_changed(conf, intfpath + ['vif-s', vif_s, 'vif-c', vif_c, 'vrf']):
+                return True
+
+    return False
 
 def has_vlan_subinterface_configured(conf, intf):
     """

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -1150,8 +1150,13 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.cli_set(['vrf', 'name', 'VRF-1', 'table', '101'])
         self.cli_set(['vrf', 'name', 'VRF-2', 'table', '102'])
         self.cli_set(['interfaces', 'ethernet', 'eth0', 'vrf', 'VRF-1'])
-        self.cli_set(['interfaces', 'vti', 'vti1', 'vrf', 'VRF-2'])
+        self.cli_set(['interfaces', 'ethernet', 'eth0', 'vif', '10', 'vrf', 'VRF-1'])
+        self.cli_set(['interfaces', 'ethernet', 'eth3', 'vif-s', '10', 'vrf', 'VRF-1'])
+        self.cli_set(['interfaces', 'ethernet', 'eth3', 'vif-s', '20', 'vif-c', '30', 'vrf', 'VRF-1'])
+        self.cli_set(['interfaces', 'vti', 'vti1', 'vrf', 'VRF-1'])
+        self.cli_set(['interfaces', 'vti', 'vti2', 'vrf', 'VRF-2'])
 
+        # commit the config
         self.cli_commit()
 
         nftables_search = [
@@ -1162,8 +1167,10 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['chain VYOS_ZONE_FORWARD'],
             ['type filter hook forward priority filter + 1'],
             ['oifname { "eth1", "eth2" }', 'counter packets', 'jump VZONE_ZONE1'],
+            ['oifname { "eth0", "vti1", "eth0.10", "eth3.10", "eth3.20.30" }', 'counter packets', 'jump VZONE_ZONE1'],
             ['oifname "VRF-1"', 'counter packets', 'jump VZONE_ZONE1'],
             ['oifname "vtun66"', 'counter packets', 'jump VZONE_ZONE2'],
+            ['oifname "vti2"', 'counter packets', 'jump VZONE_ZONE2'],
             ['oifname "VRF-2"', 'counter packets', 'jump VZONE_ZONE2'],
             ['chain VYOS_ZONE_LOCAL'],
             ['type filter hook input priority filter + 1'],
@@ -1197,8 +1204,10 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['chain VYOS_ZONE_FORWARD'],
             ['type filter hook forward priority filter + 1'],
             ['oifname { "eth1", "eth2" }', 'counter packets', 'jump VZONE_ZONE1'],
+            ['oifname { "eth0", "vti1", "eth0.10", "eth3.10", "eth3.20.30" }', 'counter packets', 'jump VZONE_ZONE1'],
             ['oifname "VRF-1"', 'counter packets', 'jump VZONE_ZONE1'],
             ['oifname "vtun66"', 'counter packets', 'jump VZONE_ZONE2'],
+            ['oifname "vti2"', 'counter packets', 'jump VZONE_ZONE2'],
             ['oifname "VRF-2"', 'counter packets', 'jump VZONE_ZONE2'],
             ['chain VYOS_ZONE_LOCAL'],
             ['type filter hook input priority filter + 1'],
@@ -1210,6 +1219,7 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['counter packets', 'drop', 'comment "zone_LOCAL default-action drop"'],
             ['chain VZONE_LOCAL_OUT'],
             ['oifname "vtun66"', 'counter packets', 'jump NAME6_LOCAL_to_ZONE2_v6'],
+            ['oifname "vti2"', 'counter packets', 'jump NAME6_LOCAL_to_ZONE2_v6'],
             ['oifname "VRF-2"', 'counter packets', 'jump NAME6_LOCAL_to_ZONE2_v6'],
             ['counter packets', 'drop', 'comment "zone_LOCAL default-action drop"'],
             ['chain VZONE_ZONE1'],
@@ -1222,6 +1232,29 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
             ['counter packets', 'drop', 'comment "zone_ZONE2 default-action drop"']
         ]
 
+        self.verify_nftables(nftables_search, 'ip vyos_filter')
+        self.verify_nftables(nftables_search_v6, 'ip6 vyos_filter')
+
+        # change memberships in vrf plus delete and add subifs
+        self.cli_set(['interfaces', 'vti', 'vti1', 'vrf', 'VRF-2'])
+        self.cli_delete(['interfaces', 'ethernet', 'eth0', 'vif', '10'])
+        self.cli_delete(['interfaces', 'ethernet', 'eth3', 'vif-s', '10'])
+        self.cli_delete(['interfaces', 'ethernet', 'eth3', 'vif-s', '20', 'vif-c', '30'])
+        self.cli_set(['interfaces', 'ethernet', 'eth0', 'vif', '20', 'vrf', 'VRF-1'])
+        self.cli_set(['interfaces', 'ethernet', 'eth3', 'vif-s', '20', 'vrf', 'VRF-1'])
+        self.cli_set(['interfaces', 'ethernet', 'eth3', 'vif-s', '20', 'vif-c', '40', 'vrf', 'VRF-1'])
+        self.cli_commit()
+
+        # make som verifications to ensure the interface swapped vrf
+        nftables_search = [
+            ['oifname { "eth0", "eth0.20", "eth3.20", "eth3.20.40" }', 'counter packets', 'jump VZONE_ZONE1'],
+            ['oifname { "vti1", "vti2" }', 'counter packets', 'jump VZONE_ZONE2'],
+        ]
+
+        nftables_search_v6 = [
+            ['oifname { "eth0", "eth0.20", "eth3.20", "eth3.20.40" }', 'counter packets', 'jump VZONE_ZONE1'],
+            ['oifname { "vti1", "vti2" }', 'counter packets', 'jump VZONE_ZONE2'],
+        ]
         self.verify_nftables(nftables_search, 'ip vyos_filter')
         self.verify_nftables(nftables_search_v6, 'ip6 vyos_filter')
 

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -142,7 +142,9 @@ def get_config(config=None):
                 if 'vrf' in local_zone_member:
                     local_zone_conf['vrf_interfaces'] = {}
                     for vrf_name in local_zone_member['vrf']:
-                        local_zone_conf['vrf_interfaces'][vrf_name] = ','.join(get_vrf_members(vrf_name))
+                        local_zone_conf['vrf_interfaces'][vrf_name] = get_vrf_members(
+                            vrf_name
+                        )
                 continue
 
             local_zone_conf['from_local'] = {}

--- a/src/conf_mode/interfaces_bonding.py
+++ b/src/conf_mode/interfaces_bonding.py
@@ -19,6 +19,7 @@ from sys import exit
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
+from vyos.configdict import is_vrf_changed
 from vyos.configdict import leaf_node_changed
 from vyos.configdict import is_member
 from vyos.configdict import is_source_interface
@@ -171,6 +172,11 @@ def get_config(config=None):
     if 'static_arp' in bond:
         set_dependents('static_arp', conf)
 
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        bond.update({'vrf_changed': {}})
+        set_dependents('firewall', conf)
+
     bond['vpp_ifaces'] = cli_ifaces_list(conf)
 
     return bond
@@ -298,7 +304,11 @@ def apply(bond):
     else:
         b.update(bond)
 
-    if dict_search('member.interface_remove', bond) or 'static_arp' in bond:
+    if (
+        dict_search('member.interface_remove', bond)
+        or 'static_arp' in bond
+        or 'vrf_changed' in bond
+    ):
         try:
             call_dependents()
         except ConfigError:

--- a/src/conf_mode/interfaces_bridge.py
+++ b/src/conf_mode/interfaces_bridge.py
@@ -18,6 +18,7 @@ from sys import exit
 
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
+from vyos.configdict import is_vrf_changed
 from vyos.configdict import node_changed
 from vyos.configdict import is_member
 from vyos.configdict import is_source_interface
@@ -129,6 +130,11 @@ def get_config(config=None):
     if 'static_arp' in bridge:
         set_dependents('static_arp', conf)
 
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        bridge.update({'vrf_changed': {}})
+        set_dependents('firewall', conf)
+
     bridge['vpp_ifaces'] = cli_ifaces_list(conf)
 
     return bridge
@@ -233,7 +239,7 @@ def apply(bridge):
         if iface.startswith(('vxlan', 'wlan')) and interface_exists(iface)
     ]
 
-    if interfaces_need_update or 'static_arp' in bridge:
+    if interfaces_need_update or 'static_arp' in bridge or 'vrf_changed' in bridge:
         try:
             call_dependents()
         except ConfigError:

--- a/src/conf_mode/interfaces_dummy.py
+++ b/src/conf_mode/interfaces_dummy.py
@@ -18,6 +18,9 @@ from sys import exit
 
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
+from vyos.configdict import is_vrf_changed
+from vyos.configdep import set_dependents
+from vyos.configdep import call_dependents
 from vyos.configverify import verify_vrf
 from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
@@ -37,7 +40,12 @@ def get_config(config=None):
     else:
         conf = Config()
     base = ['interfaces', 'dummy']
-    _, dummy = get_interface_dict(conf, base)
+    ifname, dummy = get_interface_dict(conf, base)
+
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        set_dependents('firewall', conf)
+
     return dummy
 
 def verify(dummy):
@@ -62,6 +70,9 @@ def apply(dummy):
         d.remove()
     else:
         d.update(dummy)
+
+    # run the dependents
+    call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -24,6 +24,7 @@ from vyos.configdep import set_dependents
 from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
+from vyos.configdict import is_vrf_changed
 from vyos.configdict import get_flowtable_interfaces
 from vyos.configverify import verify_address
 from vyos.configverify import verify_dhcpv6
@@ -195,6 +196,10 @@ def get_config(config=None):
     # Protocols static arp dependency
     if 'static_arp' in ethernet:
         set_dependents('static_arp', conf)
+
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        set_dependents('firewall', conf)
 
     return ethernet
 
@@ -442,8 +447,9 @@ def apply(ethernet):
         e.remove()
     else:
         e.update(ethernet)
-    if 'static_arp' in ethernet:
-        call_dependents()
+
+    # run the dependents
+    call_dependents()
 
     vpp_iface_config = dict_search(f'vpp.settings.interface.{ifname}', ethernet)
     if vpp_iface_config is not None and is_systemd_service_running('vpp.service'):

--- a/src/conf_mode/interfaces_geneve.py
+++ b/src/conf_mode/interfaces_geneve.py
@@ -21,6 +21,7 @@ from vyos.configdep import set_dependents
 from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
+from vyos.configdict import is_vrf_changed
 from vyos.configverify import verify_address
 from vyos.configverify import verify_mtu_ipv6
 from vyos.configverify import verify_bridge_delete
@@ -56,6 +57,10 @@ def get_config(config=None):
     # Protocols static arp dependency
     if 'static_arp' in geneve:
         set_dependents('static_arp', conf)
+
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        set_dependents('firewall', conf)
 
     return geneve
 
@@ -96,8 +101,8 @@ def apply(geneve):
         g = GeneveIf(**geneve)
         g.update(geneve)
 
-    if 'static_arp' in geneve:
-        call_dependents()
+    # run the dependents
+    call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_l2tpv3.py
+++ b/src/conf_mode/interfaces_l2tpv3.py
@@ -20,6 +20,7 @@ from vyos.config import Config
 from vyos.configdep import set_dependents
 from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
+from vyos.configdict import is_vrf_changed
 from vyos.configdict import leaf_node_changed
 from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
@@ -61,6 +62,10 @@ def get_config(config=None):
     # Protocols static arp dependency
     if 'static_arp' in l2tpv3:
         set_dependents('static_arp', conf)
+
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        set_dependents('firewall', conf)
 
     return l2tpv3
 
@@ -106,8 +111,8 @@ def apply(l2tpv3):
         l = L2TPv3If(**l2tpv3)
         l.update(l2tpv3)
 
-    if 'static_arp' in l2tpv3:
-        call_dependents()
+    # run the dependents
+    call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_macsec.py
+++ b/src/conf_mode/interfaces_macsec.py
@@ -23,6 +23,7 @@ from vyos.configdep import set_dependents
 from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
+from vyos.configdict import is_vrf_changed
 from vyos.configdict import is_source_interface
 from vyos.configverify import verify_vrf
 from vyos.configverify import verify_address
@@ -83,6 +84,10 @@ def get_config(config=None):
     # Protocols static arp dependency
     if 'static_arp' in macsec:
         set_dependents('static_arp', conf)
+
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        set_dependents('firewall', conf)
 
     return macsec
 
@@ -187,6 +192,9 @@ def apply(macsec):
             if os.path.isfile(wpa_suppl_conf.format(**macsec)):
                 os.unlink(wpa_suppl_conf.format(**macsec))
 
+            # run the dependents
+            call_dependents()
+
             return None
 
     # It is safe to "re-create" the interface always, there is a sanity
@@ -199,8 +207,8 @@ def apply(macsec):
         if not is_systemd_service_running(systemd_service) or 'shutdown_required' in macsec:
             call(f'systemctl reload-or-restart {systemd_service}')
 
-    if 'static_arp' in macsec:
-        call_dependents()
+    # run the dependents
+    call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_openvpn.py
+++ b/src/conf_mode/interfaces_openvpn.py
@@ -32,7 +32,10 @@ from vyos.base import DeprecationWarning
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
+from vyos.configdict import is_vrf_changed
 from vyos.configdiff import get_config_diff
+from vyos.configdep import set_dependents
+from vyos.configdep import call_dependents
 from vyos.configverify import verify_vrf
 from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_mirror_redirect
@@ -180,6 +183,10 @@ def get_config(config=None):
         openvpn['protocol_modifier']  = '6'
     else:
         openvpn['protocol_modifier'] = ''
+
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        set_dependents('firewall', conf)
 
     return openvpn
 
@@ -854,6 +861,9 @@ def apply(openvpn):
 
     o = VTunIf(**openvpn)
     o.update(openvpn)
+
+    # run the dependents
+    call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_pppoe.py
+++ b/src/conf_mode/interfaces_pppoe.py
@@ -21,6 +21,9 @@ from sys import exit
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
+from vyos.configdict import is_vrf_changed
+from vyos.configdep import set_dependents
+from vyos.configdep import call_dependents
 from vyos.configverify import verify_authentication
 from vyos.configverify import verify_source_interface
 from vyos.configverify import verify_vrf
@@ -72,6 +75,10 @@ def get_config(config=None):
         if 'mru' not in pppoe:
             pppoe['mru'] = pppoe['mtu']
 
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        set_dependents('firewall', conf)
+
     return pppoe
 
 def verify(pppoe):
@@ -119,6 +126,9 @@ def apply(pppoe):
             p = PPPoEIf(ifname)
             p.remove()
         call(f'systemctl stop ppp@{ifname}.service')
+        
+        # run the dependents and return
+        call_dependents()
         return None
 
     # reconnect should only be necessary when certain config options change,
@@ -139,6 +149,9 @@ def apply(pppoe):
         if os.path.isdir(f'/sys/class/net/{ifname}'):
             p = PPPoEIf(ifname)
             p.update(pppoe)
+
+    # run the dependents
+    call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_pseudo-ethernet.py
+++ b/src/conf_mode/interfaces_pseudo-ethernet.py
@@ -22,6 +22,7 @@ from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_source_interface
 from vyos.configdict import is_node_changed
+from vyos.configdict import is_vrf_changed
 from vyos.configverify import verify_vrf
 from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
@@ -65,6 +66,10 @@ def get_config(config=None):
     # Protocols static arp dependency
     if 'static_arp' in peth:
         set_dependents('static_arp', conf)
+
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        set_dependents('firewall', conf)
 
     return peth
 
@@ -131,8 +136,8 @@ def apply(peth):
         p = MACVLANIf(**peth)
         p.update(peth)
 
-    if 'static_arp' in peth:
-        call_dependents()
+    # run the dependents
+    call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_sstpc.py
+++ b/src/conf_mode/interfaces_sstpc.py
@@ -20,6 +20,9 @@ from sys import exit
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
+from vyos.configdict import is_vrf_changed
+from vyos.configdep import set_dependents
+from vyos.configdep import call_dependents
 from vyos.configverify import verify_authentication
 from vyos.configverify import verify_vrf
 from vyos.ifconfig import SSTPCIf
@@ -56,6 +59,10 @@ def get_config(config=None):
             sstpc.update({'shutdown_required': {}})
             # bail out early - no need to further process other nodes
             break
+
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        set_dependents('firewall', conf)
 
     return sstpc
 
@@ -107,6 +114,9 @@ def apply(sstpc):
             p = SSTPCIf(ifname)
             p.remove()
         call(f'systemctl stop ppp@{ifname}.service')
+
+        # run the dependents and return
+        call_dependents()
         return None
 
     # reconnect should only be necessary when specific options change,
@@ -127,6 +137,9 @@ def apply(sstpc):
         if os.path.isdir(f'/sys/class/net/{ifname}'):
             p = SSTPCIf(ifname)
             p.update(sstpc)
+
+    # run the dependents
+    call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_tunnel.py
+++ b/src/conf_mode/interfaces_tunnel.py
@@ -18,6 +18,9 @@ import ipaddress
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
+from vyos.configdict import is_vrf_changed
+from vyos.configdep import set_dependents
+from vyos.configdep import call_dependents
 from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_source_interface
@@ -77,6 +80,10 @@ def get_config(config=None):
 
     if 'encapsulation' in tunnel and tunnel['encapsulation'] not in ['erspan', 'ip6erspan']:
         del tunnel['parameters']['erspan']
+
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        set_dependents('firewall', conf)
 
     return tunnel
 
@@ -218,10 +225,15 @@ def apply(tunnel):
             tmp = Interface(interface)
             tmp.remove()
         if 'deleted' in tunnel:
+            # run the dependents and return
+            call_dependents()
             return None
 
     tun = TunnelIf(**tunnel)
     tun.update(tunnel)
+
+    # run the dependents
+    call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_virtual-ethernet.py
+++ b/src/conf_mode/interfaces_virtual-ethernet.py
@@ -22,6 +22,7 @@ from vyos.config import Config
 from vyos.configdep import set_dependents
 from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
+from vyos.configdict import is_vrf_changed
 from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_vrf
@@ -53,6 +54,10 @@ def get_config(config=None):
     # Protocols static arp dependency
     if 'static_arp' in veth:
         set_dependents('static_arp', conf)
+
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        set_dependents('firewall', conf)
 
     return veth
 
@@ -108,8 +113,8 @@ def apply(veth):
         p = VethIf(**veth)
         p.update(veth)
 
-    if 'static_arp' in veth:
-        call_dependents()
+    # run the dependents
+    call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_vti.py
+++ b/src/conf_mode/interfaces_vti.py
@@ -18,6 +18,9 @@ from sys import exit
 
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
+from vyos.configdict import is_vrf_changed
+from vyos.configdep import set_dependents
+from vyos.configdep import call_dependents
 from vyos.configverify import verify_mirror_redirect
 from vyos.configverify import verify_vrf
 from vyos.configverify import verify_mtu_ipv6
@@ -36,7 +39,12 @@ def get_config(config=None):
     else:
         conf = Config()
     base = ['interfaces', 'vti']
-    _, vti = get_interface_dict(conf, base)
+    ifname, vti = get_interface_dict(conf, base)
+
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        set_dependents('firewall', conf)
+
     return vti
 
 def verify(vti):
@@ -52,10 +60,17 @@ def apply(vti):
     # Remove macsec interface
     if 'deleted' in vti:
         VTIIf(**vti).remove()
+
+        # run the dependents
+        call_dependents()
+
         return None
 
     tmp = VTIIf(**vti)
     tmp.update(vti)
+
+    # run the dependents
+    call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_vxlan.py
+++ b/src/conf_mode/interfaces_vxlan.py
@@ -23,6 +23,7 @@ from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
 from vyos.configdict import leaf_node_changed
 from vyos.configdict import is_node_changed
+from vyos.configdict import is_vrf_changed
 from vyos.configdict import node_changed
 from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
@@ -88,6 +89,10 @@ def get_config(config=None):
     # Protocols static arp dependency
     if 'static_arp' in vxlan:
         set_dependents('static_arp', conf)
+
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        set_dependents('firewall', conf)
 
     return vxlan
 
@@ -257,8 +262,8 @@ def apply(vxlan):
         v = VXLANIf(**vxlan)
         v.update(vxlan)
 
-    if 'static_arp' in vxlan:
-        call_dependents()
+    # run the dependents
+    call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_wireguard.py
+++ b/src/conf_mode/interfaces_wireguard.py
@@ -22,6 +22,7 @@ from sys import exit
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
+from vyos.configdict import is_vrf_changed
 from vyos.configdict import is_source_interface
 from vyos.configdep import set_dependents
 from vyos.configdep import call_dependents
@@ -86,6 +87,10 @@ def get_config(config=None):
         )
         wireguard['prev_fwmark'] = prev.get('fwmark')
         wireguard['prev_vrf'] = prev.get('vrf')
+
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        set_dependents('firewall', conf)
 
     return wireguard
 
@@ -206,6 +211,7 @@ def apply(wireguard):
             domain_action = 'stop'
     call(f'systemctl {domain_action} vyos-domain-resolver.service')
 
+    # run the dependents
     call_dependents()
 
     return None

--- a/src/conf_mode/interfaces_wireless.py
+++ b/src/conf_mode/interfaces_wireless.py
@@ -25,6 +25,7 @@ from vyos.config import Config
 from vyos.configdep import set_dependents
 from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
+from vyos.configdict import is_vrf_changed
 from vyos.configdict import dict_merge
 from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
@@ -92,7 +93,7 @@ def get_config(config=None):
         conf = Config()
     base = ['interfaces', 'wireless']
 
-    _, wifi = get_interface_dict(conf, base)
+    ifname, wifi = get_interface_dict(conf, base)
 
     # retrieve global Wireless regulatory domain setting
     if conf.exists(country_code_path):
@@ -144,6 +145,10 @@ def get_config(config=None):
     # Protocols static arp dependency
     if 'static_arp' in wifi:
         set_dependents('static_arp', conf)
+
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        set_dependents('firewall', conf)
 
     return wifi
 
@@ -318,6 +323,9 @@ def apply(wifi):
 
     if 'deleted' in wifi:
         WiFiIf(**wifi).remove()
+
+        # run the dependents and return
+        call_dependents()
         return None
 
     while (is_systemd_service_running(f'hostapd@{interface}.service') or \
@@ -393,8 +401,8 @@ def apply(wifi):
         elif wifi['type'] == 'station':
             call(f'systemctl start wpa_supplicant@{interface}.service')
 
-    if 'static_arp' in wifi:
-        call_dependents()
+    # run the dependents
+    call_dependents()
 
     return None
 

--- a/src/conf_mode/interfaces_wwan.py
+++ b/src/conf_mode/interfaces_wwan.py
@@ -24,6 +24,7 @@ from vyos.configdep import set_dependents
 from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
+from vyos.configdict import is_vrf_changed
 from vyos.configverify import verify_authentication
 from vyos.configverify import verify_interface_exists
 from vyos.configverify import verify_mirror_redirect
@@ -92,6 +93,10 @@ def get_config(config=None):
     # Protocols static arp dependency
     if 'static_arp' in wwan:
         set_dependents('static_arp', conf)
+
+    # Check vrf membership, to ensure firewall is updated
+    if is_vrf_changed(conf, ifname):
+        set_dependents('firewall', conf)
 
     return wwan
 
@@ -170,6 +175,9 @@ def apply(wwan):
             if os.path.exists(cron_script):
                 os.unlink(cron_script)
 
+        # run the dependents
+        call_dependents()
+
         return None
 
     if 'shutdown_required' in wwan or (not is_wwan_connected(wwan['ifname'])):
@@ -192,8 +200,8 @@ def apply(wwan):
 
     w.update(wwan)
 
-    if 'static_arp' in wwan:
-        call_dependents()
+    # run the dependents
+    call_dependents()
 
     return None
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

This change reimplements the intended behaviour from #4180 aswell as from #4506, it ensures that both the vrf-member interface aswell as the vrf itself is added as an oifname -> meaning that traffic traversing and originating from withing VyOS is matches outbound.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8761

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

The tests are carried out by generating some firewall rules and checking the config from nftables - it will not generate both an oifname with the vrf member interfaces, aswell as a line for the vrf itself.

```
table ip vyos_filter {
        chain VZONE_LOCAL_OUT {
                oifname "lo" counter packets 3060 bytes 208080 return
                oifname {"eth1", "eth2" } counter packets 0 bytes 0 jump NAME_IPV4_LOCAL_TO_MGMT
                oifname {"eth1", "eth2" } counter packets 0 bytes 0 return
                oifname "MGMT" counter packets 0 bytes 0 jump NAME_IPV4_LOCAL_TO_MGMT
                oifname "MGMT" counter packets 0 bytes 0 return
        }
}
```



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
