### PR TITLE
T8990: bgp: fix VPNv4/VPNv6 leaked routes flapping on every commit

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -428,14 +428,23 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }} {{ 'as-nota
 {%         if afi_config.rd.vpn.export is vyos_defined %}
   rd vpn export {{ afi_config.rd.vpn.export }}
 {%         endif %}
+{# T8990: emit FRR's canonical "rt vpn" keyword (not the "route-target vpn" #}
+{# alias), and fold an identical import+export into "both" exactly as FRR #}
+{# does. FRR only folds on an identical, order-sensitive match, which is #}
+{# what the string compare below tests - so reordered or differing RT lists #}
+{# stay split on both sides too. This keeps the rendered config #}
+{# byte-identical to FRR's running config, so frr-reload produces no diff #}
+{# that would otherwise flap leaked routes on every commit. #}
 {%         if afi_config.route_target.vpn.both is vyos_defined %}
-  route-target vpn both {{ afi_config.route_target.vpn.both }}
+  rt vpn both {{ afi_config.route_target.vpn.both }}
+{%         elif afi_config.route_target.vpn.export is vyos_defined and afi_config.route_target.vpn.export == afi_config.route_target.vpn.import %}
+  rt vpn both {{ afi_config.route_target.vpn.export }}
 {%         else %}
 {%             if afi_config.route_target.vpn.export is vyos_defined %}
-  route-target vpn export {{ afi_config.route_target.vpn.export }}
+  rt vpn export {{ afi_config.route_target.vpn.export }}
 {%             endif %}
 {%             if afi_config.route_target.vpn.import is vyos_defined %}
-  route-target vpn import {{ afi_config.route_target.vpn.import }}
+  rt vpn import {{ afi_config.route_target.vpn.import }}
 {%             endif %}
 {%         endif %}
 {%         if afi_config.route_target.both is vyos_defined %}

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -25,6 +25,7 @@ from vyos.configsession import ConfigSessionError
 from vyos.template import is_ipv6
 from vyos.utils.process import process_named_running
 from vyos.utils.process import cmd
+from vyos.utils.file import read_file
 from vyos.frrender import bgp_daemon
 
 ASN = '64512'
@@ -1791,6 +1792,54 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         frrconfig = self.getFRRconfig(f'router bgp {ASN}', stop_section='^exit')
         self.assertIn(f'router bgp {ASN}', frrconfig)
         self.assertIn(f' neighbor {neighbor} bfd strict hold-time {bfd_hold_time}', frrconfig)
+
+    def test_bgp_33_vpn_route_target_idempotency(self):
+        # T8990: VPNv4/VPNv6 inter-VRF route-leak config must be rendered using
+        # FRR's canonical "rt vpn" keyword (not the "route-target vpn" alias),
+        # and an equal import+export route-target must be collapsed into "both"
+        # - exactly as FRR stores it. Otherwise the generated config never
+        # matches FRR's running config, frr-reload re-applies the route-target
+        # on every commit, and the leaked routes are withdrawn/reinstalled
+        # (flap) on every - even unrelated - commit.
+        #
+        # This intentionally reads the generated FRR config file instead of
+        # getFRRconfig()/vtysh: vtysh returns FRR's already-canonicalized
+        # config ("rt vpn"), so it cannot detect us emitting the
+        # "route-target vpn" alias - which is the actual T8990 defect.
+        frr_conf = '/run/frr/config/vyos.frr.conf'
+        afi_path = base_path + ['address-family', 'ipv4-unicast']
+
+        self.cli_set(afi_path + ['export', 'vpn'])
+        self.cli_set(afi_path + ['import', 'vpn'])
+        self.cli_set(afi_path + ['rd', 'vpn', 'export', f'{ASN}:1'])
+
+        # symmetric route-target via "both"
+        self.cli_set(afi_path + ['route-target', 'vpn', 'both', f'{ASN}:100'])
+        self.cli_commit()
+        frrconfig = read_file(frr_conf)
+        self.assertIn(f'  rt vpn both {ASN}:100', frrconfig)
+        self.assertNotIn('route-target vpn', frrconfig)
+        self.cli_delete(afi_path + ['route-target', 'vpn', 'both'])
+
+        # symmetric route-target via equal import + export must collapse to
+        # "both" to match FRR's canonical rendering
+        self.cli_set(afi_path + ['route-target', 'vpn', 'export', f'{ASN}:100'])
+        self.cli_set(afi_path + ['route-target', 'vpn', 'import', f'{ASN}:100'])
+        self.cli_commit()
+        frrconfig = read_file(frr_conf)
+        self.assertIn(f'  rt vpn both {ASN}:100', frrconfig)
+        self.assertNotIn('route-target vpn', frrconfig)
+        self.cli_delete(afi_path + ['route-target', 'vpn', 'export'])
+        self.cli_delete(afi_path + ['route-target', 'vpn', 'import'])
+
+        # asymmetric route-target -> separate import/export lines
+        self.cli_set(afi_path + ['route-target', 'vpn', 'export', f'{ASN}:200'])
+        self.cli_set(afi_path + ['route-target', 'vpn', 'import', f'{ASN}:300'])
+        self.cli_commit()
+        frrconfig = read_file(frr_conf)
+        self.assertIn(f'  rt vpn export {ASN}:200', frrconfig)
+        self.assertIn(f'  rt vpn import {ASN}:300', frrconfig)
+        self.assertNotIn('route-target vpn', frrconfig)
 
     def test_bgp_99_bmp(self):
         target_name = 'instance-bmp'


### PR DESCRIPTION
BGP address-family template rendered the route-target using the "route-target vpn ..." alias. FRR accepts that alias on input but its config writer only ever emits the canonical "rt vpn ..." form. `frr-reload.py `diffs the generated config against FRR's running config line by line and has no normalisation for this, so the route-target lines never matched and were deleted and re-added on every reload. Re-applying the route-target runs FRR's `vpn_leak_prechange()/postchange()`, a non-atomic withdraw-all then reinstall-all of every leaked route.

Emit the canonical "rt vpn" keyword so the rendered config round-trips through frr-reload unchanged. FRR also folds an identical import+export route-target into "both" (an order-sensitive, byte-identical match), so do the same to stay idempotent; reordered or differing lists stay split on both sides.

Add test_bgp_33_vpn_route_target_idempotency covering both / identical export+import / asymmetric route-target, reading the generated FRR config (getFRRconfig/vtysh returns FRR's already-canonical form and cannot catch the alias).

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8990
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
test_bgp_33_vpn_route_target_idempotency(__main__.TestProtocolsBGP.test_bgp_33_vpn_route_target_idempotency) ... ok

----------------------------------------------------------------------
Ran 1 test in 59.499s
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
