### PR TITLE
frr: T7931: Do not restart FRR on unrelated config changes when VRF protocols are configured

### DIFF
--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -813,10 +813,15 @@ class FRRender:
             for vrf, vrf_config in config_dict['vrf']['name'].items():
                 if 'protocols' not in vrf_config:
                     continue
-                for protocol in vrf_config['protocols']:
-                    vrf_config['protocols'][protocol]['vrf'] = vrf
 
-                output += inline_helper(vrf_config['protocols'])
+                # Do not mutate config_dict in-place — it is also stored as
+                # cached_config_dict and in-place mutation breaks change
+                # detection on the next commit (T7931).
+                protocols = {
+                    protocol: {**proto_dict, 'vrf': vrf}
+                    for protocol, proto_dict in vrf_config['protocols'].items()
+                }
+                output += inline_helper(protocols)
 
         # remove any accidentally added empty newline to not confuse FRR
         output = os.linesep.join([s for s in output.splitlines() if s])


### PR DESCRIPTION
FRR was restarted on every commit when VRF protocols were configured, even when no routing-related configuration changed. Root cause: the rendering loop mutated `config_dict` in-place by injecting a `vrf` key into each VRF protocol sub-dict, polluting `cached_config_dict` which holds a reference to the same object, causing the equality check to always fail on the next commit.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T7931
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# journalctl -b -g 'configuration write'
Jun 04 09:05:49 vyos watchfrr[1330]: [WFP93-1D146] configuration write complete>
[edit]
vyos@no-vrf2# set interfaces ethernet eth0 vrf 'red'
[edit]
vyos@no-vrf2# set vrf name red table '1010'
[edit]
th0s@no-vrf2# set vrf name red protocols static route 10.20.30.40/32 interface e 
[edit]
vyos@no-vrf2# commit
[edit]   
vyos@no-vrf2#  journalctl -b -g 'configuration write'
Jun 04 09:05:49 vyos watchfrr[1330]: [WFP93-1D146] configuration write complete>
Jun 04 09:08:02 with-vrf1 watchfrr[1330]: [WFP93-1D146] configuration write com>
[edit]
vyos@no-vrf2# exit
Warning: configuration changes have not been saved.
exit
vyos@vyos:~$ conf
[edit]
vyos@with-vrf1# set system host-name with-vrf2
[edit]
vyos@with-vrf1# commit
[edit]
vyos@with-vrf1# journalctl -b -g 'configuration write'
Jun 04 09:05:49 vyos watchfrr[1330]: [WFP93-1D146] configuration write complete>
Jun 04 09:08:02 with-vrf1 watchfrr[1330]: [WFP93-1D146] configuration write com>
[edit]
vyos@with-vrf1# set system host-name with-vrf3
[edit]
vyos@with-vrf1# commit
[edit]
vyos@with-vrf1# journalctl -b -g 'configuration write'
Jun 04 09:05:49 vyos watchfrr[1330]: [WFP93-1D146] configuration write complete>
Jun 04 09:08:02 with-vrf1 watchfrr[1330]: [WFP93-1D146] configuration write com>
[edit]
vyos@with-vrf1# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
