### PR TITLE
T8824: Add XML properties collision check to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ interface_definitions: libvyosconfig $(config_xml_obj)
 
 	$(CURDIR)/scripts/override-default $(BUILD_DIR)/interface-definitions
 	$(CURDIR)/scripts/override-help $(BUILD_DIR)/interface-definitions
+	$(CURDIR)/scripts/check-properties-collision $(BUILD_DIR)/interface-definitions
 
 	find $(BUILD_DIR)/interface-definitions -type f -name "*.xml" | xargs -I {} $(CURDIR)/scripts/build-command-templates {} $(CURDIR)/schema/interface_definition.rng $(TMPL_DIR) || exit 1
 

--- a/scripts/check-properties-collision
+++ b/scripts/check-properties-collision
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) VyOS Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+#
+
+# Use lxml xpath capability to detect multiple properties elements at the
+# same path with differing content.
+
+
+import sys
+import glob
+import logging
+import io
+from lxml import etree
+
+
+debug = False
+
+logger = logging.getLogger(__name__)
+logs_handler = logging.StreamHandler()
+logger.addHandler(logs_handler)
+
+if debug:
+    logger.setLevel(logging.DEBUG)
+else:
+    logger.setLevel(logging.INFO)
+
+
+def canonical_form(e):
+    # pylint: disable=c-extension-no-member
+    out = io.BytesIO()
+
+    etree.ElementTree(e).write_c14n(out)
+    return out.getvalue()
+
+
+def check_properties_collision(dir_name):
+    # pylint: disable=too-many-locals,too-many-branches,c-extension-no-member
+    """
+    Collect elements with help tag into dictionary indexed by name
+    attributes of ancestor path.
+    """
+    buffer = io.StringIO()
+    for fname in glob.glob(f'{dir_name}/*.xml'):
+        tree = etree.parse(fname)
+        defv = {}
+
+        xpath_str = '//properties'
+        xp = tree.xpath(xpath_str)
+
+        for element in xp:
+            ap = element.xpath('ancestor::*[@name]')
+            ap_name = [el.get('name') for el in ap]
+            ap_path_str = ' '.join(ap_name)
+            defv.setdefault(ap_path_str, []).append(element)
+
+        trivial = []
+        for k, v in defv.items():
+            if len(v) < 2:
+                trivial.append(k)
+        for i in trivial:
+            del defv[i]
+
+        for k, v in defv.items():
+            collisions = []
+            for i in v:
+                # If properties contains more than just a help element:
+                if len(list(i)) > 1:
+                    collisions.append(i)
+            if len(collisions) > 1:
+                property_set = set()
+                for j in collisions:
+                    prop = canonical_form(j)
+                    property_set.add(prop)
+                if len(property_set) > 1:
+                    buffer.write(f'Collision in file {fname}:\n')
+                    for e in collisions:
+                        buffer.write(
+                            f'Element {e.tag} at {e.sourceline} with content:\n {canonical_form(e)}\n'
+                        )
+
+    content = buffer.getvalue()
+    if content:
+        logger.info(
+            'Collisions detected: multiple <properties> elements at a path with differing content other than <help>.\n'
+            'Information beyond the first instance will be ignored in the resulting node.def file.'
+        )
+        logger.info(content)
+
+    buffer.close()
+
+
+def main():
+    if len(sys.argv) < 2:
+        logger.critical('Must specify XML directory!')
+        sys.exit(1)
+
+    dir_name = sys.argv[1]
+
+    check_properties_collision(dir_name)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Check for colliding properties elements that can obscure information in the resulting node.def. An example is shown, and resolved in https://github.com/vyos/vyos-1x/pull/5173.

Reverting the non-trivial commit in that PR, one sees that the check added here reports the collision, and ignores the trivial repeated block in firewall.xml, discussed in the same PR.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): Add preprocessor to check for colliding properties data.

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
└──> git revert 110e1ad42a17d3229cc554060f20af0429c4c184
[xml-collision-check beae47836] Revert "xml: T8467: remove unnecessary include, obscuring value help"
 1 file changed, 2 insertions(+)
└──> make clean 
...
└──> make interface_definitions
Collisions detected: multiple <properties> elements at a path with differing content other than <help>.
Information beyond the first instance will be ignored in the resulting node.def file.
Collision in file build/interface-definitions/system_conntrack.xml:
...

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
