### PR TITLE
conntrack: T8308: Add per-flow counters and VRF filter to conntrack table

### DIFF
--- a/op-mode-definitions/show-conntrack.xml.in
+++ b/op-mode-definitions/show-conntrack.xml.in
@@ -23,12 +23,46 @@
                   <help>Show conntrack entries for IPv4 protocol</help>
                 </properties>
                 <command>${vyos_op_scripts_dir}/conntrack.py show --family inet</command>
+                <children>
+                  <node name="vrf">
+                    <properties>
+                      <help>Show conntrack IPv4 entries filtered by VRF</help>
+                    </properties>
+                    <children>
+                      <virtualTagNode>
+                        <properties>
+                          <completionHelp>
+                            <path>vrf name</path>
+                          </completionHelp>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/conntrack.py show --family inet --vrf "$6"</command>
+                      </virtualTagNode>
+                    </children>
+                  </node>
+                </children>
               </node>
               <node name="ipv6">
                 <properties>
                   <help>Show conntrack entries for IPv6 protocol</help>
                 </properties>
                 <command>${vyos_op_scripts_dir}/conntrack.py show --family inet6</command>
+                <children>
+                  <node name="vrf">
+                    <properties>
+                      <help>Show conntrack IPv6 entries filtered by VRF</help>
+                    </properties>
+                    <children>
+                      <virtualTagNode>
+                        <properties>
+                          <completionHelp>
+                            <path>vrf name</path>
+                          </completionHelp>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/conntrack.py show --family inet6 --vrf "$6"</command>
+                      </virtualTagNode>
+                    </children>
+                  </node>
+                </children>
               </node>
             </children>
           </node>

--- a/src/op_mode/conntrack.py
+++ b/src/op_mode/conntrack.py
@@ -20,16 +20,21 @@ import xmltodict
 
 from tabulate import tabulate
 from vyos.utils.process import cmd
+from vyos.utils.network import get_vrf_tableid
 
 import vyos.opmode
 
 ArgFamily = typing.Literal['inet', 'inet6']
 
-def _get_xml_data(family):
+def _get_xml_data(family, orig_zone=None):
     """
     Get conntrack XML output
     """
-    return cmd(f'sudo conntrack --dump --family {family} --output xml')
+    args = ['--dump', '--family', family, '--output', 'xml']
+    if orig_zone is not None:
+        args.extend(['--orig-zone', str(orig_zone)])
+
+    return cmd(['sudo', 'conntrack'] + args)
 
 
 def _xml_to_dict(xml):
@@ -44,11 +49,11 @@ def _xml_to_dict(xml):
     return parse
 
 
-def _get_raw_data(family):
+def _get_raw_data(family, orig_zone=None):
     """
     Return: dictionary
     """
-    xml = _get_xml_data(family)
+    xml = _get_xml_data(family, orig_zone=orig_zone)
     if len(xml) == 0:
         output = {'conntrack':
             {
@@ -103,6 +108,8 @@ def get_formatted_output(dict_data):
     for entry in dict_data['conntrack']['flow']:
         orig_src, orig_dst, orig_sport, orig_dport = {}, {}, {}, {}
         reply_src, reply_dst, reply_sport, reply_dport = {}, {}, {}, {}
+        orig_packets = orig_bytes = reply_packets = reply_bytes = '0'
+        zone = ''
         proto = {}
         for meta in entry['meta']:
             direction = meta['direction']
@@ -116,6 +123,11 @@ def get_formatted_output(dict_data):
                     if meta.get('layer4').get('dport'):
                         orig_dport = meta['layer4']['dport']
                     proto = meta['layer4']['protoname']
+                if 'counters' in meta:
+                    orig_packets = meta['counters']['packets']
+                    orig_bytes = meta['counters']['bytes']
+                if 'zone' in meta:
+                    zone = meta['zone']
             if direction in ['reply']:
                 if 'layer3' in meta:
                     reply_src = meta['layer3']['src']
@@ -126,6 +138,9 @@ def get_formatted_output(dict_data):
                     if meta.get('layer4').get('dport'):
                         reply_dport = meta['layer4']['dport']
                     proto = meta['layer4']['protoname']
+                if 'counters' in meta:
+                    reply_packets = meta['counters']['packets']
+                    reply_bytes = meta['counters']['bytes']
             if direction == 'independent':
                 # T6138 flowtable offload conntrack entries without 'timeout'
                 timeout = meta.get('timeout', 'n/a')
@@ -135,12 +150,17 @@ def get_formatted_output(dict_data):
                 reply_dst = f'{reply_dst}:{reply_dport}' if reply_dport else reply_dst
                 state = meta['state'] if 'state' in meta else ''
                 mark = meta['mark'] if 'mark' in meta else ''
-                zone = meta['zone'] if 'zone' in meta else ''
+                if 'zone' in meta:
+                    zone = meta['zone']
                 data_entry = [
                     orig_src,
                     orig_dst,
+                    orig_packets,
+                    orig_bytes,
                     reply_src,
                     reply_dst,
+                    reply_packets,
+                    reply_bytes,
                     proto,
                     state,
                     timeout,
@@ -151,8 +171,12 @@ def get_formatted_output(dict_data):
     headers = [
         "Original src",
         "Original dst",
+        "Original packets",
+        "Original bytes",
         "Reply src",
         "Reply dst",
+        "Reply packets",
+        "Reply bytes",
         "Protocol",
         "State",
         "Timeout",
@@ -163,9 +187,14 @@ def get_formatted_output(dict_data):
     return output
 
 
-def show(raw: bool, family: ArgFamily):
+def show(raw: bool, family: ArgFamily, vrf: typing.Optional[str]):
     family = 'ipv6' if family == 'inet6' else 'ipv4'
-    conntrack_data = _get_raw_data(family)
+
+    orig_zone = get_vrf_tableid(vrf) if vrf else None
+    if vrf and orig_zone is None:  # VRF is specified, but tableid is not found
+        raise vyos.opmode.IncorrectValue(f'VRF \'{vrf}\' not found or has no table ID')
+
+    conntrack_data = _get_raw_data(family, orig_zone=orig_zone)
     if raw:
         return conntrack_data
     else:


### PR DESCRIPTION
## Change summary
Add two enhancements to the `show conntrack table` op-mode command:

- Display per-flow packet and byte counters (original and reply direction).
- Add VRF filter option `show conntrack table <ipv4|ipv6> vrf <vrf-name>` that maps VRF name to its conntrack table ID and passes `--orig-zone` to the underlying conntrack call.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8308

## Related PR(s)
* https://github.com/vyos/vyos-documentation/pull/2055

## How to test / Smoketest result
### Manual test
```
conf
set interfaces ethernet eth2 vrf 'FOO'
set interfaces ethernet eth3 vrf 'FOO'
set vrf bind-to-all
set vrf name BAR table '120'
set vrf name FOO table '110'
set system conntrack flow-accounting
set nat source rule 10 outbound-interface name eth2
set nat source rule 10 source address 192.168.102.0/24
set nat source rule 10 translation address masquerade
commit

vyos@vyos4:~$ show conntrack table ipv4 vrf FOO
Id          Original src    Original dst    Original packets    Original bytes    Reply src     Reply dst     Reply packets    Reply bytes    Protocol    State    Timeout    Mark    Zone
----------  --------------  --------------  ------------------  ----------------  ------------  ------------  ---------------  -------------  ----------  -------  ---------  ------  ------
2560000610  192.168.50.1    192.168.50.4    3                   252               192.168.50.4  192.168.50.1  3                252            icmp                 29         0

vyos@vyos4:~$ show conntrack table ipv4
Id          Original src    Original dst    Original packets    Original bytes    Reply src     Reply dst       Reply packets    Reply bytes    Protocol    State        Timeout    Mark    Zone
----------  --------------  --------------  ------------------  ----------------  ------------  --------------  ---------------  -------------  ----------  -----------  ---------  ------  ------
2560000610  192.168.50.1    192.168.50.4    12                  1008              192.168.50.4  192.168.50.1    12               1008           icmp                     29         0
3913691658  10.0.2.2:44244  10.0.2.15:22    90                  9629              10.0.2.15:22  10.0.2.2:44244  66               9943           tcp         ESTABLISHED  431999     0
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly