### PR TITLE
smoketests: T8845: missing base-class call to commit() in tearDownClass()

### DIFF
--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -65,16 +65,19 @@ class VyOSUnitTestSHIM:
 
         @classmethod
         def tearDownClass(cls):
-            # discard any pending changes which might caused a messed up config
-            cls._session.discard()
-            # ... and restore the initial state
-            cls._session.migrate_and_load_config(save_config)
-
             try:
+                # commit pending changes done by derived tearDownClass()
+                # implementations like CLI cleanup
                 cls._session.commit()
             except (ConfigError, ConfigSessionError):
+                # discard any pending changes which might have failed, causing a
+                # messed up config
                 cls._session.discard()
                 cls.fail(cls)
+            finally:
+                # restore previous configuration before the test
+                cls._session.migrate_and_load_config(save_config)
+                cls._session.commit()
 
         def setUp(self):
             pass


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The smoketest framework heavily relies on deriving common code paths. The tearDownClass() is called when a testcase finishes and testcases like protocols BGP delete CLI nodes before calling the base class.

The base-class never calls commit() thus the deletions are discarded instead of committed.

```
test_protocols_bgp.py
  @classmethod
  def tearDownClass(cls):
      cls.cli_delete(cls, ['policy', 'route-map'])
      cls.cli_delete(cls, ['policy', 'prefix-list'])
      cls.cli_delete(cls, ['policy', 'prefix-list6'])

      super(TestProtocolsBGP, cls).tearDownClass()
```

base class `base_vyostest_shim.py`

```
  @classmethod
  def tearDownClass(cls):
      # discard any pending changes which might caused a messed up config
      cls._session.discard()
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8845

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
All Smoketests passed

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
