### PR TITLE
password-reset: T8346: Fix password recovery when only `plaintext-password` is set

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -123,6 +123,11 @@ Depends:
   wide-dhcpv6-client,
 # Generic colorizer
   grc,
+# The package "whois" contains both a whois database client
+# that end users can find useful,
+# and the "mkpasswd" utility we use for generating hashed passwords
+# in the standalone password reset script
+  whois,
 ## End of System services and utilities
 ## For the installer
   fdisk,

--- a/src/system/standalone_root_pw_reset
+++ b/src/system/standalone_root_pw_reset
@@ -27,8 +27,23 @@ CF=/opt/vyatta/etc/config/config.boot
 ADMIN=vyos
 
 set_encrypted_password() {
-    sed -i \
-       -e "/ user $1 {/,/encrypted-password/s/encrypted-password .*\$/encrypted-password \"$2\"/" $3
+    local user=$1 epwd=$2 file=$3
+
+    # Check if encrypted-password exists within this specific user's block
+    if awk "/ user $user \{/{f=1} f && /encrypted-password/{found=1; exit} f && /^        }/{exit} END{exit !found}" "$file"; then
+        # Replace existing encrypted-password line
+        sed -i \
+           -e "/ user $user {/,/encrypted-password/s/encrypted-password .*\$/encrypted-password \"$epwd\"/" "$file"
+    else
+        # Insert encrypted-password after plaintext-password
+        sed -i \
+           -e "/ user $user {/,/plaintext-password/s/\(plaintext-password .*\)\$/\1\n                encrypted-password \"$epwd\"/" "$file"
+    fi
+}
+
+clear_plaintext_password() {
+   sed -i \
+      -e "/ user $1 {/,/plaintext-password/s/plaintext-password .*\$/plaintext-password \"\"/" $2
 }
 
 
@@ -58,6 +73,11 @@ change_password() {
     # escape any slashes in resulting password
     local eepwd=$(sed 's:/:\\/:g' <<< $epwd)
     set_encrypted_password $user $eepwd $CF
+
+    # There is issue that 'set_encrypted_password' only handles the 'encrypted-password' line,
+    # but leaves any existing 'plaintext-password' untouched (T8346).
+    # We need to clear 'plaintext-password' for the user during the password change flow.
+    clear_plaintext_password $user $CF
 }
 
 # System is so messed up that doing anything would be a mistake


### PR DESCRIPTION
## Change summary
When a user account was provisioned with only `plaintext-password` (e.g. via cloud-init), the password recovery tool failed to persist the new password across reboots. On the next boot, VyOS would re-apply the `plaintext-password` from config.boot, silently overwriting the recovered encrypted password.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8346

## How to test / Smoketest result
### Manual test
1. Instance started, login vyos/vyos success.
2. Reboot and choose 'password reset' from GRUB menu.
3. Boot into password recovery tool and set a new password for user 'vyos':
```
Do you wish to reset the admin password? (y or n) y
Which admin account do you want to reset? [vyos]
Starting process to reset the admin password...
Re-mounting root filesystem read/write...
Saving backup copy of config.boot...
Setting the administrator (vyos) password...
Enter vyos password: <new password>
Retype vyos password: <new password>
System will reboot in 10 seconds...
```
4. Reboot and try to login with new password:
```
Welcome to VyOS - vyos5 ttyS0

vyos5 login: vyos
Password: <old password>

Login incorrect
vyos5 login: vyos
Password: <new password>

---
WARNING: This VyOS system is not a stable long-term support version and
         is not intended for production use.

vyos@vyos5:~$
vyos@vyos5:~$ diff -u /config/config.boot.before_pwrecovery /config/config.boot
--- /config/config.boot.before_pwrecovery       2026-06-03 12:38:33.868100207 +0000
+++ /config/config.boot 2026-06-03 12:38:39.772000000 +0000
@@ -94,7 +94,8 @@
         }
         user vyos {
             authentication {
-                plaintext-password "vyos"
+                plaintext-password ""
+                encrypted-password "$y$j9T$oXprHr91wN3MVnjfiU/Cj.$qKSnE9tUe1hTLzDmjpKT8B.Omo1pTUtri5tyLuKkS/C"
                 public-keys user@pc {
                     key "AA...LD03"
                     type "ssh-ed25519"
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly