### PR TITLE
bgp: T8865: Reject `vni` sub-block in VRF l2vpn-evpn when `advertise-all-vni` is globally active

### DIFF
--- a/interface-definitions/include/version/bgp-version.xml.i
+++ b/interface-definitions/include/version/bgp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/bgp-version.xml.i -->
-<syntaxVersion component='bgp' version='7'></syntaxVersion>
+<syntaxVersion component='bgp' version='8'></syntaxVersion>
 <!-- include end -->

--- a/smoketest/configs/bgp-evpn-l3vpn-pe-router
+++ b/smoketest/configs/bgp-evpn-l3vpn-pe-router
@@ -227,6 +227,8 @@ vrf {
                             }
                         }
                         advertise-all-vni
+                        vni 2000 {
+                        }
                     }
                 }
                 local-as 100
@@ -253,6 +255,8 @@ vrf {
                             }
                         }
                         advertise-all-vni
+                        vni 4000 {
+                        }
                     }
                 }
                 local-as 100

--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -1092,6 +1092,73 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(vrf_path + ['protocols', 'bgp', 'address-family'])
         self.cli_commit()
 
+    def test_bgp_08_l2vpn_evpn_advertise_all_vni_conflicts_with_vrf_vni(self):
+        # T8865: Configuring a "vni" sub-block under VRF BGP l2vpn-evpn while
+        # "advertise-all-vni" is active in the default BGP instance causes FRR
+        # to return "% Failed to create VNI" and perform an early exit from config
+        # processing.
+
+        vrf1, vrf2, vrf3 = 'alfa', 'beta', 'gamma'
+        vni1, vni2, vni3 = '5050', '5051', '5052'
+        vrf1_path = ['vrf', 'name', vrf1]
+        vrf2_path = ['vrf', 'name', vrf2]
+        vrf3_path = ['vrf', 'name', vrf3]
+
+        # Set up VRFs with L3VNIs
+        self.cli_set(vrf1_path + ['vni', vni1])
+        self.cli_set(vrf1_path + ['table', '1001'])
+        self.cli_set(vrf2_path + ['vni', vni2])
+        self.cli_set(vrf2_path + ['table', '1002'])
+        self.cli_set(vrf3_path + ['vni', vni3])
+        self.cli_set(vrf3_path + ['table', '1003'])
+
+        # Configure default BGP with advertise-all-vni
+        self.cli_set(base_path + ['system-as', ASN])
+        self.cli_set(base_path + ['address-family', 'l2vpn-evpn', 'advertise-all-vni'])
+
+        # Configure VRF BGP instances
+        for vrf_path in (vrf1_path, vrf2_path, vrf3_path):
+            self.cli_set(vrf_path + ['protocols', 'bgp', 'system-as', ASN])
+            unicast_path = ['l2vpn-evpn', 'advertise', 'ipv4', 'unicast']
+            self.cli_set(
+                vrf_path + ['protocols', 'bgp', 'address-family'] + unicast_path
+            )
+
+        # Adding "vni" sub-block under any VRF l2vpn-evpn while advertise-all-vni
+        # is active globally must be rejected
+        vrf1_af_path = vrf1_path + ['protocols', 'bgp', 'address-family']
+        vrf1_vni_path = vrf1_af_path + ['l2vpn-evpn', 'vni']
+        self.cli_set(vrf1_vni_path + [vni1])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        # Remove the conflicting vni sub-block - commit must now succeed
+        self.cli_delete(vrf1_vni_path)
+        self.cli_commit()
+
+        # Verify default BGP has advertise-all-vni
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', stop_section='^exit')
+        self.assertIn(f'router bgp {ASN}', frrconfig)
+        self.assertIn(' advertise-all-vni', frrconfig)
+
+        # Verify all three VRF BGP instances are present in FRR config - this is
+        # the key regression check: FRR must not early-exit and silently drop
+        # l2vpn-evpn config for vrf2 and vrf3
+        for vrf_name, vni_name in ((vrf1, vni1), (vrf2, vni2), (vrf3, vni3)):
+            with self.subTest(vrf_name=vrf_name):
+                frr_vrf_config = self.getFRRconfig(
+                    f'router bgp {ASN} vrf {vrf_name}', stop_section='^exit'
+                )
+                self.assertIn(f'router bgp {ASN} vrf {vrf_name}', frr_vrf_config)
+                self.assertIn(' address-family l2vpn evpn', frr_vrf_config)
+                # "vni" sub-block must NOT appear under any VRF BGP instance
+                self.assertNotIn(f' vni {vni_name}', frr_vrf_config)
+
+        # Cleanup
+        for path in (base_path, vrf1_path, vrf2_path, vrf3_path):
+            self.cli_delete(path)
+        self.cli_commit()
+
     def test_bgp_09_distance_and_flowspec(self):
         distance_external = '25'
         distance_internal = '30'

--- a/src/conf_mode/protocols_bgp.py
+++ b/src/conf_mode/protocols_bgp.py
@@ -647,6 +647,29 @@ def verify(config_dict):
                         if 'route_target' in vni_config and 'advertise_all_vni' not in afi_config:
                             raise ConfigError('BGP EVPN "route-target" requires "advertise-all-vni" to be set!')
 
+                # T8865: Detect conflict between VRF-level "vni" sub-block and global
+                # "advertise-all-vni". When advertise-all-vni is active in the default
+                # BGP instance, FRR already owns all VNIs discovered from the kernel.
+                # Attempting to create the same VNI again via a VRF BGP "vni" sub-block
+                # causes FRR to return "% Failed to create VNI" and perform an early exit
+                # from config processing.
+                if vrf and 'vni' in afi_config:
+                    default_bgp_evpn = dict_search(
+                        'dependent_vrfs.default.protocols.bgp.address_family.l2vpn_evpn',
+                        bgp,
+                    )
+                    if (
+                        default_bgp_evpn is not None
+                        and 'deleted' not in default_bgp_evpn
+                    ):
+                        if 'advertise_all_vni' in default_bgp_evpn:
+                            raise ConfigError(
+                                'BGP EVPN "vni" sub-configuration conflicts with '
+                                '"advertise-all-vni" in the default BGP instance. '
+                                'Remove "vni" from the VRF l2vpn-evpn configuration '
+                                'or disable "advertise-all-vni" for the default BGP.'
+                            )
+
     return None
 
 def generate(config_dict):

--- a/src/migration-scripts/bgp/7-to-8
+++ b/src/migration-scripts/bgp/7-to-8
@@ -1,0 +1,45 @@
+# Copyright (C) VyOS Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# T8865: When "address-family l2vpn-evpn advertise-all-vni" is
+# configured remove the conflicting "vni" sub-node from each affected VRF
+# because FRR returns "Failed to create VNI".
+
+from vyos.configtree import ConfigTree
+
+vrf_base = ['vrf', 'name']
+bgp_base = ['protocols', 'bgp']
+bgp_l2vpn_evpn = bgp_base + ['address-family', 'l2vpn-evpn']
+
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(vrf_base):
+        return  # Nothing to do
+
+    # Only act when advertise-all-vni is set in the default BGP instance
+    if not config.exists(bgp_l2vpn_evpn + ['advertise-all-vni']):
+        return
+
+    for vrf in config.list_nodes(vrf_base):
+        vni_path = vrf_base + [
+            vrf,
+            'protocols',
+            'bgp',
+            'address-family',
+            'l2vpn-evpn',
+            'vni',
+        ]
+        if config.exists(vni_path):
+            config.delete(vni_path)


### PR DESCRIPTION
## Change summary
When `advertise-all-vni` is configured in the global/default BGP instance, VyOS generated a `vni <id>` sub-block under each VRF BGP `address-family l2vpn evpn` context. This conflicts with advertise-all-vni: FRR already owns all kernel VNIs and returns `% Failed to create VNI` when frr-reload.py attempts to apply the VRF-level vni sub-block. FRR then performs an early exit from config processing, silently dropping the entire l2vpn evpn address-family for all subsequent VRF BGP instances.

Example of right FRR configuration that implements the EVPN environment [here](https://docs.frrouting.org/en/latest/evpn.html#sample-configuration).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8865

## How to test / Smoketest result
### Manual test

1. Configure EVPN BGP and several VRF:
```
conf
set interfaces bridge br5042 description 'Dummy Bridge for L3VNI 5042'
set interfaces bridge br5042 member interface vxlan5042
set interfaces bridge br5042 vrf 'customer'
set interfaces bridge br5067 description 'Dummy Bridge for L3VNI 5067'
set interfaces bridge br5067 member interface vxlan5067
set interfaces bridge br5067 vrf 'other'
set interfaces bridge br5099 description 'Dummy Bridge for L3VNI 5099'
set interfaces bridge br5099 member interface vxlan5099
set interfaces bridge br5099 vrf 'third'
set interfaces dummy dum0 address '10.0.0.7/32'
set interfaces ethernet eth1 address '10.1.0.1/30'
set interfaces ethernet eth1 description 'dut -> s2'
set interfaces ethernet eth1 mtu '1600'
set interfaces ethernet eth2 address '172.16.0.7/24'
set interfaces ethernet eth2 description 'dut -> hr1 [stub]'
set interfaces ethernet eth2 mtu '1500'
set interfaces ethernet eth2 vrf 'customer'
set interfaces ethernet eth3 address '172.16.2.7/24'
set interfaces ethernet eth3 description 'dut -> hb1 [stub]'
set interfaces ethernet eth3 mtu '1500'
set interfaces ethernet eth3 vrf 'other'
set interfaces ethernet eth4 address '172.16.4.7/24'
set interfaces ethernet eth4 description 'dut -> hc1 [stub]'
set interfaces ethernet eth4 mtu '1500'
set interfaces ethernet eth4 vrf 'third'
set interfaces vxlan vxlan5042 parameters nolearning
set interfaces vxlan vxlan5042 port '4789'
set interfaces vxlan vxlan5042 source-address '10.0.0.7'
set interfaces vxlan vxlan5042 vni '5042'
set interfaces vxlan vxlan5067 parameters nolearning
set interfaces vxlan vxlan5067 port '4789'
set interfaces vxlan vxlan5067 source-address '10.0.0.7'
set interfaces vxlan vxlan5067 vni '5067'
set interfaces vxlan vxlan5099 parameters nolearning
set interfaces vxlan vxlan5099 port '4789'
set interfaces vxlan vxlan5099 source-address '10.0.0.7'
set interfaces vxlan vxlan5099 vni '5099'

set protocols bgp address-family ipv4-unicast network 10.0.0.7/32
set protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
set protocols bgp address-family l2vpn-evpn advertise-all-vni
set protocols bgp address-family l2vpn-evpn advertise-svi-ip
set protocols bgp neighbor 10.0.0.8 address-family ipv4-unicast nexthop-self
set protocols bgp neighbor 10.0.0.8 address-family ipv4-unicast soft-reconfiguration inbound
set protocols bgp neighbor 10.0.0.8 address-family l2vpn-evpn soft-reconfiguration inbound
set protocols bgp neighbor 10.0.0.8 description 's2'
set protocols bgp neighbor 10.0.0.8 remote-as '65000'
set protocols bgp neighbor 10.0.0.8 update-source 'dum0'
set protocols bgp parameters router-id '10.0.0.7'
set protocols bgp system-as '65000'
set protocols ospf interface dum0 area '0.0.0.0'
set protocols ospf interface dum0 passive
set protocols ospf interface eth1 area '0.0.0.0'
set protocols ospf interface eth1 network 'point-to-point'
set protocols ospf parameters router-id '10.0.0.7'

set vrf name customer protocols bgp address-family ipv4-unicast export vpn
set vrf name customer protocols bgp address-family ipv4-unicast import vpn
set vrf name customer protocols bgp address-family ipv4-unicast label vpn export 'auto'
set vrf name customer protocols bgp address-family ipv4-unicast network 172.16.0.0/24
set vrf name customer protocols bgp address-family ipv4-unicast rd vpn export '65000:1'
set vrf name customer protocols bgp address-family ipv4-unicast redistribute connected
set vrf name customer protocols bgp address-family ipv4-unicast route-target vpn export '65000:1'
set vrf name customer protocols bgp address-family ipv4-unicast route-target vpn import '65000:1'
set vrf name customer protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
set vrf name customer protocols bgp address-family l2vpn-evpn rd '65000:1'
set vrf name customer protocols bgp address-family l2vpn-evpn route-target export '65000:1'
set vrf name customer protocols bgp address-family l2vpn-evpn route-target import '65000:1'
set vrf name customer protocols bgp address-family l2vpn-evpn vni 5042
set vrf name customer protocols bgp parameters router-id '10.0.0.7'
set vrf name customer protocols bgp system-as '65000'
set vrf name customer table '100'
set vrf name customer vni '5042'
set vrf name other protocols bgp address-family ipv4-unicast export vpn
set vrf name other protocols bgp address-family ipv4-unicast import vpn
set vrf name other protocols bgp address-family ipv4-unicast label vpn export 'auto'
set vrf name other protocols bgp address-family ipv4-unicast network 172.16.2.0/24
set vrf name other protocols bgp address-family ipv4-unicast rd vpn export '65000:2'
set vrf name other protocols bgp address-family ipv4-unicast redistribute connected
set vrf name other protocols bgp address-family ipv4-unicast route-target vpn export '65000:2'
set vrf name other protocols bgp address-family ipv4-unicast route-target vpn import '65000:2'
set vrf name other protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
set vrf name other protocols bgp address-family l2vpn-evpn rd '65000:2'
set vrf name other protocols bgp address-family l2vpn-evpn route-target export '65000:2'
set vrf name other protocols bgp address-family l2vpn-evpn route-target import '65000:2'
set vrf name other protocols bgp address-family l2vpn-evpn vni 5067
set vrf name other protocols bgp parameters router-id '10.0.0.7'
set vrf name other protocols bgp system-as '65000'
set vrf name other table '101'
set vrf name other vni '5067'
set vrf name third protocols bgp address-family ipv4-unicast export vpn
set vrf name third protocols bgp address-family ipv4-unicast import vpn
set vrf name third protocols bgp address-family ipv4-unicast label vpn export 'auto'
set vrf name third protocols bgp address-family ipv4-unicast network 172.16.4.0/24
set vrf name third protocols bgp address-family ipv4-unicast rd vpn export '65000:3'
set vrf name third protocols bgp address-family ipv4-unicast redistribute connected
set vrf name third protocols bgp address-family ipv4-unicast route-target vpn export '65000:3'
set vrf name third protocols bgp address-family ipv4-unicast route-target vpn import '65000:3'
set vrf name third protocols bgp address-family l2vpn-evpn advertise ipv4 unicast
set vrf name third protocols bgp address-family l2vpn-evpn rd '65000:3'
set vrf name third protocols bgp address-family l2vpn-evpn route-target export '65000:3'
set vrf name third protocols bgp address-family l2vpn-evpn route-target import '65000:3'
set vrf name third protocols bgp address-family l2vpn-evpn vni 5099
set vrf name third protocols bgp parameters router-id '10.0.0.7'
set vrf name third protocols bgp system-as '65000'
set vrf name third table '102'
set vrf name third vni '5099'
commit
```

2. The commit should fail because the validation was false:
```
[ vrf name third protocols bgp ]
BGP EVPN "vni" sub-configuration conflicts with "advertise-all-vni" in
the default BGP instance. Remove "vni" from the VRF l2vpn-evpn
configuration or disable "advertise-all-vni" for the default BGP.
[[vrf name third protocols bgp]] failed
[ vrf name other protocols bgp ]
BGP EVPN "vni" sub-configuration conflicts with "advertise-all-vni" in
the default BGP instance. Remove "vni" from the VRF l2vpn-evpn
configuration or disable "advertise-all-vni" for the default BGP.
[[vrf name other protocols bgp]] failed
[ vrf name customer protocols bgp ]
BGP EVPN "vni" sub-configuration conflicts with "advertise-all-vni" in
the default BGP instance. Remove "vni" from the VRF l2vpn-evpn
configuration or disable "advertise-all-vni" for the default BGP.
[[vrf name customer protocols bgp]] failed
Commit failed
```

3. Fix the configuration by deleting the next options:
```
delete vrf name customer protocols bgp address-family l2vpn-evpn vni 5042
delete vrf name other    protocols bgp address-family l2vpn-evpn vni 5067
delete vrf name third    protocols bgp address-family l2vpn-evpn vni 5099
commit
```

4. As a result the commit should succeed and the re-call of `frr-reload.py` should not contain the message `% Failed to create VNI`:
```
vyos@vyos1# sudo /usr/lib/frr/frr-reload.py --reload --debug --stdout /run/frr/config/vyos.frr.conf
...
[6780|mgmtd] sending configuration
[6782|ripd] sending configuration
[6781|zebra] sending configuration
[6783|ripngd] sending configuration
[6784|ospfd] sending configuration
[6787|bgpd] sending configuration
[6785|ospf6d] sending configuration
[6788|isisd] sending configuration
[6786|ldpd] sending configuration
[6790|nhrpd] sending configuration
[6781|zebra] done
[6782|ripd] done
[6783|ripngd] done
[6786|ldpd] done
[6792|babeld] sending configuration
[6794|fabricd] sending configuration
[6796|staticd] sending configuration
[6797|bfdd] sending configuration
[6799|pathd] sending configuration
[6800|pim6d] sending configuration
Waiting for children to finish applying config...
[6797|bfdd] done
[6801|watchfrr] sending configuration
[6780|mgmtd] done
[6801|watchfrr] done
[6787|bgpd] done
[6788|isisd] done
[6785|ospf6d] done
[6799|pathd] done
[6796|staticd] done
[6790|nhrpd] done
[6794|fabricd] done
[6792|babeld] done
[6784|ospfd] done
[6800|pim6d] done
```

### Smoketest
```
vyos@vyos1:~$ sudo /usr/libexec/vyos/tests/smoke/cli/test_protocols_bgp.py -k test_bgp_08_l2vpn_evpn_advertise_all_vni_conflicts_with_vrf_vni
test_bgp_08_l2vpn_evpn_advertise_all_vni_conflicts_with_vrf_vni (__main__.TestProtocolsBGP.test_bgp_08_l2vpn_evpn_advertise_all_vni_conflicts_with_vrf_vni) ... ok
----------------------------------------------------------------------
Ran 1 test in 18.057s
OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly