### PR TITLE
openvpn: T8998: fix ccd-exclusive without client-config-dir

### DIFF
--- a/data/templates/openvpn/server.conf.j2
+++ b/data/templates/openvpn/server.conf.j2
@@ -102,7 +102,7 @@ ifconfig-pool {{ server.client_ip_pool.start }} {{ server.client_ip_pool.stop }}
 {%         if server.max_connections is vyos_defined %}
 max-clients {{ server.max_connections }}
 {%         endif %}
-{%         if server.client is vyos_defined %}
+{%         if server.client is vyos_defined or server.reject_unconfigured_clients is vyos_defined %}
 client-config-dir /run/openvpn/ccd/{{ ifname }}
 {%         endif %}
 {%     endif %}

--- a/smoketest/scripts/cli/test_interfaces_openvpn.py
+++ b/smoketest/scripts/cli/test_interfaces_openvpn.py
@@ -900,5 +900,33 @@ class TestInterfacesOpenVPN(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(base_path)
         self.cli_commit()
 
+    def test_openvpn_server_reject_unconfigured_clients(self):
+        # T8998: reject-unconfigured-clients without server client entries
+        # must emit both client-config-dir and ccd-exclusive
+        interface = 'vtun5020'
+        path = base_path + [interface]
+        subnet = '10.20.30.0/24'
+
+        self.cli_set(path + ['device-type', 'tun'])
+        self.cli_set(path + ['mode', 'server'])
+        self.cli_set(path + ['keep-alive', 'failure-count', '5'])
+        self.cli_set(path + ['keep-alive', 'interval', '5'])
+        self.cli_set(path + ['tls', 'ca-certificate', 'ovpn_test'])
+        self.cli_set(path + ['tls', 'certificate', 'ovpn_test'])
+        self.cli_set(path + ['tls', 'dh-params', 'ovpn_test'])
+        self.cli_set(path + ['server', 'subnet', subnet])
+        self.cli_set(path + ['server', 'reject-unconfigured-clients'])
+
+        self.cli_commit()
+
+        config_file = f'/run/openvpn/{interface}.conf'
+        config = read_file(config_file)
+
+        self.assertIn(f'client-config-dir /run/openvpn/ccd/{interface}', config)
+        self.assertIn('ccd-exclusive', config)
+
+        self.assertTrue(process_named_running(PROCESS_NAME))
+        self.assertIn(interface, interfaces())
+
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())


### PR DESCRIPTION
Emit `client-config-dir` when `reject-unconfigured-clients` is set, even without server client entries, so OpenVPN does not crash-loop.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8998
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
