### PR TITLE
geoip: T8987: Support updates via source-address/vrf

### DIFF
--- a/interface-definitions/include/firewall/global-options.xml.i
+++ b/interface-definitions/include/firewall/global-options.xml.i
@@ -171,6 +171,8 @@
             <valueless/>
           </properties>
         </leafNode>
+        #include <include/source-address-ipv4-ipv6.xml.i>
+        #include <include/interface/vrf.xml.i>
       </children>
     </node>
     <leafNode name="ip-src-route">

--- a/op-mode-definitions/geoip.xml.in
+++ b/op-mode-definitions/geoip.xml.in
@@ -6,17 +6,6 @@
         <properties>
           <help>Update GeoIP database and firewall sets</help>
         </properties>
-        <children>
-          <tagNode name="vrf">
-            <properties>
-              <help>VRF to use for GeoIP update</help>
-              <completionHelp>
-                <path>vrf name</path>
-              </completionHelp>
-            </properties>
-            <command>sudo ip vrf exec $4 ${vyos_libexec_dir}/geoip-update.py</command>
-          </tagNode>
-        </children>
         <command>sudo ${vyos_libexec_dir}/geoip-update.py</command>
       </node>
     </children>

--- a/python/vyos/geoip.py
+++ b/python/vyos/geoip.py
@@ -24,7 +24,7 @@ geoip_lock_file = '/var/lock/vyos-geoip.lock'
 
 # Raw data
 
-def geoip_download_dbip():
+def geoip_download_dbip(source_address=None):
     url = 'https://download.db-ip.com/free/dbip-country-lite-{}.csv.gz'.format(strftime("%Y-%m"))
     asn_url = 'https://download.db-ip.com/free/dbip-asn-lite-{}.csv.gz'.format(strftime("%Y-%m"))
     try:
@@ -32,13 +32,13 @@ def geoip_download_dbip():
         if not os.path.exists(dirname):
             os.mkdir(dirname)
 
-        download(dbip_database_raw, url)
-        download(dbip_asn_database_raw, asn_url)
+        download(dbip_database_raw, url, source_host=source_address)
+        download(dbip_asn_database_raw, asn_url, source_host=source_address)
         return True
     except:
         return False
 
-def geoip_download_maxmind(account_id : str, license_key: str, lite : bool) -> bool:
+def geoip_download_maxmind(account_id : str, license_key: str, lite : bool, source_address: str = None) -> bool:
     db_str = 'GeoLite2' if lite else 'GeoIP2'
     url = f'https://{account_id}:{license_key}@download.maxmind.com/geoip/databases/{db_str}-Country-CSV/download?suffix=zip'
     asn_url = f'https://{account_id}:{license_key}@download.maxmind.com/geoip/databases/{db_str}-ASN-CSV/download?suffix=zip'
@@ -47,8 +47,8 @@ def geoip_download_maxmind(account_id : str, license_key: str, lite : bool) -> b
         if not os.path.exists(dirname):
             os.mkdir(dirname)
 
-        download(mm_database_raw, url)
-        download(mm_asn_database_raw, asn_url)
+        download(mm_database_raw, url, source_host=source_address)
+        download(mm_asn_database_raw, asn_url, source_host=source_address)
         return True
     except:
         return False

--- a/src/helpers/geoip-update.py
+++ b/src/helpers/geoip-update.py
@@ -27,6 +27,7 @@ from vyos.geoip import db_is_initialised
 from vyos.geoip import db_import_dbip_ranges
 from vyos.geoip import db_import_maxmind_ranges
 from vyos.geoip import geoip_update
+from vyos.utils.process import run
 
 def get_config(conf):
     return (
@@ -41,6 +42,7 @@ def get_config(conf):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--init", help="Initialise", action="store_true")
+    parser.add_argument('--download', help="Download", action="store_true")
     args = parser.parse_args()
 
     if args.init:
@@ -56,31 +58,39 @@ if __name__ == '__main__':
 
     options, firewall, policy = get_config(conf)
 
+    src_addr = options.get('source_address', '')
+    vrf = options.get('vrf', None)
+
+    if args.download or not vrf:
+        if options['provider'] == 'db-ip':
+            print('Downloading latest DB-IP database...')
+            if not geoip_download_dbip(source_address=src_addr):
+                print('Failed to download, aborting.')
+                sys.exit(1)
+        elif options['provider'] == 'maxmind':
+            account_id = options['maxmind_account_id']
+            license_key = options['maxmind_license_key']
+            lite = 'maxmind_lite' in options
+
+            print('Downloading latest MaxMind database...')
+            if not geoip_download_maxmind(account_id, license_key, lite, source_address=src_addr):
+                print('Failed to download, aborting.')
+                sys.exit(1)
+        if args.download:
+            sys.exit(0)
+    elif vrf:
+        run(['python3', __file__, '--download'], stdout=None, stderr=None, vrf=vrf)
+
     if not db_is_initialised():
         db_initialise()
 
+    print('Extracting database...')
     if options['provider'] == 'db-ip':
-        print('Downloading latest DB-IP database...')
-        if not geoip_download_dbip():
-            print('Failed to download, aborting.')
-            sys.exit(1)
-
-        print('Extracting database...')
         if not db_import_dbip_ranges(delete_file=True):
             print('Failed to extract, aborting.')
             sys.exit(1)
 
     elif options['provider'] == 'maxmind':
-        account_id = options['maxmind_account_id']
-        license_key = options['maxmind_license_key']
-        lite = 'maxmind_lite' in options
-
-        print('Downloading latest MaxMind database...')
-        if not geoip_download_maxmind(account_id, license_key, lite):
-            print('Failed to download, aborting.')
-            sys.exit(1)
-
-        print('Extracting database...')
         if not db_import_maxmind_ranges(delete_file=True):
             print('Failed to extract, aborting.')
             sys.exit(1)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add CLI to define source-address/vrf for GeoIP updates. Used both by manual op-mode updates and cronjob.

Removes explicit vrf op-mode `update geoip vrf <name>`.

New CLI:
- `set firewall global-options geoip source-address`
- `set firewall global-options geoip vrf`

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Example with no routes in default vrf, only within "wan" vrf.
```
vyos@vyos# run update geoip
Downloading latest DB-IP database...
Unable to download "https://download.db-ip.com/free/dbip-country-lite-2026-06.csv.gz": HTTPSConnectionPool(host='download.db-ip.com', port=443): Max retries exceeded with url: /free/dbip-country-lite-2026-06.csv.gz (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f44f91a1b10>: Failed to establish a new connection: [Errno 16] Device or resource busy'))
Failed to download, aborting.
[edit]
vyos@vyos# set firewall global-options geoip vrf wan
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# run update geoip
Downloading latest DB-IP database...
Extracting database...
[edit]
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
