### PR TITLE
remote: T8956: stop leaking URL credentials in TftpC.upload()

### DIFF
--- a/python/vyos/remote.py
+++ b/python/vyos/remote.py
@@ -476,7 +476,6 @@ class TftpC:
                         vrf=self.vrf).encode())
 
     def upload(self, location: str):
-        print(f'{self.command} "{self.urlstring}"')
         with open(location, 'rb') as f:
             cmd(f'{self.command} --upload-file - "{self.urlstring}"',
                 input=f.read(), vrf=self.vrf)


### PR DESCRIPTION
## Summary

TftpC.upload() printed `{command} "{urlstring}"` to stdout before running the
command. This was debug code from the time where VRF support was added. As TFTP
has no authentication - no credentials got leaked.
`self.urlstring` is the full `urllib.parse.urlunsplit(url)` and can embed userinfo — `scheme://user:password@host/…`. Printing it exposes those credentials in op-mode output and any captured logs.

## Testing

- `python3 -m py_compile python/vyos/remote.py` passes.
- One-line deletion; no behavioural change to the upload itself (the `cmd(...)` call is untouched).

Surfaced by automated security review. The flagged code is already public on `rolling`.

Tracking: T8956

🤖 Generated by [robots](https://vyos.io)