### PR TITLE
Smoketest: T8879: add missing Kernel config tests for hypervisor platforms

### DIFF
--- a/smoketest/scripts/system/test_kernel_options.py
+++ b/smoketest/scripts/system/test_kernel_options.py
@@ -90,11 +90,6 @@ class TestKernelModules(unittest.TestCase):
             tmp = re.findall(f'{option}=(y|m)', self._config_data)
             self.assertTrue(tmp)
 
-    def test_vmware_support(self):
-        for option in ['CONFIG_VMXNET3']:
-            tmp = re.findall(f'{option}=(y|m)', self._config_data)
-            self.assertTrue(tmp)
-
     def test_container_cgroup_support(self):
         options_to_check = [
             'CONFIG_CGROUPS', 'CONFIG_MEMCG',
@@ -229,6 +224,47 @@ class TestKernelModules(unittest.TestCase):
                     tmp, msg=f'{option} must be enabled (=y or =m) on arm64'
                 )
 
+    def test_hypervisor_hyperv(self):
+        if IS_ARM64:
+            self.skipTest('Hyper-V only available on X86 platform')
+
+        options_to_check = ['CONFIG_HYPERV_VSOCKETS', 'CONFIG_HYPERV_STORAGE',
+                            'CONFIG_HYPERV_NET', 'CONFIG_HYPERV_KEYBOARD',
+                            'CONFIG_HYPERV_VTL_MODE', 'CONFIG_HYPERV_TIMER',
+                            'CONFIG_HYPERV_UTILS', 'CONFIG_HYPERV_BALLOON',
+                            'CONFIG_HYPERV_VMBUS', 'CONFIG_HYPERV_IOMMU']
+
+        for option in options_to_check:
+            tmp = re.findall(f'{option}=(y|m)', self._config_data)
+            self.assertTrue(tmp)
+
+    def test_hypervisor_vmware(self):
+        if IS_ARM64:
+            self.skipTest('VMware only available on X86 platform')
+
+        options_to_check = ['CONFIG_VMWARE_VMCI_VSOCKETS', 'CONFIG_VMXNET3',
+                            'CONFIG_VMWARE_BALLOON', 'CONFIG_VMWARE_VMCI',
+                            'CONFIG_VMWARE_PVSCSI']
+
+        for option in options_to_check:
+            tmp = re.findall(f'{option}=(y|m)', self._config_data)
+            self.assertTrue(tmp)
+
+    def test_hypervisor_virtio(self):
+        options_to_check = ['CONFIG_VIRTIO_BLK', 'CONFIG_VIRTIO_NET',
+                            'CONFIG_VIRTIO_CONSOLE', 'CONFIG_VIRTIO_ANCHOR',
+                            'CONFIG_VIRTIO_PCI_LIB',
+                            'CONFIG_VIRTIO_PCI_LIB_LEGACY',
+                            'CONFIG_VIRTIO_MENU', 'CONFIG_VIRTIO_PCI',
+                            'CONFIG_VIRTIO_PCI_LEGACY', 'CONFIG_VIRTIO_VDPA',
+                            'CONFIG_VIRTIO_BALLOON', 'CONFIG_VIRTIO_INPUT',
+                            'CONFIG_VIRTIO_MMIO',
+                            'CONFIG_VIRTIO_MMIO_CMDLINE_DEVICES',
+                            'CONFIG_VIRTIO_IOMMU']
+
+        for option in options_to_check:
+            tmp = re.findall(f'{option}=(y|m)', self._config_data)
+            self.assertTrue(tmp)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Add checks for common used Hypervisor platforms where we know VyOS runs on. Check that Linux Kernel is build with proper drivers for Hyper-V, VirtIO and VMware.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8879

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/1193

## How to test / Smoketest result
```
yos@vyos:~$ /usr/libexec/vyos/tests/smoke/system/test_kernel_options.py
test_amd_pstate (__main__.TestKernelModules.test_amd_pstate) ... ok
test_arm64 (__main__.TestKernelModules.test_arm64) ... skipped 'Not an arm64 platform'
test_bond_interface (__main__.TestKernelModules.test_bond_interface) ... ok
test_bridge_interface (__main__.TestKernelModules.test_bridge_interface) ... ok
test_container_cgroup_support (__main__.TestKernelModules.test_container_cgroup_support) ... ok
test_container_cpu (__main__.TestKernelModules.test_container_cpu) ... ok
test_dropmon_enabled (__main__.TestKernelModules.test_dropmon_enabled) ... ok
test_dummy (__main__.TestKernelModules.test_dummy) ... ok
test_hypervisor_hyperv (__main__.TestKernelModules.test_hypervisor_hyperv) ... ok
test_hypervisor_virtio (__main__.TestKernelModules.test_hypervisor_virtio) ... ok
test_hypervisor_vmware (__main__.TestKernelModules.test_hypervisor_vmware) ... ok
test_inotify_stackfs (__main__.TestKernelModules.test_inotify_stackfs) ... ok
test_ip_routing_support (__main__.TestKernelModules.test_ip_routing_support) ... ok
test_kexec (__main__.TestKernelModules.test_kexec) ... ok
test_macvlan (__main__.TestKernelModules.test_macvlan) ... ok
test_openvpn_dco (__main__.TestKernelModules.test_openvpn_dco) ... ok
test_psample_enabled (__main__.TestKernelModules.test_psample_enabled) ... ok
test_qemu_support (__main__.TestKernelModules.test_qemu_support) ... ok
test_slub (__main__.TestKernelModules.test_slub) ... ok
test_synproxy_enabled (__main__.TestKernelModules.test_synproxy_enabled) ... ok
test_vfio (__main__.TestKernelModules.test_vfio) ... ok
test_vxlan (__main__.TestKernelModules.test_vxlan) ... ok
test_wireguard (__main__.TestKernelModules.test_wireguard) ... ok
test_wwan (__main__.TestKernelModules.test_wwan) ... ok

----------------------------------------------------------------------
Ran 24 tests in 0.058s

OK (skipped=1)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
