### PR TITLE
T9015: fix thread safety of configtree read/write_cache

### DIFF
--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -72,7 +72,7 @@ class ConfigTreeError(Exception):
 
 
 class ConfigTree:
-    # pylint: disable=too-many-instance-attributes,too-many-arguments,too-many-statements,too-many-public-methods
+    # pylint: disable=too-many-instance-attributes,too-many-arguments,too-many-statements,too-many-public-methods,raise-missing-from
     def __init__(
         self,
         config_string=None,
@@ -232,7 +232,11 @@ class ConfigTree:
                 self.__config = address
                 self.__version = ''
             case ('internal', internal):
-                config = self.__read_internal(internal.encode())
+                try:
+                    cache_string = Path(internal).read_bytes()
+                except OSError as e:
+                    raise ValueError(f'Failed to read internal cache file: {e}')
+                config = self.__read_internal_string(cache_string)
                 if config is None:
                     msg = self.__get_error().decode()
                     raise ValueError(
@@ -299,7 +303,11 @@ class ConfigTree:
         return self.__version
 
     def write_cache(self, file_name):
-        self.__write_internal(self.get_tree(), file_name.encode())
+        cache_string = self.__write_internal_string(self.get_tree())
+        try:
+            Path(file_name).write_bytes(cache_string)
+        except OSError as e:
+            raise ValueError(f'Failed to write internal cache file: {e}')
 
     def write_internal_string(self) -> str:
         res = self.__write_internal_string(self.get_tree())

--- a/src/tests/test_config_tree.py
+++ b/src/tests/test_config_tree.py
@@ -14,7 +14,10 @@
 #
 #
 
+import os
 import json
+import time
+import threading
 import unittest
 from unittest import TestCase
 
@@ -29,6 +32,20 @@ class TestInitialSetup(TestCase):
             config_str = f.read()
             self.ct = ConfigTree(config_str)
 
+        self.thread_exception = None
+        self.orig_excepthook = threading.excepthook
+
+        def custom_hook(args):
+            self.thread_exception = args.exc_value
+
+        threading.excepthook = custom_hook
+
+    def tearDown(self):
+        threading.excepthook = self.orig_excepthook
+
+        if self.thread_exception:
+            raise self.thread_exception
+
     def test_subtree_from_partial(self):
         reftree = ReferenceTree(cache_file='data/reftree.cache')
 
@@ -42,6 +59,30 @@ class TestInitialSetup(TestCase):
         )
 
         self.assertEqual(self.ct, reassemble)
+
+    def test_cache_io(self):
+        config_cache = '/tmp/config.cache'
+
+        self.ct.write_cache(config_cache)
+        ct_cached = ConfigTree(internal=config_cache)
+        os.unlink(config_cache)
+
+        self.assertEqual(self.ct, ct_cached)
+
+    def test_cache_io_thread(self):
+        config_cache = '/tmp/config.cache'
+
+        def task():
+            time.sleep(0.1)
+            self.ct.write_cache(config_cache)
+            ct_cached = ConfigTree(internal=config_cache)
+            os.unlink(config_cache)
+
+            self.assertEqual(self.ct, ct_cached)
+
+        t = threading.Thread(target=task)
+        t.start()
+        t.join()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

For the configtree init from cache file, and method `write_cache`, move the file operations to Python, so that the calls into libvyosconfig only require operations on the string content. This fixes issues with thread-safety, and is the analogue of https://github.com/vyos/vyos-1x/pull/5291 for configtree. A nosetest is added.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

The provided nosetest fails without the fix; passes with it.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
