### PR TITLE
T8764: add `inheritance: true` to .coderabbit.yaml (follow-up to #5191)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -18,6 +18,12 @@
 #
 # This makes one file the single source of truth across both orgs.
 
+# Opt this repo into the inheritance chain. Without this, the file below
+# would entirely REPLACE the central baseline rather than merge per-field
+# on top of it — inheritance is disabled by default per CodeRabbit's
+# schema (https://docs.coderabbit.ai/configuration/configuration-inheritance).
+inheritance: true
+
 knowledge_base:
   jira:
     # `auto` is the cross-org-safe value: enabled on private/internal


### PR DESCRIPTION
## Change Summary

Follow-up to [#5191](https://github.com/vyos/vyos-1x/pull/5191) (already merged). Adds the missing \`inheritance: true\` top-level field to \`.coderabbit.yaml\`.

\`\`\`diff
+# Opt this repo into the inheritance chain. Without this, the file below
+# would entirely REPLACE the central baseline rather than merge per-field
+# on top of it — inheritance is disabled by default per CodeRabbit's
+# schema (https://docs.coderabbit.ai/configuration/configuration-inheritance).
+inheritance: true
+
 knowledge_base:
\`\`\`

## Why this is needed

Per [the inheritance docs](https://docs.coderabbit.ai/configuration/configuration-inheritance):

> Inheritance is **disabled by default**. You must explicitly enable it by adding \`inheritance: true\`.
>
> Without inheritance, only the highest-priority source is used.

In other words: a repository-level \`.coderabbit.yaml\` without this flag does **NOT** merge with the central baseline at [vyos/coderabbit](https://github.com/vyos/coderabbit/blob/production/.coderabbit.yaml). It REPLACES it entirely.

Today, every PR review on this repo is using only the four lines under \`knowledge_base.jira\` in this file. The central baseline's review profile (\`chill\`), path filters, finishing-touches settings, disabled-linter list, and PR-title-format rules are all being silently dropped.

## How this slipped past review on #5191

CodeRabbit's auto-review explicitly notes on public OSS repos:

> Ignoring CodeRabbit configuration file changes. For security, only the configuration from the base branch is applied for open source repositories.

So CodeRabbit reviewed #5191 against the (empty-of-this-file) base branch and couldn't see the bug. The sibling per-repo PR on a private repo ([VyOS-Networks/next-js-cpd#1](https://github.com/VyOS-Networks/next-js-cpd/pull/1)) DID surface the same issue because that PR isn't on a public-OSS repo and the security ignore doesn't apply there.

## Mirror implication

\`VyOS-Networks/vyos-1x\` already received the broken file via the gen-1 mirror pipeline; this fix will propagate to the mirror on merge.

## Related Task(s)

* https://vyos.dev/T8764
* https://vyos.dev/T8851 — fleet rollout subtask; pattern doc updated to require \`inheritance: true\` on every per-repo file going forward (the OSS security ignore means we cannot rely on CodeRabbit to catch this on vyos-org repos).

## Backport

Not applicable — review-tooling config change, no per-branch behavior difference.

🤖 Generated by [robots](https://vyos.io)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration settings to enable proper alignment with organizational standards.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vyos/vyos-1x/pull/5192)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->