### PR TITLE
dhcp-server: T8524: Validate DDNS key-name references defined tsig-key

### DIFF
--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -1356,16 +1356,6 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
                 'SXQncyBXZWRuZXNkYXkgbWFoIGR1ZGVzIQ==',
             ]
         )
-        self.cli_set(ddns + ['tsig-key', 'reverse-0-168-192', 'algorithm', 'sha256'])
-        self.cli_set(
-            ddns
-            + [
-                'tsig-key',
-                'reverse-0-168-192',
-                'secret',
-                'VGhhbmsgR29kIGl0J3MgRnJpZGF5IQ==',
-            ]
-        )
         self.cli_set(
             ddns
             + [
@@ -1413,37 +1403,6 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
                 '1053',
             ]
         )
-        self.cli_set(
-            ddns
-            + [
-                'reverse-domain',
-                '0.168.192.in-addr.arpa',
-                'dns-server',
-                '2',
-                'address',
-                '100.100.0.1',
-            ]
-        )
-        self.cli_set(
-            ddns
-            + [
-                'reverse-domain',
-                '0.168.192.in-addr.arpa',
-                'dns-server',
-                '2',
-                'port',
-                '1153',
-            ]
-        )
-        self.cli_set(
-            ddns
-            + [
-                'reverse-domain',
-                '0.168.192.in-addr.arpa',
-                'key-name',
-                'reverse-0-168-192',
-            ]
-        )
 
         shared = base_path + ['shared-network-name', shared_net_name]
 
@@ -1466,6 +1425,61 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
             pool + ['dynamic-dns-update', 'hostname-char-replacement', '_xXx_']
         )
 
+        self.cli_commit()
+
+        # DNS server without an IP address must be rejected
+        self.cli_set(
+            ddns
+            + [
+                'reverse-domain',
+                '0.168.192.in-addr.arpa',
+                'dns-server',
+                '2',
+                'port',
+                '1153',
+            ]
+        )
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        # Fix missing address — commit must now succeed
+        self.cli_set(
+            ddns
+            + [
+                'reverse-domain',
+                '0.168.192.in-addr.arpa',
+                'dns-server',
+                '2',
+                'address',
+                '100.100.0.1',
+            ]
+        )
+        self.cli_commit()
+
+        # key-name referencing a non-existent tsig-key must be rejected
+        self.cli_set(
+            ddns
+            + [
+                'reverse-domain',
+                '0.168.192.in-addr.arpa',
+                'key-name',
+                'reverse-0-168-192',
+            ]
+        )
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        # Define the missing tsig-key — commit must now succeed
+        self.cli_set(ddns + ['tsig-key', 'reverse-0-168-192', 'algorithm', 'sha256'])
+        self.cli_set(
+            ddns
+            + [
+                'tsig-key',
+                'reverse-0-168-192',
+                'secret',
+                'VGhhbmsgR29kIGl0J3MgRnJpZGF5IQ==',
+            ]
+        )
         self.cli_commit()
 
         config = read_file(KEA4_CONF)

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -232,15 +232,28 @@ def get_config(config=None):
 
     return dhcp
 
-def verify_ddns_domain_servers(domain_type, domain):
-    if 'dns_server' in domain:
-        invalid_servers = []
-        for server_no, server_config in domain['dns_server'].items():
-            if 'address' not in server_config:
-                invalid_servers.append(server_no)
-        if len(invalid_servers) > 0:
-            raise ConfigError(f'{domain_type} DNS servers {", ".join(invalid_servers)} in DDNS configuration need to have an IP address')
-    return None
+
+def verify_ddns_domain(domain_type, domains, tsig_keys):
+    for domain_name, domain_config in domains.items():
+        if 'dns_server' in domain_config:
+            invalid_servers = []
+            for server_no, server_config in domain_config['dns_server'].items():
+                if 'address' not in server_config:
+                    invalid_servers.append(server_no)
+            if len(invalid_servers) > 0:
+                raise ConfigError(
+                    f'{domain_type} domain "{domain_name}" DNS servers {", ".join(invalid_servers)} '
+                    'in DDNS configuration need to have an IP address'
+                )
+
+        if 'key_name' in domain_config:
+            key_name = domain_config['key_name']
+            if key_name not in tsig_keys:
+                raise ConfigError(
+                    f'DDNS {domain_type} domain "{domain_name}" key-name "{key_name}" '
+                    'is not defined in dynamic-dns-update tsig-key'
+                )
+
 
 def verify(dhcp):
     # bail out early - looks like removal from running config
@@ -515,11 +528,13 @@ def verify(dhcp):
             if len(invalid_keys) > 0:
                 raise ConfigError(f'Both algorithm and secret need to be set for TSIG keys: {", ".join(invalid_keys)}')
 
+        defined_tsig_keys = ddns.get('tsig_key', {}).keys()
+
         if 'forward_domain' in ddns:
-            verify_ddns_domain_servers('Forward', ddns['forward_domain'])
+            verify_ddns_domain('Forward', ddns['forward_domain'], defined_tsig_keys)
 
         if 'reverse_domain' in ddns:
-            verify_ddns_domain_servers('Reverse', ddns['reverse_domain'])
+            verify_ddns_domain('Reverse', ddns['reverse_domain'], defined_tsig_keys)
 
     if 'client_class' in dhcp:
         # Check client class values are valid


### PR DESCRIPTION
When a key-name is set under dynamic-dns-update forward-domain or reverse-domain, validate that the referenced TSIG key is defined under dynamic-dns-update tsig-key. Previously the missing key was only caught at runtime, causing kea-dhcp-ddns to fail to start with a fatal error. Also fix a pre-existing bug in `verify_ddns_domain` (formerly `verify_ddns_domain_servers`) where the function was called with the full tagNode dict but iterated as if it received a single domain config, causing the DNS server address check to never actually run.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8524
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set interfaces ethernet eth0 address 192.168.1.1/24
set service dhcp-server listen-interface 'eth0'
set service dhcp-server shared-network-name LAN subnet 192.168.1.0/24 option default-router '192.168.1.1'
set service dhcp-server shared-network-name LAN subnet 192.168.1.0/24 range 0 start '192.168.1.100'
set service dhcp-server shared-network-name LAN subnet 192.168.1.0/24 range 0 stop '192.168.1.200'
set service dhcp-server shared-network-name LAN subnet 192.168.1.0/24 subnet-id '1'

vyos@vyos# set service dhcp-server dynamic-dns-update forward-domain example.net dns-server 1 
[edit]
vyos@vyos# commit
[ service dhcp-server ]
Forward domain "example.net" DNS servers 1 in DDNS configuration need to
have an IP address
[[service dhcp-server]] failed
Commit failed
[edit]
vyos@vyos# set service dhcp-server dynamic-dns-update forward-domain example.net dns-server 1 address '192.168.1.53'
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# set service dhcp-server dynamic-dns-update forward-domain example.net key-name 'vyos-ddns'
[edit]
vyos@vyos# commit
[ service dhcp-server ]
DDNS Forward domain "example.net" key-name "vyos-ddns" is not defined in
dynamic-dns-update tsig-key
[[service dhcp-server]] failed
Commit failed
[edit]
vyos@vyos# set service dhcp-server dynamic-dns-update tsig-key vyos-ddns algorithm 'sha256'
[edit]
vyos@vyos# commit
[ service dhcp-server ]
Both algorithm and secret need to be set for TSIG keys: vyos-ddns
[[service dhcp-server]] failed
Commit failed
[edit]
vyos@vyos# set service dhcp-server dynamic-dns-update tsig-key vyos-ddns secret 'SXQncyBXZWRuZXNkYXkgbWFoIGR1ZGVzIQ=='
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# 

vyos@vyos# /usr/libexec/vyos/tests/smoke/cli/test_service_dhcp-server.py -k test_dhcp_dynamic_dns_update
test_dhcp_dynamic_dns_update (__main__.TestServiceDHCPServer.test_dhcp_dynamic_dns_update) ... ok

----------------------------------------------------------------------
Ran 1 test in 40.459s

OK
[edit]
vyos@vyos# 
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
