### PR TITLE
vyos-netlinkd: T8950: track per-interface operstate to suppress UP-to-UP DHCP restarts

### DIFF
--- a/src/services/vyos-netlinkd
+++ b/src/services/vyos-netlinkd
@@ -40,6 +40,10 @@ running = True
 # compile regex once during startup for fast match
 IFACE_RE = re.compile(r"^(?:eth|br|bond|wlan)")
 
+# Per-interface previous operstate, used to suppress DHCP restarts on
+# UP-to-UP re-notifications (e.g. post-migration gratuitous-ARP events).
+_iface_prev_operstate: dict[str, str] = {}
+
 def match_iface(ifname: str) -> bool:
     """ Helper function returning true if interface name is a match for further
     processing (e.g. restart of DHCP(v6) client)
@@ -58,6 +62,14 @@ def _handle_dhcp_events(operstate: Optional[str], ifname: str) -> None:
 
     # Only handle explicit UP/DOWN state transitions; ignore other kernel states.
     if operstate not in ['UP', 'DOWN']:
+        return None
+
+    prev = _iface_prev_operstate.get(ifname)
+    _iface_prev_operstate[ifname] = operstate
+
+    if operstate == 'UP' and prev == 'UP':
+        syslog.syslog(syslog.LOG_DEBUG,
+                      f'Suppressing DHCP restart for {ifname}: already UP')
         return None
 
     if operstate == 'DOWN':
@@ -168,7 +180,10 @@ def main():
 
                     # Deletion of a network link which has been previously added to the kernel
                     case 'RTM_DELLINK':
-                        pass
+                        attrs = dict(message.get('attrs', []))
+                        ifname = attrs.get('IFLA_IFNAME', None)
+                        if ifname:
+                            _iface_prev_operstate.pop(ifname, None)
                     case _:
                         pass
 


### PR DESCRIPTION
## Change summary

`_handle_dhcp_events()` restarts dhclient/dhcp6c on every RTM_NEWLINK that carries operstate=UP, without checking whether the interface was already UP. Normal kernel events that re-notify UP without a preceding DOWN (post-migration gratuitous-ARP, promiscuous-mode toggles) trigger unnecessary restarts. Each restart also feeds back: dhclient-script runs `ip link set dev <if> up` during PREINIT, emitting another RTM_NEWLINK(UP), which triggers another restart. One seed event becomes 10+ restarts in 15 seconds.

Track per-interface previous operstate in a module-level dict. Only restart DHCP on DOWN-to-UP transitions or first boot (no previous state recorded). UP-to-UP re-notifications are suppressed with a LOG_DEBUG message.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T8950

## Related PR(s)

None.

## How to test / Smoketest result

On a VyOS router with `set interfaces ethernet eth2 address dhcp`, trigger an UP-to-UP re-notification:

```
sudo ip link set dev eth2 up
```

Check journal output with `monitor log`:

```
vyos-netlinkd[1234]: RTM_NEWLINK -> eth2, state=UP, mac=00:50:56:b3:9d:8e
vyos-netlinkd[1234]: Suppressing DHCP restart for eth2: already UP
```

Verify DOWN-to-UP still restarts DHCP:

```
sudo ip link set dev eth2 down
sudo ip link set dev eth2 up
```

```
vyos-netlinkd[1234]: RTM_NEWLINK -> eth2, state=DOWN, mac=00:50:56:b3:9d:8e
vyos-netlinkd[1234]: Stopping dhclient@eth2.service...
vyos-netlinkd[1234]: RTM_NEWLINK -> eth2, state=UP, mac=00:50:56:b3:9d:8e
vyos-netlinkd[1234]: Restarting dhclient@eth2.service...
```

Tested on VyOS 2026.05.26-1327-rolling (KVM guest, Proxmox VE 8.4). Pre-patch, a live migration triggered 10 DHCP restarts in 15 seconds. Post-patch, zero restarts, all UP-to-UP events suppressed.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly