### PR TITLE
T8764: add per-repo CodeRabbit config — Jira VD project scope

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# Per-repo CodeRabbit override for vyos/vyos-1x.
+#
+# Most behavior is inherited from the org-level central baseline at
+# https://github.com/vyos/coderabbit/blob/production/.coderabbit.yaml
+# (loaded automatically because the central repo is named `coderabbit`
+# under the same GitHub org as this repo).
+#
+# This file is also propagated to the VyOS-Networks mirror of this repo
+# (`VyOS-Networks/vyos-1x`) by the gen-1 mirror pipeline. CodeRabbit's
+# Atlassian/Jira OAuth grant is attached to the `VyOS-Networks` org only
+# (CodeRabbit allows one GitHub-org → Jira-tenant link per install), so:
+#   - On the vyos source repo (public), `usage: auto` self-disables. No
+#     Jira context is fetched — there's no OAuth grant on this install.
+#   - On the VyOS-Networks mirror, `usage: auto` activates Jira (private
+#     repo + valid OAuth grant) and `project_keys` scopes it to VD.
+#
+# This makes one file the single source of truth across both orgs.
+
+knowledge_base:
+  jira:
+    # `auto` is the cross-org-safe value: enabled on private/internal
+    # mirror repos where Jira OAuth is connected, disabled on the public
+    # source where it is not. Avoids `enabled` (which can produce
+    # warnings on installs without OAuth).
+    usage: auto
+    # Restrict the Jira context CodeRabbit pulls in review summaries to
+    # the VyOS Dev (VD) project. PRs in this repo reference VD ticket IDs
+    # in titles (e.g. `T8849: ...` for Phorge tasks that have VD twins),
+    # so the surface area that matters is VD.
+    project_keys:
+      - VD


### PR DESCRIPTION
## Change Summary

Adds a minimal \`.coderabbit.yaml\` at the repo root with two fields under \`knowledge_base.jira\`:

\`\`\`yaml
knowledge_base:
  jira:
    usage: auto
    project_keys:
      - VD
\`\`\`

Everything else is inherited from the org-level central baseline at [vyos/coderabbit](https://github.com/vyos/coderabbit/blob/production/.coderabbit.yaml).

## Why \`usage: auto\` and not \`enabled\`

The CodeRabbit Atlassian/Jira OAuth grant is attached to the [VyOS-Networks org install only](https://github.com/VyOS-Networks/coderabbit) — CodeRabbit permits one GitHub-org → Jira-tenant link per install, and we've chosen VyOS-Networks. The vyos-org CodeRabbit install does **not** have a Jira OAuth grant.

This means the SAME \`.coderabbit.yaml\` file needs to work in two contexts:

| Context | Repo visibility | Jira OAuth | Effective behavior with \`usage: auto\` |
|---|---|---|---|
| \`vyos/vyos-1x\` (this repo, source) | public | not present | self-disables — \`auto\` skips on public repos |
| \`VyOS-Networks/vyos-1x\` (gen-1 mirror) | private/internal | present | activates and pulls VD-scoped Jira context |

The gen-1 mirror pipeline propagates dotfiles, including \`.coderabbit.yaml\`, so this single file in vyos becomes the source of truth for both repos.

\`enabled\` would be more aggressive and could produce warnings on the vyos-org install where the OAuth grant is missing. \`auto\` is the safe cross-org value.

## Why \`project_keys: [VD]\`

The VyOS Dev (VD) Jira project tracks all engineering work that has a Phorge T-ID twin (e.g. \`T8849: ...\` PR titles). Per \`.claude/data/atlassian.md\`, VD effectively started covering GitHub-PR work at \`T-ID ≥ ~T8000\` (1–2% match-rate below T8000, 55% for T8001–8500, 93% for T8501+). For vyos-1x, the relevant Jira surface is VD only — not WD (web), not IS (system-change tickets).

## Pattern

This PR is the canary for the per-repo CodeRabbit override pattern across the vyos org's fleet. After it lands clean, the same file (possibly with the same \`project_keys: [VD]\`) should be mirrored to other vyos-org source repos whose mirrors live under VyOS-Networks: \`vyos-build\`, \`vyos-documentation\`, \`vyos-http-api-tools\`, \`vyatta-cfg\`, etc. Out of scope for this PR.

## Related

- [T8764](https://vyos.dev/T8764) — CodeRabbit central-config rollout (master)
- [IS-430](https://vyos.atlassian.net/browse/IS-430) — change ticket
- [vyos/coderabbit#2](https://github.com/vyos/coderabbit/pull/2) — central-baseline PR that this depends on (must land first; without it the inheritance chain isn't populated yet)
- [VyOS-Networks/coderabbit#2](https://github.com/VyOS-Networks/coderabbit/pull/2) — sibling central-baseline PR for the mirror side

## Backport

Not applicable — review-tooling config change, no per-branch behavior difference.

🤖 Generated by [robots](https://vyos.io)

[IS-430]: https://vyos.atlassian.net/browse/IS-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ