### PR TITLE
ipsec: T7555: Implement `ikev2-reauth` for site-to-site peers

### DIFF
--- a/data/templates/ipsec/swanctl/peer.j2
+++ b/data/templates/ipsec/swanctl/peer.j2
@@ -3,6 +3,13 @@
 {# peer needs to reference the global IKE configuration for certain values #}
 {% set ike = ike_group[peer_conf.ike_group] %}
     {{ name }} {
+{# Resolve effective reauth setting: peer overrides ike-group #}
+{% set reauth = peer_conf.ikev2_reauth if peer_conf.ikev2_reauth is vyos_defined else '' %}
+{% if reauth == 'inherit' %}
+{%     set reauth = ike.ikev2_reauth is vyos_defined %}
+{% else %}
+{%     set reauth = reauth == 'yes' %}
+{% endif %}
 {% if peer_conf.authentication.ppk.id is vyos_defined %}
         ppk_id = {{ peer_conf.authentication.ppk.id }}
 {% endif %}
@@ -36,6 +43,9 @@
         reauth_time = 0
 {% elif peer_conf.connection_type is not vyos_defined or peer_conf.connection_type is vyos_defined('initiate') %}
         keyingtries = 0
+{%     if reauth and ike.key_exchange is vyos_defined('ikev2') %}
+        reauth_time = {{ ike.lifetime }}s
+{%     endif %}
 {% elif peer_conf.connection_type is vyos_defined('trap') %}
         keyingtries = 1
 {% endif %}

--- a/interface-definitions/vpn_ipsec.xml.in
+++ b/interface-definitions/vpn_ipsec.xml.in
@@ -1246,7 +1246,7 @@
                       </completionHelp>
                       <valueHelp>
                         <format>yes</format>
-                        <description>Enable remote host re-authentication during an IKE re-key. Currently broken due to a strong swan bug</description>
+                        <description>Enable remote host re-authentication during an IKE re-key</description>
                       </valueHelp>
                       <valueHelp>
                         <format>no</format>

--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -961,6 +961,77 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         # Disable PKI
         self.tearDownPKI()
 
+    def test_site_to_site_ikev2_reauth(self):
+        # T7555: Verify ikev2-reauth is correctly written to swanctl.conf
+        # and that invalid combinations are rejected by validation
+
+        local_address = '192.0.2.10'
+        ike_lifetime = '1800'
+
+        # Base PSK auth used across all sub-tests
+        psk_base_path = base_path + ['authentication', 'psk', connection_name]
+        self.cli_set(psk_base_path + ['id', local_id])
+        self.cli_set(psk_base_path + ['id', remote_id])
+        self.cli_set(psk_base_path + ['id', local_address])
+        self.cli_set(psk_base_path + ['id', peer_ip])
+        self.cli_set(psk_base_path + ['secret', secret])
+
+        peer_base_path = base_path + ['site-to-site', 'peer', connection_name]
+        self.cli_set(peer_base_path + ['authentication', 'mode', 'pre-shared-secret'])
+        self.cli_set(peer_base_path + ['default-esp-group', esp_group])
+        self.cli_set(peer_base_path + ['local-address', local_address])
+        self.cli_set(peer_base_path + ['remote-address', peer_ip])
+        self.cli_set(
+            peer_base_path + ['tunnel', '1', 'local', 'prefix', '10.0.0.0/24'],
+        )
+        self.cli_set(
+            peer_base_path + ['tunnel', '1', 'remote', 'prefix', '10.1.0.0/24'],
+        )
+
+        # ikev2-reauth on an IKEv1-only ike-group must be rejected
+        self.cli_set(base_path + ['ike-group', ike_group, 'key-exchange', 'ikev1'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'lifetime', ike_lifetime])
+        self.cli_set(peer_base_path + ['ike-group', ike_group])
+        self.cli_set(peer_base_path + ['ikev2-reauth', 'yes'])
+
+        err_msg = 'ikev2-reauth requires key-exchange ikev2 in IKE group'
+        with self.assertRaisesRegex(ConfigSessionError, err_msg):
+            self.cli_commit()
+
+        # Switch to IKEv2, enable reauth on the ike-group (valueless flag)
+        self.cli_set(base_path + ['ike-group', ike_group, 'key-exchange', 'ikev2'])
+        self.cli_set(base_path + ['ike-group', ike_group, 'ikev2-reauth'])
+        self.cli_set(peer_base_path + ['ikev2-reauth', 'inherit'])
+        self.cli_commit()
+
+        swanctl_conf = read_file(swanctl_file)
+        self.assertIn(f'reauth_time = {ike_lifetime}s', swanctl_conf)
+
+        # ikev2-reauth = yes on peer overrides group
+        self.cli_delete(base_path + ['ike-group', ike_group, 'ikev2-reauth'])
+        self.cli_set(peer_base_path + ['ikev2-reauth', 'yes'])
+        self.cli_commit()
+
+        swanctl_conf = read_file(swanctl_file)
+        self.assertIn(f'reauth_time = {ike_lifetime}s', swanctl_conf)
+
+        # ikev2-reauth = no suppresses group flag
+        self.cli_set(base_path + ['ike-group', ike_group, 'ikev2-reauth'])
+        self.cli_set(peer_base_path + ['ikev2-reauth', 'no'])
+        self.cli_commit()
+
+        swanctl_conf = read_file(swanctl_file)
+        self.assertNotIn(f'reauth_time = {ike_lifetime}s', swanctl_conf)
+
+        # connection-type trap: reauth must be suppressed
+        self.cli_set(peer_base_path + ['connection-type', 'trap'])
+        self.cli_set(peer_base_path + ['ikev2-reauth', 'yes'])
+        self.cli_commit()
+
+        swanctl_conf = read_file(swanctl_file)
+        self.assertNotIn(f'reauth_time = {ike_lifetime}s', swanctl_conf)
+        self.assertIn('keyingtries = 1', swanctl_conf)
+
 
     def test_flex_vpn_vips(self):
         local_address = '192.0.2.5'

--- a/src/conf_mode/vpn_ipsec.py
+++ b/src/conf_mode/vpn_ipsec.py
@@ -710,6 +710,22 @@ def verify(ipsec):
                         f'Childless IKE SAs be used with IKEv2! Please configure IKEv2 key-exchange in ike-group "{ike}".'
                     )
 
+            # Get the referenced IKE group config
+            ike_group_name = peer_conf.get('ike_group')
+            ike_group = ipsec['ike_group'].get(ike_group_name, {})
+
+            # 'ikev2-reauth' only valid for IKEv2
+            peer_reauth = peer_conf.get('ikev2_reauth')
+            reauth_ike_group_configured = (
+                peer_reauth == 'inherit' and 'ikev2_reauth' in ike_group
+            )
+            if peer_reauth == 'yes' or reauth_ike_group_configured:
+                if ike_group.get('key_exchange') != 'ikev2':
+                    raise ConfigError(
+                        'ikev2-reauth requires key-exchange ikev2 in IKE group! '
+                        f'Please configure IKEv2 key-exchange in ike-group "{ike_group_name}".'
+                    )
+
 
 def cleanup_pki_files():
     for path in [CERT_PATH, CA_PATH, CRL_PATH, KEY_PATH, PUBKEY_PATH]:


### PR DESCRIPTION
## Change summary
IKEv2 reauthentication was configurable via CLI but never translated into `swanctl.conf`. Add `reauth_time` to the peer connection template,driven by the `ikev2-reauth` flag on the ike-group and the per-peer override (yes/no/inherit).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7555

## Related PR(s)
* https://github.com/vyos/vyos-documentation/pull/2047

## How to test / Smoketest result

### Manual test

1.  Configure initiator: vyos1 (192.168.50.1)
```
set interfaces vti vti0 address '10.0.0.1/30'
set vpn ipsec authentication psk PEER id '192.168.50.2'
set vpn ipsec authentication psk PEER secret 'vyos-test-secret'
set vpn ipsec esp-group ESP01 lifetime '1800'
set vpn ipsec esp-group ESP01 mode 'tunnel'
set vpn ipsec esp-group ESP01 pfs 'dh-group19'
set vpn ipsec esp-group ESP01 proposal 10 encryption 'aes128gcm128'
set vpn ipsec esp-group ESP01 proposal 10 hash 'sha256'
set vpn ipsec ike-group IKEv2-REAUTH ikev2-reauth
set vpn ipsec ike-group IKEv2-REAUTH key-exchange 'ikev2'
set vpn ipsec ike-group IKEv2-REAUTH lifetime '3600'
set vpn ipsec ike-group IKEv2-REAUTH proposal 10 dh-group '20'
set vpn ipsec ike-group IKEv2-REAUTH proposal 10 encryption 'aes256'
set vpn ipsec ike-group IKEv2-REAUTH proposal 10 hash 'sha512'
set vpn ipsec interface 'eth1'
set vpn ipsec options disable-route-autoinstall
set vpn ipsec site-to-site peer VYOS2 authentication local-id '192.168.50.1'
set vpn ipsec site-to-site peer VYOS2 authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer VYOS2 authentication remote-id '192.168.50.2'
set vpn ipsec site-to-site peer VYOS2 ike-group 'IKEv2-REAUTH'
set vpn ipsec site-to-site peer VYOS2 ikev2-reauth 'yes'
set vpn ipsec site-to-site peer VYOS2 local-address '192.168.50.1'
set vpn ipsec site-to-site peer VYOS2 remote-address '192.168.50.2'
set vpn ipsec site-to-site peer VYOS2 vti bind 'vti0'
set vpn ipsec site-to-site peer VYOS2 vti esp-group 'ESP01'
```

2. Configure responder: vyos2 (192.168.50.2)
```
set interfaces vti vti0 address '10.0.0.2/30'
set vpn ipsec authentication psk PEER id '192.168.50.1'
set vpn ipsec authentication psk PEER secret 'vyos-test-secret'
set vpn ipsec esp-group ESP01 lifetime '1800'
set vpn ipsec esp-group ESP01 mode 'tunnel'
set vpn ipsec esp-group ESP01 pfs 'dh-group19'
set vpn ipsec esp-group ESP01 proposal 10 encryption 'aes128gcm128'
set vpn ipsec esp-group ESP01 proposal 10 hash 'sha256'
set vpn ipsec ike-group IKEv2-REAUTH key-exchange 'ikev2'
set vpn ipsec ike-group IKEv2-REAUTH lifetime '3600'
set vpn ipsec ike-group IKEv2-REAUTH proposal 10 dh-group '20'
set vpn ipsec ike-group IKEv2-REAUTH proposal 10 encryption 'aes256'
set vpn ipsec ike-group IKEv2-REAUTH proposal 10 hash 'sha512'
set vpn ipsec interface 'eth1'
set vpn ipsec options disable-route-autoinstall
set vpn ipsec site-to-site peer VYOS1 authentication local-id '192.168.50.2'
set vpn ipsec site-to-site peer VYOS1 authentication mode 'pre-shared-secret'
set vpn ipsec site-to-site peer VYOS1 authentication remote-id '192.168.50.1'
set vpn ipsec site-to-site peer VYOS1 connection-type 'trap'
set vpn ipsec site-to-site peer VYOS1 ike-group 'IKEv2-REAUTH'
set vpn ipsec site-to-site peer VYOS1 local-address '192.168.50.2'
set vpn ipsec site-to-site peer VYOS1 remote-address '192.168.50.1'
set vpn ipsec site-to-site peer VYOS1 vti bind 'vti0'
set vpn ipsec site-to-site peer VYOS1 vti esp-group 'ESP01'
```

3. Verify the reauthentication flag in initiator:
```
vyos@vyos1# run show vpn ipsec sa detail | grep reauth
  established 2407s ago, rekeying in 963s, reauth in 988s

vyos@vyos1# sudo cat /etc/swanctl/swanctl.conf | grep -i reauth
        reauth_time = 3600s

vyos@vyos1# sudo journalctl -u strongswan --since "60 minutes ago" | grep -i reauth
May 14 08:14:36 vyos1 charon[5151]: 08[IKE] <VYOS2|111> scheduling reauthentication in 3542s
May 14 08:14:36 vyos1 charon[5151]: 08[IKE] <VYOS2|111> rescheduling reauthentication in 23s after rekeying, lifetime
reduced to 383s
May 14 08:14:59 vyos1 charon[5151]: 01[IKE] <VYOS2|112> reauthenticating IKE_SA VYOS2[112]
May 14 08:14:59 vyos1 charon-systemd[5151]: reauthenticating IKE_SA VYOS2[112]
May 14 08:15:02 vyos1 charon[5151]: 03[IKE] <VYOS2|113> scheduling reauthentication in 3395s
```

### Smoketest
```
vyos@vyos4:~$ sudo /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
...
test_site_to_site_ikev2_reauth (__main__.TestVPNIPsec.test_site_to_site_ikev2_reauth) ... ok
...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly