### PR TITLE
T8977: Fix regression with is_addr_assigned and is_listen_port_bind_service 

### DIFF
--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -870,12 +870,13 @@ def range_to_regex(num_range):
 @register_filter('kea_address_json')
 def kea_address_json(addresses):
     from json import dumps
-    from vyos.utils.network import is_addr_assigned
+    from vyos.utils.network import get_interfaces_by_ip
 
     out = []
 
     for address in addresses:
-        ifname = is_addr_assigned(address, return_ifname=True, include_vrf=True)
+        ifaces = get_interfaces_by_ip(address, include_vrf=True)
+        ifname = ifaces[0] if ifaces else None
 
         if not ifname:
             continue

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -471,7 +471,9 @@ def is_ipv6_link_local(addr):
     return False
 
 
-def is_addr_assigned(ip_address: str, vrf=None, include_vrf=False, allow_nonlocal: bool = False) -> bool:
+def is_addr_assigned(
+    ip_address: str, vrf=None, include_vrf=False, allow_nonlocal: bool = False
+) -> bool:
     """ Verify if the given IPv4/IPv6 address is assigned to any interface """
     from netifaces import interfaces # pylint: disable = no-name-in-module
     from vyos.utils.network import get_interface_config
@@ -479,13 +481,15 @@ def is_addr_assigned(ip_address: str, vrf=None, include_vrf=False, allow_nonloca
 
     # Check if sysctl to allow nonlocal binds is set for given afi and caller allows nonlocal binds,
     # skip check accordingly
-    if allow_nonlocal and ((
-        is_ipv4_address(ip_address)
-        and sysctl_read(['net', 'ipv4', 'ip_nonlocal_bind']) == "1"
-    ) or (
-        is_ipv6_address(ip_address)
-        and sysctl_read(['net', 'ipv6', 'ip_nonlocal_bind']) == "1"
-    )):
+    if allow_nonlocal and (
+        (
+            is_ipv4_address(ip_address)
+            and sysctl_read(['net', 'ipv4', 'ip_nonlocal_bind']) == "1"
+        ) or (
+            is_ipv6_address(ip_address)
+            and sysctl_read(['net', 'ipv6', 'ip_nonlocal_bind']) == "1"
+        )
+    ):
         return True
 
     for interface in interfaces():
@@ -768,10 +772,12 @@ def is_ipv4_address(addr: str) -> bool:
     :return: bool: True if provided address is valid
     """
     from ipaddress import ip_interface
+
     try:
         return ip_interface(addr).version == 4
     except Exception:
         return False
+
 
 def is_ipv6_address(addr: str) -> bool:
     """
@@ -780,10 +786,12 @@ def is_ipv6_address(addr: str) -> bool:
     :return: bool: True if provided address is valid
     """
     from ipaddress import ip_interface
+
     try:
         return ip_interface(addr).version == 6
     except Exception:
         return False
+
 
 def is_ipv4_range(addr: str) -> bool:
     """
@@ -799,6 +807,7 @@ def is_ipv4_range(addr: str) -> bool:
     except Exception:
         return False
 
+
 def is_ipv6_range(addr: str) -> bool:
     """
     Validates if the provided address is a valid IPv6 range.
@@ -813,6 +822,7 @@ def is_ipv6_range(addr: str) -> bool:
     except Exception:
         return False
 
+
 def is_ipv4_address_or_range(addr: str) -> bool:
     """
     Validates if the provided address is a valid IPv4, CIDR or IPv4 range
@@ -821,6 +831,7 @@ def is_ipv4_address_or_range(addr: str) -> bool:
     """
     return is_ipv4_address(addr) or is_ipv4_range(addr)
 
+
 def is_ipv6_address_or_range(addr: str) -> bool:
     """
     Validates if the provided address is a valid IPv6, CIDR or IPv6 range
@@ -828,6 +839,7 @@ def is_ipv6_address_or_range(addr: str) -> bool:
     :return: bool: True if provided address is valid
     """
     return is_ipv6_address(addr) or is_ipv6_range(addr)
+
 
 def get_interfaces_by_ip(ip_address: str, vrf=None, include_vrf: bool = False) -> list:
     """

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -471,29 +471,31 @@ def is_ipv6_link_local(addr):
     return False
 
 
-def is_addr_assigned(ip_address: str, vrf=None, include_vrf=False) -> bool:
+def is_addr_assigned(ip_address: str, vrf=None, include_vrf=False, allow_nonlocal: bool = False) -> bool:
     """ Verify if the given IPv4/IPv6 address is assigned to any interface """
     from netifaces import interfaces # pylint: disable = no-name-in-module
     from vyos.utils.network import get_interface_config
     from vyos.utils.dict import dict_search
 
-    # Check if sysctl to allow nonlocal binds is set for given afi, skip check accordingly
-    if (
-        is_valid_ipv4_address_or_range(ip_address)
+    # Check if sysctl to allow nonlocal binds is set for given afi and caller allows nonlocal binds,
+    # skip check accordingly
+    if allow_nonlocal and ((
+        is_ipv4_address(ip_address)
         and sysctl_read(['net', 'ipv4', 'ip_nonlocal_bind']) == "1"
     ) or (
-        is_valid_ipv6_address_or_range(ip_address)
+        is_ipv6_address(ip_address)
         and sysctl_read(['net', 'ipv6', 'ip_nonlocal_bind']) == "1"
-    ):
+    )):
         return True
 
     for interface in interfaces():
         # Check if interface belongs to the requested VRF, if this is not the
         # case there is no need to proceed with this data set - continue loop
         # with next element
-        tmp = get_interface_config(interface)
-        if dict_search('master', tmp) != vrf and not include_vrf:
-            continue
+        if vrf is not None and not include_vrf and interface != vrf:
+            tmp = get_interface_config(interface)
+            if dict_search('master', tmp) != vrf:
+                continue
 
         if is_intf_addr_assigned(interface, ip_address):
             return True
@@ -510,6 +512,10 @@ def is_intf_addr_assigned(ifname: str, addr: str, netns: str=None) -> bool:
 
     from vyos.utils.process import rc_cmd
     from ipaddress import ip_interface
+
+    # Reject invalid addresses or address ranges
+    if not is_ipv4_address(addr) and not is_ipv6_address(addr):
+        return False
 
     netns_cmd = f'ip netns exec {netns}' if netns else ''
     rc, out = rc_cmd(f'{netns_cmd} ip --json address show dev {ifname}')
@@ -755,38 +761,73 @@ def get_nft_vrf_zone_mapping() -> dict:
         output.append({'interface' : vrf_name, 'vrf_tableid' : vrf_id})
     return output
 
-def is_valid_ipv4_address_or_range(addr: str) -> bool:
+def is_ipv4_address(addr: str) -> bool:
+    """
+    Validates if the provided address is a valid IPv4 address or CIDR.
+    :param addr: address to test
+    :return: bool: True if provided address is valid
+    """
+    from ipaddress import ip_interface
+    try:
+        return ip_interface(addr).version == 4
+    except Exception:
+        return False
+
+def is_ipv6_address(addr: str) -> bool:
+    """
+    Validates if the provided address is a valid IPv6 address or CIDR.
+    :param addr: address to test
+    :return: bool: True if provided address is valid
+    """
+    from ipaddress import ip_interface
+    try:
+        return ip_interface(addr).version == 6
+    except Exception:
+        return False
+
+def is_ipv4_range(addr: str) -> bool:
+    """
+    Validates if the provided address is a valid IPv4 range.
+    :param addr: address to test
+    :return: bool: True if provided address is valid
+    """
+    if '-' not in addr:
+        return False
+    try:
+        start, end = addr.split('-')
+        return is_ipv4_address(start) and is_ipv4_address(end)
+    except Exception:
+        return False
+
+def is_ipv6_range(addr: str) -> bool:
+    """
+    Validates if the provided address is a valid IPv6 range.
+    :param addr: address to test
+    :return: bool: True if provided address is valid
+    """
+    if '-' not in addr:
+        return False
+    try:
+        start, end = addr.split('-')
+        return is_ipv6_address(start) and is_ipv6_address(end)
+    except Exception:
+        return False
+
+def is_ipv4_address_or_range(addr: str) -> bool:
     """
     Validates if the provided address is a valid IPv4, CIDR or IPv4 range
     :param addr: address to test
     :return: bool: True if provided address is valid
     """
-    from ipaddress import ip_network
-    try:
-        if '-' in addr: # If we are checking a range, validate both address's individually
-            split = addr.split('-')
-            return is_valid_ipv4_address_or_range(split[0]) and is_valid_ipv4_address_or_range(split[1])
-        else:
-            return ip_network(addr).version == 4
-    except Exception:
-        return False
+    return is_ipv4_address(addr) or is_ipv4_range(addr)
 
-def is_valid_ipv6_address_or_range(addr: str) -> bool:
+def is_ipv6_address_or_range(addr: str) -> bool:
     """
-    Validates if the provided address is a valid IPv4, CIDR or IPv4 range
+    Validates if the provided address is a valid IPv6, CIDR or IPv6 range
     :param addr: address to test
     :return: bool: True if provided address is valid
     """
-    from ipaddress import ip_network
-    try:
-        if '-' in addr: # If we are checking a range, validate both address's individually
-            split = addr.split('-')
-            return is_valid_ipv6_address_or_range(split[0]) and is_valid_ipv6_address_or_range(split[1])
-        else:
-            return ip_network(addr).version == 6
-    except Exception:
-        return False
-
+    return is_ipv6_address(addr) or is_ipv6_range(addr)
 
 def get_interfaces_by_ip(ip_address: str, vrf=None, include_vrf: bool = False) -> list:
     """
@@ -807,9 +848,10 @@ def get_interfaces_by_ip(ip_address: str, vrf=None, include_vrf: bool = False) -
         # Check if interface belongs to the requested VRF, if this is not the
         # case there is no need to proceed with this data set - continue loop
         # with next element
-        tmp = get_interface_config(interface)
-        if vrf is not None and dict_search('master', tmp) != vrf and not include_vrf:
-            continue
+        if vrf is not None and not include_vrf and interface != vrf:
+            tmp = get_interface_config(interface)
+            if dict_search('master', tmp) != vrf:
+                continue
 
         if is_intf_addr_assigned(interface, ip_address):
             ifaces.append(interface)

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -19,6 +19,7 @@ from json import loads
 from socket import AF_INET
 from socket import AF_INET6
 from vyos.utils.process import cmdl
+from vyos.utils.system import sysctl_read
 
 def _are_same_ip(one, two):
     from socket import inet_pton
@@ -398,10 +399,13 @@ def check_port_availability(address: str = None, port: int = 0,
                 s.bind(sockaddr)
                 return True # port is free to use
         except OSError:
-            return False # port is already in use
+            # This address family is busy, but another might be free.
+            # Continue to the next one.
+            pass
 
-    # if we reach this point, no socket was tested and we assume the port is
-    # already in use - better safe then sorry
+    # If we reach this point, the port is already in use
+    # or no socket was tested, in which case it is safer
+    # to assume the port being in use
     return False
 
 
@@ -445,11 +449,12 @@ def is_listen_port_bind_service(port: int, service: str, address: str = None) ->
         pid_name = process(pid).name()
         pid_port = addr.port
 
-        if has_address:
-            if address == addr.ip and port == pid_port and service == pid_name:
+        # Ignore address check when service listening on "any address",
+        # service config might change from any to limited address scope
+        if port == pid_port and service == pid_name:
+            if not has_address:
                 return True
-        else:
-            if service == pid_name and port == pid_port:
+            if addr.ip in ('::', '0.0.0.0') or address == addr.ip:
                 return True
 
     return False
@@ -465,11 +470,22 @@ def is_ipv6_link_local(addr):
 
     return False
 
-def is_addr_assigned(ip_address, vrf=None, return_ifname=False, include_vrf=False) -> bool | str:
+
+def is_addr_assigned(ip_address: str, vrf=None, include_vrf=False) -> bool:
     """ Verify if the given IPv4/IPv6 address is assigned to any interface """
     from netifaces import interfaces # pylint: disable = no-name-in-module
     from vyos.utils.network import get_interface_config
     from vyos.utils.dict import dict_search
+
+    # Check if sysctl to allow nonlocal binds is set for given afi, skip check accordingly
+    if (
+        is_valid_ipv4_address_or_range(ip_address)
+        and sysctl_read(['net', 'ipv4', 'ip_nonlocal_bind']) == "1"
+    ) or (
+        is_valid_ipv6_address_or_range(ip_address)
+        and sysctl_read(['net', 'ipv6', 'ip_nonlocal_bind']) == "1"
+    ):
+        return True
 
     for interface in interfaces():
         # Check if interface belongs to the requested VRF, if this is not the
@@ -480,7 +496,7 @@ def is_addr_assigned(ip_address, vrf=None, return_ifname=False, include_vrf=Fals
             continue
 
         if is_intf_addr_assigned(interface, ip_address):
-            return interface if return_ifname else True
+            return True
 
     return False
 
@@ -772,26 +788,30 @@ def is_valid_ipv6_address_or_range(addr: str) -> bool:
         return False
 
 
-def get_interfaces_by_ip(ip_address: str) -> list:
+def get_interfaces_by_ip(ip_address: str, vrf=None, include_vrf: bool = False) -> list:
     """
     Return a list of all interface names assigned the given IP address.
     Args:
         ip_address (str): The IP address to search for.
+        vrf (str): If specified, only interfaces in this VRF are considered.
+        include_vrf (bool): If True, interfaces from all VRFs are considered.
     Returns:
         list: List of interface names (str) that have the given IP address assigned.
               Returns an empty list if no interface has the IP assigned.
     """
     import netifaces
-    from vyos.template import is_ipv6
-
-    addr_type = AF_INET
-    if is_ipv6(ip_address):
-        addr_type = AF_INET6
+    from vyos.utils.dict import dict_search
 
     ifaces = []
     for interface in netifaces.interfaces():
-        addresses = netifaces.ifaddresses(interface)
-        for addr_info in addresses.get(addr_type, []):
-            if addr_info.get('addr') == ip_address:
-                ifaces.append(interface)
+        # Check if interface belongs to the requested VRF, if this is not the
+        # case there is no need to proceed with this data set - continue loop
+        # with next element
+        tmp = get_interface_config(interface)
+        if vrf is not None and dict_search('master', tmp) != vrf and not include_vrf:
+            continue
+
+        if is_intf_addr_assigned(interface, ip_address):
+            ifaces.append(interface)
+
     return ifaces

--- a/smoketest/scripts/cli/test_load-balancing_haproxy.py
+++ b/smoketest/scripts/cli/test_load-balancing_haproxy.py
@@ -32,6 +32,10 @@ HAPROXY_CONF = '/run/haproxy/haproxy.cfg'
 base_path = ['load-balancing', 'haproxy']
 proxy_interface = 'eth1'
 
+haproxy_service_name = 'https_front'
+haproxy_service_port = '4433'
+haproxy_backend_name = 'bk-01'
+
 valid_ca_cert = """
 MIIDnTCCAoWgAwIBAgIUewSDtLiZbhg1YEslMnqRl1shoPcwDQYJKoZIhvcNAQEL
 BQAwVzELMAkGA1UEBhMCR0IxEzARBgNVBAgMClNvbWUtU3RhdGUxEjAQBgNVBAcM
@@ -136,8 +140,6 @@ ZXLrtgVJR9W020qTurO2f91qfU8646n11hR9ObBB1IYbagOU0Pw1Nrq/FRp/u2tx
 7i7xFz2WEiQeSCPaKYOiqM3t
 """
 
-haproxy_service_name = 'https_front'
-haproxy_backend_name = 'bk-01'
 
 def parse_haproxy_config() -> dict:
     config_str = read_file(HAPROXY_CONF)
@@ -173,8 +175,13 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
 
     def base_config(self):
         self.cli_set(base_path + ['service', haproxy_service_name, 'mode', 'http'])
-        self.cli_set(base_path + ['service', haproxy_service_name, 'port', '4433'])
-        self.cli_set(base_path + ['service', haproxy_service_name, 'backend', haproxy_backend_name])
+        self.cli_set(
+            base_path + ['service', haproxy_service_name, 'port', haproxy_service_port]
+        )
+        self.cli_set(
+            base_path
+            + ['service', haproxy_service_name, 'backend', haproxy_backend_name]
+        )
 
         self.cli_set(base_path + ['backend', haproxy_backend_name, 'mode', 'http'])
         self.cli_set(base_path + ['backend', haproxy_backend_name, 'server', haproxy_backend_name, 'address', '192.0.2.11'])
@@ -760,6 +767,82 @@ class TestLoadBalancingReverseProxy(VyOSUnitTestSHIM.TestCase):
         # The busy address must NOT appear as a HAProxy bind
         self.assertNotIn(f'bind {addr_busy}:{shared_port}', config)
         self.assertIn(f'bind [{addr_listen}]:{shared_port}', config)
+
+    def test_reverse_proxy_listen_address_lifecycle(self):
+        """T8977: adding then removing a listen-address must revert haproxy to wildcard."""
+        from vyos.utils.network import check_port_availability
+
+        # Use loopback so no real NIC is required
+        addr_v4 = '127.0.0.1'
+        addr_v6 = '::1'
+        svc_laddr_base = base_path + ['service', haproxy_service_name, 'listen-address']
+
+        # Pre-test before service binds
+        # Check port availability without address (default to 'any'), must yield true
+        self.assertTrue(
+            check_port_availability(port=int(haproxy_service_port), protocol='tcp')
+        )
+
+        # Start without a specific listen-address (listen on 'any')
+        self.base_config()
+        self.cli_commit()
+
+        # Check port availability without address (default to 'any'), must yield false
+        self.assertFalse(
+            check_port_availability(port=int(haproxy_service_port), protocol='tcp')
+        )
+
+        # Set a addr_v4 listen-address
+        self.cli_set(svc_laddr_base + [addr_v4])
+        self.cli_commit()
+
+        # Check port availability without address (default to 'any'), must yield false
+        self.assertFalse(
+            check_port_availability(port=int(haproxy_service_port), protocol='tcp')
+        )
+        # Check port availability on addr_v4, must yield false
+        self.assertFalse(
+            check_port_availability(
+                address=addr_v4, port=int(haproxy_service_port), protocol='tcp'
+            )
+        )
+        # Check port availability on addr_v6, must yield true
+        self.assertTrue(
+            check_port_availability(
+                address=addr_v6, port=int(haproxy_service_port), protocol='tcp'
+            )
+        )
+
+        # Set a addr_v6 listen-address
+        self.cli_delete(svc_laddr_base)
+        self.cli_set(svc_laddr_base + [addr_v6])
+        self.cli_commit()
+
+        # Check port availability without address (default to 'any'), must yield false
+        self.assertFalse(
+            check_port_availability(port=int(haproxy_service_port), protocol='tcp')
+        )
+        # Check port availability on addr_v4, must yield true
+        self.assertTrue(
+            check_port_availability(
+                address=addr_v4, port=int(haproxy_service_port), protocol='tcp'
+            )
+        )
+        # Check port availability on addr_v6, must yield false
+        self.assertFalse(
+            check_port_availability(
+                address=addr_v6, port=int(haproxy_service_port), protocol='tcp'
+            )
+        )
+
+        # Remove the specific listen-address
+        self.cli_delete(svc_laddr_base)
+        self.cli_commit()
+
+        # Check port availability without address (default to 'any'), must yield false
+        self.assertFalse(
+            check_port_availability(port=int(haproxy_service_port), protocol='tcp')
+        )
 
 
 if __name__ == '__main__':

--- a/src/conf_mode/load-balancing_haproxy.py
+++ b/src/conf_mode/load-balancing_haproxy.py
@@ -81,7 +81,7 @@ def verify(lb):
                 if '%' in listen_address:
                     listen_address, *_ = listen_address.split('%', maxsplit=1)
 
-                if not is_addr_assigned(listen_address):
+                if not is_addr_assigned(listen_address, allow_nonlocal=True):
                     raise ConfigError(
                         f'listen-address "{listen_address}" not assigned on any interface!'
                     )

--- a/src/services/vyos-domain-resolver
+++ b/src/services/vyos-domain-resolver
@@ -31,7 +31,7 @@ from vyos.utils.convert import human_to_seconds
 from vyos.utils.dict import dict_search_args
 from vyos.utils.kernel import WIREGUARD_REKEY_AFTER_TIME
 from vyos.utils.file import makedir, chmod_775, write_file, read_file
-from vyos.utils.network import is_valid_ipv4_address_or_range, is_valid_ipv6_address_or_range
+from vyos.utils.network import is_ipv4_address_or_range, is_ipv6_address_or_range
 from vyos.utils.process import cmdl
 from vyos.utils.process import run
 from vyos.xml_ref import get_defaults
@@ -199,9 +199,9 @@ def update_remote_group(config):
                 if not line_first_word:
                     continue
 
-                if is_valid_ipv4_address_or_range(line_first_word):
+                if is_ipv4_address_or_range(line_first_word):
                     ip_list.append(line_first_word)
-                elif is_valid_ipv6_address_or_range(line_first_word):
+                elif is_ipv6_address_or_range(line_first_word):
                     ip6_list.append(line_first_word)
                 elif line_first_word[0].isalnum():
                     invalid_list.append(line_first_word)

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -13,7 +13,16 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
+
+
+def _make_psutil_net_conn(ip, port, pid):
+    c = MagicMock()
+    c.laddr.ip = ip
+    c.laddr.port = port
+    c.pid = pid
+    return c
+
 
 class TestVyOSUtils(TestCase):
     def test_cmdl_basic(self):
@@ -117,3 +126,109 @@ class TestVyOSUtils(TestCase):
         # duplicated values
         self.assertEqual(list_to_range_str([1, 1, 2, 2, 3, 3]), '1-3')
         self.assertEqual(list_to_range_str([5, 1, 2, 2, 3, 5]), '1-3,5')
+
+    def test_is_addr_assigned_nonlocal_bind_ipv4(self):
+        """When net.ipv4.ip_nonlocal_bind=1, any valid IPv4 must return True."""
+        from vyos.utils.network import is_addr_assigned
+
+        with patch('vyos.utils.network.sysctl_read', return_value='1'):
+            self.assertTrue(is_addr_assigned('192.0.2.99'))
+
+    def test_is_addr_assigned_nonlocal_bind_ipv6(self):
+        from vyos.utils.network import is_addr_assigned
+
+        with patch('vyos.utils.network.sysctl_read', return_value='1'):
+            self.assertTrue(is_addr_assigned('2001:db8::1'))
+
+    def test_is_addr_assigned_nonlocal_bind_ipv4_off_unassigned(self):
+        """When sysctl is 0 and address is not assigned, must return False."""
+        from vyos.utils.network import is_addr_assigned
+
+        with patch('vyos.utils.network.sysctl_read', return_value='0'), patch(
+            'netifaces.interfaces', return_value=[]
+        ):
+            self.assertFalse(is_addr_assigned('192.0.2.99'))
+
+    def test_is_addr_assigned_nonlocal_bind_ipv6_off_unassigned(self):
+        """When sysctl is 0 and address is not assigned, must return False."""
+        from vyos.utils.network import is_addr_assigned
+
+        with patch('vyos.utils.network.sysctl_read', return_value='0'), patch(
+            'netifaces.interfaces', return_value=[]
+        ):
+            self.assertFalse(is_addr_assigned('2001:db8::1'))
+
+    def test_is_addr_assigned_vrf_filter(self):
+        """Address on a VRF slave should only match when vrf matches."""
+        from vyos.utils.network import is_addr_assigned
+
+        iface_cfg_red = {'master': 'red'}
+        iface_cfg_lo = {'master': None}  # loopback has no master
+
+        with patch('vyos.utils.network.sysctl_read', return_value='0'), patch(
+            'netifaces.interfaces', return_value=['lo', 'eth0']
+        ), patch(
+            'vyos.utils.network.get_interface_config',
+            side_effect=[iface_cfg_lo, iface_cfg_red],
+        ), patch(
+            'vyos.utils.network.is_intf_addr_assigned', return_value=True
+        ) as mock_is_assigned:
+            # vrf='red' → should find it on eth0
+            self.assertTrue(is_addr_assigned('10.0.0.1', vrf='red'))
+            mock_is_assigned.assert_called_once_with('eth0', '10.0.0.1')
+
+    def test_is_addr_assigned_wrong_vrf(self):
+        """Address on VRF 'red' must not match when querying vrf='blue'."""
+        from vyos.utils.network import is_addr_assigned
+
+        iface_cfg = {'master': 'red'}
+        with patch('vyos.utils.network.sysctl_read', return_value='0'), patch(
+            'netifaces.interfaces', return_value=['eth0']
+        ), patch(
+            'vyos.utils.network.get_interface_config', return_value=iface_cfg
+        ), patch(
+            'vyos.utils.network.is_intf_addr_assigned', return_value=True
+        ):
+            self.assertFalse(is_addr_assigned('10.0.0.1', vrf='blue'))
+
+    def test_is_listen_port_wildcard_ipv4(self):
+        """Service on 0.0.0.0 must match even when a specific address filter is given."""
+        from vyos.utils.network import is_listen_port_bind_service
+
+        conn = _make_psutil_net_conn('0.0.0.0', 443, 1234)
+        with patch('psutil.net_connections', return_value=[conn]), patch(
+            'psutil.Process'
+        ) as MockProc:
+            MockProc.return_value.name.return_value = 'haproxy'
+            self.assertTrue(
+                is_listen_port_bind_service(443, 'haproxy', address='194.0.2.1')
+            )
+
+    def test_is_listen_port_wildcard_ipv6(self):
+        """Service on :: must match even when an address filter is given."""
+        from vyos.utils.network import is_listen_port_bind_service
+
+        conn = _make_psutil_net_conn('::', 443, 1234)
+        with patch('psutil.net_connections', return_value=[conn]), patch(
+            'psutil.Process'
+        ) as MockProc:
+            MockProc.return_value.name.return_value = 'haproxy'
+            self.assertTrue(
+                is_listen_port_bind_service(443, 'haproxy', address='2001:db8::1')
+            )
+
+    def test_is_listen_port_specific_address_match(self):
+        """Service on specific IP must match only the exact address."""
+        from vyos.utils.network import is_listen_port_bind_service
+
+        conn = _make_psutil_net_conn('194.0.2.1', 443, 1234)
+        with patch('psutil.net_connections', return_value=[conn]), patch(
+            'psutil.Process'
+        ) as MockProc:
+            MockProc.return_value.name.return_value = 'haproxy'
+            self.assertTrue(
+                is_listen_port_bind_service(443, 'haproxy', address='194.0.2.1')
+            )
+            self.assertFalse(
+                is_listen_port_bind_service(443, 'haproxy', address='10.0.0.1')
+            )

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -174,7 +174,9 @@ class TestVyOSUtils(TestCase):
             'vyos.utils.network.is_intf_addr_assigned', return_value=True
         ) as mock_is_assigned:
             # vrf='red' → should find it on eth0
-            self.assertTrue(is_addr_assigned('10.0.0.1', vrf='red', allow_nonlocal=True))
+            self.assertTrue(
+                is_addr_assigned('10.0.0.1', vrf='red', allow_nonlocal=True)
+            )
             mock_is_assigned.assert_called_once_with('eth0', '10.0.0.1')
 
     def test_is_addr_assigned_wrong_vrf(self):
@@ -189,7 +191,9 @@ class TestVyOSUtils(TestCase):
         ), patch(
             'vyos.utils.network.is_intf_addr_assigned', return_value=True
         ):
-            self.assertFalse(is_addr_assigned('10.0.0.1', vrf='blue', allow_nonlocal=True))
+            self.assertFalse(
+                is_addr_assigned('10.0.0.1', vrf='blue', allow_nonlocal=True)
+            )
 
     def test_is_listen_port_wildcard_ipv4(self):
         """Service on 0.0.0.0 must match even when a specific address filter is given."""

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -132,13 +132,13 @@ class TestVyOSUtils(TestCase):
         from vyos.utils.network import is_addr_assigned
 
         with patch('vyos.utils.network.sysctl_read', return_value='1'):
-            self.assertTrue(is_addr_assigned('192.0.2.99'))
+            self.assertTrue(is_addr_assigned('192.0.2.99', allow_nonlocal=True))
 
     def test_is_addr_assigned_nonlocal_bind_ipv6(self):
         from vyos.utils.network import is_addr_assigned
 
         with patch('vyos.utils.network.sysctl_read', return_value='1'):
-            self.assertTrue(is_addr_assigned('2001:db8::1'))
+            self.assertTrue(is_addr_assigned('2001:db8::1', allow_nonlocal=True))
 
     def test_is_addr_assigned_nonlocal_bind_ipv4_off_unassigned(self):
         """When sysctl is 0 and address is not assigned, must return False."""
@@ -147,7 +147,7 @@ class TestVyOSUtils(TestCase):
         with patch('vyos.utils.network.sysctl_read', return_value='0'), patch(
             'netifaces.interfaces', return_value=[]
         ):
-            self.assertFalse(is_addr_assigned('192.0.2.99'))
+            self.assertFalse(is_addr_assigned('192.0.2.99', allow_nonlocal=True))
 
     def test_is_addr_assigned_nonlocal_bind_ipv6_off_unassigned(self):
         """When sysctl is 0 and address is not assigned, must return False."""
@@ -156,7 +156,7 @@ class TestVyOSUtils(TestCase):
         with patch('vyos.utils.network.sysctl_read', return_value='0'), patch(
             'netifaces.interfaces', return_value=[]
         ):
-            self.assertFalse(is_addr_assigned('2001:db8::1'))
+            self.assertFalse(is_addr_assigned('2001:db8::1', allow_nonlocal=True))
 
     def test_is_addr_assigned_vrf_filter(self):
         """Address on a VRF slave should only match when vrf matches."""
@@ -174,7 +174,7 @@ class TestVyOSUtils(TestCase):
             'vyos.utils.network.is_intf_addr_assigned', return_value=True
         ) as mock_is_assigned:
             # vrf='red' → should find it on eth0
-            self.assertTrue(is_addr_assigned('10.0.0.1', vrf='red'))
+            self.assertTrue(is_addr_assigned('10.0.0.1', vrf='red', allow_nonlocal=True))
             mock_is_assigned.assert_called_once_with('eth0', '10.0.0.1')
 
     def test_is_addr_assigned_wrong_vrf(self):
@@ -189,7 +189,7 @@ class TestVyOSUtils(TestCase):
         ), patch(
             'vyos.utils.network.is_intf_addr_assigned', return_value=True
         ):
-            self.assertFalse(is_addr_assigned('10.0.0.1', vrf='blue'))
+            self.assertFalse(is_addr_assigned('10.0.0.1', vrf='blue', allow_nonlocal=True))
 
     def test_is_listen_port_wildcard_ipv4(self):
         """Service on 0.0.0.0 must match even when a specific address filter is given."""


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Fix `is_addr_assigned` to consider nonlocal bind sysctl and `is_listen_port_bind_service` to ignore new bind addresses when currently bound service is listening to any address
Refactor `is_addr_assigned` to avoid semantic changes depending on parameter `return_ifname`
Refactor `get_interfaces_by_ip` to fulfil what is_addr_assigned was doing before when `return_ifname` was set
Change single usage of function `is_addr_assigned` expecting different semantics to use `get_interfaces_by_ip` instead

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8977

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

I tested this by manually applying this changes to a locally running VyOS instance and running the following test sequence:
```
# Booting with cloud init without haproxy service listen address attached
~$ sudo ss -tulpn
Netid    State     Recv-Q    Send-Q              Local Address:Port          Peer Address:Port    Process   
tcp      LISTEN    0         4096                            *:443                      *:*        users:(("haproxy",pid=6265,fd=8))
...
~$ config
~$ set load-balancing haproxy service gateway_tcp listen-address '194.x.x.x'
~$ commit
~$ sudo ss -tulpn
Netid    State     Recv-Q    Send-Q              Local Address:Port          Peer Address:Port    Process   
tcp      LISTEN    0         4096               194.x.x.x:443                0.0.0.0:*        users:(("haproxy",pid=6411,fd=8))
...
~$ delete load-balancing haproxy service gateway_tcp listen-address
~$ commit
~$ sudo ss -tulpn
Netid    State     Recv-Q    Send-Q              Local Address:Port          Peer Address:Port    Process   
tcp      LISTEN    0         4096                            *:443                      *:*        users:(("haproxy",pid=6265,fd=8))
...
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
