### PR TITLE
T8344: Preserve symlinks when copying config to/from TPM encrypted volume

### DIFF
--- a/src/helpers/vyos-config-encrypt.py
+++ b/src/helpers/vyos-config-encrypt.py
@@ -122,7 +122,9 @@ def encrypt_config(key, recovery_key=None, is_tpm=True):
         cmd(f'mount /dev/mapper/vyos_config {d}')
 
         # Move mount_path to encrypted volume
-        shutil.copytree(mount_path, d, copy_function=shutil.move, dirs_exist_ok=True)
+        shutil.copytree(
+            mount_path, d, symlinks=True, copy_function=shutil.move, dirs_exist_ok=True
+        )
         cmd(f'chgrp -R vyattacfg {d}')
         cmd(f'umount {d}')
 
@@ -207,7 +209,9 @@ def decrypt_config(key):
         cmd(f'mount /dev/mapper/vyos_config {d}')
 
         # Move encrypted volume to /opt/vyatta/etc/config
-        shutil.copytree(d, mount_path, copy_function=shutil.move, dirs_exist_ok=True)
+        shutil.copytree(
+            d, mount_path, symlinks=True, copy_function=shutil.move, dirs_exist_ok=True
+        )
         cmd(f'chgrp -R vyattacfg {mount_path}')
 
         cmd(f'umount {d}')


### PR DESCRIPTION
shutil.copytree() defaults to symlinks=False, so it recurses into symlinked directories and recreates them as real directories instead of preserving the symlink.
cloud-init creates /opt/vyatta/etc/config/cloud/instance as a symlink to instances/i-<id>. Enabling/disabling config encryption copied this tree with copytree() and silently turned that symlink into a real directory, causing cloud-init to fail on later runs with:
    IsADirectoryError: [Errno 21] Is a directory: '.../cloud/instance'
Pass symlinks=True to preserve symlinks during the copy.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8344
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@VyOS-for-Smoke-Tests:~$ ls -la /opt/vyatta/etc/config/cloud/
total 32
drwxr-xr-x  8 root vyattacfg 4096 Jul  3 12:21 .
drwxrwsr-x 10 root vyattacfg 4096 Jul  3 12:22 ..
drwxr-xr-x  2 root vyattacfg 4096 Jul  3 12:21 data
drwxr-xr-x  2 root vyattacfg 4096 Jul  2 13:11 handlers
lrwxrwxrwx  1 root root        58 Jul  3 12:21 instance -> /opt/vyatta/etc/config/cloud/instances/i-07206df8725764a04
drwxr-xr-x  3 root vyattacfg 4096 Jul  2 13:11 instances
drwxr-xr-x  6 root vyattacfg 4096 Jul  2 13:11 scripts
drwxr-xr-x  2 root vyattacfg 4096 Jul  2 13:11 seed
drwxr-xr-x  2 root vyattacfg 4096 Jul  2 13:11 sem
vyos@VyOS-for-Smoke-Tests:~$ encryption enable 
WARNING: VyOS will boot into a default config when encrypted without a TPM
You will need to manually login with default credentials and use "encryption load"
to mount the encrypted volume and use "load /opt/vyatta/etc/config/config.boot"
Are you sure you want to proceed? [y/N] y
Enter key: 
Confirm key: 
Enter size of encrypted config partition (MB):  (Default: 512) 
Encrypted config volume has been enabled without TPM
Backup the key in a safe place!
Key: XXXXXX
vyos@VyOS-for-Smoke-Tests:~$ ls -la /opt/vyatta/etc/config/cloud/
total 32
drwxr-xr-x  8 root vyattacfg 4096 Jul  3 12:21 .
drwxrwsr-x 10 root vyattacfg 4096 Jul  3 12:39 ..
drwxr-xr-x  2 root vyattacfg 4096 Jul  3 12:39 data
drwxr-xr-x  2 root vyattacfg 4096 Jul  2 13:11 handlers
lrwxrwxrwx  1 root vyattacfg   58 Jul  3 12:21 instance -> /opt/vyatta/etc/config/cloud/instances/i-07206df8725764a04
drwxr-xr-x  3 root vyattacfg 4096 Jul  2 13:11 instances
drwxr-xr-x  6 root vyattacfg 4096 Jul  2 13:11 scripts
drwxr-xr-x  2 root vyattacfg 4096 Jul  2 13:11 seed
drwxr-xr-x  2 root vyattacfg 4096 Jul  2 13:11 sem
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
