### PR TITLE
pki: T8877: Add ability to show private key in pem format

### DIFF
--- a/op-mode-definitions/pki.xml.in
+++ b/op-mode-definitions/pki.xml.in
@@ -541,6 +541,22 @@
                 </properties>
                 <command>${vyos_op_scripts_dir}/pki.py show_certificate --name "$4" --fingerprint "$6"</command>
               </tagNode>
+              <node name="private">
+                <properties>
+                  <help>Show x509 certificate private key</help>
+                  <completionHelp>
+                    <list>pem</list>
+                  </completionHelp>
+                </properties>
+                <children>
+                  <leafNode name="pem">
+                    <properties>
+                      <help>Show x509 certificate private key in PEM format</help>
+                    </properties>
+                    <command>${vyos_op_scripts_dir}/pki.py show_certificate --name "$4" --private --pem</command>
+                  </leafNode>
+                </children>
+              </node>
             </children>
           </tagNode>
           <tagNode name="crl">

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -1252,6 +1252,7 @@ def show_certificate_authority(
 def show_certificate(
     raw: bool,
     name: typing.Optional[str] = None,
+    private: typing.Optional[bool] = False,
     pem: typing.Optional[bool] = False,
     fingerprint: typing.Optional[ArgsFingerprint] = None,
 ):
@@ -1282,11 +1283,30 @@ def show_certificate(
             if not cert:
                 continue
 
-            if name and pem:
+            if name and pem and not (private or fingerprint):
                 print(encode_certificate(cert))
                 return
-            elif name and fingerprint:
+            elif name and fingerprint and not private:
                 print(get_certificate_fingerprint(cert, fingerprint))
+                return
+            elif name and private:
+                if 'private' in cert_dict and 'key' in cert_dict['private']:
+                    protected = 'password_protected' in cert_dict['private']
+                    private_key = load_private_key(
+                        cert_dict['private']['key'],
+                        passphrase=None,
+                        wrap_tags=True,
+                    )
+                    if private_key:
+                        print(encode_private_key(private_key, passphrase=None))
+                    else:
+                        if protected:
+                            print(f'Private key for certificate "{cert_name}" is '
+                                  'password-protected and cannot be displayed')
+                        else:
+                            print(f'Failed to load private key for certificate "{cert_name}"')
+                else:
+                    print(f'No private key found for certificate "{cert_name}"')
                 return
 
             ca_name = get_certificate_ca(cert, ca_certs)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add op-mode command having ability to show private key in pem format as part of PKI configuration. This is needed for users who want to render the certificate and its private key.

Currently, we already have `show pki certificate acme-foo pem` to render certificate in PEM format. 

We now have `show pki certificate acme-foo private pem` to render the private key of the certificate in PEM format as well.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8877

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
$ show pki certificate acme-foo private pem
-----BEGIN PRIVATE KEY-----
MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC3oU2D5oUvMv6n
J6XlR/V4zF1y6bK3D7nN2J8l7qGvO2XzC/bHjF9HhXWvX4z5F4S4V9fKx8rW2V6d
JqFw1234aBcDefGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKlMnOpQrStUvWxYzAbCd
EfGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKlMnOp
QrStUvWxYzAbCdEfGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKlMnOpQrStUvWxYzAb
CdEfGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKlMn
OpQrStUvWxYzAbCdEfGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKlMnOpQrStUvWxYz
AbCdEfGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKlMnOpQrStUvWxYzAbCdEfGhIjKl
MnOpQrStUvWxYzICAwEAAQKCAQAwd1V4fG7jK8mN9pX6XyZzQ7wE3rT9uV4yX8Zm
N3vCx7zK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN
6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN
6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN
6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN
6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmNAoGBAO8bV9zK9X7PqLmN6V5xZ3vK9X7P
qLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7P
qLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmNaoGBA things
lookverymuchlikethisinarealprivatekeyfileoYmN6V5xZ3vK9X7PqLmN6V5
Z3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmNAoGBAO8bV9zK9X7PqLmN
6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN
6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmNaoGBAL8bV9zK9X7P
qLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7P
qLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmNAoGBAO8bV9zK9X7PqLmN6V5xZ3vK
9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK
9X7PqLmN6V5xZ3vK9X7PqLmN6V5xZ3vK9X7P==
-----END PRIVATE KEY-----
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
