### PR TITLE
T8598: [Security Fix] CLI support to configure a secret for "ipv6-peer-interface-id calling-sid"

### DIFF
--- a/data/templates/accel-ppp/ppp-options.j2
+++ b/data/templates/accel-ppp/ppp-options.j2
@@ -30,6 +30,9 @@ ipv6-peer-intf-id=ipv4
 ipv6-peer-intf-id={{ ppp_options.ipv6_peer_interface_id }}
 {%         endif %}
 {%     endif %}
+{%     if ppp_options.ipv6_peer_interface_id_secret is vyos_defined %}
+ipv6-peer-intf-id-secret={{ ppp_options.ipv6_peer_interface_id_secret }}
+{%     endif %}
 ipv6-accept-peer-intf-id={{ "1" if ppp_options.ipv6_accept_peer_interface_id is vyos_defined else "0" }}
 {% endif %}
 {# MTU #}

--- a/interface-definitions/include/accel-ppp/ppp-options-ipv6-interface-id.xml.i
+++ b/interface-definitions/include/accel-ppp/ppp-options-ipv6-interface-id.xml.i
@@ -45,6 +45,19 @@
     </constraint>
   </properties>
 </leafNode>
+<leafNode name="ipv6-peer-interface-id-secret">
+  <properties>
+    <help>Secret key for generating calling-sid based IPv6 peer interface identifier (IID)</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>Secret key string used with ipv6-peer-interface-id calling-sid</description>
+    </valueHelp>
+    <constraint>
+        <regex>^[!-~]{16,128}$</regex>
+    </constraint>
+      <constraintErrorMessage>Secret must be 16 to 128 printable non-whitespace ASCII characters</constraintErrorMessage>
+  </properties>
+</leafNode>
 <leafNode name="ipv6-accept-peer-interface-id">
   <properties>
     <help>Accept peer interface identifier</help>

--- a/src/conf_mode/service_pppoe-server.py
+++ b/src/conf_mode/service_pppoe-server.py
@@ -37,6 +37,16 @@ airbag.enable()
 
 pppoe_conf = r'/run/accel-pppd/pppoe.conf'
 pppoe_chap_secrets = r'/run/accel-pppd/pppoe.chap-secrets'
+iid_secret_min_len = 16
+iid_secret_max_len = 128
+
+def _is_safe_ascii_secret(value):
+    # Restrict to ASCII printable non-whitespace characters.
+    return value.isascii() and all(ch.isprintable() and not ch.isspace() for ch in value)
+
+def _is_valid_iid_secret(value):
+    return iid_secret_min_len <= len(value) <= iid_secret_max_len and _is_safe_ascii_secret(value)
+
 
 def convert_pado_delay(pado_delay):
     new_pado_delay = {'delays_without_sessions': [],
@@ -74,6 +84,10 @@ def get_config(config=None):
     conditions = [is_node_changed(conf, base + ['client-ip-pool']),
                   is_node_changed(conf, base + ['client-ipv6-pool']),
                   is_node_changed(conf, base + ['interface'])]
+                  # IPv6 peer IID mode/secret affect negotiated session state.
+                  # Restart is required to force existing sessions to re-negotiate.
+                  is_node_changed(conf, base + ['ppp-options', 'ipv6-peer-interface-id']),
+                  is_node_changed(conf, base + ['ppp-options', 'ipv6-peer-interface-id-secret']),
     if any(conditions):
         pppoe.update({'restart_required': {}})
     pppoe['server_type'] = 'pppoe'
@@ -116,6 +130,17 @@ def verify(pppoe):
     verify_accel_ppp_name_servers(pppoe)
     verify_accel_ppp_wins_servers(pppoe)
     verify_pado_delay(pppoe)
+
+    peer_id_mode = dict_search('ppp_options.ipv6_peer_interface_id', pppoe)
+    peer_id_secret = dict_search('ppp_options.ipv6_peer_interface_id_secret', pppoe)
+    if peer_id_mode == 'calling-sid':
+        if not peer_id_secret:
+            raise ConfigError('ppp-options ipv6-peer-interface-id calling-sid requires ipv6-peer-interface-id-secret')
+        if not _is_valid_iid_secret(peer_id_secret):
+            raise ConfigError(
+                f'ppp-options ipv6-peer-interface-id-secret must be {iid_secret_min_len} to '
+                f'{iid_secret_max_len} printable non-whitespace ASCII characters'
+            )
 
     if 'interface' not in pppoe:
         raise ConfigError('At least one listen interface must be defined!')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

- CLI support to configure a secret which will be used along with calling-station-id, to generate Peer Interface Identifier (IID).
- Secret must be 16 to 128 printable non-whitespace ASCII characters.
- The secret-key can be any user string or can be generated using the existing op-mode command (1 byte = 2 characters. so for generating 16 characters use byte-size = 8):

        `run generate psk random size <byte-size>`
        
- Below actions will drop existing sessions and trigger the re-negotiation/re-creation of session with the new config.    

1. 	Deleting peer IID calling-sid config
2. 	Changing the calling-sid secret

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8598

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
When "ipv6-peer-interface-id calling-sid" is configured, an IPv6 peer IID must be generated. Below PR(#687) implements the code to generate that peer IID using the secret that we configure through the CLI being supported in this PR.
https://github.com/VyOS-Networks/vyos-build/pull/687

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

CLI VALIDATION
=> Short secret
```
vyos@vyos# set service pppoe-server ppp-options ipv6-peer-interface-id-secret your-secret
   
  Secret must be 16 to 128 printable non-whitespace ASCII characters
  Value validation failed
  Set failed
```

=> Long secret
```
vyos@vyos# run generate psk random size 65
f9b3959d00cd1f34c6a5a8d41555802ba5c4a8941c064c77674e975366e6dbf8cf3e073372e4e0ba594cd6294c99bd61276255fc80f621a44f25f994ba2d322366
[edit]
vyos@vyos# set service pppoe-server ppp-options ipv6-peer-interface-id-secret f9b3959d00cd1f34c6a5a8d41555802ba5c4a8941c064c77674e975366e6dbf8cf3e073372e4e0ba594cd6294c99bd61276255fc80f621a44f25f994ba2d322366 
  
  Secret must be 16 to 128 printable non-whitespace ASCII characters
  Value validation failed
  Set failed
```

=> Invalid secret (space and control chars)
```
vyos@vyos# set service pppoe-server ppp-options ipv6-peer-interface-id-secret 39041db23cdd7e143171cc08d3929963e685a5339ec01746c22b89e9c98c26c2462944a84cabb9e46324f6e40288292cadee23823757b7ab6 abc

  Configuration path: service pppoe-server ppp-options ipv6-peer-interface-id-secret 39041db23cdd7e143171cc08d3929963e685a5339ec01746c22b89e9c98c26c2462944a84cabb9e46324f6e40288292cadee23823757b7ab6 [abc] is not valid
  Set failed

vyos@vyos# set service pppoe-server ppp-options ipv6-peer-interface-id-secret "19e0dc3f9d980d94a7b4d16f7651dcbe121d006f8c351f99913506130c119  85a"
  
  Secret must be 16 to 128 printable non-whitespace ASCII characters
  Value validation failed
  Set failed
  
vyos@vyos# set service pppoe-server ppp-options ipv6-peer-interface-id-secret 39041db23cdd7e143171cc08d3929963e685a5339ec01746c22b89e9c98c26c2462944a84cabb9e46324f6e40288292cadee23823757b7ab663bb7494256135d%abc
  
  Secret must be 16 to 128 printable non-whitespace ASCII characters
  Value validation failed
  Set failed
```

=> Delete only secret and keep calling-sid config - Not allowed
```
vyos@vyos# del  service pppoe-server ppp-options ipv6-peer-interface-id-secret
vyos@vyos# commit
[ service pppoe-server ]
ppp-options ipv6-peer-interface-id calling-sid requires ipv6-peer-
interface-id-secret
[[service pppoe-server]] failed
Commit failed
```

=> Configure only calling-sid and no secret - Not allowed
```
vyos@vyos# set service pppoe-server ppp-options ipv6-peer-interface-id calling-sid
vyos@vyos# commit
[ service pppoe-server ]
ppp-options ipv6-peer-interface-id calling-sid requires ipv6-peer-
interface-id-secret
[[service pppoe-server]] failed
Commit failed

```
=> Configure valid secret
```
vyos@vyos# run generate psk random size 32
19e0dc3f9d980d94a7b4d16f7651dcbe121d006f8c351f99913506130c11985a
[edit]
vyos@vyos# set service pppoe-server ppp-options ipv6-peer-interface-id-secret 19e0dc3f9d980d94a7b4d16f7651dcbe121d006f8c351f99913506130c11985a
[edit]
vyos@vyos# commit
```
=> Create a PPPoE session that will use peer-IID (A = c8eb:cd29:cad9:788b) generated using the secret 
```
May 05 17:49:52 accel-pppoe[69543]: ppp0:: connect: ppp0 <--> pppoe(12:0f:f2:96:c2:00)
May 05 17:49:52 accel-pppoe[69543]: ppp0:: send [CCP ConfReq id=11 <mppe +H -M +S -L -D -C>]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: recv [IPCP ConfReq id=1 <addr 0.0.0.0> <dns1 0.0.0.0> <dns2 0.0.0.0>]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: send [IPCP ConfReq id=80 <addr 10.111.0.1>]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: send [IPCP ConfRej id=1 <dns1 0.0.0.0> <dns2 0.0.0.0>]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: recv [IPV6CP ConfReq id=1 <addr 590c:38ba:3dfc:4471>]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: send [IPV6CP ConfReq id=40 <addr 100:0:0:0>]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: send [IPV6CP ConfNak id=1 <addr c8eb:cd29:cad9:788b>]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: recv [CCP ConfReq id=1]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: send [CCP ConfAck id=1]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: recv [CCP ConfRej id=11]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: send [CCP ConfReq id=12]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: recv [IPCP ConfAck id=80 <addr 10.111.0.1>]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: recv [IPCP ConfReq id=2 <addr 0.0.0.0>]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: send [IPCP ConfNak id=2 <addr 10.111.0.0>]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: recv [IPV6CP ConfAck id=40 <addr 100:0:0:0>]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: recv [IPV6CP ConfReq id=2 <addr c8eb:cd29:cad9:788b>]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: send [IPV6CP TermAck id=2]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: recv [CCP ConfAck id=12]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: recv [IPCP ConfReq id=3 <addr 10.111.0.0>]
May 05 17:49:52 accel-pppoe[69543]: ppp0:: send [IPCP ConfAck id=3]
May 05 17:49:53 (udev-worker)[69653]: Network interface NamePolicy= disabled on kernel command line.

May 05 17:49:53 vyos-netlinkd[69005]: RTM_NEWLINK -> ppp0, state=DOWN, mac=<unknown>
May 05 17:49:53 vyos-netlinkd[69005]: RTM_NEWLINK -> ppp0, state=DOWN, mac=<unknown>
May 05 17:49:54 vyos-netlinkd[69005]: RTM_NEWLINK -> ppp0, state=UNKNOWN, mac=<unknown>
May 05 17:49:55 accel-pppoe[69543]: ppp0:: recv [IPV6CP ConfReq id=2 <addr c8eb:cd29:cad9:788b>]
May 05 17:49:55 accel-pppoe[69543]: ppp0:: send [IPV6CP ConfAck id=2]
```

=> Delete config - Session is re-created and Default Fixed peer IID is used
```
vyos@vyos# del service pppoe-server ppp-options ipv6-peer-interface-id-secret
[edit]
vyos@vyos# del service pppoe-server ppp-options ipv6-peer-interface-id
[edit]
vyos@vyos# commit

May 05 17:55:26 accel-pppoe[69698]: ppp0:: recv [IPCP ConfReq id=4 <addr 0.0.0.0> <dns1 0.0.0.0> <dns2 0.0.0.0>]
May 05 17:55:26 accel-pppoe[69698]: ppp0:: send [IPCP ConfReq id=8e <addr 10.111.0.1>]
May 05 17:55:26 accel-pppoe[69698]: ppp0:: send [IPCP ConfRej id=4 <dns1 0.0.0.0> <dns2 0.0.0.0>]
May 05 17:55:26 accel-pppoe[69698]: ppp0:: recv [IPV6CP ConfReq id=3 <addr 75a3:dd5e:ad83:c6b3>]
May 05 17:55:26 accel-pppoe[69698]: ppp0:: send [IPV6CP ConfReq id=b2 <addr 100:0:0:0>]
May 05 17:55:26 accel-pppoe[69698]: ppp0:: send [IPV6CP ConfNak id=3 <addr 200:0:0:0>]
May 05 17:55:26 accel-pppoe[69698]: ppp0:: recv [IPCP ConfAck id=8e <addr 10.111.0.1>]
May 05 17:55:26 accel-pppoe[69698]: ppp0:: recv [IPCP ConfReq id=5 <addr 0.0.0.0>]
May 05 17:55:26 accel-pppoe[69698]: ppp0:: send [IPCP ConfNak id=5 <addr 10.111.0.0>]
May 05 17:55:26 accel-pppoe[69698]: ppp0:: recv [IPV6CP ConfAck id=b2 <addr 100:0:0:0>]
May 05 17:55:26 accel-pppoe[69698]: ppp0:: recv [IPV6CP ConfReq id=4 <addr 200:0:0:0>]
May 05 17:55:26 accel-pppoe[69698]: ppp0:: send [IPV6CP ConfAck id=4]
May 05 17:55:26 accel-pppoe[69698]: ppp0:: recv [IPCP ConfReq id=6 <addr 10.111.0.0>]
May 05 17:55:26 accel-pppoe[69698]: ppp0:: send [IPCP ConfAck id=6]
```

=> Reapply the config with previously used secret - Session is re-created and same peer IID (A = c8eb:cd29:cad9:788b) is generated again to be used.

```
set service pppoe-server ppp-options ipv6-peer-interface-id-secret 19e0dc3f9d980d94a7b4d16f7651dcbe121d006f8c351f99913506130c11985a

May 05 18:04:35 accel-pppoe[69798]: ppp0:: recv [IPV6CP ConfReq id=5 <addr 889d:6fb0:fc4:e3f8>]
May 05 18:04:35 accel-pppoe[69798]: ppp0:: send [IPV6CP ConfReq id=4e <addr 100:0:0:0>]
May 05 18:04:35 accel-pppoe[69798]: ppp0:: send [IPV6CP ConfNak id=5 <addr c8eb:cd29:cad9:788b>]
May 05 18:04:35 accel-pppoe[69798]: ppp0:: recv [IPCP ConfAck id=45 <addr 10.111.0.1>]
May 05 18:04:35 accel-pppoe[69798]: ppp0:: recv [IPCP ConfReq id=8 <addr 0.0.0.0>]
May 05 18:04:35 accel-pppoe[69798]: ppp0:: send [IPCP ConfNak id=8 <addr 10.111.0.0>]
May 05 18:04:35 accel-pppoe[69798]: ppp0:: recv [IPV6CP ConfAck id=4e <addr 100:0:0:0>]
May 05 18:04:35 accel-pppoe[69798]: ppp0:: recv [IPV6CP ConfReq id=6 <addr c8eb:cd29:cad9:788b>]
May 05 18:04:35 accel-pppoe[69798]: ppp0:: send [IPV6CP ConfAck id=6]

```
=> change the secret - Session-recreated with a different peer IID - B
```
vyos@vyos# run generate psk random size 64
39041db23cdd7e143171cc08d3929963e685a5339ec01746c22b89e9c98c26c2462944a84cabb9e46324f6e40288292cadee23823757b7ab663bb7494256135d
[edit]
vyos@vyos# set service pppoe-server ppp-options ipv6-peer-interface-id-secret 39041db23cdd7e143171cc08d3929963e685a5339ec01746c22b89e9c98c26c2462944a84cabb9e46324f6e40288292cadee23823757b7ab663bb7494256135d

May 05 18:12:42 accel-pppoe[70291]: ppp0:: recv [IPV6CP ConfReq id=7 <addr 1074:2a87:4cd4:189f>]
May 05 18:12:42 accel-pppoe[70291]: ppp0:: send [IPV6CP ConfReq id=80 <addr 100:0:0:0>]
May 05 18:12:42 accel-pppoe[70291]: ppp0:: send [IPV6CP ConfNak id=7 <addr 596:61e5:b411:c506>]
May 05 18:12:42 accel-pppoe[70291]: ppp0:: recv [IPCP ConfAck id=47 <addr 10.111.0.1>]
May 05 18:12:42 accel-pppoe[70291]: ppp0:: recv [IPCP ConfReq id=b <addr 0.0.0.0>]
May 05 18:12:42 accel-pppoe[70291]: ppp0:: send [IPCP ConfNak id=b <addr 10.111.0.0>]
May 05 18:12:42 accel-pppoe[70291]: ppp0:: recv [IPV6CP ConfAck id=80 <addr 100:0:0:0>]
May 05 18:12:42 accel-pppoe[70291]: ppp0:: recv [IPV6CP ConfReq id=8 <addr 596:61e5:b411:c506>]
May 05 18:12:42 accel-pppoe[70291]: ppp0:: send [IPV6CP ConfAck id=8]

vyos@vyos# run sh pppoe-server sessions 
 ifname | username |     ip     |             ip6             | ip6-dp |    calling-sid    | rate-limit | state  |  uptime  | rx-bytes | tx-bytes 
--------+----------+------------+-----------------------------+--------+-------------------+------------+--------+----------+----------+----------
 ppp0   |          | 10.111.0.0 | fdc0::596:61e5:b411:c506/64 |        | 12:0f:f2:96:c2:00 |            | active | 00:01:46 | 692 B    | 1.3 KiB
```


=> Reboot the system with the saved config - same peer IID (column ip6) is generated again for the PPPoE session

Before reboot:
```
vyos@vyos# run sh pppoe-server sessions 
 ifname | username |     ip     |              ip6             | ip6-dp |    calling-sid    | rate-limit | state  |  uptime  | rx-bytes | tx-bytes 
--------+----------+------------+------------------------------+--------+-------------------+------------+--------+----------+----------+----------
 ppp0   |          | 10.111.0.0 | fdc0::c8eb:cd29:cad9:788b/64 |        | 12:0f:f2:96:c2:00 |            | active | 00:01:19 | 664 B    | 1.4 KiB
```

After reboot:
```
vyos@vyos# run sh pppoe-server sessions 
 ifname | username |     ip     |              ip6             | ip6-dp |    calling-sid    | rate-limit | state  |  uptime  | rx-bytes | tx-bytes 
--------+----------+------------+------------------------------+--------+-------------------+------------+--------+----------+----------+----------
 ppp0   |          | 10.111.0.0 | fdc0::c8eb:cd29:cad9:788b/64 |        | 12:0f:f2:96:c2:00 |            | active | 00:01:58 | 664 B    | 1.4 KiB
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
