### PR TITLE
ntp: T8882: add ntp polling options

### DIFF
--- a/data/templates/chrony/chrony.conf.j2
+++ b/data/templates/chrony/chrony.conf.j2
@@ -42,7 +42,16 @@ user {{ user }}
 {%         if config.pool is vyos_defined %}
 {%             set association = 'pool' %}
 {%         endif %}
-{{ association }} {{ server | replace('_', '-') }} iburst {{- ' nts' if config.nts is vyos_defined }} {{- ' noselect' if config.noselect is vyos_defined }} {{- ' prefer' if config.prefer is vyos_defined }} {{- ' xleave' if config.interleave is vyos_defined }} {{- ' port ' ~ ptp.port if ptp.port is vyos_defined and config.ptp is vyos_defined }}
+{{ association }} {{ server | replace('_', '-') }} iburst
+  {{- ' nts' if config.nts is vyos_defined }}
+  {{- ' noselect' if config.noselect is vyos_defined }}
+  {{- ' prefer' if config.prefer is vyos_defined }}
+  {{- ' xleave' if config.interleave is vyos_defined }}
+  {{- ' port ' ~ ptp.port if ptp.port is vyos_defined and config.ptp is vyos_defined }}
+  {{- ' minpoll ' ~ config.minpoll if config.minpoll is vyos_defined }}
+  {{- ' maxpoll ' ~ config.maxpoll if config.maxpoll is vyos_defined }}
+  {{- ' presend ' ~ config.presend if config.presend is vyos_defined }}
+  {{- ' extfield F323' if config.extfield_f323 is vyos_defined }}
 {%     endfor %}
 {% endif %}
 

--- a/interface-definitions/service_ntp.xml.in
+++ b/interface-definitions/service_ntp.xml.in
@@ -166,6 +166,50 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <leafNode name="minpoll">
+                <properties>
+                  <help>Set the minimum poll exponent for time between NTP polls.  Default is 6, for 2^6=64 seconds.</help>
+                  <valueHelp>
+                    <format>u32:0-24</format>
+                    <description>Poll exponent, in powers of 2 seconds.</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-24"/>
+                  </constraint>
+                </properties>
+                <defaultValue>6</defaultValue>
+              </leafNode>
+              <leafNode name="maxpoll">
+                <properties>
+                  <help>Set the maximum poll exponent for time between NTP polls.  Default is 10, for 2^10=1024 seconds.</help>
+                  <valueHelp>
+                    <format>u32:0-24</format>
+                    <description>Poll exponent, in powers of 2 seconds.</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-24"/>
+                  </constraint>
+                </properties>
+                <defaultValue>10</defaultValue>
+              </leafNode>
+              <leafNode name="presend">
+                <properties>
+                  <help>Presend an extra NTP packet before polling if more than 2^N seconds have elapsed since the last poll.</help>
+                  <valueHelp>
+                    <format>u32:0-10</format>
+                    <description>Time exponent, in powers of 2 seconds.</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-10"/>
+                  </constraint>
+                </properties>
+              </leafNode>
+              <leafNode name="extfield-f323">
+                <properties>
+                  <help>Enable extension field F323 for this peer, increasing time resolution.</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
             </children>
           </tagNode>
         </children>


### PR DESCRIPTION
## Change summary

Add 4 additional `service ntp server <host> ` options:

- `minpoll N`: passes `minpoll N` through to `chrony.conf`, sets minimum NTP polling interval for peer.
- `maxpoll N`: passes `maxpoll N` through to `chrony.conf`, sets maximum NTP polling interval for peer.
- `presend N`: passes `presend N` through to `chrony.conf`, configures pre-send/ARP warmup behavior.
- `extfield-f323`: passes `extfield F323` through to `chrony.conf`, increases precision when talking to other Chrony (or NTP 5.x) servers.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8882

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-documentation/pull/2051

## How to test / Smoketest result

Build `.deb`s and pushed onto test VyOS instance.  Manually configured all 4 fields, verified correct `chrony.conf`.

<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [X] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [X] I have updated the documentation accordingly
