### PR TITLE
ci: T8490: fix typos in comments, strings, and local identifiers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ op_mode_definitions: $(op_xml_obj)
 
 	$(CURDIR)/python/vyos/xml_ref/generate_op_cache.py --xml-dir $(BUILD_DIR)/op-mode-definitions --export-json $(DATA_DIR)/op_cache.json || exit 1
 
-	# XXX: tcpdump, ping, traceroute and mtr must be able to recursivly call themselves as the
+	# XXX: tcpdump, ping, traceroute and mtr must be able to recursively call themselves as the
 	# options are provided from the scripts themselves
 	ln -s ../node.tag $(OP_TMPL_DIR)/ping/node.tag/node.tag/
 	ln -s ../node.tag $(OP_TMPL_DIR)/traceroute/node.tag/node.tag/

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ time, so a package with malformed interface definitions will not build.
 The guidelines in a nutshell:
 
 * Use separate functions for retrieving configuration data, validating it, and
-  generating taret config, see our
+  generating target config, see our
   [documentation](https://docs.vyos.io/en/latest/contributing/development.html#python)
   for the common structure
 * Use the `get_config_dict()` API as much as possible when retrieving values from the CLI

--- a/data/templates/login/tacplus_nss.conf.j2
+++ b/data/templates/login/tacplus_nss.conf.j2
@@ -57,7 +57,7 @@ vrf={{ tacacs.vrf }}
 {% if tacacs.source_address is vyos_defined %}
 # Sets the IPv4 address used as the source IP address when communicating with
 # the TACACS+ server. IPv6 addresses are not supported, nor are hostnames.
-# The address must work when passsed to the bind() system call, that is, it must
+# The address must work when passed to the bind() system call, that is, it must
 # be valid for the interface being used.
 source_ip={{ tacacs.source_address }}
 {% endif %}

--- a/python/vyos/ifconfig/control.py
+++ b/python/vyos/ifconfig/control.py
@@ -175,13 +175,13 @@ class Control(Section):
         if convert:
             value = convert(value)
 
-        commited = self._write_sysfs(
+        committed = self._write_sysfs(
             self._sysfs_set[name]['location'].format(**config), value)
-        if not commited:
+        if not committed:
             errmsg = self._sysfs_set.get('errormsg', '')
             if errmsg:
                 raise TypeError(errmsg.format(**config))
-        return commited
+        return committed
 
     def get_interface(self, name):
         if name in self._sysfs_get:

--- a/python/vyos/ifconfig/operational.py
+++ b/python/vyos/ifconfig/operational.py
@@ -162,7 +162,7 @@ class Operational(Control):
             stats[counter] = int(self.get_interface(counter))
         return stats
 
-    def formated_stats(self, indent=4):
+    def formatted_stats(self, indent=4):
         tabs = []
         stats = self.get_stats()
         for rtx in self._stats_dir:

--- a/python/vyos/logger.py
+++ b/python/vyos/logger.py
@@ -69,32 +69,32 @@ def getLogger(name=None, **kwargs):
 
 
 def _syslog(**kwargs):
-	formating = kwargs.get('format', SHORT)
+	formatting = kwargs.get('format', SHORT)
 	handler = handlers.SysLogHandler(
 		address=kwargs.get('address', '/dev/log'),
 		facility=kwargs.get('facility', 'syslog'),
 	)
-	handler.setFormatter(logging.Formatter(formating))
+	handler.setFormatter(logging.Formatter(formatting))
 	return handler
 
 
 def _stream(**kwargs):
-	formating = kwargs.get('format', CLEAR)
+	formatting = kwargs.get('format', CLEAR)
 	handler = logging.StreamHandler(
 		stream=kwargs.get('stream', sys.stderr),
 	)
-	handler.setFormatter(logging.Formatter(formating))
+	handler.setFormatter(logging.Formatter(formatting))
 	return handler
 
 
 def _file(**kwargs):
-	formating = kwargs.get('format', CLEAR)
+	formatting = kwargs.get('format', CLEAR)
 	handler = handlers.RotatingFileHandler(
 		filename=kwargs.get('filename', 1048576),
 		maxBytes=kwargs.get('maxBytes', 1048576),
 		backupCount=kwargs.get('backupCount', 3),
 	)
-	handler.setFormatter(logging.Formatter(formating))
+	handler.setFormatter(logging.Formatter(formatting))
 	return handler
 
 
@@ -120,11 +120,11 @@ syslog = getLogger(
 # testing
 if __name__ == '__main__':
 	# from vyos.logger import getLogger
-	formating = '%(asctime)s (%(filename)s) %(levelname)s: %(message)s'
+	formatting = '%(asctime)s (%(filename)s) %(levelname)s: %(message)s'
 
 	# syslog logger
 	# syslog=True if no 'address' field is provided
-	syslog = getLogger(__name__ + '.1', syslog=True, format=formating)
+	syslog = getLogger(__name__ + '.1', syslog=True, format=formatting)
 	syslog.info('syslog test')
 
 	# steam logger

--- a/python/vyos/range_regex.py
+++ b/python/vyos/range_regex.py
@@ -34,9 +34,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 # 300-339: 3[0-3]\d
 # 340-345: 34[0-5]
 
-def range_to_regex(inpt_range):
-    if isinstance(inpt_range, str):
-        range_list = inpt_range.split('-')
+def range_to_regex(input_range):
+    if isinstance(input_range, str):
+        range_list = input_range.split('-')
         # Check input arguments
         if len(range_list) == 2:
             # The first element in range must be higher then the second

--- a/python/vyos/utils/vti_updown_db.py
+++ b/python/vyos/utils/vti_updown_db.py
@@ -156,15 +156,15 @@ class VTIUpDownDB:
 
     def setPersistentInterfaces(self, interface_list):
         """ Updates the set of persistently up interfaces to match the given list """
-        new_presistent_interfaces = set(interface_list)
-        current_presistent_interfaces = set([ifspec for ifspec in self._ifspecs if ':' not in ifspec])
-        added_presistent_interfaces = new_presistent_interfaces - current_presistent_interfaces
-        removed_presistent_interfaces = current_presistent_interfaces - new_presistent_interfaces
+        new_persistent_interfaces = set(interface_list)
+        current_persistent_interfaces = set([ifspec for ifspec in self._ifspecs if ':' not in ifspec])
+        added_persistent_interfaces = new_persistent_interfaces - current_persistent_interfaces
+        removed_persistent_interfaces = current_persistent_interfaces - new_persistent_interfaces
 
-        for interface in added_presistent_interfaces:
+        for interface in added_persistent_interfaces:
             self.add(interface)
 
-        for interface in removed_presistent_interfaces:
+        for interface in removed_persistent_interfaces:
             self.remove(interface)
 
     def commit(self, interface_dict_supplier):

--- a/scripts/build-command-op-templates
+++ b/scripts/build-command-op-templates
@@ -72,7 +72,7 @@ except Exception as e:
     sys.exit(1)
 
 if not os.access(output_dir, os.W_OK):
-    print(f"The output directory {output_dir} is not writeable")
+    print(f"The output directory {output_dir} is not writable")
     sys.exit(1)
 
 ## If we got this far, everything must be ok and we can convert the file

--- a/scripts/build-command-templates
+++ b/scripts/build-command-templates
@@ -76,7 +76,7 @@ except Exception as e:
     sys.exit(1)
 
 if not os.access(output_dir, os.W_OK):
-    print("The output directory {0} is not writeable".format(output_dir))
+    print("The output directory {0} is not writable".format(output_dir))
     sys.exit(1)
 
 ## If we got this far, everything must be ok and we can convert the file

--- a/src/conf_mode/system_host-name.py
+++ b/src/conf_mode/system_host-name.py
@@ -39,7 +39,7 @@ default_config_data = {
     'domain_search': [],
     'nameserver': [],
     'nameservers_dhcp_interfaces': {},
-    'snmpd_restart_reqired': False,
+    'snmpd_restart_required': False,
     'static_host_mapping': {}
 }
 
@@ -57,7 +57,7 @@ def get_config(config=None):
 
     base = ['system']
     if leaf_node_changed(conf, base + ['host-name']) or leaf_node_changed(conf, base + ['domain-name']):
-        hosts['snmpd_restart_reqired'] = True
+        hosts['snmpd_restart_required'] = True
 
     # This may happen if the config is not loaded yet,
     # e.g. if run by cloud-init
@@ -179,7 +179,7 @@ def apply(config):
         call(f'systemctl restart {tmp}')
 
     # If SNMP is running, restart it too
-    if process_named_running('snmpd') and config['snmpd_restart_reqired']:
+    if process_named_running('snmpd') and config['snmpd_restart_required']:
         tmp = systemd_services['snmpd']
         call(f'systemctl restart {tmp}')
 

--- a/src/helpers/run-config-migration.py
+++ b/src/helpers/run-config-migration.py
@@ -47,13 +47,13 @@ if not os.access(config_file, os.R_OK):
 
 if out_file is None:
     if not os.access(config_file, os.W_OK):
-        print(f"Config file '{config_file}' not writeable")
+        print(f"Config file '{config_file}' not writable")
         sys.exit(1)
 else:
     try:
         open(out_file, 'w').close()
     except OSError:
-        print(f"Output file '{out_file}' not writeable")
+        print(f"Output file '{out_file}' not writable")
         sys.exit(1)
 
 config_migrate = ConfigMigrate(config_file, force=force, output_file=out_file)

--- a/src/migration-scripts/l2tp/2-to-3
+++ b/src/migration-scripts/l2tp/2-to-3
@@ -69,7 +69,7 @@ def migrate(config: ConfigTree) -> None:
         prefix_old = config.return_values(ipv6_base + ['prefix'])
         # delete old prefix CLI nodes
         config.delete(ipv6_base + ['prefix'])
-        # create ned prefix tag node
+        # create new prefix tag node
         config.set(ipv6_base + ['prefix'])
         config.set_tag(ipv6_base + ['prefix'])
 
@@ -82,7 +82,7 @@ def migrate(config: ConfigTree) -> None:
         prefix_old = config.return_values(ipv6_base + ['delegate-prefix'])
         # delete old delegate prefix CLI nodes
         config.delete(ipv6_base + ['delegate-prefix'])
-        # create ned delegation tag node
+        # create new delegation tag node
         config.set(ipv6_base + ['delegate'])
         config.set_tag(ipv6_base + ['delegate'])
 

--- a/src/migration-scripts/pppoe-server/3-to-4
+++ b/src/migration-scripts/pppoe-server/3-to-4
@@ -98,7 +98,7 @@ def migrate(config: ConfigTree) -> None:
         prefix_old = config.return_values(ipv6_base + ['prefix'])
         # delete old prefix CLI nodes
         config.delete(ipv6_base + ['prefix'])
-        # create ned prefix tag node
+        # create new prefix tag node
         config.set(ipv6_base + ['prefix'])
         config.set_tag(ipv6_base + ['prefix'])
 
@@ -111,7 +111,7 @@ def migrate(config: ConfigTree) -> None:
         prefix_old = config.return_values(ipv6_base + ['delegate-prefix'])
         # delete old delegate prefix CLI nodes
         config.delete(ipv6_base + ['delegate-prefix'])
-        # create ned delegation tag node
+        # create new delegation tag node
         config.set(ipv6_base + ['delegate'])
         config.set_tag(ipv6_base + ['delegate'])
 

--- a/src/migration-scripts/system/13-to-14
+++ b/src/migration-scripts/system/13-to-14
@@ -38,10 +38,10 @@ def migrate(config: ConfigTree) -> None:
 
     # retrieve all valid timezones
     try:
-        tz_datas = cmd('timedatectl list-timezones')
+        tz_data_raw = cmd('timedatectl list-timezones')
     except OSError:
-        tz_datas = ''
-    tz_data = tz_datas.split('\n')
+        tz_data_raw = ''
+    tz_data = tz_data_raw.split('\n')
 
     if re.match(r'[Ll][Oo][Ss].+', tz):
         tz = 'America/Los_Angeles'

--- a/src/ocaml/vyos_op_run.ml
+++ b/src/ocaml/vyos_op_run.ml
@@ -286,7 +286,7 @@ let is_admin_only_command cmd =
   match res with
   | None -> false
   | Some _ ->
-    let () = Logs.debug @@ fun m -> m "Commandis reserved for admins" in
+    let () = Logs.debug @@ fun m -> m "Command is reserved for admins" in
     true
 
 let check_command_permissions perms cmd =

--- a/src/op_mode/generate_tech-support_archive.py
+++ b/src/op_mode/generate_tech-support_archive.py
@@ -99,7 +99,7 @@ def __generate_archived_files(location_path: str) -> None:
 
         return tarinfo
 
-    # Dictionary arhive_name:directory_to_arhive
+    # Dictionary archive_name:directory_to_archive
     archive_dict = {
         'etc': '/etc',
         'home': '/home',

--- a/src/op_mode/interfaces.py
+++ b/src/op_mode/interfaces.py
@@ -96,7 +96,7 @@ def _split_text(text, used=0):
     take a string and attempt to split it to fit with the width of the screen
 
     text: the string to split
-    used: number of characted already used in the screen
+    used: number of character already used in the screen
     """
     no_tty = call('tty -s')
 

--- a/src/op_mode/ipsec.py
+++ b/src/op_mode/ipsec.py
@@ -412,7 +412,7 @@ def _get_raw_connections_summary(list_conn, list_sas):
     return tun_dict
 
 
-def _get_formatted_output_conections(data):
+def _get_formatted_output_connections(data):
     from tabulate import tabulate
 
     connections = []
@@ -813,7 +813,7 @@ def show_connections(raw: bool):
         return _get_raw_data_connections(list_conns, list_sas)
 
     connections = _get_raw_data_connections(list_conns, list_sas)
-    return _get_formatted_output_conections(connections)
+    return _get_formatted_output_connections(connections)
 
 
 def show_connections_summary(raw: bool):

--- a/src/op_mode/ping.py
+++ b/src/op_mode/ping.py
@@ -179,7 +179,7 @@ def completion_failure(option: str) -> None:
     sys.exit(1)
 
 
-def expension_failure(option, completions):
+def expansion_failure(option, completions):
     reason = 'Ambiguous' if completions else 'Invalid'
     sys.stderr.write(
         '\n\n  {} command: {} [{}]\n\n'.format(reason, ' '.join(sys.argv),
@@ -201,7 +201,7 @@ def convert(command, args):
         shortname = args.first()
         longnames = complete(shortname)
         if len(longnames) != 1:
-            expension_failure(shortname, longnames)
+            expansion_failure(shortname, longnames)
         longname = longnames[0]
         if options[longname]['type'] == 'noarg':
             command = options[longname]['ping'].format(

--- a/src/op_mode/traceroute.py
+++ b/src/op_mode/traceroute.py
@@ -135,7 +135,7 @@ def completion_failure(option: str) -> None:
     sys.exit(1)
 
 
-def expension_failure(option, completions):
+def expansion_failure(option, completions):
     reason = 'Ambiguous' if completions else 'Invalid'
     sys.stderr.write(
         '\n\n  {} command: {} [{}]\n\n'.format(reason, ' '.join(sys.argv),
@@ -157,7 +157,7 @@ def convert(command, args):
         shortname = args.first()
         longnames = complete(shortname)
         if len(longnames) != 1:
-            expension_failure(shortname, longnames)
+            expansion_failure(shortname, longnames)
         longname = longnames[0]
         if options[longname]['type'] == 'noarg':
             command = options[longname]['traceroute'].format(

--- a/src/opt/vyatta/sbin/if-mib-alias
+++ b/src/opt/vyatta/sbin/if-mib-alias
@@ -107,7 +107,7 @@ sub set_oid {
     my $ifname = ifindextoname($ifindex);
     if ($ifname) {
 	system("ip li set $ifname alias '$value' >/dev/null 2>&1");
-	print "not-writeable\n"	if ($? != 0);
+	print "not-writable\n"	if ($? != 0);
     }
 }
 

--- a/src/services/api/graphql/graphql/mutations.py
+++ b/src/services/api/graphql/graphql/mutations.py
@@ -80,7 +80,7 @@ def make_mutation_resolver(mutation_name, class_name, session_func):
                         return {'success': False, 'errors': [error]}
                     return {'success': False, 'errors': ['not authenticated']}
             else:
-                # AtrributeError will have already been raised if no
+                # AttributeError will have already been raised if no
                 # auth_type; validation and defaultValue ensure it is
                 # one of the previous cases, so this is never reached.
                 pass

--- a/src/services/api/graphql/graphql/queries.py
+++ b/src/services/api/graphql/graphql/queries.py
@@ -80,7 +80,7 @@ def make_query_resolver(query_name, class_name, session_func):
                         return {'success': False, 'errors': [error]}
                     return {'success': False, 'errors': ['not authenticated']}
             else:
-                # AtrributeError will have already been raised if no
+                # AttributeError will have already been raised if no
                 # auth_type; validation and defaultValue ensure it is
                 # one of the previous cases, so this is never reached.
                 pass


### PR DESCRIPTION
## What
Clears `vyos-1x`'s typos-check hits ahead of the T8490 ruleset pilot active flip. 24 files; all single-word/identifier corrections (50 ins / 50 del, no logic/behaviour changes):

- **Comments / docs:** `recursivly`, `taret`, `passsed`, `characted`, `arhive`, `AtrributeError`; migration comments `ned`→**new**.
- **Messages / strings:** `writeable`→`writable` (×5); OCaml log `"Commandis"`→`"Command is"`.
- **Local variables** (all refs in-function): `commited`, `formating`, `presistent`; `inpt_range`→`input_range`; `tz_datas`→`tz_data_raw` (avoids the existing `tz_data` collision).
- **Self-contained identifier renames** (definition + all references in the same file): `formated_stats`; `_get_formatted_output_conections`→`…_connections`; `expension_failure`→`expansion_failure` (ping + traceroute); dict key `snmpd_restart_reqired`→`…_required`.

## Not changed — allowlisted centrally instead ([vyos/.github#153](https://github.com/vyos/.github/pull/153))
Genuine external tokens, NOT typos: `mke` (`mke2fs`), `Mak` (Maya Haab' month), `Dentifier` (RFC 4122 "IDentifier" in hostapd), and **`Forwrd`** — the literal column header from upstream VPP's `vppctl show bridge-domain detail` output. `op_mode/vpp.py` mirrors VPP's header and the VPP smoketest asserts the raw `vppctl` text, so `U-Forwrd` is **left untouched** (per reviewer feedback). The hostapd wifi/radio jargon was already allowlisted, so the gate doesn't flag it.

## Verification
`typos` clean (0 hits with central config + #153 allowlist); `python3 -m py_compile` passes on every edited `.py`; `git grep` confirms zero remaining old-identifier references. Phase-0 CodeRabbit: no findings.

Tracking: Phorge T8490 · Jira [IS-555](https://vyos.atlassian.net/browse/IS-555) (typos-ruleset pilot, Phase 2 Task 2.4).

🤖 Generated by [robots](https://vyos.io)


[IS-555]: https://vyos.atlassian.net/browse/IS-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ