### PR TITLE
T9009: op-mode: extend "monitor log" with filter level

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -121,8 +121,6 @@ Depends:
   tuned,
   beep,
   wide-dhcpv6-client,
-# Generic colorizer
-  grc,
 # The package "whois" contains both a whois database client
 # that end users can find useful,
 # and the "mkpasswd" utility we use for generating hashed passwords

--- a/op-mode-definitions/monitor-log.xml.in
+++ b/op-mode-definitions/monitor-log.xml.in
@@ -111,6 +111,15 @@
               </node>
             </children>
           </node>
+          <tagNode name="level">
+            <properties>
+              <help>Monitor log and filter messages by minimum priority level (includes all higher severities)</help>
+              <completionHelp>
+                <list>emerg alert crit err warning notice info debug</list>
+              </completionHelp>
+            </properties>
+            <command>SYSTEMD_COLORS=false journalctl --no-hostname --follow --boot -p $4</command>
+          </tagNode>
           <leafNode name="flow-accounting">
             <properties>
               <help>Monitor last lines of flow-accounting log</help>

--- a/op-mode-definitions/monitor-log.xml.in
+++ b/op-mode-definitions/monitor-log.xml.in
@@ -9,7 +9,7 @@
         <properties>
           <help>Monitor last lines of messages file</help>
         </properties>
-        <command>bash -c 'SYSTEMD_COLORS=false journalctl --no-hostname --follow --boot'</command>
+        <command>SYSTEMD_COLORS=false journalctl --no-hostname --follow --boot</command>
         <children>
           <node name="color">
             <properties>

--- a/op-mode-definitions/monitor-log.xml.in
+++ b/op-mode-definitions/monitor-log.xml.in
@@ -15,7 +15,7 @@
             <properties>
               <help>Output log in a colored fashion</help>
             </properties>
-            <command>bash -c 'SYSTEMD_COLORS=false grc journalctl --no-hostname --follow --boot'</command>
+            <command>SYSTEMD_COLORS=true journalctl --no-hostname --follow --boot</command>
           </node>
           <leafNode name="certbot">
             <properties>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

`journalctl` captures all syslog priority levels; filtering happens at query time via `-p <level>`. The existing monitor log command always shows all priorities.

A `monitor log filter <priority>` sub-command lets operators tail the journal at a specific minimum severity without having to remember journalctl flags.

`journalctl -p <level>` shows messages at that level and above (i.e., lower numeric severity values are always included — warning also shows err, crit, alert, emerg).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9009

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
