### PR TITLE
bgp: T6573: add CLI for input/output queue limits

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -264,6 +264,17 @@
 {# j2lint: disable=jinja-statements-delimeter #}
 {%- endmacro -%}
 !
+{% if parameters.input_queue_limit is vyos_defined %}
+bgp input-queue-limit {{ parameters.input_queue_limit }}
+{% else %}
+no bgp input-queue-limit
+{% endif %}
+{% if parameters.output_queue_limit is vyos_defined %}
+bgp output-queue-limit {{ parameters.output_queue_limit }}
+{% else %}
+no bgp output-queue-limit
+{% endif %}
+!
 router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }} {{ 'as-notation ' ~ parameters.as_notation | replace('as', '') if parameters.as_notation is vyos_defined }}
 {% if parameters.ebgp_requires_policy is vyos_defined %}
  bgp ebgp-requires-policy

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -1548,6 +1548,18 @@
         <valueless/>
       </properties>
     </leafNode>
+    <leafNode name="input-queue-limit">
+      <properties>
+        <help>Input Queue limit for all peers when messaging parsing.</help>
+        <valueHelp>
+          <format>u32:1-4294967295</format>
+          <description>Default 10000, Increase this only if you have the memory to handle large queues.</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-4294967295"/>
+        </constraint>
+      </properties>
+    </leafNode>
     <leafNode name="labeled-unicast">
       <properties>
         <help>BGP Labeled-unicast options</help>
@@ -1593,6 +1605,18 @@
       <properties>
         <help>Enable IGP route check for network statements</help>
         <valueless/>
+      </properties>
+    </leafNode>
+    <leafNode name="output-queue-limit">
+      <properties>
+        <help>Output Queue limit for all peers when messaging parsing.</help>
+        <valueHelp>
+          <format>u32:1-4294967295</format>
+          <description>Default 10000, Increase this only if you have the memory to handle large queues.</description>
+        </valueHelp>
+        <constraint>
+          <validator name="numeric" argument="--range 1-4294967295"/>
+        </constraint>
       </properties>
     </leafNode>
     <leafNode name="route-reflector-allow-outbound-policy">


### PR DESCRIPTION
Add input-queue-limit and output-queue-limit parameters to the VyOS CLI.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Added options to specify the bgp input/output queue limits.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T6573
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Can be tested like below and using vtysh to confirm the config has been applied/changed/removed from the running bgp daemon after each commit.
 
```
set protocols bgp parameters input-queue-limit 4294967295
set protocols bgp parameters output-queue-limit 4294967295
commit
set protocols bgp parameters input-queue-limit 429496729
set protocols bgp parameters output-queue-limit 429496729
commit
delete protocols bgp parameters output-queue-limit
delete protocols bgp parameters input-queue-limit
commit
```
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
