### PR TITLE
dhcpv6: T8862: Allow multiple addresses and prefixes for reservations

### DIFF
--- a/interface-definitions/include/dhcp/dhcpv6-server-common-config.xml.i
+++ b/interface-definitions/include/dhcp/dhcpv6-server-common-config.xml.i
@@ -242,6 +242,7 @@
                 <constraint>
                   <validator name="ipv6-address"/>
                 </constraint>
+                <multi/>
               </properties>
             </leafNode>
             <leafNode name="ipv6-prefix">
@@ -254,6 +255,7 @@
                 <constraint>
                   <validator name="ipv6-prefix"/>
                 </constraint>
+                <multi/>
               </properties>
             </leafNode>
           </children>

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -385,10 +385,10 @@ def kea6_parse_subnet(subnet, config):
                 reservation['duid'] = host_config['duid']
 
             if 'ipv6_address' in host_config:
-                reservation['ip-addresses'] = [host_config['ipv6_address']]
+                reservation['ip-addresses'] = host_config['ipv6_address']
 
             if 'ipv6_prefix' in host_config:
-                reservation['prefixes'] = [host_config['ipv6_prefix']]
+                reservation['prefixes'] = host_config['ipv6_prefix']
 
             if 'option' in host_config:
                 reservation['option-data'] = kea6_parse_options(host_config['option'])

--- a/smoketest/scripts/cli/test_service_dhcpv6-server.py
+++ b/smoketest/scripts/cli/test_service_dhcpv6-server.py
@@ -138,12 +138,16 @@ class TestServiceDHCPv6Server(VyOSUnitTestSHIM.TestCase):
 
         for client_suffix in range(1, 4):
             duid = f'00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:{client_suffix:02}'
-            ip = inc_ip(subnet, client_suffix)
-            prefix = inc_ip(subnet, client_suffix << 64) + '/64'
+            ip1 = inc_ip(subnet, client_suffix * 2 - 1)
+            ip2 = inc_ip(subnet, client_suffix * 2)
+            prefix1 = inc_ip(subnet, (client_suffix * 2 - 1) << 64) + '/64'
+            prefix2 = inc_ip(subnet, (client_suffix * 2) << 64) + '/64'
 
             self.cli_set(mapping + [f'client{client_suffix}', 'duid', duid])
-            self.cli_set(mapping + [f'client{client_suffix}', 'ipv6-address', ip])
-            self.cli_set(mapping + [f'client{client_suffix}', 'ipv6-prefix', prefix])
+            self.cli_set(mapping + [f'client{client_suffix}', 'ipv6-address', ip1])
+            self.cli_set(mapping + [f'client{client_suffix}', 'ipv6-address', ip2])
+            self.cli_set(mapping + [f'client{client_suffix}', 'ipv6-prefix', prefix1])
+            self.cli_set(mapping + [f'client{client_suffix}', 'ipv6-prefix', prefix2])
 
         # cannot have both mac-address and duid set
         with self.assertRaises(ConfigSessionError):
@@ -250,8 +254,10 @@ class TestServiceDHCPv6Server(VyOSUnitTestSHIM.TestCase):
 
         for client_suffix in range(1, 4):
             duid = f'00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:{client_suffix:02}'
-            ip = inc_ip(subnet, client_suffix)
-            prefix = inc_ip(subnet, client_suffix << 64) + '/64'
+            ip1 = inc_ip(subnet, client_suffix * 2 - 1)
+            ip2 = inc_ip(subnet, client_suffix * 2)
+            prefix1 = inc_ip(subnet, (client_suffix * 2 - 1) << 64) + '/64'
+            prefix2 = inc_ip(subnet, (client_suffix * 2) << 64) + '/64'
 
             self.verify_config_object(
                 obj,
@@ -259,8 +265,8 @@ class TestServiceDHCPv6Server(VyOSUnitTestSHIM.TestCase):
                 {
                     'hostname': f'client{client_suffix}',
                     'duid': duid,
-                    'ip-addresses': [ip],
-                    'prefixes': [prefix],
+                    'ip-addresses': [ip1, ip2],
+                    'prefixes': [prefix1, prefix2],
                 },
             )
 

--- a/src/conf_mode/service_dhcpv6-server.py
+++ b/src/conf_mode/service_dhcpv6-server.py
@@ -230,10 +230,14 @@ def verify(dhcpv6):
                             if ip_address(address) not in ip_network(subnet):
                                 raise ConfigError(f'static-mapping address for mapping "{mapping}" is not in subnet "{subnet}"!')
 
-                        if ('mac' not in mapping_config and 'duid' not in mapping_config) or \
-                            ('mac' in mapping_config and 'duid' in mapping_config):
-                            raise ConfigError(f'Either MAC address or Client identifier (DUID) is required for '
-                                              f'static mapping "{mapping}" within shared-network "{network}, {subnet}"!')
+                    if ('ipv6_address' not in mapping_config and 'ipv6_prefix' not in mapping_config):
+                        raise ConfigError('Either IPv6 address or IPv6 prefix must be set for static mapping '
+                                          f'"{mapping}" within shared-network "{network}, {subnet}"!')
+
+                    if ('mac' not in mapping_config and 'duid' not in mapping_config) or \
+                        ('mac' in mapping_config and 'duid' in mapping_config):
+                        raise ConfigError('Either MAC address or Client identifier (DUID) is required for '
+                                            f'static mapping "{mapping}" within shared-network "{network}, {subnet}"!')
 
             if 'option' in subnet_config:
                 if 'vendor_option' in subnet_config['option']:

--- a/src/conf_mode/service_dhcpv6-server.py
+++ b/src/conf_mode/service_dhcpv6-server.py
@@ -226,8 +226,9 @@ def verify(dhcpv6):
                 for mapping, mapping_config in subnet_config['static_mapping'].items():
                     if 'ipv6_address' in mapping_config:
                         # Static address must be in subnet
-                        if ip_address(mapping_config['ipv6_address']) not in ip_network(subnet):
-                            raise ConfigError(f'static-mapping address for mapping "{mapping}" is not in subnet "{subnet}"!')
+                        for address in mapping_config['ipv6_address']:
+                            if ip_address(address) not in ip_network(subnet):
+                                raise ConfigError(f'static-mapping address for mapping "{mapping}" is not in subnet "{subnet}"!')
 
                         if ('mac' not in mapping_config and 'duid' not in mapping_config) or \
                             ('mac' in mapping_config and 'duid' in mapping_config):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add support for allowing DHCPv6 to assign reservations for multiple addresses and prefixes to a single client simultaneously.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8862

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
$ python3 /usr/libexec/vyos/tests/smoke/cli/test_service_dhcpv6-server.py
test_global_nameserver (main.TestServiceDHCPv6Server.test_global_nameserver) ... ok
test_prefix_delegation (main.TestServiceDHCPv6Server.test_prefix_delegation) ... ok
test_single_pool (main.TestServiceDHCPv6Server.test_single_pool) ... ok
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
