### PR TITLE
http-api-client: T8955: enable TLS verification by default

### DIFF
--- a/python/vyos/http_api_client.py
+++ b/python/vyos/http_api_client.py
@@ -19,6 +19,7 @@ import json
 import urllib3
 import requests
 from typing import Optional
+from typing import Union
 from dataclasses import dataclass
 
 from vyos.version import get_version
@@ -51,7 +52,11 @@ class ApiClientConfig:
     key: str
     port: int = 443
     timeout: Optional[int] = None
-    verify_tls: bool = False
+    # TLS peer verification, forwarded verbatim to requests' ``verify``:
+    #   True       - verify against the system CA store (secure default)
+    #   False      - disable verification (insecure; opt-in only)
+    #   "<path>"   - verify against a custom CA bundle file/dir
+    verify_tls: Union[bool, str] = True
 
 
 class ApiClient:
@@ -60,7 +65,8 @@ class ApiClient:
     Design goals:
     - minimal surface area (thin wrapper around requests)
     - consistent error handling + typed exceptions
-    - safe defaults for VyOS typical self-signed HTTPS usage (verify_tls=False)
+    - secure defaults (verify_tls=True); deployments using self-signed
+      certificates opt into verify_tls=False or supply a CA bundle path
     """
 
     _DEFAULT_HEADERS = {
@@ -77,7 +83,9 @@ class ApiClient:
         self._session = requests.Session()
         self._session.headers.update(self._DEFAULT_HEADERS)
 
-        if not config.verify_tls:
+        # Only silence the insecure-request warning when verification has been
+        # explicitly disabled. A CA bundle path or True must keep warnings on.
+        if config.verify_tls is False:
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     @property

--- a/src/op_mode/config_sync.py
+++ b/src/op_mode/config_sync.py
@@ -68,13 +68,21 @@ def _load_config_sync_settings() -> dict:
     key = secondary.get('key')
     port = int(secondary.get('port', 443))
     timeout = int(secondary.get('timeout')) if secondary.get('timeout') else None
+    # config-sync talks to a remote secondary over HTTPS. TLS verification is
+    # off by default because secondary nodes typically present a self-signed
+    # certificate; an operator can opt in (True, or a CA bundle path) once the
+    # runtime config exposes it. TODO: surface as a proper CLI knob
+    # (set service config-sync secondary verify-tls / ca-certificate).
+    verify_tls = secondary.get('verify_tls', False)
 
     if not address or not key:
         raise opmode.UnconfiguredObject(
             'Config-sync is not fully configured: missing secondary address/key'
         )
 
-    return dict(host=address, key=key, port=port, timeout=timeout)
+    return dict(
+        host=address, key=key, port=port, timeout=timeout, verify_tls=verify_tls
+    )
 
 
 class ConfigSyncDiffManager:


### PR DESCRIPTION
## Summary

`python/vyos/http_api_client.py` defaulted `ApiClientConfig.verify_tls` to `False` and unconditionally silenced urllib3's `InsecureRequestWarning`, so the HTTP API client did **not** verify TLS peers by default.

The only real consumer is `src/op_mode/config_sync.py` (`ConfigSyncDiffManager`), which builds `ApiClientConfig(host, key, port, timeout)` **without** `verify_tls` and so inherited the insecure default. config-sync connects to a **remote** secondary VyOS node over HTTPS, so verification was silently off on a remote management channel that carries the API `key` and the full configuration — a MITM exposure.

(`src/conf_mode/system_syslog.py` has its own unrelated `verify_tls` concept for rsyslog and does **not** use this client.)

## Changes

**`python/vyos/http_api_client.py`**
- `verify_tls` now defaults to `True` and is typed `Union[bool, str]`. A string is forwarded to `requests` as a CA-bundle path (`verify=<path>`); `True`/`False` keep their `requests` meaning.
- `InsecureRequestWarning` is suppressed **only** when verification is explicitly disabled (`verify_tls is False`) — not when a CA path or `True` is configured.

**`src/op_mode/config_sync.py`**
- The runtime-settings loader now reads an optional `verify_tls` from the `secondary` block and passes it through, **defaulting to `False`** to preserve current behaviour for self-signed secondaries. The insecurity is now explicit at the call site rather than hidden in the library default.

## Blast radius / reviewer note

- **No functional regression today:** config-sync still defaults to no-verify (self-signed secondaries keep working). The change makes the *library* secure-by-default for future consumers (e.g. vyos-mcp) and makes the existing insecurity explicit and operator-overridable.
- **Follow-up (not in this PR):** a first-class CLI knob — `set service config-sync secondary verify-tls` / `ca-certificate` — to surface verification in the config tree (needs XML + a migration). Flagged with a `TODO` in `config_sync.py`.

## Testing

- `python3 -m py_compile` passes on both files.
- No new lines exceed the 88-char ruff limit (the two long lines flagged locally pre-exist and are untouched).
- No unit-test harness exists for the live HTTPS client without a running secondary; behaviour change is limited to the default value + warning-suppression condition.

Surfaced by automated security review. The flagged code is already public on `rolling`.

Tracking: T8955

🤖 Generated by [robots](https://vyos.io)