### PR TITLE
password-reset: T8985: Fix unbounded `sed` ranges corrupting other user blocks

### DIFF
--- a/src/system/standalone_root_pw_reset
+++ b/src/system/standalone_root_pw_reset
@@ -27,7 +27,11 @@ CF=/opt/vyatta/etc/config/config.boot
 ADMIN=vyos
 
 set_encrypted_password() {
-    local user=$1 epwd=$2 file=$3
+    local user_raw=$1 epwd=$2 file=$3
+    local user
+
+    # Escape the username before using it in awk/sed regexes
+    user=$(printf '%s' "$user_raw" | sed -e 's/\./\\&/g')
 
     # Check if encrypted-password exists within this specific user's block
     if awk "/ user $user \{/{f=1} f && /encrypted-password/{found=1; exit} f && /^        }/{exit} END{exit !found}" "$file"; then
@@ -35,15 +39,41 @@ set_encrypted_password() {
         sed -i \
            -e "/ user $user {/,/encrypted-password/s/encrypted-password .*\$/encrypted-password \"$epwd\"/" "$file"
     else
-        # Insert encrypted-password after plaintext-password
-        sed -i \
-           -e "/ user $user {/,/plaintext-password/s/\(plaintext-password .*\)\$/\1\n                encrypted-password \"$epwd\"/" "$file"
+        # Key-only account: no encrypted-password or plaintext-password line exists
+        # in this user's block (e.g. authentication via SSH key only).
+        if awk "/ user $user \{/{f=1} f && /authentication \{/{found=1; exit} f && /^        \}/{exit} END{exit !found}" "$file"; then
+            # 'authentication' block exists - insert encrypted-password inside it
+            sed -i \
+               -e "/ user $user {/,/authentication {/s/\(authentication {\)\$/\1\n                encrypted-password \"$epwd\"/" "$file"
+        else
+            # No authentication block at all. Without this branch the sed range
+            # above would overrun the block boundary and corrupt a later account's
+            # authentication block. Build the section from scratch instead.
+            sed -i \
+               -e "/ user $user {/a\\
+            authentication {\\
+                encrypted-password \"$epwd\"\\
+                plaintext-password \"\"\\
+            }" "$file"
+        fi
     fi
 }
 
 clear_plaintext_password() {
-   sed -i \
-      -e "/ user $1 {/,/plaintext-password/s/plaintext-password .*\$/plaintext-password \"\"/" $2
+    local user_raw=$1 file=$2
+    local user
+
+    # Escape the username before using it in awk/sed regexes
+    user=$(printf '%s' "$user_raw" | sed -e 's/\./\\&/g')
+
+    # Only clear if plaintext-password exists within this specific user's block.
+    # Without this guard, if the user has no plaintext-password line the sed
+    # range never closes inside their block and spills into the next account
+    # that does have one, wiping that account's plaintext-password instead.
+    if awk "/ user $user \{/{f=1} f && /plaintext-password/{found=1; exit} f && /^        \}/{exit} END{exit !found}" "$file"; then
+        sed -i \
+           -e "/ user $user {/,/plaintext-password/s/plaintext-password .*\$/plaintext-password \"\"/" "$file"
+    fi
 }
 
 


### PR DESCRIPTION
## Change summary
`sed` ranges keyed on a field name (`plaintext-password`, `encrypted-password`, `authentication {`) are not bounded to the target user's block. When the field is absent the range stays open past the user's closing brace and matches the first occurrence of that field in a later account.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8985

## Related PR(s)
* https://github.com/vyos/vyos-1x/pull/5253

## How to test / Smoketest result
### Manual test
1. Update `/config/config.boot` using the next example of section `login` which contains all cases described in [the task](https://vyos.dev/T8985):
```
    login {
...
        user test1user1 {
            authentication {
                encrypted-password "..."
            }
        }
        user test1user2 {
            authentication {
                plaintext-password "passw"
            }
        }
        user test2user1 {
            authentication {
                public-keys user@pc {
                    key "AAAA...BMLD03"
                    type "ssh-ed25519"
                }
            }
        }
        user test2user2 {
            authentication {
                plaintext-password "passw"
            }
        }
        user test3user1 {
            authentication {
                public-keys user@pc {
                    key "AAAAC3...D03"
                    type "ssh-ed25519"
                }
            }
        }
    }
```
2. Commit this new changes and reset password for each of users (`test1user1`, `test1user2` and etc.). 
3. Users should be able to log in using the new password.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly