### PR TITLE
https: T9022: serve the full CA certificate chain

### DIFF
--- a/smoketest/scripts/cli/test_service_https.py
+++ b/smoketest/scripts/cli/test_service_https.py
@@ -30,6 +30,9 @@ from vyos.utils.file import write_file
 from vyos.utils.process import call
 from vyos.utils.process import cmd
 from vyos.utils.process import process_named_running
+from vyos.pki import CERT_BEGIN
+from vyos.pki import encode_certificate
+from vyos.pki import load_certificate
 from vyos.xml_ref import default_value
 
 from vyos.configsession import ConfigSessionError
@@ -59,6 +62,50 @@ key_data = """
 MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgPLpD0Ohhoq0g4nhx
 2KMIuze7ucKUt/lBEB2wc03IxXyhRANCAATTUestw222qrj8+2gy5rysxYSQ50G7
 u8/3jHMM7sDwL3aWzW/zp54/LhCWUoLMjDdDEEigK4fal4ZF9aA9F0Ww
+"""
+
+# A self-contained CA chain (root CA -> intermediate CA -> server leaf
+# certificate) used to verify that the HTTPS server emits the full chain.
+# EC/prime256v1, valid until 2124; the leaf is a serverAuth certificate with
+# its matching private key.
+chain_root_ca_data = """
+MIIBajCCAQ+gAwIBAgIUBTkKqMGnfCxrlO9xcoNVop6rZbMwCgYIKoZIzj0EAwIw
+ITEfMB0GA1UEAwwWVnlPUyBzbW9rZXRlc3Qgcm9vdCBDQTAgFw0yNDAxMDEwMDAw
+MDBaGA8yMTI0MDEwMTAwMDAwMFowITEfMB0GA1UEAwwWVnlPUyBzbW9rZXRlc3Qg
+cm9vdCBDQTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABMtqjpv32fV22Wc42mEo
+OIuja0g2dFWC5GZfgUqlATuJYnWT8CQIUrsU5rkZ17/QAKYV8j15uyzu7Z/y1lh4
+Qs6jIzAhMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49
+BAMCA0kAMEYCIQC1jmfldcNt7YVWPYkEIIpEBGAF3YDQSoKw3W5AE0dAVwIhAMGD
+oZ3lJTJDQRN5RvNEgUxAcIJGk6eI5JPbzdY50M+A
+"""
+
+chain_intermediate_ca_data = """
+MIIBdDCCARqgAwIBAgIURw6/dUwu0DpNWs3tWchVfugh7OAwCgYIKoZIzj0EAwIw
+ITEfMB0GA1UEAwwWVnlPUyBzbW9rZXRlc3Qgcm9vdCBDQTAgFw0yNDAxMDEwMDAw
+MDBaGA8yMTI0MDEwMTAwMDAwMFowKTEnMCUGA1UEAwweVnlPUyBzbW9rZXRlc3Qg
+aW50ZXJtZWRpYXRlIENBMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYKjeAwqK
+w2zmRmxLSFVFWwHATyUYpFI8EyzuU3laPSy/FrOI2aDbJxeAStJzdZK7I9i/9mT7
+M/WpLjo/0KRok6MmMCQwEgYDVR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMC
+AQYwCgYIKoZIzj0EAwIDSAAwRQIhAL411m9RwX18+u4Th4XEmVOyX9KFuWjM0xdt
+AwlBC15jAiAK1UC0h3w17EnsTJLOXVhs2zUjTAH1g79sL8YvUxrrTQ==
+"""
+
+chain_cert_data = """
+MIIBpTCCAUygAwIBAgIUPUP2dDDjMOzeArLqGnnhqPaMJGAwCgYIKoZIzj0EAwIw
+KTEnMCUGA1UEAwweVnlPUyBzbW9rZXRlc3QgaW50ZXJtZWRpYXRlIENBMCAXDTI0
+MDEwMTAwMDAwMFoYDzIxMjQwMTAxMDAwMDAwWjAhMR8wHQYDVQQDDBZ2eW9zLnNt
+b2tldGVzdC5leGFtcGxlMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwVklSiSf
+VpgZVHN7m5jRGXHjoFj/v+srfmUEn1/IzRoF8KGwOWIvxcSeS26AkHKXYGzkaWpH
+ayBufJhUBvf41qNYMFYwDAYDVR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCB4AwEwYD
+VR0lBAwwCgYIKwYBBQUHAwEwIQYDVR0RBBowGIIWdnlvcy5zbW9rZXRlc3QuZXhh
+bXBsZTAKBggqhkjOPQQDAgNHADBEAiBqMUNw9Q3LIefYYZ31EpNmHz6R2j7bhDb3
+7Lgx28vhyAIgUC6hwMpFwH7gcj34Vy7+ga1ZvkpHyY1ZyQUaIi89F44=
+"""
+
+chain_key_data = """
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgYe5FRCBfdQostO/7
+8TZa4FF3I4mikSj+gifZWwWqsbuhRANCAATBWSVKJJ9WmBlUc3ubmNEZceOgWP+/
+6yt+ZQSfX8jNGgXwobA5Yi/FxJ5LboCQcpdgbORpakdrIG58mFQG9/jW
 """
 
 dh_1024 = """
@@ -242,6 +289,60 @@ class TestHTTPSService(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
         self.assertTrue(process_named_running(PROCESS_NAME))
         self.debug = False
+
+    def test_certificate_chain(self):
+        # The HTTPS server must serve the full certificate chain: the server
+        # certificate followed by every intermediate CA certificate available
+        # in the PKI, up to and including the root. Without the intermediate
+        # CA, clients that do not already trust it can not validate the
+        # presented server certificate (e.g. Let's Encrypt intermediates).
+        cert_name = 'https-chain'
+        root_ca_name = 'https-chain-root'
+        intermediate_ca_name = 'https-chain-intermediate'
+
+        root_ca_path = pki_base + ['ca', root_ca_name, 'certificate']
+        self.cli_set(root_ca_path + [chain_root_ca_data.replace('\n', '')])
+
+        intermediate_ca_path = pki_base + ['ca', intermediate_ca_name, 'certificate']
+        self.cli_set(
+            intermediate_ca_path + [chain_intermediate_ca_data.replace('\n', '')]
+        )
+
+        cert_path = pki_base + ['certificate', cert_name, 'certificate']
+        self.cli_set(cert_path + [chain_cert_data.replace('\n', '')])
+
+        cert_key_path = pki_base + ['certificate', cert_name, 'private', 'key']
+        self.cli_set(cert_key_path + [chain_key_data.replace('\n', '')])
+
+        # Reference only the leaf certificate - the intermediate CA chain must
+        # be discovered from the PKI and served automatically.
+        self.cli_set(base_path + ['certificates', 'certificate', cert_name])
+        self.cli_commit()
+
+        self.assertTrue(process_named_running(PROCESS_NAME))
+
+        # The served bundle must be the leaf certificate, then the intermediate
+        # CA, then the root CA, in that exact order - a plain certificate count
+        # would not catch a re-ordered chain.
+        expected_chain = '\n'.join(
+            encode_certificate(load_certificate(cert.replace('\n', '')))
+            for cert in (
+                chain_cert_data,
+                chain_intermediate_ca_data,
+                chain_root_ca_data,
+            )
+        ).strip()
+        cert_file = f'/run/nginx/certs/{cert_name}_cert.pem'
+        self.assertEqual(read_file(cert_file).count(CERT_BEGIN), 3)
+        self.assertEqual(read_file(cert_file), expected_chain)
+
+        # Explicitly configuring the issuing CA via "ca-certificate" must stay
+        # backwards compatible and must not duplicate or re-order certificates.
+        self.cli_set(
+            base_path + ['certificates', 'ca-certificate', intermediate_ca_name]
+        )
+        self.cli_commit()
+        self.assertEqual(read_file(cert_file), expected_chain)
 
     def test_api_missing_keys(self):
         self.cli_set(base_path + ['api'])

--- a/src/conf_mode/service_https.py
+++ b/src/conf_mode/service_https.py
@@ -30,7 +30,9 @@ from vyos.configverify import verify_pki_ca_certificate
 from vyos.configverify import verify_pki_dh_parameters
 from vyos.configdiff import get_config_diff
 from vyos.defaults import api_config_state
-from vyos.pki import wrap_certificate
+from vyos.pki import encode_certificate
+from vyos.pki import find_chain
+from vyos.pki import load_certificate
 from vyos.pki import wrap_private_key
 from vyos.pki import wrap_dh_parameters
 from vyos.template import render
@@ -176,12 +178,19 @@ def generate(https):
         cert_path = os.path.join(cert_dir, f'{cert_name}_cert.pem')
         key_path = os.path.join(cert_dir, f'{cert_name}_key.pem')
 
-        server_cert = str(wrap_certificate(pki_cert['certificate']))
+        # Build the full certificate chain (server certificate followed by any
+        # intermediate CA certificates up to the root) from the CA certificates
+        # available in the PKI. Serving the complete chain lets clients that do
+        # not yet trust the issuing intermediate CA validate the presented
+        # certificate. This mirrors the other PKI consumers (HAProxy, stunnel).
+        loaded_ca_certs = {
+            load_certificate(cert_data['certificate'])
+            for cert_data in dict_search('pki.ca', https, default={}).values()
+        }
 
-        # Append CA certificate if specified to form a full chain
-        if 'ca_certificate' in https['certificates']:
-            ca_cert = https['certificates']['ca_certificate']
-            server_cert += '\n' + str(wrap_certificate(https['pki']['ca'][ca_cert]['certificate']))
+        loaded_pki_cert = load_certificate(pki_cert['certificate'])
+        cert_full_chain = find_chain(loaded_pki_cert, loaded_ca_certs)
+        server_cert = '\n'.join(encode_certificate(c) for c in cert_full_chain)
 
         write_file(cert_path, server_cert, user=user, group=group, mode=0o644)
         write_file(key_path, wrap_private_key(pki_cert['private']['key']),


### PR DESCRIPTION
## Change summary

`set service https` previously wrote only the leaf certificate to the file
served by nginx. An intermediate CA was added to the served chain only when an
operator explicitly configured `certificates ca-certificate`, and even then
only that single CA was appended — the rest of the issuer chain was never
followed.

Clients that do not already trust the issuing intermediate CA therefore could
not build a path to a trusted root and rejected the connection. This is
increasingly common with Let's Encrypt's newer intermediates (the E-/R-series,
chaining to ISRG Root X1/X2), which are frequently absent from client trust
stores.

This change builds the complete certificate chain (leaf + every available
intermediate CA up to the root) from the CA certificates present in the PKI,
using `vyos.pki.find_chain()` — the same helper already used by HAProxy,
OpenConnect, stunnel, SSTP and the IKEv2 profile generator. `service https`
was the only PKI/TLS consumer not building the full chain. The chain is now
discovered automatically, so `ca-certificate` no longer needs to be configured
by hand; it remains accepted for backwards compatibility.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T9022

## Related PR(s)

_None_

## How to test / Smoketest result

Import a leaf certificate, its issuing intermediate CA and the root into the
PKI, then assign **only the leaf** to the HTTPS service:

```
set pki ca ROOT certificate <root-cert>
set pki ca INTERMEDIATE certificate <intermediate-cert>
set pki certificate LEAF certificate <leaf-cert>
set pki certificate LEAF private key <leaf-key>
set service https certificates certificate LEAF
commit
```

Before this change, `openssl s_client -connect 127.0.0.1:443 -showcerts` presents
only the leaf certificate. After it, the full chain (leaf + intermediate + root)
is presented, so clients that lack the intermediate can validate the server.

A smoketest (`test_certificate_chain`) is added to
`smoketest/scripts/cli/test_service_https.py`. It imports a root → intermediate
→ leaf chain, references only the leaf, and asserts the generated
`/run/nginx/certs/<name>_cert.pem` contains all three certificates. It also
verifies that explicitly setting `ca-certificate` stays backwards compatible
and does not duplicate any certificate in the chain. The smoketest executes in
the `vyos-build` QEMU smoketest harness.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
