### PR TITLE
T8600: Add option to change logging verbosity in Kea

### DIFF
--- a/data/templates/dhcp-server/kea-dhcp-ddns.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp-ddns.conf.j2
@@ -27,7 +27,7 @@
                         "pattern": "%-5p %m\n"
                     }
                 ],
-                "severity": "INFO",
+                "severity": "{{ log_level | upper }}",
                 "debuglevel": 0
             }
         ]

--- a/data/templates/dhcp-server/kea-dhcp4.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp4.conf.j2
@@ -96,7 +96,20 @@
             }
         ],
 {% if shared_network_name is vyos_defined %}
-        "shared-networks": {{ shared_network_name | kea_shared_network_json }}
+        "shared-networks": {{ shared_network_name | kea_shared_network_json }},
 {% endif %}
+        "loggers": [
+            {
+                "name": "kea-dhcp4",
+                "output_options": [
+                    {
+                        "output": "stdout",
+                        "pattern": "%-5p %m\n"
+                    }
+                ],
+                "severity": "{{ log_level | upper }}",
+                "debuglevel": 0
+            }
+        ]
     }
 }

--- a/data/templates/dhcp-server/kea-dhcp6.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp6.conf.j2
@@ -59,8 +59,20 @@
 {% endif %}
         ],
 {% if shared_network_name is vyos_defined %}
-        "shared-networks": {{ shared_network_name | kea6_shared_network_json }}
+        "shared-networks": {{ shared_network_name | kea6_shared_network_json }},
 {% endif %}
-
+        "loggers": [
+            {
+                "name": "kea-dhcp6",
+                "output_options": [
+                    {
+                        "output": "stdout",
+                        "pattern": "%-5p %m\n"
+                    }
+                ],
+                "severity": "{{ log_level | upper }}",
+                "debuglevel": 0
+            }
+        ]
     }
 }

--- a/interface-definitions/include/dhcp/dhcp-server-common-config.xml.i
+++ b/interface-definitions/include/dhcp/dhcp-server-common-config.xml.i
@@ -228,6 +228,7 @@
     <valueless/>
   </properties>
 </leafNode>
+#include <include/dhcp/log-level.xml.i>
 #include <include/listen-address-ipv4.xml.i>
 #include <include/listen-interface-multi-broadcast.xml.i>
 <tagNode name="shared-network-name">

--- a/interface-definitions/include/dhcp/dhcpv6-server-common-config.xml.i
+++ b/interface-definitions/include/dhcp/dhcpv6-server-common-config.xml.i
@@ -28,6 +28,7 @@
     <constraintErrorMessage>Preference must be between 0 and 255</constraintErrorMessage>
   </properties>
 </leafNode>
+#include <include/dhcp/log-level.xml.i>
 <tagNode name="shared-network-name">
   <properties>
     <help>DHCPv6 shared network name</help>

--- a/interface-definitions/include/dhcp/log-level.xml.i
+++ b/interface-definitions/include/dhcp/log-level.xml.i
@@ -1,0 +1,34 @@
+<!-- include start from dhcp/log-level.xml.i -->
+<leafNode name="log-level">
+  <properties>
+    <help>Logging level</help>
+    <completionHelp>
+      <list>fatal error warn info debug</list>
+    </completionHelp>
+    <valueHelp>
+      <format>fatal</format>
+      <description>Fatal log level</description>
+    </valueHelp>
+    <valueHelp>
+      <format>error</format>
+      <description>Error log level</description>
+    </valueHelp>
+    <valueHelp>
+      <format>warn</format>
+      <description>Warning log level</description>
+    </valueHelp>
+    <valueHelp>
+      <format>info</format>
+      <description>Informational log level</description>
+    </valueHelp>
+    <valueHelp>
+      <format>debug</format>
+      <description>Debug log level</description>
+    </valueHelp>
+    <constraint>
+      <regex>(fatal|error|warn|info|debug)</regex>
+    </constraint>
+  </properties>
+  <defaultValue>info</defaultValue>
+</leafNode>
+<!-- include end -->

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -1800,6 +1800,39 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         host_json = cmd(f'{HOSTSD_CLIENT} --get-hosts {tag_regex}')
         self.assertTrue(host_json)
 
+    def test_dhcp_log_level(self):
+        shared_net_name = 'SMOKE-TEST'
+        subnet_range_start = inc_ip(subnet, 10)
+        subnet_range_stop = inc_ip(subnet, 20)
+        log_level = 'error'
+
+        pool = base_path + ['shared-network-name', shared_net_name, 'subnet', subnet]
+        self.cli_set(pool + ['subnet-id', '1'])
+        self.cli_set(pool + ['option', 'domain-name', domain_name])
+        self.cli_set(pool + ['range', '0', 'start', subnet_range_start])
+        self.cli_set(pool + ['range', '0', 'stop', subnet_range_stop])
+
+        # Set log level
+        self.cli_set(base_path + ['log-level', log_level])
+        self.cli_commit()
+
+        config = read_file(KEA4_CONF)
+        obj = loads(config)
+
+        # Check log level is ERROR
+        self.verify_config_value(obj, ['Dhcp4', 'loggers', 0], 'name', 'kea-dhcp4')
+        self.verify_config_value(
+            obj, ['Dhcp4', 'loggers', 0], 'severity', log_level.upper()
+        )
+
+        # Delete log-level and check it is set to default INFO
+        self.cli_delete(base_path + ['log-level'])
+        self.cli_commit()
+
+        config = read_file(KEA4_CONF)
+        obj = loads(config)
+        self.verify_config_value(obj, ['Dhcp4', 'loggers', 0], 'severity', 'INFO')
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/src/conf_mode/service_dhcpv6-server.py
+++ b/src/conf_mode/service_dhcpv6-server.py
@@ -93,7 +93,11 @@ def get_config(config=None):
         return None
 
     dhcpv6 = conf.get_config_dict(
-        base, key_mangling=('-', '_'), get_first_key=True, no_tag_node_value_mangle=True
+        base,
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+        with_recursive_defaults=True,
     )
 
     # add vrf context if present


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8600
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set service dhcp-server dynamic-dns-update replace-client-name 'never'
set service dhcp-server shared-network-name LAN subnet 192.168.100.0/24 lease '86400'
set service dhcp-server shared-network-name LAN subnet 192.168.100.0/24 option default-router '192.168.100.1'
set service dhcp-server shared-network-name LAN subnet 192.168.100.0/24 option domain-name 'vyos.net'
set service dhcp-server shared-network-name LAN subnet 192.168.100.0/24 option name-server '192.168.100.1'
set service dhcp-server shared-network-name LAN subnet 192.168.100.0/24 option static-route 192.168.0.0/16 next-hop '192.168.100.1'
set service dhcp-server shared-network-name LAN subnet 192.168.100.0/24 range 0 start '192.168.100.10'
set service dhcp-server shared-network-name LAN subnet 192.168.100.0/24 range 0 stop '192.168.100.20'
set service dhcp-server shared-network-name LAN subnet 192.168.100.0/24 subnet-id '1'

vyos@r10# set service dhcp-server log-level 
Possible completions:
   fatal                Fatal log level
   error                Error log level
   warn                 Warning log level
   info                 Informational log level (default)
   debug                Debug log level
                        

      
[edit]
vyos@r10# set service dhcp-server log-level warn
[edit]
vyos@r10# commit
[edit]
vyos@r10# jq '.Dhcp4.loggers' /run/kea/kea-dhcp4.conf
[
  {
    "name": "kea-dhcp4",
    "output_options": [
      {
        "output": "stdout",
        "pattern": "%-5p %m\n"
      }
    ],
    "severity": "WARN",
    "debuglevel": 0
  }
]

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
