### PR TITLE
dhcp: T8933: Honor system timezone for timestamp display in op mode

### DIFF
--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -19,7 +19,6 @@ import sys
 import typing
 
 from datetime import datetime
-from datetime import timezone
 from glob import glob
 from ipaddress import ip_address
 from tabulate import tabulate
@@ -105,12 +104,8 @@ def _get_formatted_server_leases(raw_data, family='inet'):
             ipaddr = lease.get('ip')
             hw_addr = lease.get('mac')
             state = lease.get('state')
-            start = datetime.fromtimestamp(lease.get('start'), timezone.utc)
-            end = (
-                datetime.fromtimestamp(lease.get('end'), timezone.utc)
-                if lease.get('end')
-                else '-'
-            )
+            start = datetime.fromtimestamp(lease.get('start'))
+            end = datetime.fromtimestamp(lease.get('end')) if lease.get('end') else '-'
             remain = lease.get('remaining')
             pool = lease.get('pool')
             hostname = lease.get('hostname')
@@ -136,14 +131,8 @@ def _get_formatted_server_leases(raw_data, family='inet'):
             ipaddr = lease.get('ip')
             hw_addr = lease.get('mac')
             state = lease.get('state')
-            start = datetime.fromtimestamp(
-                lease.get('last_communication'), timezone.utc
-            )
-            end = (
-                datetime.fromtimestamp(lease.get('end'), timezone.utc)
-                if lease.get('end')
-                else '-'
-            )
+            start = datetime.fromtimestamp(lease.get('last_communication'))
+            end = datetime.fromtimestamp(lease.get('end')) if lease.get('end') else '-'
             remain = lease.get('remaining')
             lease_type = lease.get('type')
             pool = lease.get('pool')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The time displayed in DHCP v4/v6 server lease op-mode commands should honor system timezone and not force UTC timezone.

This would keep the timestamps in the output of `show log dhcp server` or `show log dhcpv6 server` consistent with the timestamps in the output of `show dhcp server leases` or `show dhcpv6 server leases` commands.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8933

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
### Assuming the following timezone:
```
$ timedatectl | grep "Time zone"
                Time zone: America/Chicago (CDT, -0500)
```
### Before:
```
$ show dhcp server leases sort start
IP Address     MAC address        State    Lease start                Lease expiration           Remaining    Pool    Hostname            Origin
-------------  -----------------  -------  -------------------------  -------------------------  -----------  ------  ------------------  --------
172.17.76.2    00:05:aa:bb:cc:dd  active   2026-05-28 01:22:45+00:00  2026-05-28 05:22:45+00:00  2:32:13      FOO     <redacted>          local
172.17.44.91   00:40:aa:bb:cc:dd  active   2026-05-28 01:28:27+00:00  2026-05-28 09:28:27+00:00  6:37:55      FOO     <redacted>          local
172.17.33.1    00:01:aa:bb:cc:dd  active   2026-05-28 01:39:48+00:00  2026-05-28 09:39:48+00:00  6:49:16      FOO     <redacted>          local
172.17.44.32   00:8a:aa:bb:cc:dd  active   2026-05-28 01:42:45+00:00  2026-05-28 09:42:45+00:00  6:52:13      FOO     <redacted>          local
172.17.44.13   00:df:aa:bb:cc:dd  active   2026-05-28 01:43:23+00:00  2026-05-28 09:43:23+00:00  6:52:51      FOO     <redacted>          local
172.17.60.13   00:3a:aa:bb:cc:dd  active   2026-05-28 01:58:34+00:00  2026-05-28 09:58:34+00:00  7:08:02      FOO     <redacted>          local
172.17.44.23   00:46:aa:bb:cc:dd  active   2026-05-28 02:13:10+00:00  2026-05-28 10:13:10+00:00  7:22:38      FOO     <redacted>          local
172.17.44.14   00:f0:aa:bb:cc:dd  active   2026-05-28 02:18:28+00:00  2026-05-28 10:18:28+00:00  7:27:56      FOO     <redacted>          local
172.17.60.16   00:89:aa:bb:cc:dd  active   2026-05-28 02:21:38+00:00  2026-05-28 10:21:38+00:00  7:31:06      FOO     <redacted>          local
172.17.44.19   00:61:aa:bb:cc:dd  active   2026-05-28 02:35:43+00:00  2026-05-28 10:35:43+00:00  7:45:11      FOO     <redacted>          local
172.17.44.2    00:22:aa:bb:cc:dd  active   2026-05-28 02:45:17+00:00  2026-05-28 10:45:17+00:00  7:54:45      FOO     <redacted>          local
```

### After:
```
$ show dhcp server leases sort start
IP Address     MAC address        State    Lease start          Lease expiration     Remaining    Pool    Hostname            Origin
-------------  -----------------  -------  -------------------  -------------------  -----------  ------  ------------------  --------
172.17.76.2    00:05:aa:bb:cc:dd  active   2026-05-27 20:22:45  2026-05-28 00:22:45  2:32:25      FOO     <redacted>          local
172.17.44.91   00:40:aa:bb:cc:dd  active   2026-05-27 20:28:27  2026-05-28 04:28:27  6:38:07      FOO     <redacted>          local
172.17.33.1    00:01:aa:bb:cc:dd  active   2026-05-27 20:39:48  2026-05-28 04:39:48  6:49:28      FOO     <redacted>          local
172.17.44.32   00:8a:aa:bb:cc:dd  active   2026-05-27 20:42:45  2026-05-28 04:42:45  6:52:25      FOO     <redacted>          local
172.17.44.13   00:df:aa:bb:cc:dd  active   2026-05-27 20:43:23  2026-05-28 04:43:23  6:53:03      FOO     <redacted>          local
172.17.60.13   00:3a:aa:bb:cc:dd  active   2026-05-27 20:58:34  2026-05-28 04:58:34  7:08:14      FOO     <redacted>          local
172.17.44.23   00:46:aa:bb:cc:dd  active   2026-05-27 21:13:10  2026-05-28 05:13:10  7:22:50      FOO     <redacted>          local
172.17.44.14   00:f0:aa:bb:cc:dd  active   2026-05-27 21:18:28  2026-05-28 05:18:28  7:28:08      FOO     <redacted>          local
172.17.60.16   00:89:aa:bb:cc:dd  active   2026-05-27 21:21:38  2026-05-28 05:21:38  7:31:18      FOO     <redacted>          local
172.17.44.19   00:61:aa:bb:cc:dd  active   2026-05-27 21:35:43  2026-05-28 05:35:43  7:45:23      FOO     <redacted>          local
172.17.44.2    00:22:aa:bb:cc:dd  active   2026-05-27 21:45:17  2026-05-28 05:45:17  7:54:57      FOO     <redacted>          local
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
