### PR TITLE
docs: AGENTS.md: reflect rollout 1c default-branch rename (current->rolling)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ Smoketests (`smoketest/`) run inside the QEMU harness invoked by
   at <https://vyos.dev>. This is enforced by the
   `check-pr-message.yml` reusable workflow.
 - See `CONTRIBUTING.md` for additional commit message guidance.
-- Branch model: `current` (rolling, default), `circinus` (1.5 LTS), `sagitta`
+- Branch model: `rolling` (default), `circinus` (1.5 LTS), `sagitta`
   (1.4 LTS), `equuleus` (1.3 LTS). Backports via
   `@Mergifyio backport <branch>`.
 - Default-branch protection: 2 required approvals; required status checks.


### PR DESCRIPTION
Updates `AGENTS.md` to reflect the rollout 1c default-branch rename (release-train repos `current`->`rolling`; `vyos/.github` + non-release-train `current`->`production`) and the corresponding `@current`->`@production` reusable-workflow refs.

Tracking: Phorge [T8943](https://vyos.dev/T8943) (the 1c rename that caused the drift).

Doc-only change to `AGENTS.md`. No code or workflow behavior changes.

🤖 Generated by [robots](https://vyos.io)