### PR TITLE
T8883: Fix restart PPPoE-server service when RADIUS settings change

### DIFF
--- a/src/conf_mode/service_pppoe-server.py
+++ b/src/conf_mode/service_pppoe-server.py
@@ -124,7 +124,7 @@ def get_config(config=None):
         is_node_changed(conf, base + ['client-ip-pool']),
         is_node_changed(conf, base + ['client-ipv6-pool']),
         is_node_changed(conf, base + ['interface']),
-        is_node_changed(conf, base + ['authentication', 'radius', 'dynamic-author']),
+        is_node_changed(conf, base + ['authentication', 'radius']),
         is_node_changed(conf, base + ['authentication', 'mode']),
         any(
             base_ifname(iface) in all_changed_vpp_ifaces


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Restart the PPPoE server when RADIUS configuration is modified. 
Previously, changes to settings such as `priority` and `backup` 
were not applied until the service was restarted manually.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T8883

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
PPPoE-server configuration
```
set service pppoe-server authentication mode 'radius'
set service pppoe-server authentication radius server 127.0.0.1 key 'vyos-secret'
set service pppoe-server authentication radius server 127.0.0.1 priority '1'
set service pppoe-server authentication radius server 192.168.122.14 key 'vyos-secret'
set service pppoe-server authentication radius server 192.168.122.14 priority '2'
set service pppoe-server client-ip-pool first range '100.64.0.20-100.64.0.254'
set service pppoe-server default-pool 'first'
set service pppoe-server gateway-address '100.64.0.1'
set service pppoe-server interface eth0 combined
```
Before fix
Change priority, expected restart `accel-ppp@pppoe` but the service was not restarted
```
set service pppoe-server authentication radius server 127.0.0.1 priority 5
commit

vyos@r14# sudo systemctl status accel-ppp@pppoe.service
● accel-ppp@pppoe.service - Accel-PPP - High performance VPN server application for Linux
     Loaded: loaded (/lib/systemd/system/accel-ppp@.service; disabled; preset: enabled)
     Active: active (running) since Thu 2026-05-21 12:24:10 UTC; 6min ago
   ...
```
After the fix
change priority, expected restart accel-ppp@pppoe
```
set service pppoe-server authentication radius server 127.0.0.1 priority 10
commit

vyos@r14# sudo systemctl status accel-ppp@pppoe.service
● accel-ppp@pppoe.service - Accel-PPP - High performance VPN server application for Linux
     Loaded: loaded (/lib/systemd/system/accel-ppp@.service; disabled; preset: enabled)
     Active: active (running) since Thu 2026-05-21 12:38:16 UTC; 10s ago
    ...
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
