### PR TITLE
mlxsw: T8878: Add basic support for Mellanox SN2* switches

### DIFF
--- a/interface-definitions/interfaces_ethernet.xml.in
+++ b/interface-definitions/interfaces_ethernet.xml.in
@@ -14,7 +14,7 @@
             <description>Ethernet interface name</description>
           </valueHelp>
           <constraint>
-            <regex>((eth|lan)[0-9]+|(eno|ens|enp|enx).+)</regex>
+            <regex>((eth|lan)[0-9]+|(eno|ens|enp|enx).+|sw[0-9]*p[0-9]+(s[0-9]+)?)</regex>
           </constraint>
           <constraintErrorMessage>Invalid Ethernet interface name</constraintErrorMessage>
         </properties>

--- a/interface-definitions/interfaces_vxlan.xml.in
+++ b/interface-definitions/interfaces_vxlan.xml.in
@@ -87,6 +87,18 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <leafNode name="no-udp-checksum-v4">
+                <properties>
+                  <help>Disable UDP checksum validation for IPv4</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
+              <leafNode name="no-udp-checksum-v6">
+                <properties>
+                  <help>Disable UDP checksum validation for IPv6</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
               <leafNode name="neighbor-suppress">
                 <properties>
                   <help>Enable neighbor discovery (ARP and ND) suppression</help>

--- a/interface-definitions/interfaces_vxlan.xml.in
+++ b/interface-definitions/interfaces_vxlan.xml.in
@@ -87,6 +87,12 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <leafNode name="noudpcsum">
+                <properties>
+                  <help>Do not require UDP checksums.  Required for mellanox switch support</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
               <leafNode name="neighbor-suppress">
                 <properties>
                   <help>Enable neighbor discovery (ARP and ND) suppression</help>

--- a/python/vyos/ifconfig/ethernet.py
+++ b/python/vyos/ifconfig/ethernet.py
@@ -38,11 +38,11 @@ class EthernetIf(Interface):
         **Interface.definition,
         **{
             'section': 'ethernet',
-            'prefixes': ['lan', 'eth', 'eno', 'ens', 'enp', 'enx'],
+            'prefixes': ['lan', 'eth', 'eno', 'ens', 'enp', 'enx', 'sw', 'swp'],
             'bondable': True,
             'broadcast': True,
             'bridgeable': True,
-            'eternal': '(lan|eth|eno|ens|enp|enx)[0-9]+$',
+            'eternal': '^((lan|eth|eno|ens|enp|enx)[0-9]+|sw[0-9]*p[0-9]+(s[0-9]+)?)$',
         },
     }
 

--- a/python/vyos/ifconfig/ethernet.py
+++ b/python/vyos/ifconfig/ethernet.py
@@ -38,11 +38,11 @@ class EthernetIf(Interface):
         **Interface.definition,
         **{
             'section': 'ethernet',
-            'prefixes': ['lan', 'eth', 'eno', 'ens', 'enp', 'enx'],
+            'prefixes': ['lan', 'eth', 'eno', 'ens', 'enp', 'enx', 'sw', 'swp'],
             'bondable': True,
             'broadcast': True,
             'bridgeable': True,
-            'eternal': '(lan|eth|eno|ens|enp|enx)[0-9]+$',
+            'eternal': '(lan|eth|eno|ens|enp|enx)[0-9]+|sw[0-9]*p[0-9]+(s[0-9]+)?$',
         },
     }
 

--- a/python/vyos/ifconfig/vxlan.py
+++ b/python/vyos/ifconfig/vxlan.py
@@ -67,19 +67,21 @@ class VXLANIf(Interface):
         # arguments used by iproute2. For more information please refer to:
         # - https://man7.org/linux/man-pages/man8/ip-link.8.html
         mapping = {
-            'group'                      : 'group',
-            'gpe'                        : 'gpe',
-            'parameters.external'        : 'external',
-            'parameters.ip.df'           : 'df',
-            'parameters.ip.tos'          : 'tos',
-            'parameters.ip.ttl'          : 'ttl',
-            'parameters.ipv6.flowlabel'  : 'flowlabel',
-            'parameters.nolearning'      : 'nolearning',
-            'parameters.vni_filter'      : 'vnifilter',
-            'remote'                     : 'remote',
-            'source_address'             : 'local',
-            'source_interface'           : 'dev',
-            'vni'                        : 'id',
+            'group': 'group',
+            'gpe': 'gpe',
+            'parameters.external': 'external',
+            'parameters.ip.df': 'df',
+            'parameters.ip.tos': 'tos',
+            'parameters.ip.ttl': 'ttl',
+            'parameters.ipv6.flowlabel': 'flowlabel',
+            'parameters.nolearning': 'nolearning',
+            'parameters.no_udp_checksum_v4': 'noudpcsum',
+            'parameters.no_udp_checksum_v6': 'udp6zerocsumtx udp6zerocsumrx',
+            'parameters.vni_filter': 'vnifilter',
+            'remote': 'remote',
+            'source_address': 'local',
+            'source_interface': 'dev',
+            'vni': 'id',
         }
 
         # IPv6 flowlabels can only be used on IPv6 tunnels, thus we need to

--- a/python/vyos/ifconfig/vxlan.py
+++ b/python/vyos/ifconfig/vxlan.py
@@ -75,6 +75,7 @@ class VXLANIf(Interface):
             'parameters.ip.ttl'          : 'ttl',
             'parameters.ipv6.flowlabel'  : 'flowlabel',
             'parameters.nolearning'      : 'nolearning',
+            'parameters.noudpcsum'       : 'noudpcsum',
             'parameters.vni_filter'      : 'vnifilter',
             'remote'                     : 'remote',
             'source_address'             : 'local',

--- a/python/vyos/mlxsw.py
+++ b/python/vyos/mlxsw.py
@@ -1,0 +1,32 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# The sole purpose of this module is to hold common functions used in
+# all kinds of implementations to verify the CLI configuration.
+# It is started by migrating the interfaces to the new get_config_dict()
+# approach which will lead to a lot of code that can be reused.
+
+# NOTE: imports should be as local as possible to the function which
+# makes use of it!
+
+from vyos.utils.kernel import is_module_loaded
+
+
+def is_mlxsw() -> bool:
+    """
+    Check to see if this system is using the Mellanox `mlxsw` switch
+    driver so we can enable additional validation.
+    """
+    return is_module_loaded('mlxsw_core')

--- a/src/conf_mode/interfaces_bridge.py
+++ b/src/conf_mode/interfaces_bridge.py
@@ -31,6 +31,8 @@ from vyos.configdict import has_address_configured
 from vyos.configdict import has_vrf_configured
 from vyos.configdep import set_dependents
 from vyos.configdep import call_dependents
+from vyos.base import Warning
+from vyos.mlxsw import is_mlxsw
 from vyos.utils.dict import dict_search
 from vyos.utils.network import interface_exists
 from vyos.vpp.utils import cli_ifaces_list
@@ -151,6 +153,7 @@ def verify(bridge):
     verify_vrf(bridge)
     verify_mtu_ipv6(bridge)
     verify_mirror_redirect(bridge)
+    verify_mlxsw_bridge(bridge)
 
     ifname = bridge['ifname']
 
@@ -242,6 +245,17 @@ def apply(bridge):
             )
 
     return None
+
+
+def verify_mlxsw_bridge(bridge):
+    if not is_mlxsw():
+        return None
+
+    if 'mac' not in bridge:
+        Warning('Must explicitly set bridge MAC on Mellanox switches')
+
+    return None
+
 
 if __name__ == '__main__':
     try:

--- a/src/conf_mode/interfaces_vxlan.py
+++ b/src/conf_mode/interfaces_vxlan.py
@@ -33,6 +33,7 @@ from vyos.configverify import verify_bond_bridge_member
 from vyos.configverify import verify_vrf
 from vyos.ifconfig import Interface
 from vyos.ifconfig import VXLANIf
+from vyos.mlxsw import is_mlxsw
 from vyos.template import is_ipv6
 from vyos.utils.dict import dict_search
 from vyos.utils.network import interface_exists
@@ -231,6 +232,7 @@ def verify(vxlan):
     verify_vrf(vxlan)
     verify_bond_bridge_member(vxlan)
     verify_mirror_redirect(vxlan)
+    verify_mlxsw_vxlan(vxlan)
 
     # We use a defaultValue for port, thus it's always safe to use
     if vxlan['port'] == '8472':
@@ -261,6 +263,22 @@ def apply(vxlan):
         call_dependents()
 
     return None
+
+
+def verify_mlxsw_vxlan(vxlan):
+    if not is_mlxsw():
+        return None
+
+    if (
+        dict_search('parameters.no_udp_checksum_v4', vxlan) == None
+        and dict_search('parameters.no_udp_checksum_v6', vxlan) == None
+    ):
+        Warning(
+            'Must explicitly set vxlan parameter no-udp-checksum-v4 or no-udp-checksum-v6 on Mellanox switches'
+        )
+
+    return None
+
 
 if __name__ == '__main__':
     try:

--- a/src/etc/udev/rules.d/65-vyos-net.rules
+++ b/src/etc/udev/rules.d/65-vyos-net.rules
@@ -4,6 +4,9 @@
 ACTION!="add", 				GOTO="vyos_net_end"
 SUBSYSTEM!="net",			GOTO="vyos_net_end"
 
+# Use switchport names for Mellanox switches, so interface names match the front-panel labels
+DRIVERS=="mlxsw_spectrum*", NAME="sw$attr{phys_port_name}", GOTO="vyos_net_end"
+
 # Do name change for ethernet and wireless devices only
 KERNEL!="eth*|wlan*|e*", 			GOTO="vyos_net_end"
 

--- a/src/helpers/vyos-interface-rescan.py
+++ b/src/helpers/vyos-interface-rescan.py
@@ -87,7 +87,7 @@ def get_wireless_physical_device(intf: str) -> str:
     return phy
 
 def get_interface_type(intf: str) -> str:
-    if 'eth' in intf:
+    if intf.startswith(('eth', 'lan', 'eno', 'ens', 'enp', 'enx', 'sw')):
         intf_type = 'ethernet'
     elif 'wlan' in intf:
         intf_type = 'wireless'

--- a/src/helpers/vyos-interface-rescan.py
+++ b/src/helpers/vyos-interface-rescan.py
@@ -87,7 +87,7 @@ def get_wireless_physical_device(intf: str) -> str:
     return phy
 
 def get_interface_type(intf: str) -> str:
-    if 'eth' in intf:
+    if 'eth' in intf or 'sw' in intf:
         intf_type = 'ethernet'
     elif 'wlan' in intf:
         intf_type = 'wireless'

--- a/src/ocaml/completion/list_interfaces/list_interfaces.ml
+++ b/src/ocaml/completion/list_interfaces/list_interfaces.ml
@@ -23,7 +23,7 @@ let type_to_prefix it =
     | "bonding" -> "bond"
     | "bridge" -> "br"
     | "dummy" -> "dum"
-    | "ethernet" -> "eth"
+    | "ethernet" -> "eth|sw|swp"
     | "geneve" -> "gnv"
     | "input" -> "ifb"
     | "l2tpeth" -> "l2tpeth"
@@ -44,13 +44,13 @@ let type_to_prefix it =
 
 (* filter_section to match the constraint of python.vyos.ifconfig.section
  *)
-let rx = Pcre2.regexp {|\d(\d|v|\.)*$|}
+let rx = Pcre2.regexp {|\d(\d|[psv]|\.)*$|}
 
 let filter_section s =
     let r = Pcre2.qreplace_first ~rex:rx ~templ:"" s in
     match r with
     |"bond"|"br"|"dum"|"eth"|"gnv"|"ifb"|"l2tpeth"|"lo"|"macsec" -> true
-    |"peth"|"pppoe"|"sstpc"|"tun"|"veth"|"vti"|"vtun"|"vxlan"|"wg"|"wlan"|"wwan" -> true
+    |"peth"|"pppoe"|"sstpc"|"sw"|"swp"|"tun"|"veth"|"vti"|"vtun"|"vxlan"|"wg"|"wlan"|"wwan" -> true
     | _ -> false
 
 let filter_from_prefix p s =
@@ -76,7 +76,7 @@ let filter_broadcast s =
     with Not_found -> false
 
 let filter_bridgeable s =
-    let pattern = {|^(bond|eth|gnv|l2tpeth|lo|tun|veth|vtun|vxlan|wlan)(.*)$|}
+    let pattern = {|^(bond|eth|gnv|l2tpeth|lo|sw|tun|veth|vtun|vxlan|wlan)(.*)$|}
     in
     try
         let _ = Pcre2.exec ~pat:pattern s in
@@ -84,7 +84,7 @@ let filter_bridgeable s =
     with Not_found -> false
 
 let filter_bondable s =
-    let pattern = {|^(eth|lan|eno|ens)[A-Za-z0-9_-]*$|}
+    let pattern = {|^(eth|lan|eno|ens|sw)[A-Za-z0-9_-]*$|}
     in
     try
         let _ = Pcre2.exec ~pat:pattern s in

--- a/src/services/vyos-netlinkd
+++ b/src/services/vyos-netlinkd
@@ -38,7 +38,7 @@ from vyos.utils.process import stop_systemd_unit
 running = True
 
 # compile regex once during startup for fast match
-IFACE_RE = re.compile(r"^(?:eth|br|bond|wlan)")
+IFACE_RE = re.compile(r"^(?:eth|lan|eno|ens|enp|enx|br|bond|sw|wlan)")
 
 def match_iface(ifname: str) -> bool:
     """ Helper function returning true if interface name is a match for further

--- a/src/validators/ethernet-interface
+++ b/src/validators/ethernet-interface
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-if ! [[ "$1" =~ ^(lan|eth|eno|ens|enp|enx)[0-9]+$ ]]; then
+if ! [[ "$1" =~ ^((lan|eth|eno|ens|enp|enx)[0-9]+|sw[0-9]*p[0-9]+(s[0-9]+)?)$ ]]; then
     echo "Error: $1 is not an ethernet interface"
     exit 1
 fi

--- a/src/validators/ethernet-interface
+++ b/src/validators/ethernet-interface
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if ! [[ "$1" =~ ^(lan|eth|eno|ens|enp|enx)[0-9]+$ ]]; then
+if ! [[ "$1" =~ ^(lan|eth|eno|ens|enp|enx)[0-9]+|sw[0-9]*p[0-9]+(s[0-9]+)? $ ]]; then
     echo "Error: $1 is not an ethernet interface"
     exit 1
 fi

--- a/src/validators/vrf-name
+++ b/src/validators/vrf-name
@@ -41,7 +41,7 @@ if __name__ == '__main__':
 
     # VRF name must not conflict with local interface type prefix
     pattern = r'^(?!(bond|br|dum|eth|lan|eno|ens|enp|enx|gnv|ipoe|l2tp|l2tpeth|\
-       vtun|ppp|pppoe|peth|tun|vti|vxlan|wg|wlan|wwan|\d)\d*(\.\d+)?(v.+)?).*$'
+       vtun|ppp|pppoe|peth|sw|tun|vti|vxlan|wg|wlan|wwan|\d)\d*(\.\d+)?(v.+)?).*$'
     if not re.match(pattern, vrf):
         exit(1)
 

--- a/src/validators/vrf-name
+++ b/src/validators/vrf-name
@@ -41,8 +41,9 @@ if __name__ == '__main__':
 
     # VRF name must not conflict with local interface type prefix
     pattern = r'^(?!(bond|br|dum|eth|lan|eno|ens|enp|enx|gnv|ipoe|l2tp|l2tpeth|\
-       vtun|ppp|pppoe|peth|tun|vti|vxlan|wg|wlan|wwan|\d)\d*(\.\d+)?(v.+)?).*$'
+       vtun|ppp|pppoe|peth|sw|tun|vti|vxlan|wg|wlan|wwan|\d)\d*(\.\d+)?(v.+)?).*$'
     if not re.match(pattern, vrf):
         exit(1)
 
     exit(0)
+ 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

This adds basic support for running VyOS on Mellanox's Spectrum (SN2xxx, SN3xxx, etc) switches.  With this patch, it's possible to install VyOS onto at least the [SN2010](https://network.nvidia.com/files/doc-2020/pb-sn2010.pdf) and get full hardware-offloaded support for the switch's ~1.7 Tbps performance when doing a mix of L2 bridging, L3 routing, and VxLAN tunneling.

The [kernel support for this](https://github.com/Mellanox/mlxsw/wiki) has been part of the stock kernel since at least Linux 4.4, and is supported by Mellanox.  VyOS already builds the `mlxsw` kernel module and it loads automatically when booted on the hardware.  Once this happens, all of the switch's interfaces appear as perfectly normal Linux Ethernet interfaces.  Any bridge, routing, or tunneling configurations set up via `ip` and friends get offloaded to the switch ASIC transparently.  There is no specific user-mode support needed for any of the features involved, just configure the kernel like normal and the config will be offloaded to hardware.

From user-mode's perspective, it's just a regular Linux system with lots of Ethernet interfaces.

Unfortunately, there are 2 things that need to be added to VyOS to make Mellanox's switches actually usable.
 
1.  There are practical naming issues with the switch ports; out of the box, there's no obvious mapping between the names silk-screened onto the front panel of the switch and `ethN` names.  On the SN2010, switch port 1 is `eth24`, switch port 3 is `eth20`, port 7 is `eth16`, port 22 is `eth10`, and so on.  This makes the device extremely painful to use outside of a lab environment.
2.  VxLAN interfaces need to be able to enable the `noudpcsum` parameter.  Without this, `mlxsw` refuses to let you add `vxlanN` devices to bridges, because it's not able to offload VxLAN encapsulation properly.

To fix the naming issue, this PR follows the naming recommendations from Kernel's [switchdev docs](https://docs.kernel.org/networking/switchdev.html#port-netdev-naming) and configures `udev` to rename Mellanox switch ports as `swXpYsZ` (`sw0p2s1`), for switch `X`, port `Y`, and sub-port `Z`.  This is *slightly* overly-complicated for any system with a single switch (~all uses), so I've made the switch number (`X`) optional in port regexes, and the default `udev` rule added only supports a single switch with `swpY` and `swpYsZ` names by default.

Portions of this naming scheme are hard-coded into Mellanox's switchdev driver; it sets `phys_port_name` as `pY` for full ports and `pYsZ` for ports that have been split into sub-interfaces (QSFP+ -> 4x 10Gbe, for example).  So adding a udev rule like this:

```
# from https://ipng.ch/s/articles/2023/11/11/debian-on-mellanox-sn2700-32x100g/
SUBSYSTEM=="net", ACTION=="add", DRIVERS=="mlxsw_spectrum*", \
    NAME="sw$attr{phys_port_name}"
EOF
```

Will auto-create `swp1` and `swp22s1`-style interface names as needed by hardware.

This PR adds this udev rule, regex changes needed to support `sw*` interface names, as well as adding trivial support for `noudpcsum`.

There's a long-ish discussion on this in [the forum](https://forum.vyos.io/t/vyos-on-mellanox-spectrum-snxxxx-switches-w-switchdev/17112/45).

With this PR, I'm able to boot my SN2010, turn up a mix of L2 and L3 interfaces, create two bridges, add the L2 interfaces to the bridges, and add vxlan (with EVPN) to the bridges.  I'm able to connect L2 device -> interface ethernet swp2 -> bridge br200 -> vxlan vxlan200 -> L3 interfaces swp21 and swp22 -> 2x Arista switches -> other VxLAN VTEPs.  Seems to work fine.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/vyos-documentation/pull/2050

## How to test / Smoketest result

This PR doesn't really change any code, except for nearly-trivial changes to validation shell scripts.  This will be verified by passing existing tests and by building an image that uses this and running it on actual SN2010 hardware to verify that `swpY`-style names function correctly.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
