### PR TITLE
T8360: add XML preprocessor to allow overriding help element

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ interface_definitions: libvyosconfig $(config_xml_obj)
 	rm -rf $(TMPL_DIR); mkdir -p $(TMPL_DIR)
 
 	$(CURDIR)/scripts/override-default $(BUILD_DIR)/interface-definitions
+	$(CURDIR)/scripts/override-help $(BUILD_DIR)/interface-definitions
 
 	find $(BUILD_DIR)/interface-definitions -type f -name "*.xml" | xargs -I {} $(CURDIR)/scripts/build-command-templates {} $(CURDIR)/schema/interface_definition.rng $(TMPL_DIR) || exit 1
 

--- a/scripts/override-help
+++ b/scripts/override-help
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) VyOS Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+# Use lxml xpath capability to find multiple elements with tag help
+# relative to path; copy and replace to override the initial value.
+
+import sys
+import glob
+import logging
+from copy import deepcopy
+from lxml import etree
+
+debug = False
+
+logger = logging.getLogger(__name__)
+logs_handler = logging.StreamHandler()
+logger.addHandler(logs_handler)
+
+if debug:
+    logger.setLevel(logging.DEBUG)
+else:
+    logger.setLevel(logging.INFO)
+
+
+def override_element(lst: list):
+    """
+    Allow multiple override elements; use the final one (in document order).
+    """
+    if len(lst) < 2:
+        logger.debug('passing list of single element to override_element')
+        return
+
+    # replace element with final override
+    first_element = lst[0]
+    # lxml will remove on replace, hence make a copy to avoid cleaning up
+    # empty elements
+    final_element = deepcopy(lst[-1])
+    parent = first_element.getparent()
+    parent.replace(first_element, final_element)
+
+
+def collect_and_override(dir_name):
+    # pylint: disable=too-many-locals,c-extension-no-member
+    """
+    Collect elements with help tag into dictionary indexed by name
+    attributes of ancestor path.
+    """
+    for fname in glob.glob(f'{dir_name}/*.xml'):
+        tree = etree.parse(fname)
+        root = tree.getroot()
+        defv = {}
+
+        xpath_str = '//help'
+        xp = tree.xpath(xpath_str)
+
+        for element in xp:
+            ap = element.xpath('ancestor::*[@name]')
+            ap_name = [el.get('name') for el in ap]
+            ap_path_str = ' '.join(ap_name)
+            defv.setdefault(ap_path_str, []).append(element)
+
+        trivial = []
+        for k, v in defv.items():
+            if len(v) < 2:
+                trivial.append(k)
+        for i in trivial:
+            del defv[i]
+
+        for k, v in defv.items():
+            text_set = set()
+            for e in v:
+                text_set.add(e.text)
+            if len(text_set) > 1:
+                logger.debug(f'Inconsistent help elements in file {fname}:')
+                for e in v:
+                    logger.debug(
+                        f'Element is {e.tag} with content {e.text} at {e.sourceline}'
+                    )
+
+                logger.info(f"overriding help in path '{k}'")
+                override_element(v)
+
+        revised_str = etree.tostring(root, encoding='unicode', pretty_print=True)
+
+        with open(f'{fname}', 'w') as f:
+            f.write(revised_str)
+
+
+def main():
+    if len(sys.argv) < 2:
+        logger.critical('Must specify XML directory!')
+        sys.exit(1)
+
+    dir_name = sys.argv[1]
+
+    collect_and_override(dir_name)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

As with element `defaultValue`, allow overriding the `help` element in document-order subsequent entries at a given path.
The use case is when one has included an XML block, but wants to rephrase the help text for the path, e.g.
https://github.com/vyos/vyos-1x/blob/current/interface-definitions/vpp.xml.in#L1196-L1199
```
  ...
  #include <include/vpp/acl_prefix.xml.i>
  <leafNode name="prefix">
    <properties>
      <help>Source IP prefix</help>
  ...
```

Since `node.def` files are populated on the first document-order occurrence, the current behavior is that the resulting path will show the help text of the `#include` file, namely `IP prefix`. Adding the script here allows overriding that entry.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): Add preprocessor to allow override of help element.

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Regarding the example mentioned above:

Without preprocessor:
```
vyos@vyos# set vpp acl mac tag-name test rule 137 <tab>
Possible completions:
   ...
   prefix               IP prefix
```

With preprocessor:
```
vyos@vyos# set vpp acl mac tag-name test rule 137 <tab>
Possible completions:
   ...
   prefix               Source IP prefix

```

Using a sanity check of temporarily adding `build/interface-definitions` to the local repo, one confirms that the only file modified by the `override-help` script is the existing example mentioned:

```
└──> git diff build/interface-definitions                  
diff --git a/build/interface-definitions/vpp.xml b/build/interface-definitions/vpp.xml
index 39ae39e87..6d6ec5e58 100644
--- a/build/interface-definitions/vpp.xml
+++ b/build/interface-definitions/vpp.xml
@@ -1879,8 +1879,8 @@
 <!-- include start from vpp/acl_prefix.xml.i -->
 <leafNode name="prefix">
   <properties>
-    <help>IP prefix</help>
-    <valueHelp>
+    <help>Source IP prefix</help>
+                      <valueHelp>
       <format>ipv4net</format>
       <description>IPv4 prefix</description>
     </valueHelp>
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
