### PR TITLE
T8852: migrate .github/mergify.yml to extends: mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,27 +1,30 @@
-pull_request_rules:
-  - name: Label conflicting pull requests
-    description: Add a label to a pull request with conflict to spot it easily
-    conditions:
-      - conflict
-      - '-closed'
-    actions:
-      label:
-        toggle:
-          - conflicts
+# yaml-language-server: $schema=https://docs.mergify.com/configuration/file-format/
+# Mergify configuration for vyos/vyos-1x.
+#
+# Inherits the central baseline from vyos/mergify:.mergify.yml. The central
+# baseline provides:
+#   - `defaults.actions.backport.ignore_conflicts: false`
+#   - `pull_request_rules` → label conflicting PRs with `conflicts`;
+#     T-ID format checks on PR title and commit messages.
+#   - `commands_restrictions` → restrict @Mergifyio slash commands to the
+#     org Maintainers team + vyosbot. Resolves correctly on both sides of
+#     the cross-org mirror: vyos/mergify uses @vyos/maintainers,
+#     VyOS-Networks/mergify uses @VyOS-Networks/maintainers.
+#
+# Replaces the inline T8531 predecessor config. Rollout context:
+# T8782 (Mergify central-config rollout), T8852 (fleet migration to
+# `extends:`). See https://vyos.dev/T8782, https://vyos.dev/T8852,
+# and the Confluence spec at
+# https://vyos.atlassian.net/wiki/spaces/VYOS/pages/849477640.
 
-commands_restrictions:
-  backport: &allowed
-    conditions:
-      - or:
-          - sender=@vyos/maintainers
-          - sender=vyosbot
-  copy: *allowed
-  dequeue: *allowed
-  queue: *allowed
-  rebase: *allowed
-  refresh: *allowed
-  requeue: *allowed
-  squash: *allowed
-  update: *allowed
+extends: mergify
+
+# ------------------------------------------------------------------
+# Repo-specific overlay: keep the existing `merge_protections_settings`
+# from the T8531-era inline config. This is a Mergify v8 top-level
+# setting that the central baseline does not provide. Preserving it
+# keeps the same reporting behavior (`check-runs`) that vyos-1x has
+# relied on under the inline config.
+# ------------------------------------------------------------------
 merge_protections_settings:
   reporting_method: check-runs


### PR DESCRIPTION
## Change Summary

Replace the inline T8531 predecessor Mergify config with `extends: mergify`, deferring to the per-org central baseline ([vyos/mergify](https://github.com/vyos/mergify)). Preserve the existing `merge_protections_settings: reporting_method: check-runs` overlay — the central baseline doesn't carry that key.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T8852 — Mergify `extends:` fleet migration
* https://vyos.dev/T8782 — central-config rollout (precedent)

## Related PR(s)

* Precedent for the `extends:` template: [vyos/vyos-documentation/.github/mergify.yml](https://github.com/vyos/vyos-documentation/blob/rolling/.github/mergify.yml).
* Sibling fleet PR: [vyos/vyatta-cfg#134](https://github.com/vyos/vyatta-cfg/pull/134) and 12 sibling vyos-org PRs landed today.

## Component(s) name

CI / Mergify configuration

## Proposed changes

Old `.github/mergify.yml` (27 lines) had the stock T8531 inline content plus a repo-specific `merge_protections_settings` block.

The new file is a header comment block, `extends: mergify` (inheriting `pull_request_rules`, `commands_restrictions`, and `defaults.actions.backport.ignore_conflicts: false` from the central baseline), and the preserved `merge_protections_settings` overlay.

Behavioral diff after merge:

- **commands_restrictions** — unchanged (`@vyos/maintainers` + `vyosbot`) once inherited from `vyos/mergify`.
- **Label conflicting PRs rule** — unchanged.
- **NEW:** `defaults.actions.backport.ignore_conflicts: false` — backports fail loudly on conflict instead of committing literal git markers (driven by the 2026-05-12 vyos-documentation conflict incident).
- **NEW:** T-ID format rules for PR title and commit message headlines (`invalid-title` label). vyos-1x already requires Phorge T-IDs by convention, so this rule's coverage matches existing practice.
- **Preserved:** `merge_protections_settings: reporting_method: check-runs`.

## How to test

After merge, a Maintainer can comment `@Mergifyio backport <branch>` on a merged PR to verify command authorization. Mergify itself surfaces config errors as PR comments if the YAML is malformed. The check-runs reporting behavior should be unchanged.

## Smoketest result

N/A — CI/Mergify-only change.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

## Backport

After merge, backport to `circinus` and `sagitta` via `@Mergifyio backport circinus sagitta` — those branches likely carry the same inline `.github/mergify.yml`.

🤖 Generated by [robots](https://vyos.io)