### PR TITLE
ci: T8943: complete current->rolling branch-ref migration (rollout 1c follow-up)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -45,9 +45,9 @@ test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 <!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
-- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
+- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
 - [ ] I have linked this PR to one or more Phabricator Task(s)
-- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
+- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
 - [ ] My commit headlines contain a valid Task id
 - [ ] My change requires a change to the documentation
 - [ ] I have updated the documentation accordingly

--- a/.github/config/smoketest-branches.json
+++ b/.github/config/smoketest-branches.json
@@ -1,8 +1,8 @@
 {
   "branches": {
-    "current": {
-      "vyos_mirror": "https://packages.vyos.net/repositories/current/",
-      "container_image": "vyos/vyos-build:current",
+    "rolling": {
+      "vyos_mirror": "https://packages.vyos.net/repositories/rolling/",
+      "container_image": "vyos/vyos-build:rolling",
       "vyos_build_repo": "vyos/vyos-build",
       "use_pat": false,
       "build_runner": ["ubuntu-24.04"],


### PR DESCRIPTION
## Change Summary

Rollout 1c PR #5241 renamed the `vyos-1x` default branch `current` → `rolling` and updated the 7 workflow files, but **missed two files** that still referenced the old branch name. This PR **completes #5241**.

### `.github/config/smoketest-branches.json` — bug fix (broken smoketest on `rolling`)

The branch config is keyed by `github.ref_name`. #5241 updated `package-smoketest.yml`'s triggers from `current` → `rolling` (both `push` and `pull_request_target`) but left the JSON key as `current`. Effect:

- The `current` JSON key was **orphaned** — nothing triggers a lookup for it after #5241, so removing it is safe.
- On `rolling`, `set_config` runs `jq '.branches["rolling"]'`, which returned `null` → `exit 1` (`No smoketest configuration found for branch 'rolling'`). **The integration test failed at `set_config` on every push/PR to `rolling`.**

Renaming the key `current` → `rolling` resolves the lookup. Verified end-to-end: the downstream `build_iso`/`test_*` jobs check out `vyos/vyos-build` at `ref: rolling`, and `vyos/vyos-build` has a `rolling` branch (`8669f15`), so the fix unblocks the full pipeline rather than just moving the failure forward.

The entry's `vyos_mirror` and `container_image` are also moved to the now-canonical `rolling` release stream:
- `packages.vyos.net/repositories/rolling/` (HTTP 200, live)
- `vyos/vyos-build:rolling` (actively rebuilt — last push 2026-05-31; the `current` Docker tag froze at 2026-03-27, before the rename)

This matches the self-consistent `circinus` / `sagitta` entries, where `key == vyos_mirror name == container_image tag == branch name`.

### `.github/PULL_REQUEST_TEMPLATE.md`

Two `github.com/vyos/vyos-1x/{blob,tree}/current/…` links repointed to `/rolling/` (the default branch).

## Scope of the "other occurrences" scan

A full-repo scan for git-branch references to `current` on the `rolling` branch found **only** the three above. All other `current` occurrences in the repo (~3000) are the VyOS **release-stream / version / config** vocabulary (e.g. `packages.vyos.net/repositories/current`, "current configuration", version strings) and are **intentionally left unchanged** — they are not git-branch references.

## Note for reviewers

The `vyos_mirror` / `container_image` value changes (not just the key) are a deliberate, evidence-based choice (fresh `rolling` artifacts vs. frozen `current`, plus circinus/sagitta consistency). If release engineering wants the `rolling` branch to keep building against the legacy `current` mirror/tag during a transition window, only the **key** rename is strictly required for the bug fix — say so and I'll narrow it.

Tracking: T8943

🤖 Generated by [robots](https://vyos.io)