### PR TITLE
haproxy: T8931: Improve WebSocket support for HAProxy

### DIFF
--- a/data/templates/load-balancing/haproxy.cfg.j2
+++ b/data/templates/load-balancing/haproxy.cfg.j2
@@ -206,6 +206,9 @@ backend {{ back }}
     option forwardfor
     http-request set-header X-Forwarded-Port %[dst_port]
     http-request add-header X-Forwarded-Proto https if { ssl_fc }
+{%             if back_config.http_server_close is vyos_defined %}
+    option http-server-close
+{%             endif %}
 {%         endif %}
 {%         if back_config.logging is vyos_defined %}
 {%             for facility, facility_config in back_config.logging.facility.items() %}

--- a/data/templates/load-balancing/haproxy.cfg.j2
+++ b/data/templates/load-balancing/haproxy.cfg.j2
@@ -42,6 +42,7 @@ defaults
     timeout connect {{ timeout.connect }}s
     timeout client {{ timeout.client }}s
     timeout server {{ timeout.server }}s
+    timeout tunnel {{ timeout.tunnel }}s
     errorfile 400 /etc/haproxy/errors/400.http
     errorfile 403 /etc/haproxy/errors/403.http
     errorfile 408 /etc/haproxy/errors/408.http
@@ -284,6 +285,9 @@ backend {{ back }}
 {%         endif %}
 {%         if back_config.timeout.server is vyos_defined %}
     timeout server {{ back_config.timeout.server }}s
+{%         endif %}
+{%         if back_config.timeout.tunnel is vyos_defined %}
+    timeout tunnel {{ back_config.timeout.tunnel }}s
 {%         endif %}
 {%     endfor %}
 {% endif %}

--- a/interface-definitions/include/haproxy/timeout-tunnel.xml.i
+++ b/interface-definitions/include/haproxy/timeout-tunnel.xml.i
@@ -1,0 +1,14 @@
+<!-- include start from haproxy/timeout-tunnel.xml.i -->
+<leafNode name="tunnel">
+  <properties>
+    <help>Set the maximum inactivity time on the client and server side for tunnels</help>
+    <valueHelp>
+      <format>u32:1-86400</format>
+      <description>Tunnel timeout in seconds</description>
+    </valueHelp>
+    <constraint>
+      <validator name="numeric" argument="--range 1-86400"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/haproxy/timeout.xml.i
+++ b/interface-definitions/include/haproxy/timeout.xml.i
@@ -7,6 +7,7 @@
     #include <include/haproxy/timeout-check.xml.i>
     #include <include/haproxy/timeout-connect.xml.i>
     #include <include/haproxy/timeout-server.xml.i>
+    #include <include/haproxy/timeout-tunnel.xml.i>
   </children>
 </node>
 <!-- include end -->

--- a/interface-definitions/load-balancing_haproxy.xml.in
+++ b/interface-definitions/load-balancing_haproxy.xml.in
@@ -225,6 +225,12 @@
                   </constraint>
                 </properties>
               </leafNode>
+              <leafNode name="http-server-close">
+                <properties>
+                  <help>Enable HTTP/1.x connection closing on the server side</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
               #include <include/haproxy/rule-backend.xml.i>
               <tagNode name="server">
                 <properties>

--- a/interface-definitions/load-balancing_haproxy.xml.in
+++ b/interface-definitions/load-balancing_haproxy.xml.in
@@ -399,6 +399,10 @@
               <leafNode name="server">
                 <defaultValue>50</defaultValue>
               </leafNode>
+              #include <include/haproxy/timeout-tunnel.xml.i>
+              <leafNode name="tunnel">
+                <defaultValue>300</defaultValue>
+              </leafNode>
             </children>
           </node>
           #include <include/interface/vrf.xml.i>

--- a/smoketest/scripts/cli/test_load-balancing_haproxy.py
+++ b/smoketest/scripts/cli/test_load-balancing_haproxy.py
@@ -335,6 +335,34 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
         with self.assertRaises(ConfigSessionError) as e:
             self.cli_commit()
 
+    def test_reverse_proxy_backend_websocket(self):
+        t_tunnel = '3600'
+        opt_server_close = 'http-server-close'
+
+        # Setup base
+        self.configure_pki()
+        self.base_config()
+
+        # Set minimal backend websocket configuration
+        self.cli_set(base_path + ['backend', haproxy_backend_name, opt_server_close])
+        self.cli_set(base_path + ['backend', haproxy_backend_name, 'timeout', 'tunnel', t_tunnel])
+        self.cli_set(base_path + ['backend', haproxy_backend_name, 'ssl', 'no-verify'])
+
+        self.cli_commit()
+
+        # Ensure 'http-server-close' is not used in tcp mode, to test config validation
+        self.cli_set(base_path + ['backend', haproxy_backend_name, 'mode', 'tcp'])
+        with self.assertRaises(ConfigSessionError) as e:
+            self.cli_commit()
+
+        config = read_file(HAPROXY_CONF)
+        self.assertIn(f'option {opt_server_close}', config)
+        self.assertIn(f'timeout tunnel {t_tunnel}s', config)
+        self.assertIn('option forwardfor', config)
+        self.assertIn(' http-request set-header X-Forwarded-Port %[dst_port]', config)
+        self.assertIn('http-request add-header X-Forwarded-Proto https if { ssl_fc }', config)
+        self.assertIn(f'server {haproxy_backend_name} 192.0.2.11:9090 send-proxy ssl verify none', config)
+
     def test_reverse_proxy_backend_http_check(self):
         # Setup base
         self.base_config()

--- a/smoketest/scripts/cli/test_load-balancing_haproxy.py
+++ b/smoketest/scripts/cli/test_load-balancing_haproxy.py
@@ -619,10 +619,12 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
         t_default_client = '50'
         t_default_connect = '10'
         t_default_server ='50'
+        t_default_tunnel ='300'
         t_check = '4'
         t_client = '300'
         t_connect = '12'
         t_server ='120'
+        t_tunnel ='600'
         t_front_client = '600'
 
         self.base_config()
@@ -633,6 +635,7 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
             f'timeout connect {t_default_connect}s',
             f'timeout client {t_default_client}s',
             f'timeout server {t_default_server}s',
+            f'timeout tunnel {t_default_tunnel}s'
         )
         # Check default timeout options
         config = read_file(HAPROXY_CONF)
@@ -644,6 +647,7 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['timeout', 'client', t_client])
         self.cli_set(base_path + ['timeout', 'connect', t_connect])
         self.cli_set(base_path + ['timeout', 'server', t_server])
+        self.cli_set(base_path + ['timeout', 'tunnel', t_tunnel])
         self.cli_set(base_path + ['service', haproxy_service_name, 'timeout', 'client', t_front_client])
 
         self.cli_commit()
@@ -654,6 +658,7 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
             f'timeout connect {t_connect}s',
             f'timeout client {t_client}s',
             f'timeout server {t_server}s',
+            f'timeout tunnel {t_tunnel}s',
             f'timeout client {t_front_client}s',
         )
 

--- a/src/conf_mode/load-balancing_haproxy.py
+++ b/src/conf_mode/load-balancing_haproxy.py
@@ -149,7 +149,12 @@ def verify(lb):
     for group in ['service', 'backend']:
         for config_name, config in lb[group].items():
             if 'http_response_headers' in config and config['mode'] != 'http':
-                raise ConfigError(f'{group} {config_name} must be set to http mode to use http_response_headers!')
+                raise ConfigError(f'{group} {config_name} must be set to http mode to use http-response headers!')
+
+    # Check if http-server-close is configured in any backend where mode != http
+    for config_name, config in lb['backend'].items():
+        if 'http_server_close' in config and config['mode'] != 'http':
+            raise ConfigError(f'backend {config_name} must be set to http mode to use http-server-close!')
 
 
 def generate(lb):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Improve WebSocket support in HAProxy by allowing control for two configuration parameters:

- Support for `timeout.tunnel` in default section with option to override in backend section
- Enable option `http-server-close` in backend section

Generally, WebSocket support in HAProxy in VyOS decent. Ability to adjust these couple of parameters provide additional control on WebSocket behavior.

For details of the parameters, see:
- [`timeout tunnel <timeout>`](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#timeout%20tunnel)
- [`option http-server-close`](https://www.haproxy.com/documentation/haproxy-configuration-manual/latest/#option%20http-server-close)

Also, see general guidelines of setting up WebSocket in HAProxy [here](https://www.haproxy.com/documentation/haproxy-configuration-tutorials/protocol-support/websocket/).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

https://vyos.dev/T8931

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

1. Set the maximum inactivity time on the client and server side for tunnels (default: 300)

   a. default section:
   ```
   # set load-balancing haproxy timeout tunnel 1800
   ```
   b. backend section override:
   ```
   # set load-balancing haproxy backend back-01 timeout tunnel 3600
   ```

2. Set Option `http-server-close` in backend section:
   ```
   # set load-balancing haproxy backend back-01 http-server-close
   ```

Smoketest result:
```
vyos@v26:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_load-balancing_haproxy.py 
test_reverse_proxy_backend_http_check (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_backend_http_check) ... ok
test_reverse_proxy_backend_ssl_no_verify (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_backend_ssl_no_verify) ... ok
test_reverse_proxy_backend_websocket (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_backend_websocket) ... ok
test_reverse_proxy_ca_not_exists (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_ca_not_exists) ... ok
test_reverse_proxy_cert_not_exists (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_cert_not_exists) ... ok
test_reverse_proxy_domain (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_domain) ... ok
test_reverse_proxy_http_compression (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_http_compression) ... ok
test_reverse_proxy_http_redirect (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_http_redirect) ... ok
test_reverse_proxy_http_response_headers (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_http_response_headers) ... ok
test_reverse_proxy_listen_address_no_port_conflict (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_listen_address_no_port_conflict) ... ok
test_reverse_proxy_logging (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_logging) ... ok
test_reverse_proxy_tcp_health_checks (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_tcp_health_checks) ... ok
test_reverse_proxy_tcp_health_checks_custom_port (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_tcp_health_checks_custom_port) ... ok
test_reverse_proxy_tcp_mode (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_tcp_mode) ... ok
test_reverse_proxy_timeout (__main__.TestLoadBalancingReverseProxy.test_reverse_proxy_timeout) ... ok

----------------------------------------------------------------------
Ran 15 tests in 833.048s

OK

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
