### PR TITLE
vyos-netlinkd: T8781: try IPRoute.bind() RTNL subscription first

### DIFF
--- a/src/services/vyos-netlinkd
+++ b/src/services/vyos-netlinkd
@@ -107,8 +107,17 @@ def main():
     syslog.syslog(syslog.LOG_INFO, "VyOS Netlink listener daemon started.")
 
     # Subscribe to link notifications only (not routes/rules/neigh/addr/...).
-    ipr = IPRoute(groups=RTMGRP_LINK)
-    ipr.bind()
+    ipr = IPRoute()
+    try:
+        # newer pyroute2 versions support bind group in IPRoute() constructor
+        ipr.bind(groups=RTMGRP_LINK)
+        syslog.syslog(syslog.LOG_INFO,
+            'IPRoute.bind() using groups=RTMGRP_LINK RTNL subscription')
+    except TypeError:
+        syslog.syslog(syslog.LOG_WARNING,
+            'IPRoute.bind() has no groups= support; using default RTNL subscriptions',
+        )
+        ipr.bind()
     fd = ipr.fileno()
 
     global running


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Not all pyroute2 versions which ship IPRoute() support subscribing to RTNL multicast groups. If subscribing fails, fallback to all messages.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8781

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/5199
* https://github.com/vyos/vyos-1x/pull/5200

## How to test / Smoketest result

```
May 18 17:27:25 LR1.wue3 vyos-netlinkd[10269]: VyOS Netlink listener daemon started.
May 18 17:27:25 LR1.wue3 vyos-netlinkd[10269]: IPRoute.bind() using groups=RTMGRP_LINK RTNL subscription
```

```
May 18 17:29:21 vyos-netlinkd[10269]: RTM_NEWLINK -> eth3, state=DOWN, mac=00:50:56:b3:9d:8e
May 18 17:29:21 vyos-netlinkd[10269]: RTM_NEWLINK -> eth3, state=DOWN, mac=00:50:56:b3:9d:8e
May 18 17:29:21 vyos-netlinkd[10269]: RTM_NEWLINK -> eth3, state=UP, mac=00:50:56:b3:9d:8e
May 18 17:29:22 vyos-netlinkd[10269]: RTM_NEWLINK -> eth3, state=UP, mac=00:50:56:b3:9d:8e
May 18 17:29:22 vyos-netlinkd[10269]: RTM_NEWLINK -> eth3, state=UP, mac=00:50:56:b3:9d:8e
May 18 17:29:22 vyos-netlinkd[10269]: RTM_NEWLINK -> br0, state=UP, mac=c6:11:aa:29:7e:92
May 18 17:29:23 kernel: br0: port 1(eth3) entered disabled state
May 18 17:29:23 vyos-netlinkd[10269]: RTM_NEWLINK -> eth3, state=DOWN, mac=00:50:56:b3:9d:8e
May 18 17:29:23 vyos-netlinkd[10269]: RTM_NEWLINK -> eth3, state=DOWN, mac=00:50:56:b3:9d:8e
May 18 17:29:23 vyos-netlinkd[10269]: RTM_NEWLINK -> br0, state=DOWN, mac=c6:11:aa:29:7e:92
``` 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
