### PR TITLE
serial: T8853: limit "kernel" CLI option to ttyS and ttyAMA interfaces only

### DIFF
--- a/src/conf_mode/system_console.py
+++ b/src/conf_mode/system_console.py
@@ -68,10 +68,12 @@ def verify(console):
             # If the device name still starts with usbXXX no matching tty was found
             # and it can not be used as a serial interface
             if not os.path.isdir(by_bus_dir) or not os.path.exists(by_bus_device):
-                raise ConfigError(f'Device {device} does not support being used as tty')
+                raise ConfigError(f'Device "{device}" does not support being used as tty')
         if not is_tty(device, warning=True):
             Warning(f'Device "{device}" used for console is not a TTY!')
         if 'kernel' in device_config:
+            if not (device.startswith('ttyS') or device.startswith('ttyAMA')):
+                raise ConfigError(f'Device "{device}" unsupported for Kernel boot console')
             kernel_consoles.append(device)
 
     if len(kernel_consoles) > 1:


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Recently (commit 35db941bcf `serial: T8375: add CLI option to explicitly set kernel console`) we added the CLI knob to enable the Kernel and GRUB serial console on a given device.

Currently this is supported for serial console interfaces starting with ttyS and ttyAMA only. Main limitation is that these interfaces are wired to the CPU and bootloader infos can be displayed.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8853

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/1186

## How to test / Smoketest result
```
vyos@vyos# set system console device hvc0 kernel
[edit]
vyos@vyos# commit
[ system console ]

WARNING: Device "hvc0" does not exist!


WARNING: Device "hvc0" used for console is not a TTY!

Device hvc0 unsupported for Kernel boot console
[[system console]] failed
Commit failed
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
