### PR TITLE
bgp: T5526: Fix BGP neighbor validation not raising when interface does not exist

### DIFF
--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -1841,6 +1841,40 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'  rt vpn import {ASN}:300', frrconfig)
         self.assertNotIn('route-target vpn', frrconfig)
 
+    def test_bgp_34_interface_neighbor(self):
+        peer_group = 'TESTPG'
+        interface = 'eth0'
+        self.cli_set(base_path + ['peer-group', peer_group, 'remote-as', ASN])
+
+        # Setting peer-group directly on an interface neighbor must be rejected
+        self.cli_set(base_path + ['neighbor', interface, 'peer-group', peer_group])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(base_path + ['neighbor', interface, 'peer-group'])
+
+        # Correct syntax: peer-group under the interface sub-node must succeed
+        self.cli_set(
+            base_path + ['neighbor', interface, 'interface', 'peer-group', peer_group]
+        )
+        self.cli_commit()
+
+        # Remove remote-as from peer-group so the neighbor resolves it via interface node
+        self.cli_delete(base_path + ['peer-group', peer_group, 'remote-as'])
+
+        # remote-as set directly on an interface neighbor must be rejected
+        self.cli_set(base_path + ['neighbor', interface, 'remote-as', ASN])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(base_path + ['neighbor', interface, 'remote-as'])
+
+        # Correct syntax: remote-as under the interface sub-node must succeed
+        self.cli_set(base_path + ['neighbor', interface, 'interface', 'remote-as', ASN])
+        self.cli_commit()
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', stop_section='^exit')
+        self.assertIn(
+            f' neighbor {interface} interface peer-group {peer_group}', frrconfig
+        )
+
     def test_bgp_99_bmp(self):
         target_name = 'instance-bmp'
         target_address = '127.0.0.1'

--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -26,7 +26,6 @@ from vyos.configverify import verify_vrf
 from vyos.frrender import FRRender
 from vyos.frrender import get_frrender_dict
 from vyos.template import is_ip
-from vyos.template import is_interface
 from vyos.utils.dict import dict_search
 from vyos.utils.network import get_interface_vrf
 from vyos.utils.network import is_addr_assigned
@@ -382,11 +381,21 @@ def verify(config_dict):
 
                 if is_ip(peer) and is_addr_assigned(peer, vrf):
                     raise ConfigError(f'Cannot configure local address as neighbor "{peer}"{vrf_error_msg}')
-                elif is_interface(peer):
+                elif not is_ip(peer):
+                    # T5526: Neighbor is not an IP address — treat as interface name
+                    # regardless of whether the interface currently exists on the system.
+                    # Checking physical existence would silently skip validation during
+                    # boot or config restore, allowing invalid config to reach FRR.
                     if 'peer_group' in peer_config:
-                        raise ConfigError(f'peer-group must be set under the interface node of "{peer}"')
+                        raise ConfigError(
+                            f'To assign a peer-group to an interface-based neighbor, use: '
+                            f'"set protocols bgp neighbor {peer} interface peer-group <name>"'
+                        )
                     if 'remote_as' in peer_config:
-                        raise ConfigError(f'remote-as must be set under the interface node of "{peer}"')
+                        raise ConfigError(
+                            f'To set remote-as for an interface-based neighbor, use: '
+                            f'"set protocols bgp neighbor {peer} interface remote-as <asn>"'
+                        )
                     if 'source_interface' in peer_config['interface']:
                         raise ConfigError(f'"source-interface" option not allowed for neighbor "{peer}"')
 


### PR DESCRIPTION
Validation of interface-based BGP neighbors relied on checking physical interface existence, which silently skipped the check when interface didn't exist yet, letting invalid config reach FRR. Fix by checking whether the neighbor is not an IP address instead, and improve the error messages to show the correct command.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T5526
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Before:
```
vyos@vyos# show protocols bgp 
+neighbor eth10 {
+    peer-group FOO
+}
 peer-group FOO {
     remote-as 65002
 }
 system-as 65001
[edit]
vyos@vyos# commit
[ protocols bgp ]

WARNING: BGP neighbor "eth10" requires address-family!

[13401|mgmtd] sending configuration [13404|ripngd] sending configuration
[13402|zebra] sending configuration [13403|ripd] sending configuration
[13405|ospfd] sending configuration [13407|ldpd] sending configuration
[13408|bgpd] sending configuration [13406|ospf6d] sending configuration
[13404|ripngd] done [13409|isisd] sending configuration [13401|mgmtd]
done [13402|zebra] done % Malformed address or name: eth10 line 2:
Failure to communicate[13] to bgpd, line:  neighbor eth10 peer-group FOO
% Specify remote-as or peer-group commands first line 6: Failure to
communicate[13] to bgpd, line:  no neighbor eth10 enforce-first-as
[13411|nhrpd] sending configuration [13407|ldpd] done [13405|ospfd] done
[13408|bgpd] Configuration file[/etc/frr/frr.conf] processing failure:
13 [13413|babeld] sending configuration [13403|ripd] done
[13416|watchfrr] sending configuration [13415|fabricd] sending
configuration [13406|ospf6d] done Waiting for children to finish
applying config... [13418|staticd] sending configuration [13409|isisd]
done [13413|babeld] done [13419|bfdd] sending configuration
[13411|nhrpd] done [13415|fabricd] done [13421|pathd] sending
configuration [13422|pim6d] sending configuration [13416|watchfrr] done
[13418|staticd] done [13419|bfdd] done [13422|pim6d] done [13421|pathd]
done [13426|mgmtd] sending configuration [13428|ripd] sending
configuration [13429|ripngd] sending configuration [13430|ospfd] sending
configuration [13427|zebra] sending configuration [13431|ospf6d] sending
configuration [13432|ldpd] sending configuration [13433|bgpd] sending
configuration [13434|isisd] sending configuration [13428|ripd] done
[13426|mgmtd] done % Malformed address or name: eth10 line 2: Failure to
communicate[13] to bgpd, line:  neighbor eth10 peer-group FOO
[13430|ospfd] done [13427|zebra] done % Specify remote-as or peer-group
commands first line 6: Failure to communicate[13] to bgpd, line:  no
neighbor eth10 enforce-first-as  [13436|nhrpd] sending configuration
[13429|ripngd] done [13438|babeld] sending configuration % Malformed
address or name: eth10 line 20: Failure to communicate[13] to bgpd,
line:  neighbor eth10 peer-group FOO  [13432|ldpd] done % Specify
remote-as or peer-group commands first line 24: Failure to
communicate[13] to bgpd, line:  no neighbor eth10 enforce-first-as
[13440|fabricd] sending configuration [13441|watchfrr] sending
configuration [13433|bgpd] Configuration file[/etc/frr/frr.conf]
processing failure: 13 [13443|staticd] sending configuration
[13444|bfdd] sending configuration [13431|ospf6d] done [13434|isisd]
done [13438|babeld] done [13436|nhrpd] done Waiting for children to
finish applying config... [13446|pathd] sending configuration
[13447|pim6d] sending configuration [13443|staticd] done
[13441|watchfrr] done [13440|fabricd] done [13444|bfdd] done
[13446|pathd] done [13447|pim6d] done
[[protocols bgp]] failed
Commit failed
[edit]
```
After:
```
vyos@vyos# show protocols bgp 
 peer-group FOO {
     remote-as 65002
 }
 system-as 65001
[edit]
vyos@vyos# set protocols bgp neighbor eth10 peer-group FOO 
[edit]
vyos@vyos# commit
[ protocols bgp ]

WARNING: BGP neighbor "eth10" requires address-family!

To assign a peer-group to an interface-based neighbor, use: "set
protocols bgp neighbor eth10 interface peer-group <name>"
[[protocols bgp]] failed
Commit failed
[edit]
vyos@vyos# del protocols bgp neighbor eth10 peer-group 
[edit]
vyos@vyos# set protocols bgp neighbor eth10 interface peer-group FOO
[edit]
vyos@vyos# commit
[ protocols bgp ]

WARNING: BGP neighbor "eth10" requires address-family!


[edit]
vyos@vyos# 
```

```
vyos@vyos# python3 /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py -k test_bgp_33_interface_neighbor_wrong_syntax
test_bgp_33_interface_neighbor_wrong_syntax (__main__.TestProtocolsBGP.test_bgp_33_interface_neighbor_wrong_syntax) ... ok

----------------------------------------------------------------------
Ran 1 test in 32.042s

OK
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
