### PR TITLE
T8976: explicitly remove 'kernel' entry in ttyS0 device setting on choice of 'tty' during image install

### DIFF
--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -658,6 +658,10 @@ def configure_serial_console(config_file: str, console_type: str) -> None:
     # serial was defined by user.
     if console_type == 'S':
         config.set(base + [device, 'kernel'])
+    if console_type == 'K':
+        # remove any residual setting from flavor file image build
+        if config.exists(base + [device, 'kernel']):
+            config.delete(base + [device, 'kernel'])
 
     with open(config_file, 'w') as f:
         f.write(config.to_string())


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The live build hook `95-serial.chroot` may explicitly set the device config value `kernel`. In case of image installer choice of console_type `K`, this value must be explicitly removed. _Without_ this fix, the system will (on a second reboot) reset GRUB vars console_type to `ttyS` --- as the effect of suppressed tty display output of boot messages is not apparent until the second reboot, it may be missed by those logging in by ssh after initial install.

This is due to the check here:
https://github.com/vyos/vyos-1x/blob/rolling/src/conf_mode/system_console.py#L126-L130
explicitly set for choice `S` of console_type during image install here:
https://github.com/vyos/vyos-1x/blob/rolling/src/op_mode/image_installer.py#L657-L659

It must likewise be explicitly removed for choice `K`, as there may be a residual setting from the image build live hook.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Install image in VM with choice of console_type 'K' (tested in KVM). Reboot twice. Without this fix or a reasonable variant, display output of boot messages to tty will be absent.

One can check the GRUB vars after the second boot: they are overwritten to 'ttyS' despite the choice of 'K' on image install.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
