### PR TITLE
vrf: T8936: Specify `pref 1998` when deleting fwmark routing rules on VRF removal

### DIFF
--- a/python/vyos/defaults.py
+++ b/python/vyos/defaults.py
@@ -110,3 +110,8 @@ activation_hint = os.path.join(directories['data'], '.activation_hint')
 config_sync_exclusion_list = os.path.join(
     directories['data'], 'config-sync-exclude.json'
 )
+
+# IP rule priority for WireGuard fwmark-based VRF routing rules.
+# Sits between the l3mdev rule (1000) and the l3mdev unreachable rule (2000),
+# ensuring fwmark-tagged tunnel packets are routed into the correct VRF table.
+wireguard_fwmark_pref = '1998'

--- a/smoketest/scripts/cli/test_interfaces_wireguard.py
+++ b/smoketest/scripts/cli/test_interfaces_wireguard.py
@@ -21,6 +21,7 @@ from base_interfaces_test import BasicInterfaceTest
 from base_interfaces_test import VyOSUnitTestSHIM
 
 from vyos.configsession import ConfigSessionError
+from vyos.defaults import wireguard_fwmark_pref
 from vyos.utils.file import read_file
 from vyos.utils.process import cmd
 from vyos.utils.process import is_systemd_service_running
@@ -282,29 +283,29 @@ class WireGuardInterfaceTest(BasicInterfaceTest.TestCase):
 
         hex_fwmark = hex(int(mark))
 
-        # Verify ip rule at priority 1998 routes fwmark-tagged packets into the VRF
-        tmp = cmd(f'ip rule show priority 1998')
+        # Verify WireGuard fwmark routing rule is created at wireguard_fwmark_pref priority
+        tmp = cmd(f'ip rule show priority {wireguard_fwmark_pref}')
         self.assertIn(f'fwmark {hex_fwmark} lookup {vrf}', tmp)
 
         # Remove VRF from the interface — ip rule must be cleaned up
         self.cli_delete(base_interface_path + ['vrf'])
         self.cli_commit()
 
-        tmp = cmd(f'ip rule show priority 1998')
+        tmp = cmd(f'ip rule show priority {wireguard_fwmark_pref}')
         self.assertNotIn(f'fwmark {hex_fwmark}', tmp)
 
         # Re-add VRF — ip rule must be re-created
         self.cli_set(base_interface_path + ['vrf', vrf])
         self.cli_commit()
 
-        tmp = cmd(f'ip rule show priority 1998')
+        tmp = cmd(f'ip rule show priority {wireguard_fwmark_pref}')
         self.assertIn(f'fwmark {hex_fwmark} lookup {vrf}', tmp)
 
         # Delete the interface entirely — ip rule must be removed
         self.cli_delete(base_interface_path)
         self.cli_commit()
 
-        tmp = cmd(f'ip rule show priority 1998')
+        tmp = cmd(f'ip rule show priority {wireguard_fwmark_pref}')
         self.assertNotIn(f'fwmark {hex_fwmark}', tmp)
 
         self.cli_delete(['vrf', 'name', vrf])

--- a/src/conf_mode/interfaces_wireguard.py
+++ b/src/conf_mode/interfaces_wireguard.py
@@ -31,6 +31,7 @@ from vyos.configverify import verify_bridge_delete
 from vyos.configverify import verify_mtu_ipv6
 from vyos.configverify import verify_mirror_redirect
 from vyos.configverify import verify_bond_bridge_member
+from vyos.defaults import wireguard_fwmark_pref
 from vyos.ifconfig import WireGuardIf
 from vyos.utils.kernel import check_kmod
 from vyos.utils.network import check_port_availability
@@ -174,7 +175,7 @@ def apply(wireguard):
             if table_id is not None:
                 for afi in ['-4', '-6']:
                     call(
-                        f'ip {afi} rule del pref 1998 fwmark {prev_fwmark} table {table_id}'
+                        f'ip {afi} rule del pref {wireguard_fwmark_pref} fwmark {prev_fwmark} table {table_id}'
                     )
 
     # Add ip rule to route fwmark-marked WireGuard tunnel packets into the
@@ -185,7 +186,7 @@ def apply(wireguard):
         table_id = get_vrf_tableid(wireguard['vrf'])
         for afi in ['-4', '-6']:
             call(
-                f'ip {afi} rule add pref 1998 fwmark {wireguard["fwmark"]} table {table_id}'
+                f'ip {afi} rule add pref {wireguard_fwmark_pref} fwmark {wireguard["fwmark"]} table {table_id}'
             )
 
     domain_resolver_usage = '/run/use-vyos-domain-resolver-interfaces-wireguard-' + wireguard['ifname']

--- a/src/conf_mode/vrf.py
+++ b/src/conf_mode/vrf.py
@@ -23,6 +23,7 @@ import vyos.defaults
 from vyos.config import Config
 from vyos.configdict import node_changed
 from vyos.configverify import verify_route_map
+from vyos.defaults import wireguard_fwmark_pref
 from vyos.firewall import conntrack_required
 from vyos.frrender import FRRender
 from vyos.frrender import get_frrender_dict
@@ -265,10 +266,10 @@ def apply(vrf):
                 # Remove map element
                 cmd(f'nft {nft_del_element}')
 
-            # Remove all ip rules pointing to this VRF table
+            # Remove WireGuard fwmark routing rules created for this VRF table
             table_id = get_vrf_tableid(tmp)
             for afi in ['-4', '-6']:
-                while call(f'ip {afi} rule del table {table_id}') == 0:
+                while call(f'ip {afi} rule del pref {wireguard_fwmark_pref} table {table_id}') == 0:
                     pass
 
             # Delete the VRF Kernel interface


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8936
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
