### PR TITLE
ethtool: T8964: Fix crash when NIC does not support ring-buffer configuration

### DIFF
--- a/python/vyos/ethtool.py
+++ b/python/vyos/ethtool.py
@@ -181,15 +181,17 @@ class Ethtool:
         # Configuration of RX/TX ring-buffers is not supported on every device,
         # thus when it's impossible return None
         if rx_tx not in ['rx', 'tx']:
-            ValueError('Ring-buffer type must be either "rx" or "tx"')
-        return str(self._ring_buffer.get(f'{rx_tx}-max', None))
+            raise ValueError('Ring-buffer type must be either "rx" or "tx"')
+        value = self._ring_buffer.get(f'{rx_tx}-max') if self._ring_buffer else None
+        return str(value) if value is not None else None
 
     def get_ring_buffer(self, rx_tx):
         # Configuration of RX/TX ring-buffers is not supported on every device,
         # thus when it's impossible return None
         if rx_tx not in ['rx', 'tx']:
-            ValueError('Ring-buffer type must be either "rx" or "tx"')
-        return str(self._ring_buffer.get(rx_tx, None))
+            raise ValueError('Ring-buffer type must be either "rx" or "tx"')
+        value = self._ring_buffer.get(rx_tx) if self._ring_buffer else None
+        return str(value) if value is not None else None
 
     def check_speed_duplex(self, speed, duplex):
         """ Check if the passed speed and duplex combination is supported by


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Before the fix:
```
vyos@vyos-cloudinit-test# ethtool --show-ring eth0
netlink error: Operation not supported
[edit]
vyos@vyos-cloudinit-test# 
[edit]
vyos@vyos-cloudinit-test# set interfaces ethernet eth0 ring-buffer rx 256
[edit]
vyos@vyos-cloudinit-test# commit
[ interfaces ethernet eth0 ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 146, in run_script
    script.verify(c)
  File "/usr/libexec/vyos//conf_mode/interfaces_ethernet.py", line 419, in verify
    verify_ring_buffer(ethernet, ethtool)
  File "/usr/libexec/vyos//conf_mode/interfaces_ethernet.py", line 239, in verify_ring_buffer
    max_rx = ethtool.get_ring_buffer_max('rx')
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/ethtool.py", line 187, in get_ring_buffer_max
    return str(self._ring_buffer.get(f'{rx_tx}-max', None))
               ~~~~~~~~~~~~~~~~~^^^
TypeError: 'NoneType' object has no attribute 'get'

[[interfaces ethernet eth0]] failed
Commit failed
[edit]

```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8964
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos-cloudinit-test# set interfaces ethernet eth0 ring-buffer rx 256
[edit]
vyos@vyos-cloudinit-test# commit
[ interfaces ethernet eth0 ]
Driver does not support RX ring-buffer configuration!
[[interfaces ethernet eth0]] failed
Commit failed
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
