### PR TITLE
T8993: initialize ReferenceTree module from string not file

### DIFF
--- a/libvyosconfig/lib/bindings.ml
+++ b/libvyosconfig/lib/bindings.ml
@@ -135,6 +135,17 @@ let write_internal_reference_tree c_ptr file =
     with Internal.Write_error msg ->
         error_message := msg
 
+let read_internal_string_reference_tree s =
+    (* alert exn Internal.read_string:
+        [Internal.Read_error] caught
+     *)
+    try
+        error_message := "";
+        let rt = (IR.read_string[@alert "-exn"]) s in
+        Ctypes.Root.create rt
+    with Internal.Read_error msg ->
+        error_message := msg; Ctypes.null
+
 let create_node c_ptr path =
     (* alert exn CT.create_node:
         [Vytree.Empty_path] caught
@@ -546,6 +557,7 @@ struct
   let () = I.internal "to_json_reference_tree" ((ptr void) @-> returning string) render_json_reference_tree
   let () = I.internal "read_internal_reference_tree" (string @-> returning (ptr void)) read_internal_reference_tree
   let () = I.internal "write_internal_reference_tree" ((ptr void) @-> string @-> returning void) write_internal_reference_tree
+  let () = I.internal "read_internal_string_reference_tree" (string @-> returning (ptr void)) read_internal_string_reference_tree
   let () = I.internal "create_node" ((ptr void) @-> string @-> returning int) create_node
   let () = I.internal "set_add_value" ((ptr void) @-> string @-> string @-> returning int) set_add_value
   let () = I.internal "set_replace_value" ((ptr void) @-> string @-> string @-> returning int) set_replace_value

--- a/python/vyos/referencetree.py
+++ b/python/vyos/referencetree.py
@@ -14,6 +14,7 @@
 # along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
 from ctypes import cdll, c_char_p, c_void_p, c_bool
+from pathlib import Path
 
 from vyos.defaults import reference_tree_cache
 
@@ -25,7 +26,7 @@ class ReferenceTreeError(Exception):
 
 
 class ReferenceTree:
-    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-instance-attributes,raise-missing-from
     def __init__(self, cache_file=reference_tree_cache, libpath=LIBPATH):
         self.__pointer = None
         self.__lib = cdll.LoadLibrary(libpath)
@@ -35,9 +36,9 @@ class ReferenceTree:
         self.__get_error.argtypes = []
         self.__get_error.restype = c_char_p
 
-        self.__read_internal = self.__lib.read_internal_reference_tree
-        self.__read_internal.argtypes = [c_char_p]
-        self.__read_internal.restype = c_void_p
+        self.__read_internal_string = self.__lib.read_internal_string_reference_tree
+        self.__read_internal_string.argtypes = [c_char_p]
+        self.__read_internal_string.restype = c_void_p
 
         self.__write_internal = self.__lib.write_internal_reference_tree
         self.__write_internal.argtypes = [c_void_p, c_char_p]
@@ -53,7 +54,12 @@ class ReferenceTree:
         self.__equal.argtypes = [c_void_p, c_void_p]
         self.__equal.restype = c_bool
 
-        pointer = self.__read_internal(cache_file.encode())
+        try:
+            cache_string = Path(cache_file).read_bytes()
+        except OSError as e:
+            raise ValueError(f'Failed to read cache_file: {e}')
+
+        pointer = self.__read_internal_string(cache_string)
         if pointer is None:
             msg = self.__get_error().decode()
             raise ValueError(f'Failed to read internal rep: {msg}')


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Fix initialization error in config-sync mask exclusive. The root cause is the non-thread safety of the vyos1x-config function reading reference tree cache from file; solution is to read string in Python and pass to thread-safe version `read_string`. This is one instance of the general adoption in T9015.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

As described in T8993, config-sync is now stable when config-sync diff is run before the _first_ synchronization has taken place.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
