### PR TITLE
T8467: fix obscured definition of completion help in XML

### DIFF
--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -1719,7 +1719,6 @@
     #include <include/bgp/neighbor-disable-connected-check.xml.i>
     #include <include/bgp/neighbor-ebgp-multihop.xml.i>
     #include <include/bgp/neighbor-graceful-restart.xml.i>
-    #include <include/bgp/neighbor-graceful-restart.xml.i>
     #include <include/bgp/neighbor-local-as.xml.i>
     #include <include/bgp/neighbor-local-role.xml.i>
     #include <include/bgp/neighbor-override-capability.xml.i>

--- a/interface-definitions/system_conntrack.xml.in
+++ b/interface-definitions/system_conntrack.xml.in
@@ -84,7 +84,6 @@
                           </completionHelp>
                         </properties>
                       </leafNode>
-                      #include <include/ip-protocol.xml.i>
                       <leafNode name="protocol">
                         <properties>
                           <help>Protocol to match (protocol name, number, or "all")</help>
@@ -170,7 +169,6 @@
                           </completionHelp>
                         </properties>
                       </leafNode>
-                      #include <include/ip-protocol.xml.i>
                       <leafNode name="protocol">
                         <properties>
                           <help>Protocol to match (protocol name, number, or "all")</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The result here is rather trivial, however, it is necessary for implementation of overriding help elements in interface definitions (https://vyos.dev/T8360); it is recommended as correcting a loss of information, even if the case itself is of minor importance.

Inclusion of common XML definitions in assembling the final (valid) XML interface definitions is indispensable, however, one must exercise care in not obscuring definitions: the script `build-command-templates` will only populate a `node.def` file on the first occurrence of an element.

Thankfully, the test script included below only finds one case of loss of information, contained in the first commit. The second commit simply removes a redundant include, discovered by the test script.

Running the test script after merging these fixes reveals two remaining cases:
(1)  a non-problematic 'collision' in firewall.xml. A collision is defined as two XML blocks at the same path containing properties elements containing more than just the help entry (which is often repeated at subsequent path definitions, when defining new children). In the case of firewall.xml it is due to multiple inclusions of the same block, under different names: `interface-definitions/include/firewall/action.xml.i` and `interface-definitions/include/firewall/action-forward.xml.i` have the same content.
(2) a non-trivial difference in help text at the same path in `build/interface-definitions/vpp.xml`. This is precisely a case to be addressed in https://vyos.dev/T8360, for which this PR is a prerequisite.

For reference, the test script used is attached.
[check-redundant-properties.py](https://github.com/user-attachments/files/27450298/check-redundant-properties.py)

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Without this PR:
```
vyos@vyos# set system conntrack ignore ipv4 rule 137 protocol <tab>
Possible completions:
   <text>               Protocol name
   ah                   
   ax.25                
   dccp                 
   ...
```

With this PR:
```
vyos@vyos# set system conntrack ignore ipv4 rule 137 protocol <tab>
Possible completions:
   all                  All IP protocols
   tcp_udp              Both TCP and UDP
   <0-255>              IP protocol number
   <protocol>           IP protocol name
   !<protocol>          IP protocol name
   ah                   
   ax.25                
   dccp
   ...

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
