### PR TITLE
T8910: ipoe-server: expose accel-ppp idle-timeout option

### DIFF
--- a/data/templates/accel-ppp/ipoe.config.j2
+++ b/data/templates/accel-ppp/ipoe.config.j2
@@ -38,6 +38,9 @@ level={{ log.level }}
 
 [ipoe]
 verbose=1
+{% if idle_timeout is vyos_defined %}
+idle-timeout={{ idle_timeout }}
+{% endif %}
 {% if lua_file is vyos_defined %}
 lua-file={{ lua_file }}
 {% endif %}

--- a/interface-definitions/include/accel-ppp/idle-timeout.xml.i
+++ b/interface-definitions/include/accel-ppp/idle-timeout.xml.i
@@ -1,0 +1,15 @@
+<!-- include start from accel-ppp/idle-timeout.xml.i -->
+<leafNode name="idle-timeout">
+  <properties>
+    <help>Disconnect idle sessions after the specified time (in seconds)</help>
+    <valueHelp>
+      <format>u32:0-86400</format>
+      <description>Idle timeout in seconds</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 0-86400"/>
+    </constraint>
+    <constraintErrorMessage>Idle timeout must be in range 0 to 86400</constraintErrorMessage>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/service_ipoe-server.xml.in
+++ b/interface-definitions/service_ipoe-server.xml.in
@@ -233,6 +233,7 @@
           #include <include/accel-ppp/default-ipv6-pool.xml.i>
           #include <include/accel-ppp/extended-scripts.xml.i>
           #include <include/accel-ppp/gateway-address-multi.xml.i>
+          #include <include/accel-ppp/idle-timeout.xml.i>
           #include <include/accel-ppp/limits.xml.i>
           #include <include/accel-ppp/max-concurrent-sessions.xml.i>
           #include <include/accel-ppp/shaper.xml.i>

--- a/smoketest/scripts/cli/test_service_ipoe-server.py
+++ b/smoketest/scripts/cli/test_service_ipoe-server.py
@@ -319,6 +319,25 @@ delegate={delegate_2_prefix},{delegate_mask},name={pool_name}"""
         conf.read(self._config_file)
         self.assertIn(f'start={start_session}', conf['ipoe']['interface'])
 
+    def test_ipoe_server_idle_timeout(self):
+        idle_timeout = '300'
+
+        self.basic_config()
+        self.cli_commit()
+
+        # Default: no idle-timeout emitted
+        conf = ConfigParser(allow_no_value=True, delimiters='=', strict=False)
+        conf.read(self._config_file)
+        self.assertNotIn('idle-timeout', conf['ipoe'])
+
+        # Configure idle-timeout
+        self.set(['idle-timeout', idle_timeout])
+        self.cli_commit()
+
+        conf = ConfigParser(allow_no_value=True, delimiters='=', strict=False)
+        conf.read(self._config_file)
+        self.assertEqual(conf['ipoe']['idle-timeout'], idle_timeout)
+
     @unittest.skip("PPP is not a part of IPoE")
     def test_accel_ppp_options(self):
         pass


### PR DESCRIPTION
Add a CLI knob to terminate idle IPoE sessions after a configurable timeout:

  `set service ipoe-server idle-timeout <0-86400>`

Currently there is no way to age out stale IPoE sessions: clients that go silent (powered off, link down) leave a session record on the router indefinitely. accel-ppp natively supports idle-timeout in its [ipoe] section.

The option is added as a shared accel-ppp include so it can be reused by other accel-ppp services in follow-up PRs.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8910
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
set interfaces ethernet eth0 address '203.0.113.73/29'
set service ipoe-server gateway-address '198.51.100.65/29'
set service ipoe-server authentication mode 'noauth'
set service ipoe-server client-ip-pool TEST range '192.168.4.0/24'
set service ipoe-server default-pool 'TEST'
set service ipoe-server interface eth0 mode 'l2'
set service ipoe-server interface eth0 start-session 'unclassified-packet'

set service ipoe-server idle-timeout 60

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
