### PR TITLE
vpp: T8979: Fix defunct interface retaining IP addresses after crash

### DIFF
--- a/python/vyos/vpp/control_host.py
+++ b/python/vyos/vpp/control_host.py
@@ -444,8 +444,10 @@ def flush_ip(iface_name: str) -> None:
     Args:
         iface_name (str): name of an interface
     """
-    iproute = IPRoute()
-    iproute.flush_addr(label=iface_name)
+    with IPRoute() as iproute:
+        index = iproute.link_lookup(ifname=iface_name)
+        if index:
+            iproute.flush_addr(index=index[0])
 
 
 def get_eth_channels(iface_name: str) -> dict:


### PR DESCRIPTION
`flush_ip()` used `flush_addr(label=iface_name)` which only matches addresses whose label equals exactly the interface name. Secondary IP addresses are assigned with :N suffixed labels (e.g. `defunct_eth0:2`, `defunct_eth0:3`) and are not matched, so they remain on the interface. Fix by flushing addresses by interface `index` instead of `label`, which removes all addresses regardless of their label.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8979
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Test with Mellanox NIC (mlx5_core driver)
Config:
```
set interfaces ethernet eth0 address '10.120.0.1/16'
set interfaces ethernet eth0 address '172.17.85.1/24'
set interfaces ethernet eth0 address '172.17.86.1/24'

set vpp settings interface eth0

commit
```
Then stop VPP to simulate a crash:
```
sudo kill -3 `pidof vpp`
```
Before the fix defunct interface retained all IP addresses except the first.
```
29: defunct_eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1496 qdisc mq state UP group default qlen 1000
    link/ether e0:9d:73:bc:92:04 brd ff:ff:ff:ff:ff:ff
    altname eno12399np0
    altname enp195s0f0np0
    inet 172.17.85.1/24 brd 172.17.85.255 scope global defunct_eth0:2
       valid_lft forever preferred_lft forever
    inet 172.17.86.1/24 brd 172.17.86.255 scope global defunct_eth0:3
       valid_lft forever preferred_lft forever
31: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UNKNOWN group default qlen 1000
    link/ether e0:9d:73:bc:92:04 brd ff:ff:ff:ff:ff:ff
    inet 10.120.0.1/16 brd 10.120.255.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet 172.17.85.1/24 brd 172.17.85.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet 172.17.86.1/24 brd 172.17.86.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::e29d:73ff:febc:9204/64 scope link
       valid_lft forever preferred_lft forever
```
After the fix:
```
20: defunct_eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1496 qdisc mq state UP group default qlen 1000
    link/ether e0:9d:73:bc:92:04 brd ff:ff:ff:ff:ff:ff
    altname eno12399np0
    altname enp195s0f0np0
21: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether e0:9d:73:bc:92:04 brd ff:ff:ff:ff:ff:ff
    inet 10.120.0.1/16 brd 10.120.255.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet 172.17.85.1/24 brd 172.17.85.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet 172.17.86.1/24 brd 172.17.86.255 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fe80::e29d:73ff:febc:9204/64 scope link 
       valid_lft forever preferred_lft forever
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
