### PR TITLE
T8612: upgrade frr to 10.6.1

### DIFF
--- a/smoketest/scripts/cli/test_protocols_ospf.py
+++ b/smoketest/scripts/cli/test_protocols_ospf.py
@@ -310,6 +310,11 @@ class TestProtocolsOSPF(VyOSUnitTestSHIM.TestCase):
         for network in networks:
             self.cli_set(base_path + ['area', area, 'network', network])
 
+        # FRR requires router to be ABR for virtual-link to work
+        self.cli_set(base_path + ['area', '0', 'network', '192.178.0.0/16'])
+        self.cli_set(['interfaces', 'dummy', dummy_if, 'address', '172.16.0.9/12'])
+        self.cli_set(['interfaces', 'dummy', dummy_if, 'address', '192.178.0.9/16'])
+
         # commit changes
         self.cli_commit()
 


### PR DESCRIPTION
## Change summary

FRR commit 4257c1dc28e71234f9338f1623a8fe677445db7e introduced check that in OSPF virtual-link is allowed only for ABR router. Added second area in our test so that router is ABR and check is passed.

While investigating other issue I've noticed missing `commit` in tearDownClass of test test_protocols_ospfv3.py. Added in separate commit.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [X] Other (please describe): upgrade FRR to 10.6.1

## Related Task(s)

* https://vyos.dev/T8612

## Related PR(s)

* https://github.com/vyos/vyos-build/pull/1183

## How to test / Smoketest result

See description in https://github.com/vyos/vyos-build/pull/1183

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly