### PR TITLE
ipsec: T8954: Bump strongSwan deps to version 5.9.11

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -303,14 +303,14 @@ Depends:
   nfct,
   nftables (>= 0.9.3),
 # For "vpn ipsec"
-  strongswan (>= 5.9),
-  strongswan-swanctl (>= 5.9),
-  charon-systemd,
-  libcharon-extra-plugins (>=5.9),
-  libcharon-extauth-plugins (>=5.9),
-  libstrongswan-extra-plugins (>=5.9),
-  libstrongswan-standard-plugins (>=5.9),
-  python3-vici (>= 5.7.2),
+  strongswan (>= 5.9.11),
+  strongswan-swanctl (>= 5.9.11),
+  charon-systemd (>= 5.9.11),
+  libcharon-extra-plugins (>= 5.9.11),
+  libcharon-extauth-plugins (>= 5.9.11),
+  libstrongswan-extra-plugins (>= 5.9.11),
+  libstrongswan-standard-plugins (>= 5.9.11),
+  python3-vici (>= 5.9.11),
 # End "vpn ipsec"
 # For "nat64"
   jool,


### PR DESCRIPTION
## Change summary
When strongSwan package is not available on `packages.vyos.net`, it causes the Debain 5.9.8 package version to be used, which fails the tests.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8954

## How to test / Smoketest result
### Manual test
```
vyos@vyos5:~$ show version all  | match "(strongswan|charon|vici)"
ii  charon-systemd                   5.9.11-2+vyos0                           amd64        strongSwan IPsec client, systemd support
ii  libcharon-extauth-plugins        5.9.11-2+vyos0                           amd64        strongSwan charon library (extended authentication plugins)
ii  libcharon-extra-plugins          5.9.11-2+vyos0                           amd64        strongSwan charon library (extra plugins)
ii  libstrongswan                    5.9.11-2+vyos0                           amd64        strongSwan utility and crypto library
ii  libstrongswan-extra-plugins      5.9.11-2+vyos0                           amd64        strongSwan utility and crypto library (extra plugins)
ii  libstrongswan-standard-plugins   5.9.11-2+vyos0                           amd64        strongSwan utility and crypto library (standard plugins)
ii  python3-vici                     5.9.11-2+vyos0                           all          Native Python interface for strongSwan's VICI protocol
ii  strongswan                       5.9.11-2+vyos0                           all          IPsec VPN solution metapackage
ii  strongswan-charon                5.9.11-2+vyos0                           amd64        strongSwan Internet Key Exchange daemon
ii  strongswan-libcharon             5.9.11-2+vyos0                           amd64        strongSwan charon library
ii  strongswan-starter               5.9.11-2+vyos0                           amd64        strongSwan daemon starter and configuration file parser
ii  strongswan-swanctl               5.9.11-2+vyos0                           amd64        strongSwan IPsec client, swanctl command

vyos@vyos5:~$ /usr/libexec/vyos/tests/smoke/cli/test_vpn_ipsec.py
test_dhcp_fail_handling (__main__.TestVPNIPsec.test_dhcp_fail_handling) ... ok
...
test_site_to_site_x509 (__main__.TestVPNIPsec.test_site_to_site_x509) ... ok
----------------------------------------------------------------------
Ran 21 tests in 167.238s
OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly