### PR TITLE
qos: T7965:  Fix qos fails to reapply on dynamic interfaces after reconnection

### DIFF
--- a/src/conf_mode/qos.py
+++ b/src/conf_mode/qos.py
@@ -349,6 +349,32 @@ def generate(qos):
     return None
 
 
+def apply_interface(qos, ifname):
+    """ Clear and re-apply QoS for a single interface only. """
+    run(f'tc qdisc del dev {ifname} parent ffff:')
+    run(f'tc qdisc del dev {ifname} root')
+
+    if not qos or 'interface' not in qos or ifname not in qos['interface']:
+        return None
+
+    interface_config = qos['interface'][ifname]
+    if not verify_interface_exists(qos, ifname, state_required=True, warning_only=True):
+        # When shaper is bound to a dialup (e.g. PPPoE) interface it is
+        # possible that it is yet not available when the QoS code runs.
+        # Skip the configuration and inform the user via warning_only=True
+        return None
+
+    for direction in ['egress', 'ingress']:
+        # bail out early if shaper for given direction is not used at all
+        if direction not in interface_config:
+            continue
+
+        shaper_type, shaper_config = get_shaper(qos, interface_config, direction)
+        shaper_type(ifname).update(shaper_config, direction)
+
+    return None
+
+
 def apply(qos):
     # Always delete "old" shapers first
     for interface in interfaces():
@@ -361,21 +387,8 @@ def apply(qos):
     if not qos or 'interface' not in qos:
         return None
 
-    for interface, interface_config in qos['interface'].items():
-        if not verify_interface_exists(qos, interface, state_required=True, warning_only=True):
-            # When shaper is bound to a dialup (e.g. PPPoE) interface it is
-            # possible that it is yet not available when to QoS code runs.
-            # Skip the configuration and inform the user via warning_only=True
-            continue
-
-        for direction in ['egress', 'ingress']:
-            # bail out early if shaper for given direction is not used at all
-            if direction not in interface_config:
-                continue
-
-            shaper_type, shaper_config = get_shaper(qos, interface_config, direction)
-            tmp = shaper_type(interface)
-            tmp.update(shaper_config, direction)
+    for ifname in qos['interface']:
+        apply_interface(qos, ifname)
 
     return None
 

--- a/src/op_mode/connect_disconnect.py
+++ b/src/op_mode/connect_disconnect.py
@@ -18,9 +18,7 @@ import os
 import argparse
 
 from psutil import process_iter
-from time import sleep
 
-from vyos.configquery import ConfigTreeQuery
 from vyos.utils.process import call
 from vyos.utils.commit import commit_in_progress
 from vyos.utils.network import is_wwan_connected
@@ -60,17 +58,6 @@ def connect(interface):
             call(f'VYOS_TAGNODE_VALUE={interface} /usr/libexec/vyos/conf_mode/interfaces_wwan.py')
     else:
         print(f'Unknown interface {interface}, cannot connect. Aborting!')
-
-    # Reaply QoS configuration
-    config = ConfigTreeQuery()
-    if config.exists(f'qos interface {interface}'):
-        count = 1
-        while commit_in_progress():
-            if ( count % 60 == 0 ):
-                print(f'Commit still in progress after {count}s - waiting')
-            count += 1
-            sleep(1)
-        call('/usr/libexec/vyos/conf_mode/qos.py')
 
 def disconnect(interface):
     """ Disconnect dialer interface """

--- a/src/services/vyos-netlinkd
+++ b/src/services/vyos-netlinkd
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import importlib.util
 import re
 import sys
 import syslog
@@ -34,15 +35,23 @@ from vyos.utils.boot import boot_configuration_complete
 from vyos.utils.commit import commit_in_progress2
 from vyos.utils.dict import dict_search
 from vyos.utils.process import cmd
-from vyos.utils.process import call
 from vyos.utils.process import is_systemd_service_active
 from vyos.utils.process import stop_systemd_unit
+
+def _load_conf_mode_qos():
+    spec = importlib.util.spec_from_file_location(
+        'conf_mode_qos', '/usr/libexec/vyos/conf_mode/qos.py')
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+_conf_mode_qos = _load_conf_mode_qos()
 
 running = True
 
 # compile regex once during startup for fast match
 IFACE_RE = re.compile(r"^(?:eth|br|bond|wlan|pppoe|sstpc|wwan)")
-dynamic_qos_interfaces: set[str] = set()
+_dynamic_qos_interfaces: set[str] = set()
 
 # Per-interface previous operstate, used to suppress DHCP restarts on
 # UP-to-UP re-notifications (e.g. post-migration gratuitous-ARP events).
@@ -66,32 +75,30 @@ def _handle_dynamic_qos_events(event: str, ifname: str,
     if not _is_dynamic_qos_iface(ifname):
         return None
 
-    if event in ['RTM_NEWLINK', 'RTM_DELLINK']:
-        if event == 'RTM_NEWLINK' and operstate != 'DOWN':
+    match event:
+        case 'RTM_NEWLINK' if operstate != 'DOWN':
             return None
 
-        if ifname in dynamic_qos_interfaces:
-            syslog.syslog(syslog.LOG_DEBUG,
-                          f'Clearing QoS re-apply state on dynamic interface {ifname}...')
-            dynamic_qos_interfaces.discard(ifname)
+        case 'RTM_NEWLINK' | 'RTM_DELLINK':
+            if ifname in _dynamic_qos_interfaces:
+                syslog.syslog(syslog.LOG_DEBUG,
+                              f'Clearing QoS re-apply state on dynamic interface {ifname}...')
+                _dynamic_qos_interfaces.discard(ifname)
 
-        return None
+        case 'RTM_NEWADDR':
+            if ifname in _dynamic_qos_interfaces:
+                syslog.syslog(syslog.LOG_DEBUG,
+                              f'QoS already re-applied on dynamic interface {ifname}, skipping...')
+                return None
 
-    if event != 'RTM_NEWADDR':
-        return None
+            qos = _conf_mode_qos.get_config()
+            if not qos or 'interface' not in qos or ifname not in qos['interface']:
+                return None
 
-    if ifname in dynamic_qos_interfaces:
-        syslog.syslog(syslog.LOG_DEBUG,
-                      f'QoS already re-applied on dynamic interface {ifname}, skipping...')
-        return None
-
-    syslog.syslog(syslog.LOG_INFO,
-                  f'Re-applying QoS on dynamic interface {ifname}...')
-    call(f'/usr/libexec/vyos/conf_mode/qos.py')
-
-    dynamic_qos_interfaces.add(ifname)
-
-    return None
+            syslog.syslog(syslog.LOG_INFO,
+                          f'Re-applying QoS on dynamic interface {ifname}...')
+            _conf_mode_qos.apply_interface(qos, ifname)
+            _dynamic_qos_interfaces.add(ifname)
 
 def sigterm_handler(signo, frame):
     global running
@@ -206,9 +213,16 @@ def main():
                 ifname = attrs.get('IFLA_IFNAME', None) or attrs.get('IFA_LABEL', None)
 
                 if not ifname and 'index' in message:
-                    links = ipr.get_links(message['index'])
-                    if links:
-                        ifname = dict(links[0].get('attrs', [])).get('IFLA_IFNAME', None)
+                    try:
+                        links = ipr.get_links(message['index'])
+                        if links:
+                            ifname = dict(links[0].get('attrs', [])).get('IFLA_IFNAME', None)
+                    except NetlinkError:
+                        # Interface can disappear between the netlink event
+                        # arriving and this get_links() lookup (e.g. pppoe
+                        # teardown). Skip the message rather than breaking
+                        # the entire ipr.get() batch with an ENODEV error.
+                        continue
 
                 # Bail out early - no interface name in the message
                 if not ifname:
@@ -232,7 +246,10 @@ def main():
                     # Address added to an interface. For dynamic interfaces, this
                     # means the connection completed and QoS can be re-applied.
                     case 'RTM_NEWADDR':
-                        syslog.syslog(syslog.LOG_DEBUG, f'RTM_NEWADDR -> {ifname}')
+                        addr = attrs.get('IFA_ADDRESS', '<unknown>')
+                        prefixlen = message.get('prefixlen', '')
+                        syslog.syslog(syslog.LOG_DEBUG,
+                                      f'RTM_NEWADDR -> {ifname}, addr={addr}/{prefixlen}')
                         _handle_dynamic_qos_events(event, ifname)
 
                     # Deletion of a network link which has been previously added to the kernel
@@ -241,7 +258,7 @@ def main():
                         ifname = attrs.get('IFLA_IFNAME', None)
                         if ifname:
                             _iface_prev_operstate.pop(ifname, None)
-                        _handle_dynamic_qos_events(event, ifname)
+                            _handle_dynamic_qos_events(event, ifname)
                     case _:
                         pass
 

--- a/src/services/vyos-netlinkd
+++ b/src/services/vyos-netlinkd
@@ -23,6 +23,8 @@ import select
 from pyroute2 import IPRoute # pylint: disable = no-name-in-module
 from pyroute2 import NetlinkError # pylint: disable = no-name-in-module
 from pyroute2.netlink.rtnl import RTMGRP_LINK
+from pyroute2.netlink.rtnl import RTMGRP_IPV4_IFADDR
+from pyroute2.netlink.rtnl import RTMGRP_IPV6_IFADDR
 from time import sleep
 from typing import Optional
 
@@ -32,13 +34,15 @@ from vyos.utils.boot import boot_configuration_complete
 from vyos.utils.commit import commit_in_progress2
 from vyos.utils.dict import dict_search
 from vyos.utils.process import cmd
+from vyos.utils.process import call
 from vyos.utils.process import is_systemd_service_active
 from vyos.utils.process import stop_systemd_unit
 
 running = True
 
 # compile regex once during startup for fast match
-IFACE_RE = re.compile(r"^(?:eth|br|bond|wlan)")
+IFACE_RE = re.compile(r"^(?:eth|br|bond|wlan|pppoe|sstpc|wwan)")
+dynamic_qos_interfaces: set[str] = set()
 
 # Per-interface previous operstate, used to suppress DHCP restarts on
 # UP-to-UP re-notifications (e.g. post-migration gratuitous-ARP events).
@@ -49,6 +53,45 @@ def match_iface(ifname: str) -> bool:
     processing (e.g. restart of DHCP(v6) client)
     """
     return IFACE_RE.match(ifname) is not None
+
+def _is_dynamic_qos_iface(ifname: str) -> bool:
+    """ Helper function returning true if interface requires QoS re-apply
+    after first address assignment.
+    """
+    return ifname.startswith(('pppoe', 'sstpc', 'wwan'))
+
+def _handle_dynamic_qos_events(event: str, ifname: str,
+                               operstate: Optional[str] = None) -> None:
+    """ Re-apply QoS for dynamic interfaces after they receive an address. """
+    if not _is_dynamic_qos_iface(ifname):
+        return None
+
+    if event in ['RTM_NEWLINK', 'RTM_DELLINK']:
+        if event == 'RTM_NEWLINK' and operstate != 'DOWN':
+            return None
+
+        if ifname in dynamic_qos_interfaces:
+            syslog.syslog(syslog.LOG_DEBUG,
+                          f'Clearing QoS re-apply state on dynamic interface {ifname}...')
+            dynamic_qos_interfaces.discard(ifname)
+
+        return None
+
+    if event != 'RTM_NEWADDR':
+        return None
+
+    if ifname in dynamic_qos_interfaces:
+        syslog.syslog(syslog.LOG_DEBUG,
+                      f'QoS already re-applied on dynamic interface {ifname}, skipping...')
+        return None
+
+    syslog.syslog(syslog.LOG_INFO,
+                  f'Re-applying QoS on dynamic interface {ifname}...')
+    call(f'/usr/libexec/vyos/conf_mode/qos.py')
+
+    dynamic_qos_interfaces.add(ifname)
+
+    return None
 
 def sigterm_handler(signo, frame):
     global running
@@ -118,13 +161,13 @@ def main():
                    facility=syslog.LOG_DAEMON)
     syslog.syslog(syslog.LOG_INFO, "VyOS Netlink listener daemon started.")
 
-    # Subscribe to link notifications only (not routes/rules/neigh/addr/...).
+    # Subscribe to link and address notifications only (not routes/rules/neigh/...).
     ipr = IPRoute()
     try:
         # newer pyroute2 versions support bind group in IPRoute() constructor
-        ipr.bind(groups=RTMGRP_LINK)
+        ipr.bind(groups=RTMGRP_LINK | RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR)
         syslog.syslog(syslog.LOG_INFO,
-            'IPRoute.bind() using groups=RTMGRP_LINK RTNL subscription')
+            'IPRoute.bind() using link and address RTNL subscriptions')
     except TypeError:
         syslog.syslog(syslog.LOG_WARNING,
             'IPRoute.bind() has no groups= support; using default RTNL subscriptions',
@@ -158,25 +201,39 @@ def main():
             # Receive and process any messages
             for message in ipr.get():
                 # Parse NETLINK message
-                match message['event']:
+                event = message['event']
+                attrs = dict(message.get('attrs', []))
+                ifname = attrs.get('IFLA_IFNAME', None) or attrs.get('IFA_LABEL', None)
+
+                if not ifname and 'index' in message:
+                    links = ipr.get_links(message['index'])
+                    if links:
+                        ifname = dict(links[0].get('attrs', [])).get('IFLA_IFNAME', None)
+
+                # Bail out early - no interface name in the message
+                if not ifname:
+                    continue
+                # Bail out early - not interested in interface type
+                if not match_iface(ifname):
+                    continue
+
+                match event:
                     # Message received during interface creation or modification
                     # e.g. link up/down.
                     case 'RTM_NEWLINK':
-                        attrs = dict(message.get('attrs', []))
-                        ifname = attrs.get('IFLA_IFNAME', None)
                         mac = attrs.get('IFLA_ADDRESS', '<unknown>')
                         operstate = attrs.get('IFLA_OPERSTATE', None)
                         syslog.syslog(syslog.LOG_DEBUG,
                                       f'RTM_NEWLINK -> {ifname}, state={operstate}, mac={mac}')
 
-                        # Bail out early - no interface name in the message
-                        if not ifname:
-                            continue
-                        # Bail out early - not interested in interface type
-                        if not match_iface(ifname):
-                            continue
-
+                        _handle_dynamic_qos_events(event, ifname, operstate)
                         _handle_dhcp_events(operstate, ifname)
+
+                    # Address added to an interface. For dynamic interfaces, this
+                    # means the connection completed and QoS can be re-applied.
+                    case 'RTM_NEWADDR':
+                        syslog.syslog(syslog.LOG_DEBUG, f'RTM_NEWADDR -> {ifname}')
+                        _handle_dynamic_qos_events(event, ifname)
 
                     # Deletion of a network link which has been previously added to the kernel
                     case 'RTM_DELLINK':
@@ -184,6 +241,7 @@ def main():
                         ifname = attrs.get('IFLA_IFNAME', None)
                         if ifname:
                             _iface_prev_operstate.pop(ifname, None)
+                        _handle_dynamic_qos_events(event, ifname)
                     case _:
                         pass
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
- Update `vyos-netlinkd` to subscribe to IPv4/IPv6 address events and re-apply QoS when dynamic interfaces such as `pppoe`, `sstpc`, and `wwan` receive an address.
- Remove QoS re-apply logic from `connect_disconnect.py`, since dynamic interface QoS restoration is now handled by `vyos-netlinkd` on `RTM_NEWADDR`.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://vyos.dev/T7965
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
