### PR TITLE
high-availability: T7059: Allow disabling persistent connections for virtual-server

### DIFF
--- a/data/templates/high-availability/keepalived.conf.j2
+++ b/data/templates/high-availability/keepalived.conf.j2
@@ -228,7 +228,9 @@ virtual_server fwmark {{ vserver_config.fwmark }} {
 {%         elif vserver_config.forward_method is vyos_defined('tunnel') %}
     lb_kind TUN
 {%         endif %}
+{%         if vserver_config.persistence_timeout | int > 0 %}
     persistence_timeout {{ vserver_config.persistence_timeout }}
+{%         endif %}
     protocol {{ vserver_config.protocol | upper }}
 {%         if vserver_config.real_server is vyos_defined %}
 {%             for rserver, rserver_config in vserver_config.real_server.items() %}

--- a/interface-definitions/high-availability.xml.in
+++ b/interface-definitions/high-availability.xml.in
@@ -513,11 +513,15 @@
             <properties>
               <help>Timeout for persistent connections</help>
               <valueHelp>
+                <format>u32:0</format>
+                <description>Disable persistent connections</description>
+              </valueHelp>
+              <valueHelp>
                 <format>u32:1-86400</format>
                 <description>Timeout for persistent connections</description>
               </valueHelp>
               <constraint>
-                <validator name="numeric" argument="--range 1-86400"/>
+                <validator name="numeric" argument="--range 0-86400"/>
               </constraint>
             </properties>
             <defaultValue>300</defaultValue>

--- a/smoketest/scripts/cli/test_high-availability_virtual-server.py
+++ b/smoketest/scripts/cli/test_high-availability_virtual-server.py
@@ -83,6 +83,13 @@ class TestHAVirtualServer(VyOSUnitTestSHIM.TestCase):
             self.assertIn(f'{proto.upper()}_CHECK', config)
             self.assertIn(f'connect_timeout {connection_timeout}', config)
 
+        # Verify persistence_timeout is not set when value is 0
+        self.cli_set(vserver_base + [vs, 'persistence-timeout', '0'])
+        self.cli_commit()
+
+        config = read_file(KEEPALIVED_CONF)
+        self.assertNotIn('persistence_timeout', config)
+
     def test_02_ha_virtual_server_and_vrrp(self):
         algo = 'least-connection'
         delay = '15'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7059
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-documentation/pull/2053
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set interfaces ethernet eth1 address '50.106.9.46/24'

set interfaces loopback lo address '172.16.0.1/32'
set interfaces loopback lo address '172.16.0.2/32'
set interfaces loopback lo address '172.16.1.1/32'
set interfaces loopback lo address '172.16.1.2/32'

set high-availability virtual-server http address '50.106.9.46'
set high-availability virtual-server http algorithm 'weighted-round-robin'
set high-availability virtual-server http delay-loop '1'
set high-availability virtual-server http persistence-timeout '300'
set high-availability virtual-server http port '8080'
set high-availability virtual-server http protocol 'tcp'
set high-availability virtual-server http real-server 172.16.0.1 port '80'
set high-availability virtual-server http real-server 172.16.0.2 port '80'
set high-availability virtual-server http real-server 172.16.1.1 port '80'
set high-availability virtual-server http real-server 172.16.1.2 port '80'
commit

# Start Python HTTP servers 
sudo python3 -m http.server --bind 172.16.0.1 80 &
sudo python3 -m http.server --bind 172.16.0.2 80 &
sudo python3 -m http.server --bind 172.16.1.1 80 &
sudo python3 -m http.server --bind 172.16.1.2 80 &

# run test loop
for i in $(seq 1 256); do curl -s http://50.106.9.46:8080/ & done

vyos@vyos:~$ sudo ipvsadm -L -n
IP Virtual Server version 1.2.1 (size=4096)
Prot LocalAddress:Port Scheduler Flags
  -> RemoteAddress:Port           Forward Weight ActiveConn InActConn
TCP  50.106.9.46:8080 wrr
  -> 172.16.0.1:80                Masq    1      0          50        
  -> 172.16.0.2:80                Masq    1      0          50        
  -> 172.16.1.1:80                Masq    1      0          50        
  -> 172.16.1.2:80                Masq    1      0          50        
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
