### PR TITLE
VPP: T8972: Fix VPP/LCP VRF table synchronization for VPP-managed Ethernet interfaces and Ethernet VIFs.

### DIFF
--- a/python/vyos/vpp/control_vpp.py
+++ b/python/vyos/vpp/control_vpp.py
@@ -26,6 +26,8 @@ from typing import TypeVar, ParamSpec, Literal
 from vpp_papi import VPPApiClient
 from vpp_papi import VPPIOError, VPPValueError
 
+from vyos.vpp.utils import vpp_ip_addresses_by_index
+
 # define types for static type checkers
 AnyType = TypeVar('AnyType')
 AnyParam = ParamSpec('AnyParam')
@@ -300,6 +302,110 @@ class VPPControl:
         based on the current state of the kernel.
         """
         return self.__vpp_api_client.api.lcp_nl_resync()
+
+    @_Decorators.api_call
+    def get_interface_ip_table(self, ifname: str, is_ipv6: bool = False) -> int | None:
+        """Return the IP FIB table ID assigned to an interface.
+
+        Args:
+            ifname (str): Interface name in VPP.
+            is_ipv6 (bool, optional): Return IPv6 table ID if True. Defaults to False.
+
+        Returns:
+            int | None: FIB table ID or None if the interface is not found.
+        """
+        iface_index = self.get_sw_if_index(ifname)
+        if iface_index is None:
+            return None
+
+        response = self.__vpp_api_client.api.sw_interface_get_table(
+            sw_if_index=iface_index,
+            is_ipv6=is_ipv6,
+        )
+        if response.retval != 0:
+            return None
+
+        return response.vrf_id
+
+    @_Decorators.api_call
+    def set_interface_ip_table(
+        self, ifname: str, table_id: int, is_ipv6: bool = False
+    ) -> None:
+        """Assign an interface to an IP FIB table.
+
+        Args:
+            ifname (str): Interface name in VPP.
+            table_id (int): FIB table ID.
+            is_ipv6 (bool, optional): Set IPv6 table if True. Defaults to False.
+        """
+        iface_index = self.get_sw_if_index(ifname)
+        if iface_index is None:
+            return None
+
+        self.__vpp_api_client.api.sw_interface_set_table(
+            sw_if_index=iface_index,
+            is_ipv6=is_ipv6,
+            vrf_id=table_id,
+        )
+
+    @_Decorators.api_call
+    def add_del_interface_ip_address(
+        self, ifname: str, address: str, is_add: bool = True
+    ) -> None:
+        """Add or delete an interface IP address in VPP.
+
+        Args:
+            ifname (str): Interface name in VPP.
+            address (str): Interface prefix, for example "192.0.2.1/24".
+            is_add (bool, optional): Add address if True, delete if False.
+                Defaults to True.
+        """
+        iface_index = self.get_sw_if_index(ifname)
+        if iface_index is None:
+            return None
+
+        self.__vpp_api_client.api.sw_interface_add_del_address(
+            sw_if_index=iface_index,
+            is_add=is_add,
+            del_all=False,
+            prefix=address,
+        )
+
+    def move_interface_to_ip_table_preserve_addresses(
+        self, ifname: str, table_id: int
+    ) -> None:
+        """Move an interface to an IP FIB table while preserving its addresses.
+
+        VPP keeps connected routes in the interface IP table that was active when
+        addresses were added. Re-adding the same addresses after the table move
+        recreates connected routes in the target table.
+
+        Args:
+            ifname (str): Interface name in VPP.
+            table_id (int): Target FIB table ID.
+        """
+
+        iface_index = self.get_sw_if_index(ifname)
+        if iface_index is None:
+            return None
+
+        for is_ipv6 in [False, True]:
+            current_table = self.get_interface_ip_table(ifname, is_ipv6=is_ipv6)
+            if current_table is None or current_table == table_id:
+                continue
+
+            addresses = vpp_ip_addresses_by_index(
+                self.__vpp_api_client.api,
+                iface_index,
+                is_ipv6=is_ipv6,
+            )
+            for address in addresses:
+                self.add_del_interface_ip_address(ifname, address, is_add=False)
+
+            self.set_interface_ip_table(ifname, table_id, is_ipv6=is_ipv6)
+
+            for address in addresses:
+                self.add_del_interface_ip_address(ifname, address)
 
     @_Decorators.check_retval
     @_Decorators.api_call

--- a/python/vyos/vpp/utils.py
+++ b/python/vyos/vpp/utils.py
@@ -194,7 +194,7 @@ def vpp_ip_addresses_by_index(vpp_api, index: int, is_ipv6: bool = False) -> lis
     ip_address_dump = vpp_api.ip_address_dump(sw_if_index=index, is_ipv6=is_ipv6)
     while ip_address_dump:
         ip_address_details = ip_address_dump.pop()
-        ip_addresses_list.append(str(ip_address_details._asdict().get('prefix')))
+        ip_addresses_list.append(str(ip_address_details.prefix))
     return ip_addresses_list
 
 

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -35,6 +35,7 @@ from vyos.utils.system import sysctl_read
 from vyos.utils.network import interface_exists
 from vyos.system import image
 from vyos.vpp import VPPControl
+from vyos.vpp.utils import vpp_ip_addresses_by_index
 from vyos.vpp.utils import vpp_iface_name_transform
 from vyos.vpp.config_resource_checks.resource_defaults import default_resource_map
 
@@ -1512,6 +1513,93 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.assertEqual(
             list(acl_interfaces[0].acls)[: acl_interfaces[0].count], [acl_index]
         )
+
+    def test_24_vpp_lcp_vrf_table_sync(self):
+        vlan = '20'
+        subif = f'{interface}.{vlan}'
+        address = '100.100.100.1/24'
+        fib_route = '100.100.100.1/32'
+        mgmt_vrf = 'mgmt'
+        test_vrf = 'test1'
+
+        def assert_vpp_lcp_table(table_id):
+            vpp = VPPControl()
+            subif_index = vpp.get_sw_if_index(subif)
+            self.assertIsNotNone(subif_index)
+            self.assertEqual(vpp.get_interface_ip_table(subif), table_id)
+            self.assertIn(address, vpp_ip_addresses_by_index(vpp.api, subif_index))
+
+        def assert_fib_route(table_id, expected=True):
+            _, out = rc_cmd(f'sudo vppctl show ip fib table {table_id}')
+            if expected:
+                self.assertIn(fib_route, out)
+            else:
+                self.assertNotIn(fib_route, out)
+
+        self.cli_set(['vrf', 'name', mgmt_vrf, 'table', '1000'])
+        self.cli_set(
+            ['interfaces', 'ethernet', interface, 'vif', vlan, 'address', address]
+        )
+        self.cli_set(
+            ['interfaces', 'ethernet', interface, 'vif', vlan, 'vrf', mgmt_vrf]
+        )
+        self.cli_commit()
+
+        assert_vpp_lcp_table(1000)
+        assert_fib_route(0, expected=False)
+        assert_fib_route(1000)
+
+        self.cli_delete(['interfaces', 'ethernet', interface, 'vif', vlan, 'address'])
+        self.cli_commit()
+
+        vpp = VPPControl()
+        subif_index = vpp.get_sw_if_index(subif)
+        self.assertIsNotNone(subif_index)
+        self.assertEqual(vpp.get_interface_ip_table(subif), 1000)
+        self.assertNotIn(address, vpp_ip_addresses_by_index(vpp.api, subif_index))
+        assert_fib_route(0, expected=False)
+        assert_fib_route(1000, expected=False)
+
+        self.cli_set(
+            ['interfaces', 'ethernet', interface, 'vif', vlan, 'address', address]
+        )
+        self.cli_commit()
+
+        assert_vpp_lcp_table(1000)
+        assert_fib_route(0, expected=False)
+        assert_fib_route(1000)
+
+        self.cli_delete(['interfaces', 'ethernet', interface, 'vif', vlan, 'vrf'])
+        self.cli_commit()
+
+        assert_vpp_lcp_table(0)
+        assert_fib_route(0)
+        assert_fib_route(1000, expected=False)
+
+        self.cli_set(
+            ['interfaces', 'ethernet', interface, 'vif', vlan, 'vrf', mgmt_vrf]
+        )
+        self.cli_commit()
+
+        assert_vpp_lcp_table(1000)
+        assert_fib_route(0, expected=False)
+        assert_fib_route(1000)
+
+        self.cli_set(['vrf', 'name', test_vrf, 'table', '2000'])
+        self.cli_set(
+            ['interfaces', 'ethernet', interface, 'vif', vlan, 'vrf', test_vrf]
+        )
+        self.cli_commit()
+
+        assert_vpp_lcp_table(2000)
+        assert_fib_route(0, expected=False)
+        assert_fib_route(1000, expected=False)
+        assert_fib_route(2000)
+
+        self.cli_delete(['interfaces', 'ethernet', interface, 'vif', vlan])
+        self.cli_delete(['vrf', 'name', test_vrf])
+        self.cli_delete(['vrf', 'name', mgmt_vrf])
+        self.cli_commit()
 
 
 if __name__ == '__main__':

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -45,6 +45,7 @@ from vyos.utils.dict import dict_search
 from vyos.utils.dict import dict_to_paths_values
 from vyos.utils.dict import dict_set
 from vyos.utils.dict import dict_delete
+from vyos.utils.network import get_vrf_tableid
 from vyos.utils.process import is_systemd_service_running
 from vyos.vpp.config_verify import verify_vpp_remove_interface
 from vyos.vpp.control_vpp import VPPControl
@@ -473,7 +474,35 @@ def apply(ethernet):
             mtu = e.get_mtu()
             vpp_api.set_iface_mtu(lcp_name, mtu)
 
+        sync_vpp_lcp_vrf_tables(ethernet, vpp_api)
+
     return None
+
+
+def sync_vpp_lcp_vrf_tables(ethernet: dict, vpp_api: VPPControl) -> None:
+    """Synchronize VyOS VRF assignment to VPP IP FIB table binding."""
+
+    def iter_vpp_lcp_vrf_targets() -> list[tuple[str, int]]:
+        interfaces = [ethernet['ifname']]
+        for vif in ethernet.get('vif', {}).values():
+            interfaces.append(vif['ifname'])
+        for vif_s in ethernet.get('vif_s', {}).values():
+            interfaces.append(vif_s['ifname'])
+            for vif_c in vif_s.get('vif_c', {}).values():
+                interfaces.append(vif_c['ifname'])
+        return [(iface, get_vrf_tableid(iface) or 0) for iface in interfaces]
+
+    lcp_vpp_ifaces = {
+        pair.get('vpp_name_hw')
+        for pair in vpp_api.lcp_pairs_list()
+        if pair.get('vpp_name_hw')
+    }
+
+    for ifname, table_id in iter_vpp_lcp_vrf_targets():
+        if ifname not in lcp_vpp_ifaces:
+            continue
+
+        vpp_api.move_interface_to_ip_table_preserve_addresses(ifname, table_id)
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
## Change summary

Fix VPP/LCP VRF table synchronization for VPP-managed Ethernet interfaces and
Ethernet VIFs.

VyOS correctly assigns the Linux/control-plane interface to a VRF, but the
corresponding VPP interface was not explicitly moved to the matching VPP FIB
table. As a result, connected routes for VPP/LCP-managed interfaces could remain
in VPP table `0` even when the VyOS interface was assigned to a non-default VRF.

This change adds targeted VPP interface table synchronization using PAPI. When a
VPP-managed Ethernet interface or Ethernet VIF has a VyOS VRF assigned, the
corresponding VPP interface is bound to the VRF table ID. When the VRF is
removed, the interface is moved back to table `0`. Existing VPP interface
addresses are preserved during table moves by removing them before the table
change and re-adding them afterwards.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T8972

## How to test / Smoketest result

Manual testing was performed in a GNS3 VyOS lab with VPP enabled on `eth1`.

Initial configuration:

```shell
set vpp settings interface eth1
set vrf name mgmt table 1000
set interfaces ethernet eth1 vif 20 address 100.100.100.1/24
set interfaces ethernet eth1 vif 20 vrf mgmt
commit
```

The VPP interface address output showed that `eth1.20` was bound to VPP table
`1000`:

```text
eth1.20 (up):
  L3 100.100.100.1/24 ip4 table-id 1000 fib-idx 1
```

`100.100.100.0/24` and `100.100.100.1/32` were present in VPP FIB table
`1000` and were not present in table `0`.

Address delete/re-add was tested:

```shell
delete interfaces ethernet eth1 vif 20 address
commit
```

After commit, the address disappeared from `vppctl show int addr`, and no
`100.100.100.*` routes were present in VPP table `0` or table `1000`.

Then the address was added back:

```shell
set interfaces ethernet eth1 vif 20 address 100.100.100.1/24
commit
```

After commit, the address returned to `eth1.20` in VPP table `1000`, and the
connected routes appeared only in table `1000`.

VRF removal was tested:

```shell
delete interfaces ethernet eth1 vif 20 vrf
commit
```

After commit, `eth1.20` still had `100.100.100.1/24`, but without
`ip4 table-id 1000`:

```text
eth1.20 (up):
  L3 100.100.100.1/24
```

Connected routes moved to VPP table `0` and disappeared from table `1000`.

VRF add-back was tested:

```shell
set interfaces ethernet eth1 vif 20 vrf mgmt
commit
```

After commit, `eth1.20` was again bound to table `1000`:

```text
eth1.20 (up):
  L3 100.100.100.1/24 ip4 table-id 1000 fib-idx 1
```

Connected routes moved back to table `1000` and disappeared from table `0`.

VRF change was tested:

```shell
set vrf name test1 table 2000
set interfaces ethernet eth1 vif 20 vrf test1
commit
```

After commit, `eth1.20` was bound to VPP table `2000`:

```text
eth1.20 (up):
  L3 100.100.100.1/24 ip4 table-id 2000 fib-idx 2
```

Connected routes disappeared from tables `0` and `1000`, and appeared only in
VPP table `2000`.

A dedicated smoketest was added:

```text
smoketest/scripts/cli/test_vpp.py::TestVPP::test_24_vpp_lcp_vrf_table_sync
```

Local checks run:

```shell
python3 -m py_compile python/vyos/vpp/control_vpp.py src/conf_mode/interfaces_ethernet.py src/conf_mode/vrf.py smoketest/scripts/cli/test_vpp.py
darker --check --diff --revision rolling python/vyos/vpp/control_vpp.py src/conf_mode/interfaces_ethernet.py src/conf_mode/vrf.py
darker --check --diff --revision origin/fix-vpp-lcp-vrf-table smoketest/scripts/cli/test_vpp.py
git diff --check
```


## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
