### PR TITLE
dhcpv6: T8953: Add validation for duplicate static-mapping address and prefix

### DIFF
--- a/smoketest/scripts/cli/test_service_dhcpv6-server.py
+++ b/smoketest/scripts/cli/test_service_dhcpv6-server.py
@@ -368,6 +368,44 @@ class TestServiceDHCPv6Server(VyOSUnitTestSHIM.TestCase):
         # Check for running process
         self.assertTrue(process_named_running(PROCESS_NAME))
 
+    def test_static_mapping_duplicate_address_prefix(self):
+        shared_net_name = 'SMOKE-DUP'
+        pool = base_path + ['shared-network-name', shared_net_name, 'subnet', subnet]
+        mapping = pool + ['static-mapping']
+
+        self.cli_set(pool + ['subnet-id', '1'])
+        duid1 = '00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:01'
+        duid2 = '00:01:00:01:12:34:56:78:aa:bb:cc:dd:ee:02'
+        dup_addr = inc_ip(subnet, 10)
+        dup_prefix = inc_ip(subnet, 1 << 64) + '/64'
+
+        # commit valid config with a single address mapping
+        self.cli_set(mapping + ['client1', 'duid', duid1])
+        self.cli_set(mapping + ['client1', 'ipv6-address', dup_addr])
+        self.cli_commit()
+
+        # adding a second mapping with the same address must fail
+        self.cli_set(mapping + ['client2', 'duid', duid2])
+        self.cli_set(mapping + ['client2', 'ipv6-address', dup_addr])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_delete(mapping + ['client1'])
+        self.cli_commit()
+
+        # commit valid config with a single prefix mapping
+        self.cli_set(mapping + ['client1', 'duid', duid1])
+        self.cli_set(mapping + ['client1', 'ipv6-prefix', dup_prefix])
+        self.cli_commit()
+
+        # adding a second mapping with the same prefix must fail
+        self.cli_set(mapping + ['client2', 'ipv6-prefix', dup_prefix])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_delete(mapping + ['client1'])
+        self.cli_commit()
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/src/conf_mode/service_dhcpv6-server.py
+++ b/src/conf_mode/service_dhcpv6-server.py
@@ -223,12 +223,25 @@ def verify(dhcpv6):
 
             # Static mappings don't require anything (but check if IP is in subnet if it's set)
             if 'static_mapping' in subnet_config:
+                reserved_addresses = []
+                reserved_prefixes = []
                 for mapping, mapping_config in subnet_config['static_mapping'].items():
                     if 'ipv6_address' in mapping_config:
                         # Static address must be in subnet
                         for address in mapping_config['ipv6_address']:
                             if ip_address(address) not in ip_network(subnet):
                                 raise ConfigError(f'static-mapping address for mapping "{mapping}" is not in subnet "{subnet}"!')
+                            if address in reserved_addresses:
+                                raise ConfigError(f'Duplicate IPv6 address "{address}" in static-mapping "{mapping}" '
+                                                  f'within shared-network "{network}", subnet "{subnet}"!')
+                            reserved_addresses.append(address)
+
+                    if 'ipv6_prefix' in mapping_config:
+                        for prefix in mapping_config['ipv6_prefix']:
+                            if prefix in reserved_prefixes:
+                                raise ConfigError(f'Duplicate IPv6 prefix "{prefix}" in static-mapping "{mapping}" '
+                                                  f'within shared-network "{network}", subnet "{subnet}"!')
+                            reserved_prefixes.append(prefix)
 
                     if ('ipv6_address' not in mapping_config and 'ipv6_prefix' not in mapping_config):
                         raise ConfigError('Either IPv6 address or IPv6 prefix must be set for static mapping '


### PR DESCRIPTION
Kea reported duplicate address/prefix reservations only at runtime; validation
is now done at commit time so the error is caught before Kea is invoked.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8955
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# python3 /usr/libexec/vyos/tests/smoke/cli/test_service_dhcpv6-server.py
test_global_nameserver (__main__.TestServiceDHCPv6Server.test_global_nameserver) ... ok
test_prefix_delegation (__main__.TestServiceDHCPv6Server.test_prefix_delegation) ... ok
test_single_pool (__main__.TestServiceDHCPv6Server.test_single_pool) ... ok
test_static_mapping_duplicate_address_prefix (__main__.TestServiceDHCPv6Server.test_static_mapping_duplicate_address_prefix) ... ok

----------------------------------------------------------------------
Ran 4 tests in 56.534s

OK
[edit]
vyos@vyos# 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
