### PR TITLE
bgp: T8607: Add CLI support for BGP update-delay and establish-wait

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -669,6 +669,9 @@ bgp route-reflector allow-outbound-policy
 {% if parameters.tcp_keepalive.idle is vyos_defined and parameters.tcp_keepalive.interval is vyos_defined and parameters.tcp_keepalive.probes is vyos_defined %}
  bgp tcp-keepalive {{ parameters.tcp_keepalive.idle }} {{ parameters.tcp_keepalive.interval }} {{ parameters.tcp_keepalive.probes }}
 {% endif %}
+{% if parameters.update_delay.max_delay is vyos_defined %}
+ update-delay {{ parameters.update_delay.max_delay }}{{ ' ' ~ parameters.update_delay.establish_wait if parameters.update_delay.establish_wait is vyos_defined }}
+{% endif %}
 {% if srv6.locator is vyos_defined %}
  segment-routing srv6
   locator {{ srv6.locator }}

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -1687,6 +1687,41 @@
         </leafNode>
       </children>
     </node>
+    <node name="update-delay">
+      <properties>
+        <help>BGP update-delay read-only mode</help>
+      </properties>
+      <children>
+        <leafNode name="max-delay">
+          <properties>
+            <help>Maximum delay before exiting read-only mode</help>
+            <valueHelp>
+              <format>u32:0</format>
+              <description>Disable feature</description>
+            </valueHelp>
+            <valueHelp>
+              <format>u32:1-3600</format>
+              <description>Delay in seconds</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 0-3600"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="establish-wait">
+          <properties>
+            <help>Time to wait for peers to reach Established state before determining expected peers</help>
+            <valueHelp>
+              <format>u32:1-3600</format>
+              <description>Wait time in seconds</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 1-3600"/>
+            </constraint>
+          </properties>
+        </leafNode>
+      </children>
+    </node>
   </children>
 </node>
 <tagNode name="peer-group">

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -329,6 +329,8 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         tcp_keepalive_idle = '66'
         tcp_keepalive_interval = '77'
         tcp_keepalive_probes = '22'
+        max_delay = '120'
+        establish_wait = '60'
 
         self.cli_set(base_path + ['parameters', 'allow-martian-nexthop'])
         self.cli_set(base_path + ['parameters', 'disable-ebgp-connected-route-check'])
@@ -376,6 +378,21 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['address-family', 'ipv6-unicast', 'maximum-paths', 'ebgp', max_path_v6])
         self.cli_set(base_path + ['address-family', 'ipv6-unicast', 'maximum-paths', 'ibgp', max_path_v6ibgp])
 
+        # BGP update-delay
+        self.cli_set(
+            base_path + ['parameters', 'update-delay', 'establish-wait', '200']
+        )
+        # establish-wait should not be set without max-delay
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(base_path + ['parameters', 'update-delay', 'max-delay', max_delay])
+        # establish-wait should not be greater than max-delay
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(
+            base_path + ['parameters', 'update-delay', 'establish-wait', establish_wait]
+        )
+
         # commit changes
         self.cli_commit()
 
@@ -408,6 +425,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f' bgp tcp-keepalive {tcp_keepalive_idle} {tcp_keepalive_interval} {tcp_keepalive_probes}', frrconfig)
         self.assertNotIn(f'bgp ebgp-requires-policy', frrconfig)
         self.assertIn(f' no bgp suppress-duplicates', frrconfig)
+        self.assertIn(f' update-delay {max_delay} {establish_wait}', frrconfig)
 
         afiv4_config = self.getFRRconfig(f'router bgp {ASN}', stop_section='^exit',
                                          start_subsection=' address-family ipv4 unicast',

--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -478,6 +478,20 @@ def verify(config_dict):
         if not {'idle', 'interval', 'probes'} <= set(bgp['parameters']['tcp_keepalive']):
             raise ConfigError('TCP keepalive incomplete - idle, keepalive and probes must be set')
 
+    # Validate BGP update-delay: 'establish-wait' requires 'max-delay' and must not exceed it
+    if dict_search('parameters.update_delay', bgp) != None:
+        update_delay = dict_search('parameters.update_delay.max_delay', bgp)
+        establish_wait = dict_search('parameters.update_delay.establish_wait', bgp)
+        if establish_wait is not None:
+            if update_delay is None:
+                raise ConfigError(
+                    'BGP update-delay establish-wait requires max-delay to be set!'
+                )
+            if int(establish_wait) > int(update_delay):
+                raise ConfigError(
+                    'BGP update-delay establish-wait cannot be greater than max-delay!'
+                )
+
     # Address Family specific validation
     if 'address_family' in bgp:
         for afi, afi_config in bgp['address_family'].items():


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8607
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-documentation/pull/1891
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set protocols bgp system-as 65001

vyos@r10# set protocols bgp parameters update-delay 
Possible completions:
   establish-wait       Time to wait for peers to reach Established state during update delay
   max-delay            Maximum delay for BGP updates after restart or clear

      
[edit]
vyos@r10# set protocols bgp parameters update-delay establish-wait 200
[edit]
vyos@r10# commit
BGP update-delay establish-wait requires max-delay to be set!
[[protocols bgp]] failed
Commit failed
[edit]
vyos@r10# set protocols bgp parameters update-delay max-delay 100
[edit]
vyos@r10# commit
[ protocols bgp ]
BGP update-delay establish-wait cannot be greater than max-delay!
[[protocols bgp]] failed
Commit failed
[edit]
vyos@r10# set protocols bgp parameters update-delay max-delay 210
[edit]
vyos@r10# commit
[ protocols bgp ]

[edit]
vyos@r10# cat /run/frr/config/frr.conf 
frr version 10.5.2
frr defaults traditional
hostname r10
log syslog notifications
log timestamp precision 3
no log unique-id
service integrated-vtysh-config
!
ip route 0.0.0.0/0 10.217.32.254 eth2 tag 210 210
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp reject-as-sets
 no bgp default ipv4-unicast
 update-delay 210 200
 no bgp network import-check
exit
!
[edit]

vyos@r10# /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py -k test_bgp_01_simple
test_bgp_01_simple (__main__.TestProtocolsBGP.test_bgp_01_simple) ... ok

----------------------------------------------------------------------
Ran 1 test in 33.299s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
