### PR TITLE
qos: T8996: Implement set-dscp packet remarking for shaper policy

### DIFF
--- a/python/vyos/qos/base.py
+++ b/python/vyos/qos/base.py
@@ -241,6 +241,13 @@ class QoSBase:
             for cls, cls_config in config['class'].items():
                 self._build_base_qdisc(cls_config, int(cls))
 
+
+                # Get DSCP value for packet remarking via tc pedit action
+                set_dscp = dict_search('set_dscp', cls_config)
+                dscp_value = None
+                if set_dscp:
+                    dscp_value = str(self._get_dsfield(set_dscp))
+
                 # every match criteria has it's tc instance
                 filter_cmd_base = ['tc', 'filter', 'add', 'dev', self._interface,
                                     'parent', f'{self._parent:x}:']
@@ -263,8 +270,10 @@ class QoSBase:
                                     has_filter = True
                                     break
 
-                        tmp = dict_search(f'ether.protocol', match_config) or 'all'
-                        filter_cmd += ['protocol', str(tmp)]
+                        filter_protocol = (
+                            dict_search(f'ether.protocol', match_config) or 'all'
+                        )
+                        filter_cmd += ['protocol', filter_protocol]
 
                         if self.qostype in ['shaper', 'shaper_hfsc'] and 'prio' not in filter_cmd:
                             filter_cmd += ['prio', str(index)]
@@ -361,9 +370,29 @@ class QoSBase:
                                         elif af == 'ipv6':
                                             filter_cmd += ['match', 'u8', str(mask), str(mask), 'at', '53']
 
+                        # Build pedit action to rewrite DSCP on matched packets.
+                        # retain 0xfc preserves ECN bits (bottom 2 bits of TOS/Traffic Class).
+                        # Non-IP match types skip pedit to avoid corrupting
+                        # non-IP packets, unless ether protocol is ip or ipv6.
+                        dscp_action = []
+                        if dscp_value is not None:
+                            proto = str(filter_protocol).lower()
+                            is_ipv4 = 'ip' in match_config or proto in ('ip', '0x0800', '2048')
+                            is_ipv6 = 'ipv6' in match_config or proto in ('ipv6', '0x86dd', '34525')
+                            if is_ipv4:
+                                dscp_action = ['action', 'pedit', 'ex', 'munge', 'ip',
+                                               'dsfield', 'set', dscp_value, 'retain', '0xfc',
+                                               'pipe', 'action', 'csum', 'ip4h']
+                            elif is_ipv6:
+                                dscp_action = ['action', 'pedit', 'ex', 'munge',
+                                               'ip6', 'traffic_class', 'set', dscp_value, 'retain', '0xfc']
+
                         if index != max_index or not has_action_policy:
                             # avoid duplicate last match rule
                             cls = int(cls)
+                            # add pedit before flowid for filters without police
+                            if dscp_action:
+                                filter_cmd += dscp_action
                             filter_cmd += ['flowid', f'{self._parent:x}:{cls:x}']
                             self._cmdl(filter_cmd)
 
@@ -373,6 +402,9 @@ class QoSBase:
                     if has_action_policy and has_filter:
                         # For "vif" "basic match" is used instead of "action police" T5961
                         if not match_vlan:
+                            # chain pedit before police with pipe
+                            if dscp_action:
+                                filter_cmd += dscp_action + ['pipe']
                             filter_cmd += ['action', 'police']
 
                             if 'exceed' in cls_config:
@@ -393,6 +425,9 @@ class QoSBase:
                             if 'mtu' in cls_config:
                                 mtu = cls_config['mtu']
                                 filter_cmd += ['mtu', str(mtu)]
+                        elif dscp_action:
+                            # vlan match skips police (T5961) but still needs pedit
+                            filter_cmd += dscp_action
 
                         cls = int(cls)
                         filter_cmd += ['flowid', f'{self._parent:x}:{cls:x}']
@@ -429,6 +464,32 @@ class QoSBase:
                 class_id_max = self._get_class_max_id(config)
                 default_cls_id = int(class_id_max) +1
             self._build_base_qdisc(config['default'], default_cls_id)
+
+            # Default class has no match filters, so catch-all filters
+            # are needed to attach the pedit action for DSCP remarking.
+            # Separate filters per protocol to avoid corrupting non-IP packets (e.g. ARP).
+            # IPv4 uses u32 catch-all, IPv6 uses basic classifier (u32 doesn't support protocol ipv6).
+            # prio 255/256 ensures class filters match first.
+            set_dscp = dict_search('set_dscp', config['default'])
+            if set_dscp and self.qostype == 'shaper':
+                dscp_value = str(self._get_dsfield(set_dscp))
+                filter_cmd = ['tc', 'filter', 'replace', 'dev', self._interface,
+                              'parent', f'{self._parent:x}:']
+                filter_cmd += ['prio', '255', 'protocol', 'ip', 'u32',
+                               'match', 'u32', '0', '0']
+                filter_cmd += ['action', 'pedit', 'ex', 'munge',
+                               'ip', 'dsfield', 'set', dscp_value, 'retain', '0xfc',
+                               'pipe', 'action', 'csum', 'ip4h']
+                filter_cmd += ['flowid', f'{self._parent:x}:{default_cls_id:x}']
+                self._cmdl(filter_cmd)
+
+                filter_cmd = ['tc', 'filter', 'replace', 'dev', self._interface,
+                              'parent', f'{self._parent:x}:']
+                filter_cmd += ['prio', '256', 'protocol', 'ipv6', 'basic']
+                filter_cmd += ['action', 'pedit', 'ex', 'munge', 'ip6',
+                               'traffic_class', 'set', dscp_value, 'retain', '0xfc']
+                filter_cmd += ['flowid', f'{self._parent:x}:{default_cls_id:x}']
+                self._cmdl(filter_cmd)
 
         if self.qostype == 'limiter':
             if 'default' in config:

--- a/smoketest/scripts/cli/test_qos.py
+++ b/smoketest/scripts/cli/test_qos.py
@@ -614,15 +614,23 @@ class TestQoS(VyOSUnitTestSHIM.TestCase):
 
         for interface in self._interfaces:
             shaper_name = f'qos-shaper-{interface}'
+            shaper_path = base_path + ['policy', 'shaper', shaper_name]
+            class_path = shaper_path + ['class', '23']
 
             self.cli_set(base_path + ['interface', interface, 'egress', shaper_name])
-            self.cli_set(base_path + ['policy', 'shaper', shaper_name, 'bandwidth', f'{bandwidth}mbit'])
-            self.cli_set(base_path + ['policy', 'shaper', shaper_name, 'default', 'bandwidth', f'{default_bandwidth}mbit'])
-            self.cli_set(base_path + ['policy', 'shaper', shaper_name, 'default', 'ceiling', f'{default_ceil}mbit'])
-            self.cli_set(base_path + ['policy', 'shaper', shaper_name, 'default', 'queue-type', 'fair-queue'])
-            self.cli_set(base_path + ['policy', 'shaper', shaper_name, 'class', '23', 'bandwidth', f'{class_bandwidth}mbit'])
-            self.cli_set(base_path + ['policy', 'shaper', shaper_name, 'class', '23', 'ceiling', f'{class_ceil}mbit'])
-            self.cli_set(base_path + ['policy', 'shaper', shaper_name, 'class', '23', 'match', '10', 'ip', 'destination', 'address', dst_address])
+            self.cli_set(shaper_path + ['bandwidth', f'{bandwidth}mbit'])
+            self.cli_set(
+                shaper_path + ['default', 'bandwidth', f'{default_bandwidth}mbit']
+            )
+            self.cli_set(shaper_path + ['default', 'ceiling', f'{default_ceil}mbit'])
+            self.cli_set(shaper_path + ['default', 'queue-type', 'fair-queue'])
+            self.cli_set(shaper_path + ['default', 'set-dscp', 'AF11'])
+            self.cli_set(class_path + ['bandwidth', f'{class_bandwidth}mbit'])
+            self.cli_set(class_path + ['ceiling', f'{class_ceil}mbit'])
+            self.cli_set(
+                class_path
+                + ['match', '10', 'ip', 'destination', 'address', dst_address]
+            )
 
             bandwidth += 1
             default_bandwidth += 1
@@ -650,6 +658,16 @@ class TestQoS(VyOSUnitTestSHIM.TestCase):
 
             for config_entry in config_entries:
                 self.assertIn(config_entry, output)
+
+            # set-dscp on default class: catch-all filters with pedit
+            # AF11 = DSCP 10 << 2 = 0x28
+            filter_output = get_tc_filter_details(interface)
+            self.assertIn('pedit', filter_output)
+            self.assertIn('protocol ip pref 255', filter_output)
+            self.assertIn('at ipv4+0: val 00280000', filter_output)
+            self.assertIn('csum (iph)', filter_output)
+            self.assertIn('protocol ipv6 pref 256', filter_output)
+            self.assertIn('at ipv6+0: val 02800000', filter_output)
 
             bandwidth += 1
             default_bandwidth += 1
@@ -1323,6 +1341,74 @@ class TestQoS(VyOSUnitTestSHIM.TestCase):
             else:
                 self.assertIn(f'filter parent 1: protocol {proto} pref',
                               get_tc_filter_details(interface))
+
+
+    def test_25_shaper_set_dscp(self):
+        interface = self._interfaces[0]
+        shaper_name = f'qos-shaper-{interface}'
+        shaper_path = base_path + ['policy', 'shaper', shaper_name]
+        class_path = shaper_path + ['class', '10']
+
+        self.cli_set(base_path + ['interface', interface, 'egress', shaper_name])
+        self.cli_set(shaper_path + ['bandwidth', '100mbit'])
+        self.cli_set(shaper_path + ['default', 'bandwidth', '10mbit'])
+        self.cli_set(class_path + ['bandwidth', '50mbit'])
+        self.cli_set(class_path + ['set-dscp', 'CS4'])
+
+        # IPv4 match: pedit should target ipv4+0
+        self.cli_set(
+            class_path + ['match', 'RULE', 'ip', 'source', 'address', '172.17.1.2/32']
+        )
+        self.cli_commit()
+
+        # CS4 = DSCP 32 << 2 = 0x80
+        filter_output = get_tc_filter_details(interface)
+        self.assertIn('action order 1:  pedit', filter_output)
+        self.assertIn('at ipv4+0: val 00800000', filter_output)
+        self.assertIn('csum (iph)', filter_output)
+        self.assertNotIn('at ipv6+0', filter_output)
+
+        # IPv6 match: pedit should target ipv6+0
+        self.cli_delete(class_path + ['match', 'RULE'])
+        self.cli_set(
+            class_path + ['match', 'RULE', 'ipv6', 'source', 'address', '2001:db8::/32']
+        )
+        self.cli_set(class_path + ['set-dscp', 'AF21'])
+        self.cli_commit()
+
+        # AF21 = DSCP 18 << 2 = 0x48
+        filter_output = get_tc_filter_details(interface)
+        self.assertIn('action order 1:  pedit', filter_output)
+        self.assertIn('at ipv6+0: val 04800000', filter_output)
+        self.assertNotIn('at ipv4+0', filter_output)
+
+        # Ether match with protocol all: pedit is skipped to avoid
+        # corrupting non-IP packets
+        self.cli_delete(class_path + ['match', 'RULE'])
+        self.cli_set(class_path + ['match', 'RULE', 'ether', 'protocol', 'all'])
+        self.cli_set(class_path + ['set-dscp', '46'])
+        self.cli_commit()
+
+        filter_output = get_tc_filter_details(interface)
+        self.assertNotIn('pedit', filter_output)
+
+        # Ether match with protocol ip: pedit targets ipv4+0 only
+        self.cli_set(class_path + ['match', 'RULE', 'ether', 'protocol', 'ip'])
+        self.cli_commit()
+
+        # numeric 46 << 2 = 0xb8
+        filter_output = get_tc_filter_details(interface)
+        self.assertIn('action order 1:  pedit', filter_output)
+        self.assertIn('at ipv4+0: val 00b80000', filter_output)
+        self.assertIn('csum (iph)', filter_output)
+        self.assertNotIn('at ipv6+0', filter_output)
+
+        # Removing set-dscp: no pedit should remain
+        self.cli_delete(class_path + ['set-dscp'])
+        self.cli_commit()
+
+        filter_output = get_tc_filter_details(interface)
+        self.assertNotIn('pedit', filter_output)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The set-dscp option was defined in XML but never implemented in
Python — no tc commands were generated to rewrite DSCP on egress.

Add tc pedit actions to shaper filter commands. The pedit target
is chosen per-match: IPv4 uses "ip dsfield", IPv6 uses
"ip6 traffic_class". Ether matches with protocol ip or ipv6 also
get the corresponding pedit; other non-IP match types skip pedit
to avoid corrupting packets like ARP. The retain 0xfc mask
preserves ECN bits. For IPv4, a csum ip4h action recalculates
the header checksum after pedit. For the default class, separate
catch-all filters (prio 255/256) are added per protocol.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8996
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
on Router 1:
```
set interfaces ethernet eth1 address '172.17.1.1/24'

set qos policy shaper TEST bandwidth '100mbit'
set qos policy shaper TEST default bandwidth '50mbit'
set qos policy shaper TEST class 10 bandwidth '50mbit'
set qos policy shaper TEST class 10 match RULE ip source address '172.17.1.0/24'
set qos policy shaper TEST class 10 set-dscp 'AF21'
set qos interface eth1 egress 'TEST'
commit

# Check the tc filter output
vyos@vyos# tc -details filter show dev eth1
filter parent 1: protocol all pref 1 u32 chain 0 
filter parent 1: protocol all pref 1 u32 chain 0 fh 800: ht divisor 1 
filter parent 1: protocol all pref 1 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 flowid 1:a not_in_hw 
  match ac110100/ffffff00 at 12
	action order 1:  pedit action pipe keys 1
 	 index 1 ref 1 bind 1
	 key #0  at ipv4+0: val 00480000 mask ff03ffff

	action order 2: csum (iph) action pipe
	index 1 ref 1 bind 1

	action order 3:  police 0x1 rate 50Mbit burst 15Kb mtu 2Kb action reclassify overhead 0b linklayer ethernet 
	ref 1 bind 1 

[edit]
vyos@vyos# 
```
On Router 2:
ping 172.17.1.1 and check tcpdump
```
vyos@vyos:~$ sudo tcpdump -i eth1 -v -n -c 5 icmp
tcpdump: listening on eth1, link-type EN10MB (Ethernet), snapshot length 262144 bytes
07:48:58.224684 IP (tos 0x0, ttl 64, id 42890, offset 0, flags [DF], proto ICMP (1), length 84)
    172.17.1.2 > 172.17.1.1: ICMP echo request, id 5428, seq 1, length 64
07:48:58.228465 IP (tos 0x48, ttl 64, id 24353, offset 0, flags [none], proto ICMP (1), length 84)
    172.17.1.1 > 172.17.1.2: ICMP echo reply, id 5428, seq 1, length 64
07:48:59.225868 IP (tos 0x0, ttl 64, id 43283, offset 0, flags [DF], proto ICMP (1), length 84)
    172.17.1.2 > 172.17.1.1: ICMP echo request, id 5428, seq 2, length 64
07:48:59.227104 IP (tos 0x48, ttl 64, id 25311, offset 0, flags [none], proto ICMP (1), length 84)
    172.17.1.1 > 172.17.1.2: ICMP echo reply, id 5428, seq 2, length 64
07:49:00.227590 IP (tos 0x0, ttl 64, id 44175, offset 0, flags [DF], proto ICMP (1), length 84)
    172.17.1.2 > 172.17.1.1: ICMP echo request, id 5428, seq 3, length 64
5 packets captured
6 packets received by filter
0 packets dropped by kernel
vyos@vyos:~$ 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
