### PR TITLE
T8980: update config sync diff for exclude mask

### DIFF
--- a/python/vyos/config_mgmt.py
+++ b/python/vyos/config_mgmt.py
@@ -38,7 +38,6 @@ from vyos.configtree import ConfigTreeError
 from vyos.configsession import ConfigSession
 from vyos.configsession import ConfigSessionError
 from vyos.configtree import diff_compare
-from vyos.configtree import DiffTree
 from vyos.load_config import load
 from vyos.load_config import LoadConfigError
 from vyos.defaults import directories
@@ -451,80 +450,6 @@ Proceed ?"""
             r2 = int(options[1])
 
         return self.compare(commands=cmnds, rev1=r1, rev2=r2)
-
-    def _format_remote_diff(self, diff_tree: DiffTree, path: list, commands: bool):
-        add_tree = diff_tree.add
-        del_tree = diff_tree.delete
-        command_prefix = ' '.join(path)
-
-        result_lines = []
-        if commands:
-            # Process the deleted elements into command format and filter based on prefix (path)
-            for line in del_tree.to_commands(op='delete').splitlines():
-                if line.startswith(f'delete {command_prefix}'):
-                    result_lines.append(line)
-
-            # Process the added elements into command format and filter based on prefix (path)
-            for line in add_tree.to_commands(op='set').splitlines():
-                if line.startswith(f'set {command_prefix}'):
-                    result_lines.append(line)
-        else:
-            with_node = len(path) > 1
-            # Retrieve subtrees for the specified path from both added and deleted trees
-            del_tree = del_tree.get_subtree(path, with_node=with_node)
-            add_tree = add_tree.get_subtree(path, with_node=with_node)
-
-            # Convert the subtrees to string lines for further processing
-            del_tree_lines = str(del_tree).splitlines()
-            add_tree_lines = str(add_tree).splitlines()
-
-            # Format the lines with a prefix ('-', '+') and filter out empty lines
-            del_lines = [f'- {l}' for l in del_tree_lines if l.strip()]
-            add_lines = [f'+ {l}' for l in add_tree_lines if l.strip()]
-
-            if del_lines or add_lines:
-                # Adjust command prefix if a node is present in the path
-                command_prefix = ' '.join(path[:-1]) if with_node else command_prefix
-                if command_prefix:
-                    result_lines.append(f'[{command_prefix}]')
-
-                # Combine both deleted and added lines and process them
-                result_lines.extend(del_lines + add_lines)
-
-        # Join the result lines into a single string, excluding empty lines
-        return '\n'.join((line for line in result_lines if line.strip()))
-
-    def remote_compare(
-        self,
-        source: str,
-        remote_tree: ConfigTree,
-        path: Optional[list] = None,
-        commands: bool = False,
-    ) -> str:
-        """
-        Compares a local configuration tree with a remote
-        configuration tree based on the specified source ('running', 'candidate', 'saved').
-        """
-        path = path or []
-
-        # Determine the correct local configuration tree based on the 'source' parameter
-        if source == 'running':
-            local_tree = self.active_config
-        elif source == 'candidate':
-            local_tree = self.working_config
-        elif source == 'saved':
-            local_tree = self._get_saved_config_tree()
-        else:
-            raise ConfigMgmtError(
-                'Invalid source, must be one of: running, candidate, saved'
-            )
-
-        try:
-            diff_tree = DiffTree(remote_tree, local_tree)
-        except ConfigTreeError as e:
-            raise ConfigMgmtError(e) from e
-
-        return self._format_remote_diff(diff_tree, path, commands)
 
     # Initialization and post-commit hooks for conf-mode
     #

--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -19,6 +19,8 @@ import logging
 
 from ctypes import cdll, c_char_p, c_void_p, c_int, c_bool
 from typing import TYPE_CHECKING
+from pathlib import Path
+
 
 # https://peps.python.org/pep-0484/#forward-references
 # for type 'ConfigDict'
@@ -264,6 +266,19 @@ class ConfigTree:
         self.__migration = os.environ.get('VYOS_MIGRATION')
         if self.__migration:
             self.migration_log = logging.getLogger('vyos.migrate')
+
+    @classmethod
+    def load_file(cls, location):
+        # pylint: disable=raise-missing-from
+        config_file = Path(location)
+        if not config_file.exists():
+            raise ConfigTreeError(f'Missing config file at {location}')
+        try:
+            config_tree = cls(config_file.read_text())
+        except (OSError, ValueError, TypeError) as e:
+            raise ConfigTreeError(f'Corrupted config file at {location}: {e}')
+
+        return config_tree
 
     def __del__(self):
         if self.__config is not None:

--- a/python/vyos/derivedtree.py
+++ b/python/vyos/derivedtree.py
@@ -18,6 +18,7 @@ from vyos.referencetree import ReferenceTree
 from vyos.configtree import ConfigTree
 from vyos.configtree import ConfigTreeError
 from vyos.configtree import subtree_from_partial
+from vyos.configtree import mask_exclusive
 
 
 class DerivedTreeError(Exception):
@@ -29,7 +30,7 @@ def subtree_from_list_of_partial_paths(
     paths: list[list[str]],
     accumulator: ConfigTree = None,
     reference_tree: ReferenceTree = None,
-):
+) -> ConfigTree:
     """Return the union of subtrees of the ConfigTree argument matching each
     of the 'partial' paths. A partial path is one that may or may not
     contain intervening tag node values, in which case it will match for all
@@ -61,3 +62,15 @@ def subtree_from_list_of_partial_paths(
         raise DerivedTreeError(f'Nonsensical paths: {errors}')
 
     return accumulator
+
+
+def apply_exclusion_list(
+    config_tree: ConfigTree, exclusion_list: list[list[str]]
+) -> ConfigTree:
+    mask_ex = subtree_from_list_of_partial_paths(config_tree, exclusion_list)
+    try:
+        masked = mask_exclusive(config_tree, mask_ex)
+    except ConfigTreeError as e:
+        raise DerivedTreeError(str(e)) from e
+
+    return masked

--- a/python/vyos/utils/config.py
+++ b/python/vyos/utils/config.py
@@ -75,6 +75,18 @@ def write_saved_value(path: list, value=None, config_path: str=config_file):
 
     write_file(config_path, ct.to_string())
 
+
+def get_saved_config_tree() -> 'ConfigTree':
+    # pylint: disable=import-outside-toplevel
+    """Return config tree of saved config.
+
+    Raises ConfigTreeError.
+    """
+    from vyos.configtree import ConfigTree
+
+    return ConfigTree.load_file(config_file)
+
+
 def flag(l: list) -> list:
     res = [l[0:i] for i,_ in enumerate(l, start=1)]
     return res

--- a/src/op_mode/config_sync.py
+++ b/src/op_mode/config_sync.py
@@ -28,6 +28,9 @@ from vyos.configtree import ConfigTree
 from vyos.configtree import ConfigTreeError
 from vyos.configtree import DiffTree
 from vyos.config import Config
+from vyos.derivedtree import apply_exclusion_list
+from vyos.derivedtree import DerivedTreeError
+from vyos.defaults import config_sync_exclusion_list
 
 CONFIG_FILE = Path('/run/config_sync_conf.conf')
 
@@ -121,6 +124,14 @@ class ConfigSyncDiffManager:
         except ConfigTreeError as e:
             raise opmode.InternalError(f'Unable to build remote ConfigTree: {e}') from e
 
+    def _get_exclude_list(self) -> list[list[str]]:
+        # add as instance method, for future access to CLI settings from self.Config
+        exclude_file = Path(config_sync_exclusion_list)
+        if not exclude_file.exists():
+            raise opmode.InternalError('Config-sync exclusion list file not available')
+
+        return read_json(exclude_file, defaultonfailure=[])
+
     def _format_remote_diff(self, diff_tree: DiffTree, path: list, commands: bool):
         add_tree = diff_tree.add
         del_tree = diff_tree.delete
@@ -192,8 +203,16 @@ class ConfigSyncDiffManager:
                 'Invalid source, must be one of: running, candidate, saved'
             )
 
+        exclude_list = self._get_exclude_list()
+
         try:
-            diff_tree = DiffTree(remote_tree, local_tree)
+            masked_local = apply_exclusion_list(local_tree, exclude_list)
+            masked_remote = apply_exclusion_list(remote_tree, exclude_list)
+        except DerivedTreeError as e:
+            raise opmode.InternalError(str(e)) from e
+
+        try:
+            diff_tree = DiffTree(masked_remote, masked_local)
         except ConfigTreeError as e:
             raise opmode.InternalError(str(e)) from e
 

--- a/src/op_mode/config_sync.py
+++ b/src/op_mode/config_sync.py
@@ -23,10 +23,11 @@ from vyos import http_api_client as http
 from vyos.utils.file import read_json
 from vyos.utils.dict import dict_to_paths
 from vyos.utils.list import list_contains_sublist
+from vyos.utils.config import get_saved_config_tree
 from vyos.configtree import ConfigTree
 from vyos.configtree import ConfigTreeError
-from vyos.config_mgmt import ConfigMgmt
-from vyos.config_mgmt import ConfigMgmtError
+from vyos.configtree import DiffTree
+from vyos.config import Config
 
 CONFIG_FILE = Path('/run/config_sync_conf.conf')
 
@@ -60,6 +61,7 @@ def _load_config_sync_sections() -> list:
 
 
 def _load_config_sync_settings() -> dict:
+    # pylint: disable=use-dict-literal
     """Load remote API settings from config-sync service runtime JSON file"""
 
     cfg = _read_json_config()
@@ -82,9 +84,12 @@ class ConfigSyncDiffManager:
         api_settings = _load_config_sync_settings()
         self._client = http.ApiClient(http.ApiClientConfig(**api_settings))
 
-        self._config_mgmt = ConfigMgmt()
+        self._config = Config()
+        self.running_config = self._config.get_config_tree(effective=True)
+        self.session_config = self._config.get_config_tree(effective=False)
 
     def _get_remote_config_tree(self, section_path: list = None) -> ConfigTree:
+        # pylint: disable=redefined-outer-name
         """
         Retrieve remote config (or subtree) as ConfigTree via HTTPS API.
 
@@ -116,6 +121,84 @@ class ConfigSyncDiffManager:
         except ConfigTreeError as e:
             raise opmode.InternalError(f'Unable to build remote ConfigTree: {e}') from e
 
+    def _format_remote_diff(self, diff_tree: DiffTree, path: list, commands: bool):
+        add_tree = diff_tree.add
+        del_tree = diff_tree.delete
+        command_prefix = ' '.join(path)
+
+        result_lines = []
+        if commands:
+            # Process the deleted elements into command format and filter based on prefix (path)
+            for line in del_tree.to_commands(op='delete').splitlines():
+                if line.startswith(f'delete {command_prefix}'):
+                    result_lines.append(line)
+
+            # Process the added elements into command format and filter based on prefix (path)
+            for line in add_tree.to_commands(op='set').splitlines():
+                if line.startswith(f'set {command_prefix}'):
+                    result_lines.append(line)
+        else:
+            with_node = len(path) > 1
+            # Retrieve subtrees for the specified path from both added and deleted trees
+            del_tree = del_tree.get_subtree(path, with_node=with_node)
+            add_tree = add_tree.get_subtree(path, with_node=with_node)
+
+            # Convert the subtrees to string lines for further processing
+            del_tree_lines = str(del_tree).splitlines()
+            add_tree_lines = str(add_tree).splitlines()
+
+            # Format the lines with a prefix ('-', '+') and filter out empty lines
+            del_lines = [f'- {l}' for l in del_tree_lines if l.strip()]  # noqa: E741
+            add_lines = [f'+ {l}' for l in add_tree_lines if l.strip()]  # noqa: E741
+
+            if del_lines or add_lines:
+                # Adjust command prefix if a node is present in the path
+                command_prefix = ' '.join(path[:-1]) if with_node else command_prefix
+                if command_prefix:
+                    result_lines.append(f'[{command_prefix}]')
+
+                # Combine both deleted and added lines and process them
+                result_lines.extend(del_lines + add_lines)
+
+        # Join the result lines into a single string, excluding empty lines
+        return '\n'.join((line for line in result_lines if line.strip()))
+
+    def remote_compare(
+        self,
+        source: str,
+        remote_tree: ConfigTree,
+        path: typing.Optional[list] = None,
+        commands: bool = False,
+    ) -> str:
+        # pylint: disable=redefined-outer-name
+        """
+        Compares a local configuration tree with a remote
+        configuration tree based on the specified source ('running', 'candidate', 'saved').
+        """
+        path = path or []
+
+        # Determine the correct local configuration tree based on the 'source' parameter
+        if source == 'running':
+            local_tree = self.running_config
+        elif source == 'candidate':
+            local_tree = self.session_config
+        elif source == 'saved':
+            try:
+                local_tree = get_saved_config_tree()
+            except ConfigTreeError as e:
+                raise opmode.InternalError(str(e)) from e
+        else:
+            raise opmode.IncorrectValue(
+                'Invalid source, must be one of: running, candidate, saved'
+            )
+
+        try:
+            diff_tree = DiffTree(remote_tree, local_tree)
+        except ConfigTreeError as e:
+            raise opmode.InternalError(str(e)) from e
+
+        return self._format_remote_diff(diff_tree, path, commands)
+
     def get_sync_diff(
         self,
         source: str,
@@ -127,15 +210,12 @@ class ConfigSyncDiffManager:
         results = []
         remote_tree = self._get_remote_config_tree()
         for section_path in sections:
-            try:
-                result = self._config_mgmt.remote_compare(
-                    source,
-                    remote_tree,
-                    path=section_path,
-                    commands=commands,
-                )
-            except ConfigMgmtError as e:
-                raise opmode.InternalError(str(e)) from e
+            result = self.remote_compare(
+                source,
+                remote_tree,
+                path=section_path,
+                commands=commands,
+            )
 
             result = result.strip()
             if result:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Op-mode config-sync diff operations need to be updated to be exclusion mask aware.
In addition to applying the exclusion mask to the configtrees passed to the diff function, some minor refactoring and simplifications have been added for clarity and to support the planned extension to CLI-defined exclusion paths.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

Configure http api on secondary server. Configure config-sync on primary server:
```
vyos@vyos# show service config-sync section
 interfaces {
     ethernet
 }
[edit]
vyos@vyos# set interfaces ethernet eth2 description foo
[edit]
vyos@vyos# run show configuration secondary sync commands candidate
set interfaces ethernet eth2 description 'foo'
[edit]

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
