### PR TITLE
T8881: dns: expose PowerDNS recursor cache tuning options

### DIFF
--- a/data/templates/dns-forwarding/recursor.conf.j2
+++ b/data/templates/dns-forwarding/recursor.conf.j2
@@ -20,6 +20,15 @@ max-cache-entries={{ cache_size }}
 # negative TTL for NXDOMAIN
 max-negative-ttl={{ negative_ttl }}
 
+# refresh-on-ttl-perc
+refresh-on-ttl-perc={{ refresh_on_ttl_perc }}
+
+# nothing-below-nxdomain
+nothing-below-nxdomain={{ nothing_below_nxdomain }}
+
+# minimum-ttl-override
+minimum-ttl-override={{ minimum_ttl_override }}
+
 # timeout
 network-timeout={{ timeout }}
 

--- a/data/templates/dns-forwarding/recursor.conf.j2
+++ b/data/templates/dns-forwarding/recursor.conf.j2
@@ -20,8 +20,8 @@ max-cache-entries={{ cache_size }}
 # negative TTL for NXDOMAIN
 max-negative-ttl={{ negative_ttl }}
 
-# refresh-on-ttl-perc
-refresh-on-ttl-perc={{ refresh_on_ttl_perc }}
+# TTL refresh percentage
+refresh-on-ttl-perc={{ ttl_percent }}
 
 # nothing-below-nxdomain
 nothing-below-nxdomain={{ nothing_below_nxdomain }}

--- a/interface-definitions/service_dns_forwarding.xml.in
+++ b/interface-definitions/service_dns_forwarding.xml.in
@@ -684,9 +684,9 @@
                 </properties>
                 <defaultValue>0</defaultValue>
               </leafNode>
-              <leafNode name="refresh-on-ttl-perc">
+              <leafNode name="ttl-percent">
                 <properties>
-                  <help>Refresh cached records when remaining TTL is below this percent of the original (0 to disable)</help>
+                  <help>Refresh cached records when remaining TTL is below this percentage of the original TTL (0 to disable)</help>
                   <valueHelp>
                     <format>u32:0-100</format>
                     <description>Percentage of original TTL remaining before refresh</description>

--- a/interface-definitions/service_dns_forwarding.xml.in
+++ b/interface-definitions/service_dns_forwarding.xml.in
@@ -686,7 +686,7 @@
               </leafNode>
               <leafNode name="refresh-on-ttl-perc">
                 <properties>
-                  <help>Refresh cached records when remaining TTL is below this percent of the original (0 disables)</help>
+                  <help>Refresh cached records when remaining TTL is below this percent of the original (0 to disable)</help>
                   <valueHelp>
                     <format>u32:0-100</format>
                     <description>Percentage of original TTL remaining before refresh</description>

--- a/interface-definitions/service_dns_forwarding.xml.in
+++ b/interface-definitions/service_dns_forwarding.xml.in
@@ -684,6 +684,56 @@
                 </properties>
                 <defaultValue>0</defaultValue>
               </leafNode>
+              <leafNode name="refresh-on-ttl-perc">
+                <properties>
+                  <help>Refresh cached records when remaining TTL is below this percent of the original (0 disables)</help>
+                  <valueHelp>
+                    <format>u32:0-100</format>
+                    <description>Percentage of original TTL remaining before refresh</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-100"/>
+                  </constraint>
+                </properties>
+                <defaultValue>0</defaultValue>
+              </leafNode>
+              <leafNode name="nothing-below-nxdomain">
+                <properties>
+                  <help>NXDOMAIN subtree handling (RFC 8020)</help>
+                  <completionHelp>
+                    <list>no dnssec yes</list>
+                  </completionHelp>
+                  <valueHelp>
+                    <format>no</format>
+                    <description>Do not apply RFC 8020 processing</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>dnssec</format>
+                    <description>Apply RFC 8020 only for DNSSEC-validated NXDOMAIN records</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>yes</format>
+                    <description>Apply for any cached NXDOMAIN that is not bogus</description>
+                  </valueHelp>
+                  <constraint>
+                    <regex>(no|dnssec|yes)</regex>
+                  </constraint>
+                </properties>
+                <defaultValue>dnssec</defaultValue>
+              </leafNode>
+              <leafNode name="minimum-ttl-override">
+                <properties>
+                  <help>Minimum TTL in seconds for cached DNS records</help>
+                  <valueHelp>
+                    <format>u32:0-2147483647</format>
+                    <description>Minimum cached record TTL in seconds</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="numeric" argument="--range 0-2147483647"/>
+                  </constraint>
+                </properties>
+                <defaultValue>1</defaultValue>
+              </leafNode>
               <leafNode name="timeout">
                 <properties>
                   <help>Number of milliseconds to wait for a remote authoritative server to respond</help>

--- a/smoketest/scripts/cli/test_service_dns_forwarding.py
+++ b/smoketest/scripts/cli/test_service_dns_forwarding.py
@@ -133,17 +133,17 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
 
     # PowerDNS cache-related recursor options
     def test_recursor_cache_options(self):
-        refresh_on_ttl_perc = '10'
+        ttl_percent = '10'
         nothing_below_nxdomain = 'yes'
         minimum_ttl_override = '30'
 
-        self.cli_set(base_path + ['refresh-on-ttl-perc', refresh_on_ttl_perc])
+        self.cli_set(base_path + ['ttl-percent', ttl_percent])
         self.cli_set(base_path + ['nothing-below-nxdomain', nothing_below_nxdomain])
         self.cli_set(base_path + ['minimum-ttl-override', minimum_ttl_override])
 
         self.cli_commit()
 
-        self.assertEqual(get_config_value('refresh-on-ttl-perc'), refresh_on_ttl_perc)
+        self.assertEqual(get_config_value('refresh-on-ttl-perc'), ttl_percent)
         self.assertEqual(get_config_value('nothing-below-nxdomain'), nothing_below_nxdomain)
         self.assertEqual(get_config_value('minimum-ttl-override'), minimum_ttl_override)
 

--- a/smoketest/scripts/cli/test_service_dns_forwarding.py
+++ b/smoketest/scripts/cli/test_service_dns_forwarding.py
@@ -131,6 +131,28 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         tmp = get_config_value('local-port')
         self.assertEqual(tmp, '53')
 
+    # PowerDNS cache-related recursor options
+    def test_recursor_cache_options(self):
+        refresh_on_ttl_perc = '10'
+        nothing_below_nxdomain = 'yes'
+        minimum_ttl_override = '30'
+
+        self.cli_set(base_path + ['refresh-on-ttl-perc', refresh_on_ttl_perc])
+        self.cli_set(base_path + ['nothing-below-nxdomain', nothing_below_nxdomain])
+        self.cli_set(base_path + ['minimum-ttl-override', minimum_ttl_override])
+
+        self.cli_commit()
+
+        self.assertEqual(get_config_value('refresh-on-ttl-perc'), refresh_on_ttl_perc)
+        self.assertEqual(get_config_value('nothing-below-nxdomain'), nothing_below_nxdomain)
+        self.assertEqual(get_config_value('minimum-ttl-override'), minimum_ttl_override)
+
+    def test_nothing_below_nxdomain(self):
+        for option in ['no', 'dnssec', 'yes']:
+            self.cli_set(base_path + ['nothing-below-nxdomain', option])
+            self.cli_commit()
+            self.assertEqual(get_config_value('nothing-below-nxdomain'), option)
+
     def test_dnssec(self):
         # DNSSEC option testing
         options = ['off', 'process-no-validate', 'process', 'log-fail', 'validate']


### PR DESCRIPTION
## Summary

- Expose three PowerDNS Recursor cache-related settings under `service dns forwarding`: `refresh-on-ttl-perc`, `nothing-below-nxdomain`, and `minimum-ttl-override`.
- Render the options into `recursor.conf` via the existing Jinja template.
- Add smoketest coverage for setting values and for all `nothing-below-nxdomain` modes (`no`, `dnssec`, `yes`).

## Test plan

- [ ] Run `smoketest/scripts/cli/test_service_dns_forwarding.py` (new `test_recursor_cache_options` and `test_nothing_below_nxdomain`).
- [ ] On a test system: `set service dns forwarding refresh-on-ttl-perc 10`, `nothing-below-nxdomain yes`, `minimum-ttl-override 30`; commit; verify `/run/pdns-recursor/recursor.conf` contains the expected directives.
- [ ] Confirm defaults match PowerDNS expectations (`refresh-on-ttl-perc` 0, `nothing-below-nxdomain` dnssec, `minimum-ttl-override` 1).
- [ ] (Optional) Companion doc update in vyos-documentation `docs/configuration/service/dns.md`.


Made with [Cursor](https://cursor.com)