### PR TITLE
T9002: grant CAP_NET_RAW to blackbox-exporter when ICMP modules are configured

### DIFF
--- a/data/templates/prometheus/blackbox_exporter.service.j2
+++ b/data/templates/prometheus/blackbox_exporter.service.j2
@@ -1,4 +1,14 @@
-{% set vrf_command = 'ip vrf exec ' ~ vrf ~ ' runuser -u node_exporter -- ' if vrf is vyos_defined else '' %}
+{% set icmp_enabled = modules is vyos_defined and modules.icmp is vyos_defined and modules.icmp.name is vyos_defined %}
+{% if vrf is vyos_defined %}
+{%     if icmp_enabled %}
+{# j2lint: disable=operator-enclosed-by-spaces #}
+{%         set vrf_command = 'ip vrf exec ' ~ vrf ~ ' setpriv --reuid=node_exporter --regid=node_exporter --init-groups --inh-caps=+net_raw --ambient-caps=+net_raw -- ' %}
+{%     else %}
+{%         set vrf_command = 'ip vrf exec ' ~ vrf ~ ' runuser -u node_exporter -- ' %}
+{%     endif %}
+{% else %}
+{%     set vrf_command = '' %}
+{% endif %}
 [Unit]
 Description=Blackbox Exporter
 Documentation=https://github.com/prometheus/blackbox_exporter
@@ -7,6 +17,10 @@ After=network.target
 [Service]
 {% if vrf is not vyos_defined %}
 User=node_exporter
+{% endif %}
+{% if vrf is not vyos_defined and icmp_enabled %}
+AmbientCapabilities=CAP_NET_RAW
+CapabilityBoundingSet=CAP_NET_RAW
 {% endif %}
 ExecStart={{ vrf_command }}/usr/sbin/blackbox_exporter \
 {% if listen_address is vyos_defined %}

--- a/smoketest/scripts/cli/test_service_monitoring_prometheus.py
+++ b/smoketest/scripts/cli/test_service_monitoring_prometheus.py
@@ -158,6 +158,52 @@ class TestMonitoringPrometheus(VyOSUnitTestSHIM.TestCase):
         # Check for running process
         self.assertTrue(process_named_running(BLACKBOX_EXPORTER_PROCESS_NAME))
 
+    def test_05_blackbox_exporter_with_icmp(self):
+        vrf_name = 'bbx'
+        be_path = base_path + ['blackbox-exporter']
+        self.cli_set(be_path + ['listen-address', listen_ip])
+        self.cli_set(
+            be_path
+            + ['modules', 'icmp', 'name', 'ping4', 'preferred-ip-protocol', 'ipv4']
+        )
+
+        self.cli_commit()
+
+        # Verify CAP_NET_RAW is granted when ICMP module is configured (no VRF case)
+        file_content = read_file(blackbox_exporter_service_file)
+        self.assertIn('AmbientCapabilities=CAP_NET_RAW', file_content)
+        self.assertIn('CapabilityBoundingSet=CAP_NET_RAW', file_content)
+
+        # Check for running process
+        self.assertTrue(process_named_running(BLACKBOX_EXPORTER_PROCESS_NAME))
+
+        self.cli_delete(be_path + ['modules', 'icmp'])
+        self.cli_commit()
+
+        # Verify CAP_NET_RAW is removed when ICMP module is deleted
+        file_content = read_file(blackbox_exporter_service_file)
+        self.assertNotIn('CAP_NET_RAW', file_content)
+        self.assertTrue(process_named_running(BLACKBOX_EXPORTER_PROCESS_NAME))
+
+        # VRF + ICMP should use setpriv with net_raw capabilities
+        self.cli_set(['vrf', 'name', vrf_name, 'table', '1111'])
+        self.cli_set(be_path + ['vrf', vrf_name])
+        self.cli_set(
+            be_path
+            + ['modules', 'icmp', 'name', 'ping4', 'preferred-ip-protocol', 'ipv4']
+        )
+        self.cli_commit()
+
+        # Verify VRF uses setpriv instead of systemd capabilities
+        file_content = read_file(blackbox_exporter_service_file)
+        self.assertIn('setpriv', file_content)
+        self.assertIn('--ambient-caps=+net_raw', file_content)
+        self.assertIn('--inh-caps=+net_raw', file_content)
+        self.assertNotIn('AmbientCapabilities=CAP_NET_RAW', file_content)
+
+        # Cleanup VRF
+        self.cli_delete(['vrf', 'name', vrf_name])
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/src/conf_mode/service_monitoring_prometheus.py
+++ b/src/conf_mode/service_monitoring_prometheus.py
@@ -20,6 +20,8 @@ from sys import exit
 
 from vyos.config import Config
 from vyos.configdict import is_node_changed
+from vyos.configdict import node_changed
+from vyos.configdiff import Diff
 from vyos.configverify import verify_vrf
 from vyos.template import render
 from vyos.utils.process import call
@@ -76,6 +78,12 @@ def get_config(config=None):
     tmp = False
     for node in ['vrf', 'config-file']:
         tmp = tmp or is_node_changed(conf, base + ['blackbox-exporter', node])
+    modules_changed = node_changed(
+        conf,
+        base + ['blackbox-exporter', 'modules'],
+        expand_nodes=Diff.ADD | Diff.DELETE,
+    )
+    tmp = tmp or 'icmp' in modules_changed
     if tmp:
         monitoring.update({'blackbox_exporter_restart_required': {}})
 


### PR DESCRIPTION
The blackbox-exporter runs as node_exporter user which cannot create ICMP sockets due to restricted ping_group_range. Add CAP_NET_RAW capability to the systemd service when ICMP modules are configured. In non-VRF mode, use systemd AmbientCapabilities/CapabilityBoundingSet. In VRF mode, replace runuser with setpriv to preserve the capability across the UID change.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T9002
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set service monitoring prometheus blackbox-exporter listen-address 0.0.0.0
set service monitoring prometheus blackbox-exporter modules icmp name ping4 preferred-ip-protocol ipv4
commit

vyos@vyos# cat /etc/systemd/system/blackbox_exporter.service
[Unit]
Description=Blackbox Exporter
Documentation=https://github.com/prometheus/blackbox_exporter
After=network.target

[Service]
User=node_exporter
AmbientCapabilities=CAP_NET_RAW
CapabilityBoundingSet=CAP_NET_RAW
ExecStart=/usr/sbin/blackbox_exporter \
        --web.listen-address=0.0.0.0:9115 \
        --config.file=/run/blackbox_exporter/config.yml
[Install]
WantedBy=multi-user.target
[edit]
vyos@vyos# curl -G http://localhost:9115/probe -d target=8.8.8.8 -d module=ping4
# HELP probe_dns_lookup_time_seconds Returns the time taken for probe dns lookup in seconds
# TYPE probe_dns_lookup_time_seconds gauge
probe_dns_lookup_time_seconds 3.7701e-05
# HELP probe_duration_seconds Returns how long the probe took to complete in seconds
# TYPE probe_duration_seconds gauge
probe_duration_seconds 0.004283723
# HELP probe_icmp_duration_seconds Duration of icmp request by phase
# TYPE probe_icmp_duration_seconds gauge
probe_icmp_duration_seconds{phase="resolve"} 3.7701e-05
probe_icmp_duration_seconds{phase="rtt"} 0.003044281
probe_icmp_duration_seconds{phase="setup"} 0.000628996
# HELP probe_icmp_reply_hop_limit Replied packet hop limit (TTL for ipv4)
# TYPE probe_icmp_reply_hop_limit gauge
probe_icmp_reply_hop_limit 118
# HELP probe_ip_addr_hash Specifies the hash of IP address. It's useful to detect if the IP address changes.
# TYPE probe_ip_addr_hash gauge
probe_ip_addr_hash 2.350491669e+09
# HELP probe_ip_protocol Specifies whether probe ip protocol is IP4 or IP6
# TYPE probe_ip_protocol gauge
probe_ip_protocol 4
# HELP probe_success Displays whether or not the probe was a success
# TYPE probe_success gauge
probe_success 1
[edit]
vyos@vyos# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
