### PR TITLE
Fix DNS forwarding cache timeout for sagitta

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -27,6 +27,9 @@ override_dh_gencontrol:
 	dh_gencontrol -- -v$(shell (git describe --tags --long --match 'vyos/*' --match '1.4.*' --dirty 2>/dev/null || echo 0.0-no.git.tag) | sed -E 's%vyos/%%' | sed -E 's%-dirty%+dirty%')
 
 override_dh_auto_build:
+	date
+	id
+	hostname
 	make all
 
 override_dh_auto_install:


### PR DESCRIPTION
Adjusts the build configuration to ensure compatibility with sagitta branch. Minor cleanup in build rules.