### PR TITLE
T8822: Add BFD strict mode for BGP

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -34,6 +34,9 @@
 {%     if config.bfd.profile is vyos_defined %}
  neighbor {{ neighbor }} bfd profile {{ config.bfd.profile }}
 {%     endif %}
+{%     if config.bfd.strict is vyos_defined %}
+ neighbor {{ neighbor }} bfd strict {{ 'hold-time ' ~ config.bfd.strict.hold_time if config.bfd.strict.hold_time is vyos_defined else '' }}
+{%     endif %}
 {% endif %}
 {% if config.capability.dynamic is vyos_defined %}
  neighbor {{ neighbor }} capability dynamic

--- a/interface-definitions/include/bgp/neighbor-bfd.xml.i
+++ b/interface-definitions/include/bgp/neighbor-bfd.xml.i
@@ -11,6 +11,25 @@
         <valueless/>
       </properties>
     </leafNode>
+    <node name="strict">
+      <properties>
+        <help>Strict mode</help>
+      </properties>
+      <children>
+        <leafNode name="hold-time">
+          <properties>
+            <help>BFD hold time</help>
+            <valueHelp>
+              <format>u32:1-4294967295</format>
+              <description>BFD hold time in seconds</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 1-4294967295"/>
+            </constraint>
+          </properties>
+        </leafNode>
+      </children>
+    </node>
   </children>
 </node>
 <!-- include end -->

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -1707,6 +1707,19 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
 
             self.cli_commit()
 
+    def test_bgp_32_bfd_strict(self):
+        neighbor = '192.0.2.22'
+        bfd_hold_time = '23'
+
+        self.cli_set(base_path + ['neighbor', neighbor, 'remote-as', ASN])
+        self.cli_set(base_path + ['neighbor', neighbor, 'bfd', 'strict', 'hold-time', bfd_hold_time])
+
+        self.cli_commit()
+
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', stop_section='^exit')
+        self.assertIn(f'router bgp {ASN}', frrconfig)
+        self.assertIn(f' neighbor {neighbor} bfd strict hold-time {bfd_hold_time}', frrconfig)
+
     def test_bgp_99_bmp(self):
         target_name = 'instance-bmp'
         target_address = '127.0.0.1'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add BFD strict mode for BGP
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T8822

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
config:
```
vyos@r14:~$ show conf com | match bgp
set protocols bgp neighbor 192.0.2.55 bfd strict hold-time '23'
set protocols bgp neighbor 192.0.2.55 remote-as '65001'
set protocols bgp system-as '65001'
vyos@r14:~$ 
```
Frr:
```
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp reject-as-sets
 no bgp default ipv4-unicast
 no bgp network import-check
 neighbor 192.0.2.55 remote-as 65001
 neighbor 192.0.2.55 bfd
 neighbor 192.0.2.55 bfd strict hold-time 23
 no neighbor 192.0.2.55 enforce-first-as
exit
!

```
Smoketest:
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py -k test_bgp_32_bfd_strict
test_bgp_32_bfd_strict (__main__.TestProtocolsBGP.test_bgp_32_bfd_strict) ... ok

----------------------------------------------------------------------
Ran 1 test in 3.929s

OK
vyos@r14:~$
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
