### PR TITLE
ipsec: T8975: lock vti-up-down state DB to prevent lost updates under concurrent rekey

### DIFF
--- a/python/vyos/ifconfig/vti.py
+++ b/python/vyos/ifconfig/vti.py
@@ -15,7 +15,7 @@
 
 from vyos.ifconfig.interface import Interface
 from vyos.utils.dict import dict_search
-from vyos.utils.vti_updown_db import vti_updown_db_exists, open_vti_updown_db_readonly
+from vyos.utils.vti_updown_db import open_vti_updown_db_readonly
 
 @Interface.register
 class VTIIf(Interface):
@@ -64,14 +64,14 @@ class VTIIf(Interface):
         """
         Set interface administrative state to be 'up' or 'down'.
 
-        The interface will only be brought 'up' if ith is attached to an
+        The interface will only be brought 'up' if it is attached to an
         active ipsec site-to-site connection or remote access connection.
         """
         if state == 'down' or self.bypass_vti_updown_db:
             super().set_admin_state(state)
-        elif vti_updown_db_exists():
+        else:
             with open_vti_updown_db_readonly() as db:
-                if db.wantsInterfaceUp(self.ifname):
+                if db is not None and db.wantsInterfaceUp(self.ifname):
                     super().set_admin_state(state)
 
     def get_mac(self):

--- a/python/vyos/utils/vti_updown_db.py
+++ b/python/vyos/utils/vti_updown_db.py
@@ -18,55 +18,67 @@ import os
 from contextlib import contextmanager
 from syslog import syslog
 
+from vyos.utils.locking import Lock
+
 VTI_WANT_UP_IFLIST = '/tmp/ipsec_vti_interfaces'
+VTI_UPDOWN_LOCK_NAME = 'ipsec_vti_updown'
 
 def vti_updown_db_exists():
     """ Returns true if the database exists """
     return os.path.exists(VTI_WANT_UP_IFLIST)
 
 @contextmanager
+def _vti_updown_db_lock():
+    """Serialise access to the VTI up/down DB across the concurrent updown-hook
+    invocations (one per VTI) that strongSwan fires during a coordinated rekey,
+    which would otherwise lost-update the shared state file."""
+    lock = Lock(VTI_UPDOWN_LOCK_NAME)
+    lock.acquire()  # timeout=0 -> block until acquired
+    try:
+        yield
+    finally:
+        lock.release()
+
+
+@contextmanager
 def open_vti_updown_db_for_create_or_update():
     """ Opens the database for reading and writing, creating the database if it does not exist """
-    if vti_updown_db_exists():
-        f = open(VTI_WANT_UP_IFLIST, 'r+')
-    else:
-        f = open(VTI_WANT_UP_IFLIST, 'x+')
-    try:
-        db = VTIUpDownDB(f)
-        yield db
-    finally:
-        f.close()
+    with _vti_updown_db_lock():
+        mode = 'r+' if vti_updown_db_exists() else 'x+'
+        with open(VTI_WANT_UP_IFLIST, mode) as f:
+            yield VTIUpDownDB(f)
 
 @contextmanager
 def open_vti_updown_db_for_update():
     """ Opens the database for reading and writing, returning an error if it does not exist """
-    f = open(VTI_WANT_UP_IFLIST, 'r+')
-    try:
-        db = VTIUpDownDB(f)
-        yield db
-    finally:
-        f.close()
+    with _vti_updown_db_lock():
+        with open(VTI_WANT_UP_IFLIST, 'r+') as f:
+            yield VTIUpDownDB(f)
 
 @contextmanager
 def open_vti_updown_db_readonly():
-    """ Opens the database for reading, returning an error if it does not exist """
-    f = open(VTI_WANT_UP_IFLIST, 'r')
-    try:
-        db = VTIUpDownDB(f)
-        yield db
-    finally:
-        f.close()
+    """Opens the database for reading. Yields None if the database does not exist."""
+    with _vti_updown_db_lock():
+        if not vti_updown_db_exists():
+            yield None
+            return
+        with open(VTI_WANT_UP_IFLIST, 'r') as f:
+            yield VTIUpDownDB(f)
 
 def remove_vti_updown_db():
-    """ Brings down any interfaces referenced by the database and removes the database """
-    # We need to process the DB first to bring down any interfaces still up
-    with open_vti_updown_db_for_update() as db:
-        db.removeAllOtherInterfaces([])
-        # this usage of commit will only ever bring down interfaces,
-        # do not need to provide a functional interface dict supplier
-        db.commit(lambda _: None)
-
-    os.unlink(VTI_WANT_UP_IFLIST)
+    """Brings down any interfaces referenced by the database and removes the database, if it exists."""
+    with _vti_updown_db_lock():
+        if not vti_updown_db_exists():
+            return
+        # We hold the lock already; open the file directly rather than via the
+        # locking context manager to avoid re-acquiring (which would deadlock).
+        with open(VTI_WANT_UP_IFLIST, 'r+') as f:
+            db = VTIUpDownDB(f)
+            db.removeAllOtherInterfaces([])
+            # this usage of commit will only ever bring down interfaces,
+            # do not need to provide a functional interface dict supplier
+            db.commit(lambda _: None)
+        os.unlink(VTI_WANT_UP_IFLIST)
 
 class VTIUpDownDB:
     # The VTI Up-Down DB is a text-based database of space-separated "ifspecs".

--- a/src/conf_mode/vpn_ipsec.py
+++ b/src/conf_mode/vpn_ipsec.py
@@ -50,7 +50,6 @@ from vyos.utils.network import interface_exists
 from vyos.utils.dict import dict_search
 from vyos.utils.dict import dict_search_args
 from vyos.utils.process import call
-from vyos.utils.vti_updown_db import vti_updown_db_exists
 from vyos.utils.vti_updown_db import open_vti_updown_db_for_create_or_update
 from vyos.utils.vti_updown_db import remove_vti_updown_db
 from vyos import ConfigError
@@ -900,8 +899,7 @@ def apply(ipsec):
     systemd_service = 'strongswan.service'
     if not ipsec or 'deleted' in ipsec:
         call(f'systemctl stop {systemd_service}')
-        if vti_updown_db_exists():
-            remove_vti_updown_db()
+        remove_vti_updown_db()
     else:
         call(f'systemctl reload-or-restart {systemd_service}')
         if ipsec['enabled_vti_interfaces']:
@@ -909,7 +907,7 @@ def apply(ipsec):
                 db.removeAllOtherInterfaces(ipsec['enabled_vti_interfaces'])
                 db.setPersistentInterfaces(ipsec['persistent_vti_interfaces'])
                 db.commit(lambda interface: ipsec['vti_interface_dicts'][interface])
-        elif vti_updown_db_exists():
+        else:
             remove_vti_updown_db()
     if ipsec:
         if ipsec.get('nhrp_exists', False):

--- a/src/tests/test_vti_updown_db.py
+++ b/src/tests/test_vti_updown_db.py
@@ -1,0 +1,249 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import tempfile
+import unittest
+
+from unittest.mock import MagicMock, patch
+
+import vyos.utils.vti_updown_db as _vti_mod
+from vyos.utils.vti_updown_db import VTIUpDownDB
+
+
+class TestVTIUpDownDBLogic(unittest.TestCase):
+    """Exercise the in-memory DB API without calling commit()."""
+
+    def setUp(self):
+        self.tmpfile = tempfile.NamedTemporaryFile(delete=False)
+        self.tmpfile.close()
+        self._path_patcher = patch.object(
+            _vti_mod, 'VTI_WANT_UP_IFLIST', self.tmpfile.name
+        )
+        self._path_patcher.start()
+
+    def tearDown(self):
+        self._path_patcher.stop()
+        if os.path.exists(self.tmpfile.name):
+            os.unlink(self.tmpfile.name)
+
+    def test_add_makes_interface_wanted_up(self):
+        """add() marks the interface as wanted-up."""
+        from vyos.utils.vti_updown_db import open_vti_updown_db_for_create_or_update
+
+        with patch('vyos.utils.vti_updown_db.Lock', MagicMock()):
+            with open_vti_updown_db_for_create_or_update() as db:
+                db.add('vti0', 'conn-a', 'IKEv2')
+                self.assertTrue(db.wantsInterfaceUp('vti0'))
+
+    def test_remove_clears_interface(self):
+        """remove() clears the entry; wantsInterfaceUp returns False when no entries remain."""
+        from vyos.utils.vti_updown_db import open_vti_updown_db_for_create_or_update
+
+        with patch('vyos.utils.vti_updown_db.Lock', MagicMock()):
+            with open_vti_updown_db_for_create_or_update() as db:
+                db.add('vti0', 'conn-a', 'IKEv2')
+                db.remove('vti0', 'conn-a', 'IKEv2')
+                self.assertFalse(db.wantsInterfaceUp('vti0'))
+
+    def test_multiple_connections_same_interface(self):
+        """Interface stays wanted-up until all its connection entries are removed."""
+        from vyos.utils.vti_updown_db import open_vti_updown_db_for_create_or_update
+
+        with patch('vyos.utils.vti_updown_db.Lock', MagicMock()):
+            with open_vti_updown_db_for_create_or_update() as db:
+                db.add('vti0', 'conn-a', 'IKEv2')
+                db.add('vti0', 'conn-b', 'IKEv2')
+                db.remove('vti0', 'conn-a', 'IKEv2')
+                # conn-b still present
+                self.assertTrue(db.wantsInterfaceUp('vti0'))
+                db.remove('vti0', 'conn-b', 'IKEv2')
+                self.assertFalse(db.wantsInterfaceUp('vti0'))
+
+    def test_remove_all_other_interfaces(self):
+        """removeAllOtherInterfaces() drops entries for interfaces not in the keep list."""
+        from vyos.utils.vti_updown_db import open_vti_updown_db_for_create_or_update
+
+        with patch('vyos.utils.vti_updown_db.Lock', MagicMock()):
+            with open_vti_updown_db_for_create_or_update() as db:
+                db.add('vti0', 'conn-a', 'IKEv2')
+                db.add('vti1', 'conn-b', 'IKEv2')
+                db.removeAllOtherInterfaces(['vti0'])
+                self.assertTrue(db.wantsInterfaceUp('vti0'))
+                self.assertFalse(db.wantsInterfaceUp('vti1'))
+
+    def test_set_persistent_interfaces(self):
+        """setPersistentInterfaces() adds bare-name (persistent) entries."""
+        from vyos.utils.vti_updown_db import open_vti_updown_db_for_create_or_update
+
+        with patch('vyos.utils.vti_updown_db.Lock', MagicMock()):
+            with open_vti_updown_db_for_create_or_update() as db:
+                db.setPersistentInterfaces(['vti0', 'vti1'])
+                # Persistent entries have no colon in the ifspec.
+                persistent = {s for s in db._ifspecs if ':' not in s}
+                self.assertEqual(persistent, {'vti0', 'vti1'})
+                self.assertTrue(db.wantsInterfaceUp('vti0'))
+                self.assertTrue(db.wantsInterfaceUp('vti1'))
+
+    def test_seed_from_file(self):
+        """VTIUpDownDB reads pre-existing entries from the file on open."""
+        with open(self.tmpfile.name, 'w') as f:
+            f.write('vti0:conn-a:IKEv2 vti1:conn-b:IKEv2')
+
+        from vyos.utils.vti_updown_db import open_vti_updown_db_readonly
+
+        with patch('vyos.utils.vti_updown_db.Lock', MagicMock()):
+            with open_vti_updown_db_readonly() as db:
+                self.assertTrue(db.wantsInterfaceUp('vti0'))
+                self.assertTrue(db.wantsInterfaceUp('vti1'))
+
+    def test_readonly_yields_none_when_db_absent(self):
+        """open_vti_updown_db_readonly() yields None (no raise) when the DB file is absent."""
+        from vyos.utils.vti_updown_db import open_vti_updown_db_readonly
+
+        # Point at a path that does not exist.
+        missing = os.path.join(tempfile.gettempdir(), 'nonexistent_vti_updown_db_test')
+        if os.path.exists(missing):
+            os.unlink(missing)
+        with patch.object(_vti_mod, 'VTI_WANT_UP_IFLIST', missing):
+            with patch('vyos.utils.vti_updown_db.Lock', MagicMock()):
+                with open_vti_updown_db_readonly() as db:
+                    self.assertIsNone(db)
+
+
+class TestVTIUpDownDBLockWiring(unittest.TestCase):
+    """Verify Lock is acquired before yielding and released on context exit."""
+
+    def setUp(self):
+        self.tmpfile = tempfile.NamedTemporaryFile(delete=False)
+        self.tmpfile.close()
+        self._path_patcher = patch.object(
+            _vti_mod, 'VTI_WANT_UP_IFLIST', self.tmpfile.name
+        )
+        self._path_patcher.start()
+
+    def tearDown(self):
+        self._path_patcher.stop()
+        if os.path.exists(self.tmpfile.name):
+            os.unlink(self.tmpfile.name)
+
+    def _make_lock_mock(self):
+        lock_instance = MagicMock()
+        lock_cls = MagicMock(return_value=lock_instance)
+        return lock_cls, lock_instance
+
+    def test_create_or_update_acquires_and_releases(self):
+        """open_vti_updown_db_for_create_or_update() acquires the lock before yielding and releases it on exit."""
+        from vyos.utils.vti_updown_db import open_vti_updown_db_for_create_or_update
+
+        lock_cls, lock_inst = self._make_lock_mock()
+        with patch('vyos.utils.vti_updown_db.Lock', lock_cls):
+            with open_vti_updown_db_for_create_or_update() as _db:
+                lock_inst.acquire.assert_called_once()
+                lock_inst.release.assert_not_called()
+            lock_inst.release.assert_called_once()
+
+    def test_update_acquires_and_releases(self):
+        """open_vti_updown_db_for_update() acquires the lock before yielding and releases it on exit."""
+        from vyos.utils.vti_updown_db import open_vti_updown_db_for_update
+
+        lock_cls, lock_inst = self._make_lock_mock()
+        with patch('vyos.utils.vti_updown_db.Lock', lock_cls):
+            with open_vti_updown_db_for_update() as _db:
+                lock_inst.acquire.assert_called_once()
+                lock_inst.release.assert_not_called()
+            lock_inst.release.assert_called_once()
+
+    def test_readonly_acquires_and_releases(self):
+        """open_vti_updown_db_readonly() acquires the lock before yielding and releases it on exit."""
+        from vyos.utils.vti_updown_db import open_vti_updown_db_readonly
+
+        lock_cls, lock_inst = self._make_lock_mock()
+        with patch('vyos.utils.vti_updown_db.Lock', lock_cls):
+            with open_vti_updown_db_readonly() as _db:
+                lock_inst.acquire.assert_called_once()
+                lock_inst.release.assert_not_called()
+            lock_inst.release.assert_called_once()
+
+
+class TestRemoveVTIUpDownDBLockOrdering(unittest.TestCase):
+    """remove_vti_updown_db() must hold the lock across os.unlink."""
+
+    def setUp(self):
+        self.tmpfile = tempfile.NamedTemporaryFile(delete=False)
+        self.tmpfile.close()
+        self._path_patcher = patch.object(
+            _vti_mod, 'VTI_WANT_UP_IFLIST', self.tmpfile.name
+        )
+        self._path_patcher.start()
+
+    def tearDown(self):
+        self._path_patcher.stop()
+        # File may have been unlinked by the function under test.
+        if os.path.exists(self.tmpfile.name):
+            os.unlink(self.tmpfile.name)
+
+    def test_lock_held_across_unlink(self):
+        """os.unlink fires before lock.release(), proving the lock covers the unlink."""
+        from vyos.utils.vti_updown_db import remove_vti_updown_db
+
+        lock_inst = MagicMock()
+        lock_cls = MagicMock(return_value=lock_inst)
+
+        # Record lock.release call_count at the moment os.unlink fires.
+        release_count_at_unlink = []
+
+        def _observe_unlink(path):
+            release_count_at_unlink.append(lock_inst.release.call_count)
+
+        with patch('vyos.utils.vti_updown_db.Lock', lock_cls):
+            with patch.object(VTIUpDownDB, 'commit'):
+                with patch.object(_vti_mod.os, 'unlink', side_effect=_observe_unlink):
+                    remove_vti_updown_db()
+
+        lock_inst.acquire.assert_called_once()
+        lock_inst.release.assert_called_once()
+        self.assertTrue(release_count_at_unlink, 'os.unlink was never called')
+        self.assertEqual(
+            release_count_at_unlink[0],
+            0,
+            'lock.release() was called before os.unlink -- unlink is not protected by the lock',
+        )
+
+    def test_remove_noop_when_db_absent(self):
+        """remove_vti_updown_db() returns without raising and does not unlink when the DB is absent."""
+        from vyos.utils.vti_updown_db import remove_vti_updown_db
+
+        # No DB file present.
+        os.unlink(self.tmpfile.name)
+        self.assertFalse(os.path.exists(self.tmpfile.name))
+
+        lock_inst = MagicMock()
+        lock_cls = MagicMock(return_value=lock_inst)
+
+        with patch('vyos.utils.vti_updown_db.Lock', lock_cls):
+            with patch.object(
+                _vti_mod.os,
+                'unlink',
+                side_effect=AssertionError('os.unlink must not be called'),
+            ) as unlink_mock:
+                remove_vti_updown_db()
+                unlink_mock.assert_not_called()
+
+        lock_inst.acquire.assert_called_once()
+        lock_inst.release.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Change summary

The IPsec vti-up-down hook DB (`/tmp/ipsec_vti_interfaces`, managed by `python/vyos/utils/vti_updown_db.py`) is read-modify-written without an inter-process lock, so concurrent hook invocations during a coordinated rekey lost-update each other and strand VTI interfaces admin-down while their CHILD_SA stays installed. This serialises all DB access by reusing `vyos.utils.locking.Lock`, wrapping the three context managers and holding the lock across `remove_vti_updown_db()`'s unlink.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T8975
* https://vyos.dev/T7062 (same VTI-admin-down symptom, likely the same root cause)
* https://vyos.dev/T6574 (same script and symptom class, related but distinct trigger)

## Related PR(s)

None.

## How to test / Smoketest result

Unit test, run as CI runs it:

```
$ PYTHONPATH=python/ python3 -m nose2 -v src.tests.test_vti_updown_db
```

10 tests, all pass.

A standalone deterministic reproducer (`reproduce.py`, attached to the Phabricator task T8975 and inlined below so a reviewer can grab it either way) drives 64 concurrent up-client hook invocations. On a stock VyOS 2026.05.26-1327-rolling image it reports "LOST 63 of 64" (exit 1); with this patch in place it reports "0 lost" (exit 0).

<details>
<summary>reproduce.py (expand to view)</summary>

```python
#!/usr/bin/env python3
#
# Minimal reproduction for the vti_updown_db.py lost-update race.
#
# This drives the exact code path the IPsec updown hook uses on an
# up-client event (src/etc/ipsec.d/vti-up-down):
#
#     with open_vti_updown_db_for_create_or_update() as db:
#         db.add(interface, connection, protocol)
#         db.commit(supply_interface_dict)
#
# but from N processes released at the same instant by a barrier, and with a
# no-op interface_dict_supplier so it never touches a real interface (the
# named vtiN interfaces do not exist, so commit() only rewrites the state
# file and performs no `ip link` operations).
#
# strongSwan fires this hook once per CHILD_SA event, per VTI. During a
# coordinated rekey, N of them run concurrently. open_vti_updown_db_*()
# does an unlocked read-modify-write of /tmp/ipsec_vti_interfaces: every
# process reads the same copy, each writes back only its own addition, and
# the last writer's commit() wins. The rest are lost, and the hook that
# lost its add leaves that interface admin-down.
#
# Run as root on a VyOS instance:
#   python3 reproduce.py
#
# Stock image: prints "LOST <N-1> of <N>".  Exit code 1.
# With the patched python/vyos/utils/vti_updown_db.py in place: "0 lost". Exit 0.

import multiprocessing as mp
import os
import sys

from vyos.utils.vti_updown_db import (
    open_vti_updown_db_for_create_or_update,
    VTI_WANT_UP_IFLIST,
)

N = 64


def up_client(index, barrier):
    """What the up-client hook does, minus the real interface bring-up."""
    barrier.wait()  # release all workers into the critical section together
    with open_vti_updown_db_for_create_or_update() as db:
        db.add(f'vti{index}', f'peer-vti{index}', 'v4')
        # no-op supplier: vtiN does not exist, so commit() only rewrites the
        # state file (no `ip link`, no VTIIf instantiation).
        db.commit(lambda _interface: {'disable': True})


def main():
    # Pre-create an empty DB so every worker takes the existing-file (r+)
    # path. This isolates the lost-update race from the separate x+ create
    # race (both are fixed by the same lock).
    with open(VTI_WANT_UP_IFLIST, 'w'):
        pass

    barrier = mp.Barrier(N)
    workers = [mp.Process(target=up_client, args=(i, barrier)) for i in range(N)]
    for w in workers:
        w.start()
    for w in workers:
        w.join()

    with open(VTI_WANT_UP_IFLIST) as f:
        entries = [e for e in f.read().split() if e]
    survived = {e.split(':')[0] for e in entries}
    lost = [f'vti{i}' for i in range(N) if f'vti{i}' not in survived]

    print(f'fired {N} concurrent up-client events; '
          f'DB retained {len(survived)} of {N} interfaces')
    if lost:
        print(f'LOST {len(lost)} of {N} updates '
              f'(these interfaces would be stranded admin-down): '
              f'{", ".join(lost)}')
        sys.exit(1)
    print('0 lost: all updates serialised correctly')
    sys.exit(0)


if __name__ == '__main__':
    main()
```

</details>

Fleet validation: I deployed the patch as a hotpatch on a 12-tunnel home-edge router. Two strongswan restarts (each a full reinit storm across all 12 tunnels) produced zero stranded interfaces, and all 12 iBGP-over-VTI sessions recovered. Before the patch the same restart reliably stranded multiple VTIs.

The existing IPsec/VTI smoketests (`smoketest/scripts/cli/test_vpn_ipsec.py`, `smoketest/scripts/cli/test_interfaces_vti.py`) should be run for regression in a VyOS build environment. I have not run them yet.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s) (T8975)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable (pending VyOS build environment)
- [x] My commit headlines contain a valid Task id (pending T-number)
- [ ] My change requires a change to the documentation (not required)
- [ ] I have updated the documentation accordingly (not required)