### PR TITLE
nat: T8939: fix KeyError: 'group' exception

### DIFF
--- a/python/vyos/nat.py
+++ b/python/vyos/nat.py
@@ -37,7 +37,7 @@ def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
                 operator = '!='
                 iiface = iiface[1:]
             output.append(f'iifname {operator} {{{iiface}}}')
-        else:
+        elif 'group' in rule_conf['inbound_interface']:
             iiface = rule_conf['inbound_interface']['group']
             if iiface[0] == '!':
                 operator = '!='
@@ -52,7 +52,7 @@ def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
                 operator = '!='
                 oiface = oiface[1:]
             output.append(f'oifname {operator} {{{oiface}}}')
-        else:
+        elif 'group' in rule_conf['outbound_interface']:
             oiface = rule_conf['outbound_interface']['group']
             if oiface[0] == '!':
                 operator = '!='
@@ -80,7 +80,6 @@ def parse_nat_rule(rule_conf, rule_id, nat_type, ipv6=False):
             if redirect_port:
                 translation_output.append(f'to {redirect_port}')
         else:
-
             translation_prefix = nat_type[:1]
             translation_output = [f'{translation_prefix}nat']
 

--- a/smoketest/scripts/cli/test_nat66.py
+++ b/smoketest/scripts/cli/test_nat66.py
@@ -110,11 +110,13 @@ class TestNAT66(VyOSUnitTestSHIM.TestCase):
         destination_address = 'fc00::1'
         translation_address = 'fc01::1'
         source_address = 'fc02::1'
-        self.cli_set(dst_path + ['rule', '1', 'inbound-interface', 'name', 'eth1'])
+        in_interface = 'eth1'
+
+        self.cli_set(dst_path + ['rule', '1', 'inbound-interface', 'name', in_interface])
         self.cli_set(dst_path + ['rule', '1', 'destination', 'address', destination_address])
         self.cli_set(dst_path + ['rule', '1', 'translation', 'address', translation_address])
 
-        self.cli_set(dst_path + ['rule', '2', 'inbound-interface', 'name', 'eth1'])
+        self.cli_set(dst_path + ['rule', '2', 'inbound-interface', 'name', in_interface])
         self.cli_set(dst_path + ['rule', '2', 'destination', 'address', destination_address])
         self.cli_set(dst_path + ['rule', '2', 'source', 'address', source_address])
         self.cli_set(dst_path + ['rule', '2', 'exclude'])
@@ -123,10 +125,19 @@ class TestNAT66(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         nftables_search = [
-            ['iifname "eth1"', 'ip6 daddr fc00::1', 'dnat to fc01::1'],
-            ['iifname "eth1"', 'ip6 saddr fc02::1', 'ip6 daddr fc00::1', 'return']
+            [f'iifname "{in_interface}"', 'ip6 daddr fc00::1', 'dnat to fc01::1'],
+            [f'iifname "{in_interface}"', 'ip6 saddr fc02::1', 'ip6 daddr fc00::1', 'return']
         ]
+        self.verify_nftables(nftables_search, 'ip6 vyos_nat')
 
+        # T8939 - remove inbound-interface name
+        self.cli_delete(dst_path + ['rule', '2', 'inbound-interface', 'name'])
+        self.cli_commit()
+
+        nftables_search = [
+            [f'iifname "{in_interface}"', 'ip6 daddr fc00::1', 'dnat to fc01::1'],
+            ['ip6 saddr fc02::1', 'ip6 daddr fc00::1', 'return']
+        ]
         self.verify_nftables(nftables_search, 'ip6 vyos_nat')
 
     def test_destination_nat66_protocol(self):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Prevent access to missing dictionary key by probing for availability. On removal of inbound-interface or outbound-interface name CLI node, there was a guard missing when accessing the CLI dictionary containing the config data.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8939

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

```
vyos@vyos:~$  /usr/libexec/vyos/tests/smoke/cli/test_nat66.py
test_destination_nat66 (__main__.TestNAT66.test_destination_nat66) ... ok
test_destination_nat66_network_group (__main__.TestNAT66.test_destination_nat66_network_group) ... ok
test_destination_nat66_prefix (__main__.TestNAT66.test_destination_nat66_prefix) ... ok
test_destination_nat66_protocol (__main__.TestNAT66.test_destination_nat66_protocol) ... ok
test_destination_nat66_without_translation_address (__main__.TestNAT66.test_destination_nat66_without_translation_address) ... ok
test_firewall_group_dependence (__main__.TestNAT66.test_firewall_group_dependence) ... ok
test_nat66_no_rules (__main__.TestNAT66.test_nat66_no_rules) ... ok
test_source_nat66 (__main__.TestNAT66.test_source_nat66) ... ok
test_source_nat66_address (__main__.TestNAT66.test_source_nat66_address) ... ok
test_source_nat66_network_group (__main__.TestNAT66.test_source_nat66_network_group) ... ok
test_source_nat66_protocol (__main__.TestNAT66.test_source_nat66_protocol) ... ok
test_source_nat66_required_translation_prefix (__main__.TestNAT66.test_source_nat66_required_translation_prefix) ... ok

----------------------------------------------------------------------
Ran 12 tests in 27.109s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
