### PR TITLE
pki: T8994: add graceful error handling in case certbot fails

### DIFF
--- a/src/conf_mode/pki.py
+++ b/src/conf_mode/pki.py
@@ -167,6 +167,7 @@ def certbot_renew(config: dict, force: bool=False) -> None:
 
     # Determine services using ACME based certificates
     pre_hook_services = []
+    stop_services = []
     for used_by, _ in dict_search_recursive(config, 'used_by'):
         pre_hook_services.extend(used_by)
     # Remove duplicate items from list
@@ -174,16 +175,21 @@ def certbot_renew(config: dict, force: bool=False) -> None:
     # Automatically add services in use to pre_hook_services depending on service
     # name in vyos.defaults.systemd_services
     if pre_hook_services:
-        services = []
         for service in pre_hook_services:
             if service in systemd_services:
-                services.append(systemd_services[service])
-        tmp += ' --pre-hook "systemctl stop ' + ' '.join(services) + '"'
+                stop_services.append(systemd_services[service])
+        tmp += ' --pre-hook "systemctl stop ' + ' '.join(stop_services) + '"'
 
     if force:
         tmp += ' --force-renewal'
 
-    print(cmd(tmp, raising=ConfigError, message=f'Certbot renew failed!'))
+    try:
+        print(cmd(tmp, raising=ConfigError, message=f'Certbot renew failed!'))
+    except ConfigError as e:
+        print(e)
+        for service in stop_services:
+            print(f'Restarting "{service}" with non-renewed certificate...')
+            cmd(f'systemctl restart {service}')
     return None
 
 def get_config(config=None):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

If ACME and certbot are used for PKI and e.g. haproxy it can become an issue if certbot is blocked by the firewall. The renewal service will fail and tear-down the production service - even if the certificate is yet not expired.

The production service was not restarted. This has been changed as every service which is stopped prior to the renew is later restarted even upon failure of renewing said certificate.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8994

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Manually tested in error condition.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
