### PR TITLE
dhcp: T8848: Fix timezone pcode data

### DIFF
--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -144,7 +144,7 @@ def kea_parse_options(config):
 
     if 'time_zone' in config:
         with open('/usr/share/zoneinfo/' + config['time_zone'], 'rb') as f:
-            tz_string = f.read().split(b'\n')[-2].decode('utf-8')
+            tz_string = f.read().split(b'\n')[-2].decode('utf-8').replace(',', '\\,')
 
         options.append({'name': 'pcode', 'data': tz_string})
         options.append({'name': 'tcode', 'data': config['time_zone']})

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -574,7 +574,7 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         self.verify_config_object(
             obj,
             ['Dhcp4', 'shared-networks', 0, 'subnet4', 0, 'option-data'],
-            {'name': 'pcode', 'data': 'GMT0BST,M3.5.0/1,M10.5.0'},
+            {'name': 'pcode', 'data': 'GMT0BST\\,M3.5.0/1\\,M10.5.0'},
         )
         self.verify_config_object(
             obj,


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
According to Kea documentation:
When a data field is a string and that string contains the comma (`,`; U+002C) character, the comma must be escaped with two backslashes (`\\,`; U+005C) because both the routine splitting of CSV data into fields and JSON use the same escape character. A single escape (`\,`) would make the JSON invalid.

Accordingly, the pcode generated for time-zone should have
the `,` double escaped. For example, `"GMT0BST,M3.5.0/1,M10.5.0"`
should be rendered as `"GMT0BST\\,M3.5.0/1\\,M10.5.0"`.

See: https://kea.readthedocs.io/en/stable/arm/dhcp4-srv.html#standard-dhcpv4-options

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8848

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
$ python3 /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py
test_dhcp_client_class (__main__.TestServiceDHCPServer.test_dhcp_client_class) ... ok
test_dhcp_dynamic_dns_update (__main__.TestServiceDHCPServer.test_dhcp_dynamic_dns_update) ... ok
test_dhcp_exclude_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_in_range) ... ok
test_dhcp_exclude_not_in_range (__main__.TestServiceDHCPServer.test_dhcp_exclude_not_in_range) ... ok
test_dhcp_high_availability (__main__.TestServiceDHCPServer.test_dhcp_high_availability) ... ok
test_dhcp_high_availability_standby (__main__.TestServiceDHCPServer.test_dhcp_high_availability_standby) ... ok
test_dhcp_hostsd_lease_sync (__main__.TestServiceDHCPServer.test_dhcp_hostsd_lease_sync) ... ok
test_dhcp_multiple_pools (__main__.TestServiceDHCPServer.test_dhcp_multiple_pools) ... ok
test_dhcp_on_interface_with_vrf (__main__.TestServiceDHCPServer.test_dhcp_on_interface_with_vrf) ... ok
test_dhcp_relay_server (__main__.TestServiceDHCPServer.test_dhcp_relay_server) ... ok
test_dhcp_single_pool_options (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options) ... ok
test_dhcp_single_pool_options_scoped (__main__.TestServiceDHCPServer.test_dhcp_single_pool_options_scoped) ... ok
test_dhcp_single_pool_range (__main__.TestServiceDHCPServer.test_dhcp_single_pool_range) ... ok
test_dhcp_single_pool_static_mapping (__main__.TestServiceDHCPServer.test_dhcp_single_pool_static_mapping) ... ok
test_dhcp_vendor_option_ubiquiti (__main__.TestServiceDHCPServer.test_dhcp_vendor_option_ubiquiti) ... ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
