### PR TITLE
op-mode: T9009: add "show log priority <level>" command

### DIFF
--- a/op-mode-definitions/monitor-log.xml.in
+++ b/op-mode-definitions/monitor-log.xml.in
@@ -111,15 +111,6 @@
               </node>
             </children>
           </node>
-          <tagNode name="level">
-            <properties>
-              <help>Monitor log and filter messages by minimum priority level (includes all higher severities)</help>
-              <completionHelp>
-                <list>emerg alert crit err warning notice info debug</list>
-              </completionHelp>
-            </properties>
-            <command>SYSTEMD_COLORS=false journalctl --no-hostname --follow --boot -p $4</command>
-          </tagNode>
           <tagNode name="facility">
             <properties>
               <help>Monitor last lines of messages file and filter by specified facility</help>
@@ -217,6 +208,15 @@
             </properties>
             <command>journalctl --no-hostname --boot --follow --unit accel-ppp@pppoe.service</command>
           </leafNode>
+          <tagNode name="priority">
+            <properties>
+              <help>Monitor last lines of messages file and filter by minimum priority level (includes all higher severities)</help>
+              <completionHelp>
+                <list>emerg alert crit err warning notice info debug</list>
+              </completionHelp>
+            </properties>
+            <command>SYSTEMD_COLORS=false journalctl --no-hostname --follow --boot --priority=$4</command>
+          </tagNode>
           <node name="protocol">
             <properties>
               <help>Monitor routing protocol logs</help>

--- a/op-mode-definitions/show-log.xml.in
+++ b/op-mode-definitions/show-log.xml.in
@@ -7,7 +7,7 @@
     <children>
      <node name="log">
         <properties>
-          <help>Show contents of current master logging buffer</help>
+          <help>Show contents of logging buffer</help>
         </properties>
         <command>journalctl --no-hostname --boot</command>
         <children>
@@ -771,6 +771,15 @@
             </properties>
             <command>journalctl --no-hostname --boot --unit accel-ppp@pppoe.service</command>
           </leafNode>
+          <tagNode name="priority">
+            <properties>
+              <help>Show contents of logging buffer and filter messages by minimum priority level (includes all higher severities)</help>
+              <completionHelp>
+                <list>emerg alert crit err warning notice info debug</list>
+              </completionHelp>
+            </properties>
+            <command>SYSTEMD_COLORS=false journalctl --no-hostname --boot --priority=$4</command>
+          </tagNode>
           <node name="protocol">
             <properties>
               <help>Show log for Routing Protocol</help>


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9009

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/5288

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
