### PR TITLE
T9031: Fix updating pppoe server protocols

### DIFF
--- a/src/conf_mode/service_pppoe-server.py
+++ b/src/conf_mode/service_pppoe-server.py
@@ -126,6 +126,7 @@ def get_config(config=None):
         is_node_changed(conf, base + ['interface']),
         is_node_changed(conf, base + ['authentication', 'radius']),
         is_node_changed(conf, base + ['authentication', 'mode']),
+        is_node_changed(conf, base + ['authentication', 'protocols']),
         any(
             base_ifname(iface) in all_changed_vpp_ifaces
             for iface in pppoe.get('interface', {})


### PR DESCRIPTION
## Change summary

Authentication protocols are implemented as modules in accel-ppp-ng.
The CLI setting configures which modules need to be loaded, for this change to take effect pppoe server must be restarted.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T9031

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

Server config:

```
set service pppoe-server interface eth1
set service pppoe-server gateway-address '192.0.2.1'
set service pppoe-server client-ip-pool RV-POOL range '192.0.2.100-192.0.2.110'
set service pppoe-server default-pool 'RV-POOL'
set service pppoe-server authentication mode 'local'
set service pppoe-server authentication local-users username test password 'test'
set service pppoe-server authentication protocols 'mschap-v2'
commit
```

Client config:

```
set interfaces pppoe pppoe0 source-interface 'eth1'
set interfaces pppoe pppoe0 no-default-route
set interfaces pppoe pppoe0 authentication username 'test'
set interfaces pppoe pppoe0 authentication password 'test'
commit
```

Change protocol on server:

```
set service pppoe-server authentication protocols 'pap'
commit
save
```

Check on client that nothing changed with `journalctl`.

Reboot server - now PAP method is used.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools - no generated code.
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
