### PR TITLE
wireguard: T8509: Add fwmark ip rules for VRF-bound interfaces

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_wireguard.py
+++ b/smoketest/scripts/cli/test_interfaces_wireguard.py
@@ -253,5 +253,62 @@ class WireGuardInterfaceTest(BasicInterfaceTest.TestCase):
         # Ensure the service is no longer running after WireGuard interface is deleted
         self.assertFalse(is_systemd_service_running(domain_resolver))
 
+    def test_wireguard_vrf_fwmark(self):
+        # T8509 Check fwmark ip rule created for WireGuard interface with VRF
+        interface = 'wg0'
+        port = '12345'
+        privkey = '6ISOkASm6VhHOOSz/5iIxw+Q9adq9zA17iMM4X40dlc='
+        pubkey = 'n1CUsmR0M2LUUsyicBd6blZICwUqqWWHbu4ifZ2/9gk='
+        mark = '101'
+        vrf_table = '200'
+        vrf = 'testvrf'
+
+        base_interface_path = base_path + [interface]
+        self.cli_set(base_interface_path + ['address', '172.16.0.1/24'])
+        self.cli_set(base_interface_path + ['private-key', privkey])
+        self.cli_set(base_interface_path + ['port', port])
+
+        peer_base_path = base_interface_path + ['peer', 'VyOS']
+        self.cli_set(peer_base_path + ['port', port])
+        self.cli_set(peer_base_path + ['public-key', pubkey])
+        self.cli_set(peer_base_path + ['allowed-ips', '169.254.0.0/16'])
+        self.cli_set(peer_base_path + ['address', '192.0.2.1'])
+
+        self.cli_set(base_interface_path + ['fwmark', mark])
+        self.cli_set(base_interface_path + ['vrf', vrf])
+        self.cli_set(['vrf', 'name', vrf, 'table', vrf_table])
+
+        self.cli_commit()
+
+        hex_fwmark = hex(int(mark))
+
+        # Verify ip rule at priority 1998 routes fwmark-tagged packets into the VRF
+        tmp = cmd(f'ip rule show priority 1998')
+        self.assertIn(f'fwmark {hex_fwmark} lookup {vrf}', tmp)
+
+        # Remove VRF from the interface — ip rule must be cleaned up
+        self.cli_delete(base_interface_path + ['vrf'])
+        self.cli_commit()
+
+        tmp = cmd(f'ip rule show priority 1998')
+        self.assertNotIn(f'fwmark {hex_fwmark}', tmp)
+
+        # Re-add VRF — ip rule must be re-created
+        self.cli_set(base_interface_path + ['vrf', vrf])
+        self.cli_commit()
+
+        tmp = cmd(f'ip rule show priority 1998')
+        self.assertIn(f'fwmark {hex_fwmark} lookup {vrf}', tmp)
+
+        # Delete the interface entirely — ip rule must be removed
+        self.cli_delete(base_interface_path)
+        self.cli_commit()
+
+        tmp = cmd(f'ip rule show priority 1998')
+        self.assertNotIn(f'fwmark {hex_fwmark}', tmp)
+
+        self.cli_delete(['vrf', 'name', vrf])
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/src/conf_mode/interfaces_wireguard.py
+++ b/src/conf_mode/interfaces_wireguard.py
@@ -34,6 +34,7 @@ from vyos.configverify import verify_bond_bridge_member
 from vyos.ifconfig import WireGuardIf
 from vyos.utils.kernel import check_kmod
 from vyos.utils.network import check_port_availability
+from vyos.utils.network import get_vrf_tableid
 from vyos.utils.network import is_wireguard_key_pair
 from vyos.utils.process import call
 from vyos import ConfigError
@@ -74,6 +75,16 @@ def get_config(config=None):
             set_dependents('vxlan', conf, tmp)
         else:
             wireguard['is_source_interface'] = tmp
+
+    if is_node_changed(conf, base + [ifname, 'fwmark']) or is_node_changed(
+        conf, base + [ifname, 'vrf']
+    ):
+        wireguard['fwmark_vrf_changed'] = {}
+        prev = conf.get_config_dict(
+            base + [ifname], effective=True, key_mangling=('-', '_'), get_first_key=True
+        )
+        wireguard['prev_fwmark'] = prev.get('fwmark')
+        wireguard['prev_vrf'] = prev.get('vrf')
 
     return wireguard
 
@@ -153,6 +164,29 @@ def apply(wireguard):
         wg.remove()
     else:
         wg.update(wireguard)
+
+    # delete old fwmark-based ip rule if fwmark or VRF was changed
+    if 'fwmark_vrf_changed' in wireguard or 'deleted' in wireguard:
+        prev_fwmark = wireguard.get('prev_fwmark')
+        prev_vrf = wireguard.get('prev_vrf')
+        if prev_fwmark is not None and prev_vrf is not None:
+            table_id = get_vrf_tableid(prev_vrf)
+            if table_id is not None:
+                for afi in ['-4', '-6']:
+                    call(
+                        f'ip {afi} rule del pref 1998 fwmark {prev_fwmark} table {table_id}'
+                    )
+
+    # Add ip rule to route fwmark-marked WireGuard tunnel packets into the
+    # correct VRF routing table. This is required for VRF-bound WireGuard
+    # interfaces with fwmark set, so that outgoing encapsulated packets use the
+    # proper VRF routes (otherwise, they may be unroutable or use the main table).
+    if wireguard.get('fwmark', '0') != '0' and 'vrf' in wireguard:
+        table_id = get_vrf_tableid(wireguard['vrf'])
+        for afi in ['-4', '-6']:
+            call(
+                f'ip {afi} rule add pref 1998 fwmark {wireguard["fwmark"]} table {table_id}'
+            )
 
     domain_resolver_usage = '/run/use-vyos-domain-resolver-interfaces-wireguard-' + wireguard['ifname']
 

--- a/src/conf_mode/vrf.py
+++ b/src/conf_mode/vrf.py
@@ -265,6 +265,12 @@ def apply(vrf):
                 # Remove map element
                 cmd(f'nft {nft_del_element}')
 
+            # Remove all ip rules pointing to this VRF table
+            table_id = get_vrf_tableid(tmp)
+            for afi in ['-4', '-6']:
+                while call(f'ip {afi} rule del table {table_id}') == 0:
+                    pass
+
             # Delete the VRF Kernel interface
             call(f'ip link delete dev {tmp}')
 


### PR DESCRIPTION
When a WireGuard interface has both fwmark and VRF configured, outgoing tunnel packets marked with the fwmark were not routed into the correct VRF routing table, causing them to hit the l3mdev unreachable rule instead. Add an ip rule at priority 1998 (after l3mdev at 1000 and before l3mdev unreachable at 2000) to route fwmark-tagged packets into the correct VRF routing table.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8509
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set interfaces wireguard wg99 address '172.27.42.2/30'
set interfaces wireguard wg99 fwmark '101'
set interfaces wireguard wg99 peer CFBOM address '100.96.0.2'
set interfaces wireguard wg99 peer CFBOM allowed-ips '0.0.0.0/0'
set interfaces wireguard wg99 peer CFBOM port '10006'
set interfaces wireguard wg99 peer CFBOM public-key 'XXXXXXXXXX'
set interfaces wireguard wg99 port '49501'
set interfaces wireguard wg99 private-key 'XXXXXXXXXX'
set interfaces wireguard wg99 vrf 'TEST'
set vrf name TEST table '101'

vyos@r10# ip rule show
1000:	from all lookup [l3mdev-table]
1998:	from all fwmark 0x65 lookup TEST
2000:	from all lookup [l3mdev-table] unreachable
32765:	from all lookup local
32766:	from all lookup main
32767:	from all lookup default
[edit]

vyos@r10:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_wireguard.py -k test_wireguard_vrf_fwmark
test_wireguard_vrf_fwmark (__main__.WireGuardInterfaceTest.test_wireguard_vrf_fwmark) ... ok

----------------------------------------------------------------------
Ran 1 test in 23.812s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
