### PR TITLE
vpp: T8913: Skip bond teardown for non-structural config changes

### DIFF
--- a/python/vyos/ifconfig/vpp/bond.py
+++ b/python/vyos/ifconfig/vpp/bond.py
@@ -17,6 +17,7 @@
 
 from vyos.ifconfig import Interface
 from vyos.ifconfig.vpp.interface import VPPInterface
+from vyos.utils.dict import dict_search
 
 
 class VPPBondInterface(Interface, VPPInterface):
@@ -135,13 +136,24 @@ class VPPBondInterface(Interface, VPPInterface):
             # Delete bonding interface
             self.delete_bond()
 
+            self.index = None
+
     def update(self, config):
         # Add bond interface
-        self.add_bond()
+        if self.index is None:
+            self.add_bond()
+
+        # Delete removed members
+        members = self.get_members()
+        config_members = dict_search('member.interface', config, default=[])
+        for member in members:
+            if member not in config_members:
+                self.detach_member(interface=member)
 
         # Add members to bond
-        for member in config.get('member', {}).get('interface', []):
-            self.add_member(interface=member)
+        for member in config_members:
+            if member not in members:
+                self.add_member(interface=member)
 
         # Apply VPP-specific interface settings
         VPPInterface.update(self, config)

--- a/src/conf_mode/vpp_interfaces_bonding.py
+++ b/src/conf_mode/vpp_interfaces_bonding.py
@@ -18,6 +18,7 @@
 
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
+from vyos.configdict import is_node_changed
 from vyos.configdep import set_dependents, call_dependents
 from vyos.configverify import verify_mtu_ipv6
 from vyos import ConfigError
@@ -107,6 +108,12 @@ def get_config(config=None) -> dict:
         get_first_key=True,
         no_tag_node_value_mangle=True,
     )
+
+    iface_path = ['interfaces', 'vpp', 'bonding', ifname]
+    rebuild_required_nodes = ['mode', 'hash-policy', 'mac']
+    for node in rebuild_required_nodes:
+        if is_node_changed(conf, iface_path + [node]):
+            config.update({'rebuild_required': {}})
 
     config['bond_members'] = deps_bond_dict(conf)
 
@@ -225,10 +232,12 @@ def apply(config):
 
     ifname = config.get('ifname')
     bond = VPPBondInterface(ifname, config)
-    bond.remove()
+
+    if 'deleted' in config or 'rebuild_required' in config:
+        bond.remove()
 
     if 'deleted' in config:
-        return
+        return None
 
     bond.update(config)
 


### PR DESCRIPTION
VPP bond teardown was triggered on every commit regardless of what changed, dropping all subinterfaces and BGP sessions even for trivial changes like descriptions or IP addresses. Only mode, hash-policy and mac_address require full recreation since VPP has no in-place update API for these; all other changes are now applied incrementally.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8913
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
