### PR TITLE
docs: T8937: fix typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to VyOS
 
-You wan't to help us improve VyOS? This is awesome!
+You want to help us improve VyOS? This is awesome!
 
 We accept any kind of Pull Requests on GitHub. In order to get your changes into
 the main repository as smooth as possible please take yourself some time and


### PR DESCRIPTION
Tier 1.1 verification followup for the Mergify-replaceable GHA retire sweep.

Fixes a long-standing typo: `wan't` → `want` in the first line of CONTRIBUTING.md.

This trivial change also serves as a live probe confirming that `mergify[bot]` is now the sole labeling/assigning actor on `vyos/vyos-1x` after [#5234](https://github.com/vyos/vyos-1x/pull/5234) deleted the 4 GHA caller workflows (`add-pr-labels.yml`, `auto-author-assign.yml`, `check-pr-message.yml`, `label-backport.yml`).

Advances: T8937

🤖 Generated by [robots](https://vyos.io)