### PR TITLE
vyos.utils: T8981: catch_broken_pipe() decorator must return func(*args, **kwargs)

### DIFF
--- a/python/vyos/utils/io.py
+++ b/python/vyos/utils/io.py
@@ -117,7 +117,7 @@ def catch_broken_pipe(func):
     import sys
     def wrapped(*args, **kwargs):
         try:
-            func(*args, **kwargs)
+            return func(*args, **kwargs)
         except (BrokenPipeError, KeyboardInterrupt):
             # Flush output to /dev/null and bail out.
             os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno()) # pylint: disable = no-member


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

`show system commit diff <rev>` produces no output (`exit 0`) for any revision, regardless of how much the revisions differ. The revision store and diff engine are intact - `show system commit file <rev>` works, and so does `ConfigMgmt().compare(rev1=0, rev2=1)` which returns the correct diff when called directly.

Commit a29d73d00 (`op-mode: T8362: "compare" command lacks catch_broken_pipe decorator`) added `@catch_broken_pipe` to `ConfigMgmt.show_commit_diff` to suppress `BrokenPipeError` tracebacks when piping output, but the decorator calls the wrapped function without returning its value. Thus the op-mode framework will receive None and prints nothing.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8981

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-1x/pull/5037

## How to test / Smoketest result
```
vyos@vyos:~$ show system commit diff 3
[system syslog]
- global {
-     facility all {
-         level "info"
-     }
-     facility local7 {
-         level "debug"
-     }
- }
+ local {
+     facility all {
+         level "info"
+     }
+     facility local7 {
+         level "debug"
+     }
+ }
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
