### PR TITLE
dhcp: T8941: Support filter and sorting combination on DHCPv4/v6 server lease entries in op mode

### DIFF
--- a/op-mode-definitions/dhcp.xml.in
+++ b/op-mode-definitions/dhcp.xml.in
@@ -398,12 +398,23 @@
                       </completionHelp>
                     </properties>
                     <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet6 --vrf '' --pool $6</command>
+                    <children>
+                      <tagNode name="sort">
+                        <properties>
+                          <help>Show DHCPv6 server leases sorted by the specified key</help>
+                          <completionHelp>
+                            <list>end duid hostname ip last_communication remaining state type</list>
+                          </completionHelp>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet6 --vrf '' --pool $6 --sort $8</command>
+                      </tagNode>
+                    </children>
                   </tagNode>
                   <tagNode name="sort">
                     <properties>
                       <help>Show DHCPv6 server leases sorted by the specified key</help>
                       <completionHelp>
-                        <list>end duid ip last_communication pool remaining state type</list>
+                        <list>end duid hostname ip last_communication pool remaining state type</list>
                       </completionHelp>
                     </properties>
                     <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet6 --vrf '' --sort $6</command>
@@ -416,6 +427,17 @@
                       </completionHelp>
                     </properties>
                     <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet6 --vrf '' --state $6</command>
+                    <children>
+                      <tagNode name="sort">
+                        <properties>
+                          <help>Show DHCPv6 server leases sorted by the specified key</help>
+                          <completionHelp>
+                            <list>end duid hostname ip last_communication pool remaining type</list>
+                          </completionHelp>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet6 --vrf '' --state $6 --sort $8</command>
+                      </tagNode>
+                    </children>
                   </tagNode>
                 </children>
               </node>
@@ -429,16 +451,27 @@
                     <properties>
                       <help>Show DHCPv6 server static mappings for a specific pool</help>
                       <completionHelp>
-                        <path>service dhcp-server shared-network-name</path>
+                        <path>service dhcpv6-server shared-network-name</path>
                       </completionHelp>
                     </properties>
                     <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet6 --vrf '' --pool $6</command>
+                    <children>
+                      <tagNode name="sort">
+                        <properties>
+                          <help>Show DHCPv6 server static mappings sorted by the specified key</help>
+                          <completionHelp>
+                            <list>duid hostname ip mac</list>
+                          </completionHelp>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet6 --vrf '' --pool $6 --sort $8</command>
+                      </tagNode>
+                    </children>
                   </tagNode>
                   <tagNode name="sort">
                     <properties>
                       <help>Show DHCPv6 server static mappings sorted by the specified key</help>
                       <completionHelp>
-                        <list>ip mac duid pool</list>
+                        <list>duid hostname ip mac pool</list>
                       </completionHelp>
                     </properties>
                     <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet6 --vrf '' --sort $6</command>
@@ -484,12 +517,23 @@
                           </completionHelp>
                         </properties>
                         <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet6 --vrf $5 --pool $8</command>
+                        <children>
+                          <tagNode name="sort">
+                            <properties>
+                              <help>Show DHCPv6 server leases sorted by the specified key</help>
+                              <completionHelp>
+                                <list>end duid hostname ip last_communication remaining state type</list>
+                              </completionHelp>
+                            </properties>
+                            <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet6 --vrf $5 --pool $8 --sort $10</command>
+                          </tagNode>
+                        </children>
                       </tagNode>
                       <tagNode name="sort">
                         <properties>
                           <help>Show DHCPv6 server leases sorted by the specified key</help>
                           <completionHelp>
-                            <list>end duid ip last_communication pool remaining state type</list>
+                            <list>end duid hostname ip last_communication pool remaining state type</list>
                           </completionHelp>
                         </properties>
                         <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet6 --vrf $5 --sort $8</command>
@@ -502,6 +546,17 @@
                           </completionHelp>
                         </properties>
                         <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet6 --vrf $5 --state $8</command>
+                        <children>
+                          <tagNode name="sort">
+                            <properties>
+                              <help>Show DHCPv6 server leases sorted by the specified key</help>
+                              <completionHelp>
+                                <list>end duid hostname ip last_communication pool remaining type</list>
+                              </completionHelp>
+                            </properties>
+                            <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet6 --vrf $5 --state $8 --sort $10</command>
+                          </tagNode>
+                        </children>
                       </tagNode>
                     </children>
                   </node>
@@ -515,16 +570,27 @@
                         <properties>
                           <help>Show DHCPv6 server static mappings for a specific pool</help>
                           <completionHelp>
-                            <path>service dhcp-server shared-network-name</path>
+                            <path>service dhcpv6-server shared-network-name</path>
                           </completionHelp>
                         </properties>
                         <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet6 --vrf $5 --pool $8</command>
+                        <children>
+                          <tagNode name="sort">
+                            <properties>
+                              <help>Show DHCPv6 server static mappings sorted by the specified key</help>
+                              <completionHelp>
+                                <list>duid hostname ip mac</list>
+                              </completionHelp>
+                            </properties>
+                            <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet6 --vrf $5 --pool $8 --sort $10</command>
+                          </tagNode>
+                        </children>
                       </tagNode>
                       <tagNode name="sort">
                         <properties>
                           <help>Show DHCPv6 server static mappings sorted by the specified key</help>
                           <completionHelp>
-                            <list>ip mac duid pool</list>
+                            <list>duid hostname ip mac pool</list>
                           </completionHelp>
                         </properties>
                         <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet6 --vrf $5 --sort $8</command>

--- a/op-mode-definitions/dhcp.xml.in
+++ b/op-mode-definitions/dhcp.xml.in
@@ -112,6 +112,17 @@
                       </completionHelp>
                     </properties>
                     <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet --vrf '' --origin $6</command>
+                    <children>
+                      <tagNode name="sort">
+                        <properties>
+                          <help>Show DHCP server leases sorted by the specified key</help>
+                          <completionHelp>
+                            <list>end hostname ip mac pool remaining start state</list>
+                          </completionHelp>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet --vrf '' --origin $6 --sort $8</command>
+                      </tagNode>
+                    </children>
                   </tagNode>
                   <tagNode name="pool">
                     <properties>
@@ -121,6 +132,17 @@
                       </completionHelp>
                     </properties>
                     <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet --vrf '' --pool $6</command>
+                    <children>
+                      <tagNode name="sort">
+                        <properties>
+                          <help>Show DHCP server leases sorted by the specified key</help>
+                          <completionHelp>
+                            <list>end hostname ip mac remaining start state</list>
+                          </completionHelp>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet --vrf '' --pool $6 --sort $8</command>
+                      </tagNode>
+                    </children>
                   </tagNode>
                   <tagNode name="sort">
                     <properties>
@@ -139,6 +161,17 @@
                       </completionHelp>
                     </properties>
                     <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet --vrf '' --state $6</command>
+                    <children>
+                      <tagNode name="sort">
+                        <properties>
+                          <help>Show DHCP server leases sorted by the specified key</help>
+                          <completionHelp>
+                            <list>end hostname ip mac pool remaining start</list>
+                          </completionHelp>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet --vrf '' --state $6 --sort $8</command>
+                      </tagNode>
+                    </children>
                   </tagNode>
                 </children>
               </node>
@@ -156,12 +189,23 @@
                       </completionHelp>
                     </properties>
                     <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet --vrf '' --pool $6</command>
+                    <children>
+                      <tagNode name="sort">
+                        <properties>
+                          <help>Show DHCP server static mappings sorted by the specified key</help>
+                          <completionHelp>
+                            <list>duid hostname ip mac</list>
+                          </completionHelp>
+                        </properties>
+                        <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet --vrf '' --pool $6 --sort $8</command>
+                      </tagNode>
+                    </children>
                   </tagNode>
                   <tagNode name="sort">
                     <properties>
                       <help>Show DHCP server static mappings sorted by the specified key</help>
                       <completionHelp>
-                        <list>ip mac duid pool</list>
+                        <list>duid hostname ip mac pool</list>
                       </completionHelp>
                     </properties>
                     <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet --vrf '' --sort $6</command>
@@ -207,6 +251,17 @@
                           </completionHelp>
                         </properties>
                         <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet --vrf $5 --origin $8</command>
+                        <children>
+                          <tagNode name="sort">
+                            <properties>
+                              <help>Show DHCP server leases sorted by the specified key</help>
+                              <completionHelp>
+                                <list>end hostname ip mac pool remaining start state</list>
+                              </completionHelp>
+                            </properties>
+                            <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet --vrf $5 --origin $8 --sort $10</command>
+                          </tagNode>
+                        </children>
                       </tagNode>
                       <tagNode name="pool">
                         <properties>
@@ -216,6 +271,17 @@
                           </completionHelp>
                         </properties>
                         <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet --vrf $5 --pool $8</command>
+                        <children>
+                          <tagNode name="sort">
+                            <properties>
+                              <help>Show DHCP server leases sorted by the specified key</help>
+                              <completionHelp>
+                                <list>end hostname ip mac remaining start state</list>
+                              </completionHelp>
+                            </properties>
+                            <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet --vrf $5 --pool $8 --sort $10</command>
+                          </tagNode>
+                        </children>
                       </tagNode>
                       <tagNode name="sort">
                         <properties>
@@ -234,6 +300,17 @@
                           </completionHelp>
                         </properties>
                         <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet --vrf $5 --state $8</command>
+                        <children>
+                          <tagNode name="sort">
+                            <properties>
+                              <help>Show DHCP server leases sorted by the specified key</help>
+                              <completionHelp>
+                                <list>end hostname ip mac pool remaining start</list>
+                              </completionHelp>
+                            </properties>
+                            <command>${vyos_op_scripts_dir}/dhcp.py show_server_leases --family inet --vrf $5 --state $8 --sort $10</command>
+                          </tagNode>
+                        </children>
                       </tagNode>
                     </children>
                   </node>
@@ -251,12 +328,23 @@
                           </completionHelp>
                         </properties>
                         <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet --vrf $5 --pool $8</command>
+                        <children>
+                          <tagNode name="sort">
+                            <properties>
+                              <help>Show DHCP server static mappings sorted by the specified key</help>
+                              <completionHelp>
+                                <list>duid hostname ip mac</list>
+                              </completionHelp>
+                            </properties>
+                            <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet --vrf $5 --pool $8 --sort $10</command>
+                          </tagNode>
+                        </children>
                       </tagNode>
                       <tagNode name="sort">
                         <properties>
                           <help>Show DHCP server static mappings sorted by the specified key</help>
                           <completionHelp>
-                            <list>ip mac duid pool</list>
+                            <list>duid hostname ip mac pool</list>
                           </completionHelp>
                         </properties>
                         <command>${vyos_op_scripts_dir}/dhcp.py show_server_static_mappings --family inet --vrf $5 --sort $8</command>

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -64,6 +64,7 @@ sort_valid_inet = [
 sort_valid_inet6 = [
     'end',
     'duid',
+    'hostname',
     'ip',
     'last_communication',
     'pool',
@@ -71,7 +72,7 @@ sort_valid_inet6 = [
     'state',
     'type',
 ]
-mapping_sort_valid = ['mac', 'ip', 'pool', 'duid']
+mapping_sort_valid = ['mac', 'hostname', 'ip', 'pool', 'duid']
 
 stale_warn_msg = 'DHCP server is configured but not started. Data may be stale.'
 

--- a/src/op_mode/dhcp.py
+++ b/src/op_mode/dhcp.py
@@ -93,9 +93,9 @@ def _get_raw_server_leases(
 
     if sorted:
         if sorted == 'ip':
-            mappings.sort(key=lambda x: ip_address(x['ip']))
+            mappings.sort(key=lambda x: ip_address(val) if (val := x.get('ip')) else '')
         else:
-            mappings.sort(key=lambda x: x[sorted])
+            mappings.sort(key=lambda x: x.get(sorted) or '')
     return mappings
 
 
@@ -238,9 +238,9 @@ def _get_raw_server_static_mappings(config, family='inet', pool=None, sorted=Non
 
     if sorted:
         if sorted == 'ip':
-            mappings.sort(key=lambda x: ip_address(x['ip']))
+            mappings.sort(key=lambda x: ip_address(val) if (val := x.get('ip')) else '')
         else:
-            mappings.sort(key=lambda x: x[sorted])
+            mappings.sort(key=lambda x: x.get(sorted) or '')
     return mappings
 
 
@@ -251,10 +251,11 @@ def _get_formatted_server_static_mappings(raw_data):
         pool = entry.get('pool')
         subnet = entry.get('subnet')
         hostname = entry.get('hostname')
-        ip_addr = entry.get('ip', 'N/A')
-        mac_addr = entry.get('mac', 'N/A')
-        duid = entry.get('duid', 'N/A')
-        desc = entry.get('description', 'N/A')
+        # These fields may be either None or '', display 'N/A' in both cases
+        ip_addr = entry.get('ip') or 'N/A'
+        mac_addr = entry.get('mac') or 'N/A'
+        duid = entry.get('duid') or 'N/A'
+        desc = entry.get('description') or 'N/A'
         data_entries.append([pool, subnet, hostname, ip_addr, mac_addr, duid, desc])
 
     headers = [


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

- Support filter and sorting combination on DHCPv4/v6 server lease entries in op mode.
- Add `hostname` as a valid sort key for both DHCPv4 and DHCPv6 leases and static mappings.
- Fix typo in the completion help for DHCPv6 leases sorting.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8941

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

`sort`-ing is now available as a node in the filter related chains
- `origin`, `pool`, `state` for `dhcp server leases`
- `pool`, `state` for `dhcpv6 server leases`
- `pool` for `dhcp server static-mapping`
- `pool` for `dhcpv6 server static-mapping`

### Before:
```
vyos@vyos:~$ show dhcp server leases pool TMP 
Possible completions:
  <Enter>               Execute the current command

vyos@vyos:~$ show dhcp server static-mappings pool TMP 
Possible completions:
  <Enter>               Execute the current command
```

### After (note addition of `sort` as possible completion):
```
vyos@vyos:~$ show dhcp server leases pool TMP 
Possible completions:
  <Enter>               Execute the current command
  sort                  Show DHCP server leases sorted by the specified key

vyos@vyos:~$ show dhcp server static-mappings pool TMP 
Possible completions:
  <Enter>               Execute the current command
  sort                  Show DHCP server leases sorted by the specified key
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
