### PR TITLE
wwan: T8412: Fix commit failure when modem is absent or not connected

### DIFF
--- a/python/vyos/ifconfig/wwan.py
+++ b/python/vyos/ifconfig/wwan.py
@@ -26,6 +26,10 @@ class WWANIf(Interface):
         },
     }
 
+    def _create(self):
+        # we can not create this interface as it is managed by the Kernel
+        pass
+
     def remove(self):
         """
         Remove interface from config. Removing the interface deconfigures all

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -238,7 +238,11 @@ def is_wwan_connected(interface):
 
     modem = interface.lstrip('wwan')
 
-    tmp = cmd(f'mmcli --modem {modem} --output-json')
+    try:
+        tmp = cmd(f'mmcli --modem {modem} --output-json')
+    except OSError:
+        return False
+
     tmp = loads(tmp)
 
     # return True/False if interface is in connected state

--- a/src/conf_mode/interfaces_wwan.py
+++ b/src/conf_mode/interfaces_wwan.py
@@ -149,9 +149,15 @@ def apply(wwan):
         modem = wwan['ifname'].lstrip('wwan')
         base_cmd = f'mmcli --modem {modem}'
         # Number of bearers is limited - always disconnect first
-        cmd(f'{base_cmd} --simple-disconnect')
+        call(f'{base_cmd} --simple-disconnect')
 
     w = WWANIf(wwan['ifname'])
+
+    # We cannot proceed with the configuration if the modem is not detected - so we bail out
+    # and wait for the next cronjob run to re-apply the configuration.
+    if not w.exists(wwan['ifname']):
+        return None
+
     if 'deleted' in wwan or 'disable' in wwan:
         w.remove()
 


### PR DESCRIPTION
`mmcli --simple-disconnect` can be called when the modem bearer is not active. This causes cmd() to raise a `PermissionError` and abort the commit. Handle the case gracefully so the configuration can be committed before the modem is physically present or fully connected.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8412
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
