### PR TITLE
kea: T8763: Fix vendor-encapsulated-options space

### DIFF
--- a/data/templates/dhcp-server/kea-dhcp4.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp4.conf.j2
@@ -41,10 +41,10 @@
                 "type": "string"
             },
             {
-                "name": "unifi-controller",
+                "name": "ubnt",
                 "code": 1,
                 "type": "ipv4-address",
-                "space": "ubnt"
+                "space": "vendor-encapsulated-options-space"
             }
         ],
 {% if dynamic_dns_update is vyos_defined %}

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -153,8 +153,13 @@ def kea_parse_options(config):
         config, 'vendor_option', 'ubiquiti', 'unifi_controller'
     )
     if unifi_controller:
+        options.append({'name': 'vendor-encapsulated-options'})
         options.append(
-            {'name': 'unifi-controller', 'data': unifi_controller, 'space': 'ubnt'}
+            {
+                'name': 'ubnt',
+                'data': unifi_controller,
+                'space': 'vendor-encapsulated-options-space',
+            }
         )
 
     return options

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -103,8 +103,10 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         try:
             tmp = cmd('grep -i kea /var/log/messages | tail -n 100')
         except OSError:
-            tmp = "No relevant log entries"
-        self.assertTrue(process_named_running(PROCESS_NAME), msg=f'Service not running, log: {tmp}')
+            tmp = 'No relevant log entries'
+        self.assertTrue(
+            process_named_running(PROCESS_NAME), msg=f'Service not running, log: {tmp}'
+        )
 
     def test_dhcp_single_pool_range(self):
         shared_net_name = 'SMOKE-1'
@@ -114,7 +116,9 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         range_1_start = inc_ip(subnet, 40)
         range_1_stop = inc_ip(subnet, 50)
 
-        self.setup_single_pool_range(range_0_start, range_0_stop, range_1_start, range_1_stop, shared_net_name)
+        self.setup_single_pool_range(
+            range_0_start, range_0_stop, range_1_start, range_1_stop, shared_net_name
+        )
 
         # commit changes
         self.cli_commit()
@@ -149,14 +153,14 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
             obj,
             ['Dhcp4', 'shared-networks', 0, 'user-context'],
             'enable-ping-check',
-            True
+            True,
         )
 
         self.verify_config_value(
             obj,
             ['Dhcp4', 'shared-networks', 0, 'subnet4', 0, 'user-context'],
             'enable-ping-check',
-            True
+            True,
         )
 
         # Verify options
@@ -191,7 +195,9 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         # Check for running process
         self.verify_service_running()
 
-    def setup_single_pool_range(self, range_0_start, range_0_stop, range_1_start, range_1_stop, shared_net_name):
+    def setup_single_pool_range(
+        self, range_0_start, range_0_stop, range_1_start, range_1_stop, shared_net_name
+    ):
         self.cli_set(base_path + ['listen-interface', interface])
         self.cli_set(base_path + ['shared-network-name', shared_net_name, 'ping-check'])
 
@@ -223,34 +229,82 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         range_1_start = inc_ip(subnet, 40)
         range_1_stop = inc_ip(subnet, 50)
 
-        self.setup_single_pool_range(range_0_start, range_0_stop, range_1_start, range_1_stop, shared_net_name)
+        self.setup_single_pool_range(
+            range_0_start, range_0_stop, range_1_start, range_1_stop, shared_net_name
+        )
 
-        self.cli_set(base_path + ['shared-network-name', shared_net_name, 'subnet', subnet, 'client-class', 'test'])
+        self.cli_set(
+            base_path
+            + [
+                'shared-network-name',
+                shared_net_name,
+                'subnet',
+                subnet,
+                'client-class',
+                'test',
+            ]
+        )
 
         # check validate() - Client class referenced that doesn't exist yet
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
 
-        self.cli_delete(base_path + ['shared-network-name', shared_net_name, 'subnet', subnet, 'client-class', 'test'])
+        self.cli_delete(
+            base_path
+            + [
+                'shared-network-name',
+                shared_net_name,
+                'subnet',
+                subnet,
+                'client-class',
+                'test',
+            ]
+        )
 
-        self.cli_set(base_path + ['shared-network-name', shared_net_name, 'subnet', subnet, 'range', '0', 'client-class', 'test'])
+        self.cli_set(
+            base_path
+            + [
+                'shared-network-name',
+                shared_net_name,
+                'subnet',
+                subnet,
+                'range',
+                '0',
+                'client-class',
+                'test',
+            ]
+        )
 
         # check validate() - Client class referenced that doesn't exist yet
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
 
-        self.cli_set(base_path + ['shared-network-name', shared_net_name, 'subnet', subnet, 'client-class', 'test'])
+        self.cli_set(
+            base_path
+            + [
+                'shared-network-name',
+                shared_net_name,
+                'subnet',
+                subnet,
+                'client-class',
+                'test',
+            ]
+        )
 
         client_class = base_path + ['client-class', 'test']
 
         # Test that invalid hex is rejected
-        self.cli_set(client_class + ['relay-agent-information', 'circuit-id', '0xHELLOWORLD'])
+        self.cli_set(
+            client_class + ['relay-agent-information', 'circuit-id', '0xHELLOWORLD']
+        )
 
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
 
         self.cli_delete(client_class + ['relay-agent-information', 'circuit-id'])
-        self.cli_set(client_class + ['relay-agent-information', 'remote-id', '0xHELLOWORLD'])
+        self.cli_set(
+            client_class + ['relay-agent-information', 'remote-id', '0xHELLOWORLD']
+        )
 
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
@@ -269,8 +323,12 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(client_class + ['relay-agent-information', 'remote-id'])
 
         # Test hex strings
-        self.cli_set(client_class + ['relay-agent-information', 'circuit-id', '0x666f6f'])
-        self.cli_set(client_class + ['relay-agent-information', 'remote-id', '0x626172'])
+        self.cli_set(
+            client_class + ['relay-agent-information', 'circuit-id', '0x666f6f']
+        )
+        self.cli_set(
+            client_class + ['relay-agent-information', 'remote-id', '0x626172']
+        )
 
         self.cli_commit()
 
@@ -279,20 +337,21 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
     def check_client_class_in_config(self):
         config = read_file(KEA4_CONF)
         obj = loads(config)
+        self.verify_config_value(obj, ['Dhcp4', 'client-classes', 0], 'name', 'test')
         self.verify_config_value(
-            obj, ['Dhcp4', 'client-classes', 0], 'name', 'test'
+            obj,
+            ['Dhcp4', 'client-classes', 0],
+            'test',
+            'relay4[1].hex == 0x666f6f and relay4[2].hex == 0x626172',
         )
         self.verify_config_value(
-            obj, ['Dhcp4', 'client-classes', 0], 'test',
-            'relay4[1].hex == 0x666f6f and relay4[2].hex == 0x626172'
+            obj, ['Dhcp4', 'shared-networks', 0, 'subnet4', 0], 'client-class', 'test'
         )
         self.verify_config_value(
-            obj, ['Dhcp4', 'shared-networks', 0, 'subnet4', 0], 'client-class',
-            'test'
-        )
-        self.verify_config_value(
-            obj, ['Dhcp4', 'shared-networks', 0, 'subnet4', 0, 'pools', 0],
-            'client-class', 'test'
+            obj,
+            ['Dhcp4', 'shared-networks', 0, 'subnet4', 0, 'pools', 0],
+            'client-class',
+            'test',
         )
         # Check for running process
         self.verify_service_running()
@@ -306,9 +365,22 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         range_1_stop = inc_ip(subnet, 50)
         unifi_controller = '10.0.0.10'
 
-        self.setup_single_pool_range(range_0_start, range_0_stop, range_1_start, range_1_stop, shared_net_name)
+        self.setup_single_pool_range(
+            range_0_start, range_0_stop, range_1_start, range_1_stop, shared_net_name
+        )
 
-        self.cli_set(base_path + ['shared-network-name', shared_net_name, 'option', 'vendor-option', 'ubiquiti', 'unifi-controller', unifi_controller])
+        self.cli_set(
+            base_path
+            + [
+                'shared-network-name',
+                shared_net_name,
+                'option',
+                'vendor-option',
+                'ubiquiti',
+                'unifi-controller',
+                unifi_controller,
+            ]
+        )
 
         self.cli_commit()
 
@@ -323,7 +395,11 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.verify_config_object(
             obj,
             ['Dhcp4', 'shared-networks', 0, 'option-data'],
-            {'name': 'ubnt', 'space': 'vendor-encapsulated-options-space', 'data': unifi_controller},
+            {
+                'name': 'ubnt',
+                'space': 'vendor-encapsulated-options-space',
+                'data': unifi_controller,
+            },
         )
         self.verify_service_running()
 
@@ -363,15 +439,14 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.cli_set(pool + ['option', 'bootfile-server', bootfile_server])
         self.cli_set(pool + ['option', 'wpad-url', wpad])
         self.cli_set(pool + ['option', 'server-identifier', server_identifier])
-        self.cli_set(
-            pool + ['option', 'capwap-controller', capwap_access_controller]
-        )
+        self.cli_set(pool + ['option', 'capwap-controller', capwap_access_controller])
 
         static_route = '10.0.0.0/24'
         static_route_nexthop = '192.0.2.1'
 
         self.cli_set(
-            pool + ['option', 'static-route', static_route, 'next-hop', static_route_nexthop]
+            pool
+            + ['option', 'static-route', static_route, 'next-hop', static_route_nexthop]
         )
         self.cli_set(pool + ['option', 'ipv6-only-preferred', ipv6_only_preferred])
         self.cli_set(pool + ['option', 'time-zone', 'Europe/London'])
@@ -1258,7 +1333,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         shared_net_name = 'SMOKE-1DDNS'
 
         range_0_start = inc_ip(subnet, 10)
-        range_0_stop  = inc_ip(subnet, 20)
+        range_0_stop = inc_ip(subnet, 20)
 
         self.cli_set(base_path + ['listen-interface', interface])
 
@@ -1272,17 +1347,103 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.cli_set(ddns + ['update-on-renew', 'enable'])
 
         self.cli_set(ddns + ['tsig-key', 'domain-lan-updates', 'algorithm', 'sha256'])
-        self.cli_set(ddns + ['tsig-key', 'domain-lan-updates', 'secret', 'SXQncyBXZWRuZXNkYXkgbWFoIGR1ZGVzIQ=='])
+        self.cli_set(
+            ddns
+            + [
+                'tsig-key',
+                'domain-lan-updates',
+                'secret',
+                'SXQncyBXZWRuZXNkYXkgbWFoIGR1ZGVzIQ==',
+            ]
+        )
         self.cli_set(ddns + ['tsig-key', 'reverse-0-168-192', 'algorithm', 'sha256'])
-        self.cli_set(ddns + ['tsig-key', 'reverse-0-168-192', 'secret', 'VGhhbmsgR29kIGl0J3MgRnJpZGF5IQ=='])
-        self.cli_set(ddns + ['forward-domain', 'domain.lan', 'dns-server', '1', 'address', '192.168.0.1'])
-        self.cli_set(ddns + ['forward-domain', 'domain.lan', 'dns-server', '2', 'address', '100.100.0.1'])
-        self.cli_set(ddns + ['forward-domain', 'domain.lan', 'key-name', 'domain-lan-updates'])
-        self.cli_set(ddns + ['reverse-domain', '0.168.192.in-addr.arpa', 'dns-server', '1', 'address', '192.168.0.1'])
-        self.cli_set(ddns + ['reverse-domain', '0.168.192.in-addr.arpa', 'dns-server', '1', 'port', '1053'])
-        self.cli_set(ddns + ['reverse-domain', '0.168.192.in-addr.arpa', 'dns-server', '2', 'address', '100.100.0.1'])
-        self.cli_set(ddns + ['reverse-domain', '0.168.192.in-addr.arpa', 'dns-server', '2', 'port', '1153'])
-        self.cli_set(ddns + ['reverse-domain', '0.168.192.in-addr.arpa', 'key-name', 'reverse-0-168-192'])
+        self.cli_set(
+            ddns
+            + [
+                'tsig-key',
+                'reverse-0-168-192',
+                'secret',
+                'VGhhbmsgR29kIGl0J3MgRnJpZGF5IQ==',
+            ]
+        )
+        self.cli_set(
+            ddns
+            + [
+                'forward-domain',
+                'domain.lan',
+                'dns-server',
+                '1',
+                'address',
+                '192.168.0.1',
+            ]
+        )
+        self.cli_set(
+            ddns
+            + [
+                'forward-domain',
+                'domain.lan',
+                'dns-server',
+                '2',
+                'address',
+                '100.100.0.1',
+            ]
+        )
+        self.cli_set(
+            ddns + ['forward-domain', 'domain.lan', 'key-name', 'domain-lan-updates']
+        )
+        self.cli_set(
+            ddns
+            + [
+                'reverse-domain',
+                '0.168.192.in-addr.arpa',
+                'dns-server',
+                '1',
+                'address',
+                '192.168.0.1',
+            ]
+        )
+        self.cli_set(
+            ddns
+            + [
+                'reverse-domain',
+                '0.168.192.in-addr.arpa',
+                'dns-server',
+                '1',
+                'port',
+                '1053',
+            ]
+        )
+        self.cli_set(
+            ddns
+            + [
+                'reverse-domain',
+                '0.168.192.in-addr.arpa',
+                'dns-server',
+                '2',
+                'address',
+                '100.100.0.1',
+            ]
+        )
+        self.cli_set(
+            ddns
+            + [
+                'reverse-domain',
+                '0.168.192.in-addr.arpa',
+                'dns-server',
+                '2',
+                'port',
+                '1153',
+            ]
+        )
+        self.cli_set(
+            ddns
+            + [
+                'reverse-domain',
+                '0.168.192.in-addr.arpa',
+                'key-name',
+                'reverse-0-168-192',
+            ]
+        )
 
         shared = base_path + ['shared-network-name', shared_net_name]
 
@@ -1290,7 +1451,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.cli_set(shared + ['dynamic-dns-update', 'conflict-resolution', 'enable'])
         self.cli_set(shared + ['dynamic-dns-update', 'ttl-percent', '75'])
 
-        pool = shared + [ 'subnet', subnet]
+        pool = shared + ['subnet', subnet]
 
         self.cli_set(pool + ['subnet-id', '1'])
 
@@ -1301,7 +1462,9 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.cli_set(pool + ['dynamic-dns-update', 'generated-prefix', 'myfunnyprefix'])
         self.cli_set(pool + ['dynamic-dns-update', 'qualifying-suffix', 'suffix.lan'])
         self.cli_set(pool + ['dynamic-dns-update', 'hostname-char-set', 'xXyYzZ'])
-        self.cli_set(pool + ['dynamic-dns-update', 'hostname-char-replacement', '_xXx_'])
+        self.cli_set(
+            pool + ['dynamic-dns-update', 'hostname-char-replacement', '_xXx_']
+        )
 
         self.cli_commit()
 
@@ -1314,9 +1477,19 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         # Verify global DDNS parameters in the main config file
         self.verify_config_value(
             obj,
-            ['Dhcp4'], 'dhcp-ddns',
-            {'enable-updates': True, 'server-ip': '127.0.0.1', 'server-port': 53001, 'sender-ip': '', 'sender-port': 0,
-                'max-queue-size': 1024, 'ncr-protocol': 'UDP', 'ncr-format': 'JSON'})
+            ['Dhcp4'],
+            'dhcp-ddns',
+            {
+                'enable-updates': True,
+                'server-ip': '127.0.0.1',
+                'server-port': 53001,
+                'sender-ip': '',
+                'sender-port': 0,
+                'max-queue-size': 1024,
+                'ncr-protocol': 'UDP',
+                'ncr-format': 'JSON',
+            },
+        )
 
         self.verify_config_value(obj, ['Dhcp4'], 'ddns-send-updates', True)
         self.verify_config_value(obj, ['Dhcp4'], 'ddns-use-conflict-resolution', True)
@@ -1326,56 +1499,118 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.verify_config_value(obj, ['Dhcp4'], 'ddns-update-on-renew', True)
 
         # Verify scoped DDNS parameters in the main config file
-        self.verify_config_value(obj, ['Dhcp4', 'shared-networks'], 'name', shared_net_name)
-        self.verify_config_value(obj, ['Dhcp4', 'shared-networks'], 'ddns-send-updates', True)
-        self.verify_config_value(obj, ['Dhcp4', 'shared-networks'], 'ddns-use-conflict-resolution', True)
-        self.verify_config_value(obj, ['Dhcp4', 'shared-networks'], 'ddns-ttl-percent', 0.75)
+        self.verify_config_value(
+            obj, ['Dhcp4', 'shared-networks'], 'name', shared_net_name
+        )
+        self.verify_config_value(
+            obj, ['Dhcp4', 'shared-networks'], 'ddns-send-updates', True
+        )
+        self.verify_config_value(
+            obj, ['Dhcp4', 'shared-networks'], 'ddns-use-conflict-resolution', True
+        )
+        self.verify_config_value(
+            obj, ['Dhcp4', 'shared-networks'], 'ddns-ttl-percent', 0.75
+        )
 
-        self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'subnet', subnet)
-        self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'id', 1)
-        self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'ddns-send-updates', True)
-        self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'ddns-generated-prefix', 'myfunnyprefix')
-        self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'ddns-qualifying-suffix', 'suffix.lan')
-        self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'hostname-char-set', 'xXyYzZ')
-        self.verify_config_value(obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'hostname-char-replacement', '_xXx_')
+        self.verify_config_value(
+            obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'subnet', subnet
+        )
+        self.verify_config_value(
+            obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'id', 1
+        )
+        self.verify_config_value(
+            obj, ['Dhcp4', 'shared-networks', 0, 'subnet4'], 'ddns-send-updates', True
+        )
+        self.verify_config_value(
+            obj,
+            ['Dhcp4', 'shared-networks', 0, 'subnet4'],
+            'ddns-generated-prefix',
+            'myfunnyprefix',
+        )
+        self.verify_config_value(
+            obj,
+            ['Dhcp4', 'shared-networks', 0, 'subnet4'],
+            'ddns-qualifying-suffix',
+            'suffix.lan',
+        )
+        self.verify_config_value(
+            obj,
+            ['Dhcp4', 'shared-networks', 0, 'subnet4'],
+            'hostname-char-set',
+            'xXyYzZ',
+        )
+        self.verify_config_value(
+            obj,
+            ['Dhcp4', 'shared-networks', 0, 'subnet4'],
+            'hostname-char-replacement',
+            '_xXx_',
+        )
 
         # Verify keys and domains configuration in the D2 config
         self.verify_config_object(
             d2_obj,
             ['DhcpDdns', 'tsig-keys'],
-            {'name': 'domain-lan-updates', 'algorithm': 'HMAC-SHA256', 'secret': 'SXQncyBXZWRuZXNkYXkgbWFoIGR1ZGVzIQ=='}
+            {
+                'name': 'domain-lan-updates',
+                'algorithm': 'HMAC-SHA256',
+                'secret': 'SXQncyBXZWRuZXNkYXkgbWFoIGR1ZGVzIQ==',
+            },
         )
         self.verify_config_object(
             d2_obj,
             ['DhcpDdns', 'tsig-keys'],
-            {'name': 'reverse-0-168-192', 'algorithm': 'HMAC-SHA256', 'secret': 'VGhhbmsgR29kIGl0J3MgRnJpZGF5IQ=='}
+            {
+                'name': 'reverse-0-168-192',
+                'algorithm': 'HMAC-SHA256',
+                'secret': 'VGhhbmsgR29kIGl0J3MgRnJpZGF5IQ==',
+            },
         )
 
-        self.verify_config_value(d2_obj, ['DhcpDdns', 'forward-ddns', 'ddns-domains', 0], 'name', 'domain.lan')
-        self.verify_config_value(d2_obj, ['DhcpDdns', 'forward-ddns', 'ddns-domains', 0], 'key-name', 'domain-lan-updates')
+        self.verify_config_value(
+            d2_obj,
+            ['DhcpDdns', 'forward-ddns', 'ddns-domains', 0],
+            'name',
+            'domain.lan',
+        )
+        self.verify_config_value(
+            d2_obj,
+            ['DhcpDdns', 'forward-ddns', 'ddns-domains', 0],
+            'key-name',
+            'domain-lan-updates',
+        )
         self.verify_config_object(
             d2_obj,
             ['DhcpDdns', 'forward-ddns', 'ddns-domains', 0, 'dns-servers'],
-            {'ip-address': '192.168.0.1'}
-            )
+            {'ip-address': '192.168.0.1'},
+        )
         self.verify_config_object(
             d2_obj,
             ['DhcpDdns', 'forward-ddns', 'ddns-domains', 0, 'dns-servers'],
-            {'ip-address': '100.100.0.1'}
-            )
+            {'ip-address': '100.100.0.1'},
+        )
 
-        self.verify_config_value(d2_obj, ['DhcpDdns', 'reverse-ddns', 'ddns-domains', 0], 'name', '0.168.192.in-addr.arpa')
-        self.verify_config_value(d2_obj, ['DhcpDdns', 'reverse-ddns', 'ddns-domains', 0], 'key-name', 'reverse-0-168-192')
+        self.verify_config_value(
+            d2_obj,
+            ['DhcpDdns', 'reverse-ddns', 'ddns-domains', 0],
+            'name',
+            '0.168.192.in-addr.arpa',
+        )
+        self.verify_config_value(
+            d2_obj,
+            ['DhcpDdns', 'reverse-ddns', 'ddns-domains', 0],
+            'key-name',
+            'reverse-0-168-192',
+        )
         self.verify_config_object(
             d2_obj,
             ['DhcpDdns', 'reverse-ddns', 'ddns-domains', 0, 'dns-servers'],
-            {'ip-address': '192.168.0.1', 'port': 1053}
-            )
+            {'ip-address': '192.168.0.1', 'port': 1053},
+        )
         self.verify_config_object(
             d2_obj,
             ['DhcpDdns', 'reverse-ddns', 'ddns-domains', 0, 'dns-servers'],
-            {'ip-address': '100.100.0.1', 'port': 1153}
-            )
+            {'ip-address': '100.100.0.1', 'port': 1153},
+        )
 
         # Check for running process
         self.assertTrue(process_named_running(PROCESS_NAME))

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -297,6 +297,36 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         # Check for running process
         self.verify_service_running()
 
+    def test_dhcp_vendor_option_ubiquiti(self):
+        shared_net_name = 'SMOKE-1'
+
+        range_0_start = inc_ip(subnet, 10)
+        range_0_stop = inc_ip(subnet, 20)
+        range_1_start = inc_ip(subnet, 40)
+        range_1_stop = inc_ip(subnet, 50)
+        unifi_controller = '10.0.0.10'
+
+        self.setup_single_pool_range(range_0_start, range_0_stop, range_1_start, range_1_stop, shared_net_name)
+
+        self.cli_set(base_path + ['shared-network-name', shared_net_name, 'option', 'vendor-option', 'ubiquiti', 'unifi-controller', unifi_controller])
+
+        self.cli_commit()
+
+        config = read_file(KEA4_CONF)
+        obj = loads(config)
+
+        self.verify_config_object(
+            obj,
+            ['Dhcp4', 'shared-networks', 0, 'option-data'],
+            {'name': 'vendor-encapsulated-options'},
+        )
+        self.verify_config_object(
+            obj,
+            ['Dhcp4', 'shared-networks', 0, 'option-data'],
+            {'name': 'ubnt', 'space': 'vendor-encapsulated-options-space', 'data': unifi_controller},
+        )
+        self.verify_service_running()
+
     def test_dhcp_single_pool_options(self):
         shared_net_name = 'SMOKE-0815'
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Currently, the Kea DHCP configuration file generates the option definition and option data in a non-compliant manner.

Specifically, per [Kea documentation](https://kea.readthedocs.io/en/latest/arm/dhcp4-srv.html#dhcpv4-vendor-specific-options), the option spaces to carry vendor specific option (code 43) should be among the two predfined ones `dhcpv4` or `vendor-encapsulated-options-space`. Additionally, the vendor specific information is carried through the `name`, not `space`.

- Change option space from 'ubnt' to 'vendor-encapsulated-options-space'.
- Change option name from 'unifi-controller' to 'ubnt'.
- Add 'vendor-encapsulated-options' option (in addition to adding unifi controller IP address under the option name 'ubnt') if unifi-controller is configured.

This fixes missing unifi-controller option in DHCP response when unifi devices request for controller IP address via option 43. That is, `set service dhcp-server ... vendor-option ubiquiti unifi-controller` works now.

Note: I retained to option code `1` instead of `43` so that adding future vendor specific options are cleaner.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8763

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
### Relevant tcpdump traffic:

#### Before:
Notice `Parameter-Request` Vendor-Option (43) requested by client, but missing in server response.
```
tcpdump: listening on eth3, link-type EN10MB (Ethernet), snapshot length 262144 bytes
21:09:14.376290 IP (tos 0x0, ttl 64, id 0, offset 0, flags [none], proto UDP (17), length 328)
    0.0.0.0.68 > 255.255.255.255.67: BOOTP/DHCP, Request from aa:bb:cc:dd:ee:ff, length 300, xid 0xc62f9277, secs 47401, Flags [none]
	  Client-Ethernet-Address aa:bb:cc:dd:ee:ff
	  Vendor-rfc1048 Extensions
	    Magic Cookie 0x63825363
	    DHCP-Message (53), length 1: Discover
	    Client-ID (61), length 7: ether aa:bb:cc:dd:ee:ff
	    MSZ (57), length 2: 576
	    Parameter-Request (55), length 8: 
	      Subnet-Mask (1), Default-Gateway (3), Domain-Name-Server (6), Hostname (12)
	      Domain-Name (15), BR (28), NTP (42), Vendor-Option (43)
	    Vendor-Class (60), length 4: "ubnt"
21:09:14.377661 IP (tos 0x10, ttl 128, id 0, offset 0, flags [DF], proto UDP (17), length 351)
    10.10.10.1.67 > 10.10.1.1.68: BOOTP/DHCP, Reply, length 323, xid 0xc62f9277, Flags [none]
	  Your-IP 10.10.1.1
	  Client-Ethernet-Address aa:bb:cc:dd:ee:ff
	  Vendor-rfc1048 Extensions
	    Magic Cookie 0x63825363
	    DHCP-Message (53), length 1: Offer
	    Subnet-Mask (1), length 4: 255.255.240.0
	    Default-Gateway (3), length 4: 10.10.10.1
	    Domain-Name-Server (6), length 4: 10.10.10.1
	    Hostname (12), length 8: "unifi-ap"
	    Domain-Name (15), length 12: "my.home.arpa"
	    NTP (42), length 4: 10.10.10.1
	    Lease-Time (51), length 4: 86400
	    Server-ID (54), length 4: 10.10.10.1
	    Client-ID (61), length 7: ether aa:bb:cc:dd:ee:ff
```

#### After: 
Notice `Parameter-Request` Vendor-Option (43) requested by client, *and* the server response has appropriate response data (`Vendor-Option (43), length 6: 1.4.10.10.16.1`).
```
tcpdump: listening on eth3, link-type EN10MB (Ethernet), snapshot length 262144 bytes
21:16:18.069157 IP (tos 0x0, ttl 64, id 0, offset 0, flags [none], proto UDP (17), length 328)
    0.0.0.0.68 > 255.255.255.255.67: BOOTP/DHCP, Request from aa:bb:cc:dd:ee:ff, length 300, xid 0x5cb79567, secs 47420, Flags [none]
	  Client-Ethernet-Address aa:bb:cc:dd:ee:ff
	  Vendor-rfc1048 Extensions
	    Magic Cookie 0x63825363
	    DHCP-Message (53), length 1: Discover
	    Client-ID (61), length 7: ether aa:bb:cc:dd:ee:ff
	    MSZ (57), length 2: 576
	    Parameter-Request (55), length 8: 
	      Subnet-Mask (1), Default-Gateway (3), Domain-Name-Server (6), Hostname (12)
	      Domain-Name (15), BR (28), NTP (42), Vendor-Option (43)
	    Vendor-Class (60), length 4: "ubnt"
21:16:18.070768 IP (tos 0x10, ttl 128, id 0, offset 0, flags [DF], proto UDP (17), length 359)
    10.10.10.1.67 > 10.10.1.1.68: BOOTP/DHCP, Reply, length 331, xid 0x5cb79567, Flags [none]
	  Your-IP 10.10.1.1
	  Client-Ethernet-Address aa:bb:cc:dd:ee:ff
	  Vendor-rfc1048 Extensions
	    Magic Cookie 0x63825363
	    DHCP-Message (53), length 1: Offer
	    Subnet-Mask (1), length 4: 255.255.240.0
	    Default-Gateway (3), length 4: 10.10.10.1
	    Domain-Name-Server (6), length 4: 10.10.10.1
	    Hostname (12), length 8: "unifi-ap"
	    Domain-Name (15), length 12: "my.home.arpa"
	    NTP (42), length 4: 10.10.10.1
	    Vendor-Option (43), length 6: 1.4.10.10.16.1
	    Lease-Time (51), length 4: 85976
	    Server-ID (54), length 4: 10.10.10.1
	    Client-ID (61), length 7: ether aa:bb:cc:dd:ee:ff
```
### Manual verification
The actual propagation of vendor specific option (code 43) can also be verified by getting into the ssh shell of Unifi device and verifying that `/etc/hosts` contains static entry for `unifi` with the controller IP address.

### Smoketest:
```
$ python3 /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py
test_dhcp_client_class (__main__.TestServiceDHCPServer.test_dhcp_client_class) ... ok
test_dhcp_dynamic_dns_update (__main__.TestServiceDHCPServer.test_dhcp_dynamic_dns_update) ... ok
test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
test_dhcp_high_availability (__main__.TestServiceDHCPServer.test_dhcp_high_availability) ... ok
test_dhcp_high_availability_standby (__main__.TestServiceDHCPServer.test_dhcp_high_availability_standby) ... ok
test_dhcp_hostsd_lease_sync (__main__.TestServiceDHCPServer.test_dhcp_hostsd_lease_sync) ... ok
test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
test_dhcp_on_interface_with_vrf (__main__.TestServiceDHCPServer.test_dhcp_on_interface_with_vrf) ... ok
test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... ok
test_dhcp_single_pool_options_scoped (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options_scoped) ... ok
test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... ok
test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... ok
test_dhcp_vendor_option_ubiquiti (__main__.TestServiceDHCPServer.test_dhcp_vendor_option_ubiquiti) ... ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
