### PR TITLE
bgp: T9013: Add BMP source-interface support

### DIFF
--- a/data/templates/frr/bgpd.frr.j2
+++ b/data/templates/frr/bgpd.frr.j2
@@ -538,7 +538,7 @@ router bgp {{ system_as }} {{ 'vrf ' ~ vrf if vrf is vyos_defined }} {{ 'as-nota
 {%                 endif %}
 {%             endif %}
 {%             if bmp_config.address is vyos_defined %}
-  bmp connect {{ bmp_config.address }} port {{ bmp_config.port }} min-retry {{ bmp_config.min_retry }} max-retry {{ bmp_config.max_retry }}
+  bmp connect {{ bmp_config.address }} port {{ bmp_config.port }} min-retry {{ bmp_config.min_retry }} max-retry {{ bmp_config.max_retry }} {{ 'source-interface ' ~ bmp_config.source_interface if bmp_config.source_interface is vyos_defined }}
 {%             endif %}
 {%         endfor %}
  exit

--- a/interface-definitions/include/bgp/protocol-common-config.xml.i
+++ b/interface-definitions/include/bgp/protocol-common-config.xml.i
@@ -874,6 +874,7 @@
       <children>
         #include <include/address-ipv4-ipv6-single.xml.i>
         #include <include/port-number.xml.i>
+        #include <include/source-interface.xml.i>
         <leafNode name="port">
           <defaultValue>5000</defaultValue>
         </leafNode>

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -1852,6 +1852,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         mirror_buffer = '32000000'
         bmp_path = base_path + ['bmp']
         target_path = bmp_path + ['target', target_name]
+        source_iface = 'eth0'
 
         # by default the 'bmp' module not loaded for the bgpd expect Error
         self.cli_set(bmp_path)
@@ -1879,6 +1880,7 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
 
         # config other bmp options
         self.cli_set(target_path + ['address', target_address])
+        self.cli_set(target_path + ['source-interface', source_iface])
         self.cli_set(bmp_path + ['mirror-buffer-limit', mirror_buffer])
         self.cli_set(target_path + ['port', target_port])
         self.cli_set(target_path + ['min-retry', min_retry])
@@ -1899,7 +1901,21 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'bmp monitor ipv6 unicast {monitor_ipv6}', frrconfig)
         self.assertIn(f'bmp monitor ipv4 unicast loc-rib', frrconfig)
         self.assertIn(f'bmp monitor ipv6 unicast loc-rib', frrconfig)
-        self.assertIn(f'bmp connect {target_address} port {target_port} min-retry {min_retry} max-retry {max_retry}', frrconfig)
+        self.assertIn(
+            f'bmp connect {target_address} port {target_port} min-retry {min_retry} max-retry {max_retry} source-interface {source_iface}',
+            frrconfig,
+        )
+
+        # verify source-interface is removed from FRR config after deletion
+        self.cli_delete(target_path + ['source-interface'])
+        self.cli_commit()
+
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', stop_section='^exit')
+        self.assertIn(
+            f'bmp connect {target_address} port {target_port} min-retry {min_retry} max-retry {max_retry}',
+            frrconfig,
+        )
+        self.assertNotIn('source-interface', frrconfig)
 
     def test_bgp_100_link_state(self):
         router_id = '127.0.0.1'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T9013
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-build/pull/1225
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set system frr bmp
commit 
run restart bgp

set protocols bgp system-as '65001'
set protocols bgp bmp target test address '192.0.0.1'
set protocols bgp bmp target test source-interface eth1
commit

vyos@vyos# vtysh -c "show running-config bgpd"
Building configuration...

Current configuration:
!
frr version 10.6.1
frr defaults traditional
hostname vyos
service integrated-vtysh-config
!
router bgp 65001
 no bgp ebgp-requires-policy
 no bgp reject-as-sets
 no bgp default ipv4-unicast
 no bgp network import-check
 !
 bmp targets test
  bmp connect 192.0.0.1 port 5000 min-retry 1000 max-retry 2000 source-interface eth1
 exit
exit
!
end
[edit]
vyos@vyos# 


vyos@vyos# python3 /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py -k test_bgp_99_bmp
test_bgp_99_bmp (__main__.TestProtocolsBGP.test_bgp_99_bmp) ... ok

----------------------------------------------------------------------
Ran 1 test in 40.299s

OK
[edit]
vyos@vyos# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
