### PR TITLE
Policy: T8823: validation of GE and LE according FRR instructions

### DIFF
--- a/smoketest/scripts/cli/test_policy.py
+++ b/smoketest/scripts/cli/test_policy.py
@@ -709,6 +709,56 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
         for rule in test_range:
             tmp = f'ip prefix-list {prefix_list} seq {rule} permit {prefix} le {rule}'
             self.assertIn(tmp, config)
+    def test_prefix_list_ge_le_validation(self):
+        # FRR requires mask_length <= ge <= le for prefix-list rules
+        base = base_path + ['prefix-list', 'getest', 'rule', '10']
+        base6 = base_path + ['prefix-list6', 'getest6', 'rule', '10']
+
+        # ge < mask_length should be rejected
+        self.cli_set(base + ['action', 'permit'])
+        self.cli_set(base + ['prefix', '192.0.2.0/24'])
+        self.cli_set(base + ['ge', '16'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(base + ['ge'])
+
+        # le < mask_length should be rejected
+        self.cli_set(base + ['le', '16'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(base + ['le'])
+
+        # ge > le should be rejected
+        self.cli_set(base + ['ge', '28'])
+        self.cli_set(base + ['le', '26'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(base + ['ge'])
+        self.cli_delete(base + ['le'])
+
+        # valid ge <= le >= mask_length should commit
+        self.cli_set(base + ['ge', '25'])
+        self.cli_set(base + ['le', '28'])
+        self.cli_commit()
+        self.cli_delete(base_path + ['prefix-list', 'getest'])
+
+        # same checks for prefix-list6
+        self.cli_set(base6 + ['action', 'permit'])
+        self.cli_set(base6 + ['prefix', '2a06:9801:2c0::/44'])
+        self.cli_set(base6 + ['ge', '48'])
+        self.cli_set(base6 + ['le', '44'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(base6 + ['ge'])
+        self.cli_delete(base6 + ['le'])
+
+        # valid IPv6 ge/le
+        self.cli_set(base6 + ['ge', '48'])
+        self.cli_set(base6 + ['le', '64'])
+        self.cli_commit()
+        self.cli_delete(base_path + ['prefix-list6', 'getest6'])
+        self.cli_commit()
+
     def test_route_map_community_set(self):
         test_data = {
             "community-configuration": {

--- a/smoketest/scripts/cli/test_policy.py
+++ b/smoketest/scripts/cli/test_policy.py
@@ -709,6 +709,7 @@ class TestPolicy(VyOSUnitTestSHIM.TestCase):
         for rule in test_range:
             tmp = f'ip prefix-list {prefix_list} seq {rule} permit {prefix} le {rule}'
             self.assertIn(tmp, config)
+
     def test_prefix_list_ge_le_validation(self):
         # FRR requires mask_length <= ge <= le for prefix-list rules
         base = base_path + ['prefix-list', 'getest', 'rule', '10']

--- a/src/conf_mode/policy.py
+++ b/src/conf_mode/policy.py
@@ -168,8 +168,10 @@ def verify(config_dict):
                         raise ConfigError(f'A prefix {mandatory_error}')
 
                     mask_len = int(rule_config['prefix'].split('/')[1])
-                    ge = int(rule_config['ge']) if 'ge' in rule_config else None
-                    le = int(rule_config['le']) if 'le' in rule_config else None
+                    ge = dict_search('ge', rule_config)
+                    le = dict_search('le', rule_config)
+                    ge = int(ge) if ge is not None else None
+                    le = int(le) if le is not None else None
 
                     if ge is not None and ge < mask_len:
                         raise ConfigError(

--- a/src/conf_mode/policy.py
+++ b/src/conf_mode/policy.py
@@ -170,20 +170,18 @@ def verify(config_dict):
                     mask_len = int(rule_config['prefix'].split('/')[1])
                     ge = dict_search('ge', rule_config)
                     le = dict_search('le', rule_config)
-                    ge = int(ge) if ge is not None else None
-                    le = int(le) if le is not None else None
 
-                    if ge is not None and ge < mask_len:
+                    if ge and int(ge) < mask_len:
                         raise ConfigError(
                             f'{policy_hr} {instance} rule {rule}: "ge" ({ge}) must be >= '
                             f'prefix length ({mask_len})'
                         )
-                    if le is not None and le < mask_len:
+                    if le and int(le) < mask_len:
                         raise ConfigError(
                             f'{policy_hr} {instance} rule {rule}: "le" ({le}) must be >= '
                             f'prefix length ({mask_len})'
                         )
-                    if ge is not None and le is not None and ge > le:
+                    if ge and le and int(ge) > int(le):
                         raise ConfigError(
                             f'{policy_hr} {instance} rule {rule}: "ge" ({ge}) must be <= '
                             f'"le" ({le})'

--- a/src/conf_mode/policy.py
+++ b/src/conf_mode/policy.py
@@ -174,15 +174,18 @@ def verify(config_dict):
                     if ge is not None and ge < mask_len:
                         raise ConfigError(
                             f'{policy_hr} {instance} rule {rule}: "ge" ({ge}) must be >= '
-                            f'prefix length ({mask_len})')
+                            f'prefix length ({mask_len})'
+                        )
                     if le is not None and le < mask_len:
                         raise ConfigError(
                             f'{policy_hr} {instance} rule {rule}: "le" ({le}) must be >= '
-                            f'prefix length ({mask_len})')
+                            f'prefix length ({mask_len})'
+                        )
                     if ge is not None and le is not None and ge > le:
                         raise ConfigError(
                             f'{policy_hr} {instance} rule {rule}: "ge" ({ge}) must be <= '
-                            f'"le" ({le})')
+                            f'"le" ({le})'
+                        )
 
                     if rule_config in entries:
                         raise ConfigError(

--- a/src/conf_mode/policy.py
+++ b/src/conf_mode/policy.py
@@ -167,6 +167,23 @@ def verify(config_dict):
                     if 'prefix' not in rule_config:
                         raise ConfigError(f'A prefix {mandatory_error}')
 
+                    mask_len = int(rule_config['prefix'].split('/')[1])
+                    ge = int(rule_config['ge']) if 'ge' in rule_config else None
+                    le = int(rule_config['le']) if 'le' in rule_config else None
+
+                    if ge is not None and ge < mask_len:
+                        raise ConfigError(
+                            f'{policy_hr} {instance} rule {rule}: "ge" ({ge}) must be >= '
+                            f'prefix length ({mask_len})')
+                    if le is not None and le < mask_len:
+                        raise ConfigError(
+                            f'{policy_hr} {instance} rule {rule}: "le" ({le}) must be >= '
+                            f'prefix length ({mask_len})')
+                    if ge is not None and le is not None and ge > le:
+                        raise ConfigError(
+                            f'{policy_hr} {instance} rule {rule}: "ge" ({ge}) must be <= '
+                            f'"le" ({le})')
+
                     if rule_config in entries:
                         raise ConfigError(
                             f'Rule "{rule}" contains a duplicate prefix definition!')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
When a policy prefix-list rule is committed with a ge value greater than le (i.e. the range constraint mask ≤  ge ≤  le is violated), FRR's fabricd rejects the configuration with a validation error.

steps to reproduce
```
set policy prefix-list6 list rule 10 ge '48'
set policy prefix-list6 list rule 10 le '44'
set policy prefix-list6 list rule 10 prefix '2222:2222:2a0::/44'
set policy prefix-list6 list rule 10 action permit
commit
```

commit will get stuck

you will see on log
```
[MHYBZ-5A04C][EC 100663334] error processing configuration change: error [validation] event [validate] operation [modify] xpath [/frr-filter:lib/prefix-list[type='ipv6'][name='list']/entry[sequence='10']/ipv6-prefix-length-greater-or-equ$

[HCBHP-DW7C2] Locking for DS 1 failed, Err: 'Lock already taken on datastore running by session: 0 txn-id: 94712618811396' vty 0x562444069d80
```

According to the documentation
https://docs.frrouting.org/en/latest/filter.html#ip-prefix-list

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8823

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
