### PR TITLE
python: T8859: enforce positive integer min_keysize in verify_diffie_hellman_length

### DIFF
--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -424,24 +424,29 @@ def verify_vlan_config(config):
             verify_mtu_ipv6(c_vlan)
 
 
-def verify_diffie_hellman_length(file, min_keysize):
-    """ Verify Diffie-Hellamn keypair length given via file. It must be greater
-    then or equal to min_keysize """
+def verify_diffie_hellman_length(file: str, min_keysize: int):
+    """ Verify Diffie-Hellman keypair length given via file. It must be greater
+    than or equal to min_keysize.
+
+    Raises TypeError if min_keysize is not an integer and ValueError if it is
+    not a positive integer - both indicate a logic error in the caller. """
     import os
     import re
     from vyos.utils.process import cmd
 
-    try:
-        min_keysize_int = int(min_keysize)
-    except (TypeError, ValueError):
-        return False
+    if isinstance(min_keysize, bool) or not isinstance(min_keysize, int):
+        raise TypeError(
+            f'min_keysize must be an integer, got {type(min_keysize).__name__}')
+    if min_keysize < 1:
+        raise ValueError(
+            f'min_keysize must be a positive integer, got {min_keysize}')
 
     if os.path.exists(file):
-        out = cmd(f'openssl dhparam -inform PEM -in {file} -text')
-        prog = re.compile('\d+\s+bit')
+        out = cmd(['openssl', 'dhparam', '-inform', 'PEM', '-in', file, '-text'])
+        prog = re.compile(r'\d+\s+bit')
         if prog.search(out):
             bits = prog.search(out)[0].split()[0]
-            if int(bits) >= min_keysize_int:
+            if int(bits) >= min_keysize:
                 return True
 
     return False

--- a/python/vyos/configverify.py
+++ b/python/vyos/configverify.py
@@ -432,8 +432,8 @@ def verify_diffie_hellman_length(file, min_keysize):
     from vyos.utils.process import cmd
 
     try:
-        keysize = str(min_keysize)
-    except:
+        min_keysize_int = int(min_keysize)
+    except (TypeError, ValueError):
         return False
 
     if os.path.exists(file):
@@ -441,7 +441,7 @@ def verify_diffie_hellman_length(file, min_keysize):
         prog = re.compile('\d+\s+bit')
         if prog.search(out):
             bits = prog.search(out)[0].split()[0]
-            if int(bits) >= int(min_keysize):
+            if int(bits) >= min_keysize_int:
                 return True
 
     return False

--- a/src/tests/test_configverify.py
+++ b/src/tests/test_configverify.py
@@ -18,14 +18,26 @@ from vyos.utils.process import cmd
 
 dh_file = '/tmp/dh.pem'
 
-class TestDictSearch(TestCase):
+class TestVerifyDiffieHellmanLength(TestCase):
     def setUp(self):
         pass
 
     def test_dh_key_none(self):
-        self.assertFalse(verify_diffie_hellman_length('/tmp/non_existing_file', '1024'))
+        self.assertFalse(verify_diffie_hellman_length('/tmp/non_existing_file', 1024))
 
     def test_dh_key_512(self):
-        key_len = '512'
+        key_len = 512
         cmd(f'openssl dhparam -out {dh_file} {key_len}')
         self.assertTrue(verify_diffie_hellman_length(dh_file, key_len))
+
+    def test_dh_keysize_not_integer(self):
+        with self.assertRaises(TypeError):
+            verify_diffie_hellman_length(dh_file, '1024')
+        with self.assertRaises(TypeError):
+            verify_diffie_hellman_length(dh_file, True)
+
+    def test_dh_keysize_not_positive(self):
+        with self.assertRaises(ValueError):
+            verify_diffie_hellman_length(dh_file, -512)
+        with self.assertRaises(ValueError):
+            verify_diffie_hellman_length(dh_file, 0)


### PR DESCRIPTION
Tracked in Phorge [T8859](https://vyos.dev/T8859).

## Defect

`verify_diffie_hellman_length(file, min_keysize)` in `python/vyos/configverify.py` wrapped `str(min_keysize)` in `try/except`, but the later `int(min_keysize)` on the comparison line could still raise `ValueError` for non-numeric input, and the local `keysize` variable was computed but never used.

## Fix (redesigned per review)

Per [dmbaturin's review](https://github.com/vyos/vyos-1x/pull/5194#pullrequestreview-4363459966): the function has no production callers — its only consumers are its own unit tests in `src/tests/test_configverify.py` (verified by grep) — so the contract is free to change. An invalid `min_keysize` is a logic error in the calling script and now fails loudly instead of silently returning `False`:

- Signature is now `verify_diffie_hellman_length(file: str, min_keysize: int)`.
- Raises `TypeError` if `min_keysize` is not an integer at all (`bool` explicitly rejected).
- Raises `ValueError` if `min_keysize` is not a positive integer (`0` and negatives rejected).
- The silent `try/except` and the unused variable are gone; the bits comparison uses the argument directly.

Two adjacent hardenings in the same function, both surfaced by pre-PR CodeRabbit review:

- `openssl dhparam` is invoked with list arguments instead of an interpolated command string, so the file path never reaches a shell (`vyos.utils.process.popen` auto-selects `shell=True` for strings containing spaces).
- The bit-count regex is a raw string (`r'\d+\s+bit'`), removing the invalid-escape-sequence warning on modern Python.

## Behavior change

None for valid positive-integer inputs. Non-integer or non-positive `min_keysize` now raises `TypeError`/`ValueError` instead of returning `False` — intentional per review; no production code hits these paths.

## Test plan

- [x] Unit tests updated to pass integer keysizes and extended to cover both exception paths (`'1024'`/`True` → `TypeError`; `-512`/`0` → `ValueError`). All 4 pass locally, including the real `openssl dhparam` round-trip.
- [ ] CLI smoketests pass.

## Provenance

Found by Copilot during review of [vyos/vyos-1x#5074](https://github.com/vyos/vyos-1x/pull/5074) — the configverify changes were dropped from that PR per [dmbaturin's scope narrowing](https://github.com/vyos/vyos-1x/pull/5074#pullrequestreview-4281666376). This defect is independent of the broader configverify redesign concerns (MTU helpers taking defaults as args) and can be fixed in isolation.

🤖 Generated by [robots](https://vyos.io)
