### PR TITLE
smoketest: T9048: harden DHCP client process checks against CI timing races

### DIFF
--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -47,6 +47,12 @@ dhclient_process_name = 'dhclient'
 dhcp6c_base_dir = directories['dhcp6_client_dir']
 dhcp6c_process_name = 'dhcp6c'
 
+# Daemon startup/shutdown on a loaded CI runner can exceed 10 seconds. The
+# polls in process_named_running() and wait_for_result() complete as soon as
+# the expected state is reached, so a longer window only delays the failure
+# path.
+PROCESS_WAIT_TIMEOUT = 60
+
 MSG_TESTCASE_UNSUPPORTED = 'unsupported on interface family'
 
 server_ca_root_cert_data = """
@@ -208,18 +214,40 @@ class BasicInterfaceTest:
                 for map_entry in ct_map:
                      self.assertNotEqual(intf, map_entry['interface'])
 
-            # No daemon started during tests should remain running
+            # No daemon started during tests should remain running. A client
+            # daemon may still be shutting down after its config was removed,
+            # so grant a grace period before declaring a leak.
             for daemon in ['dhcp6c', 'dhclient']:
                 # if _interface list is populated do a more fine grained search
                 # by also checking the cmd arguments passed to the daemon
                 if self._interfaces:
                     for tmp in self._interfaces:
-                        self.assertFalse(process_named_running(daemon, tmp))
+                        _, pid = self.wait_for_result(
+                            lambda d=daemon, i=tmp: process_named_running(d, i), None,
+                            timeout=PROCESS_WAIT_TIMEOUT)
+                        self.assertFalse(pid)
                 else:
-                    self.assertFalse(process_named_running(daemon))
+                    _, pid = self.wait_for_result(
+                        lambda d=daemon: process_named_running(d), None,
+                        timeout=PROCESS_WAIT_TIMEOUT)
+                    self.assertFalse(pid)
 
             # always forward to base class
             super().tearDown()
+
+        def get_process_cmdline(self, process_name, interface, pid):
+            # dhclient re-executes itself while daemonizing - the PID found
+            # right after commit may already be gone when /proc is read.
+            # Re-resolve the PID once instead of failing on the transient one.
+            # NB: read_file() re-raises on failure unless defaultonfailure is
+            # set to a non-None value.
+            cmdline = read_file(f'/proc/{pid}/cmdline', defaultonfailure='')
+            if not cmdline:
+                pid = process_named_running(process_name, cmdline=interface,
+                                            timeout=PROCESS_WAIT_TIMEOUT)
+                self.assertTrue(pid)
+                cmdline = read_file(f'/proc/{pid}/cmdline')
+            return cmdline
 
         def test_dhcp_disable_interface(self):
             if not self._test_dhcp:
@@ -269,7 +297,8 @@ class BasicInterfaceTest:
 
             for interface in self._interfaces:
                 # Check if dhclient process runs
-                dhclient_pid = process_named_running(dhclient_process_name, cmdline=interface, timeout=10)
+                dhclient_pid = process_named_running(dhclient_process_name, cmdline=interface,
+                                                     timeout=PROCESS_WAIT_TIMEOUT)
                 self.assertTrue(dhclient_pid)
 
                 dhclient_config = read_file(f'{dhclient_base_dir}/dhclient_{interface}.conf')
@@ -281,7 +310,8 @@ class BasicInterfaceTest:
                 self.assertIn(f'send user-class "{user_class}";', dhclient_config)
 
                 # and the commandline has the appropriate options
-                cmdline = read_file(f'/proc/{dhclient_pid}/cmdline')
+                cmdline = self.get_process_cmdline(dhclient_process_name,
+                                                   interface, dhclient_pid)
                 self.assertIn(f'-e\x00IF_METRIC={distance}', cmdline)
 
         def test_dhcp_vrf(self):
@@ -309,13 +339,15 @@ class BasicInterfaceTest:
                 self.assertEqual(tmp, vrf_name)
 
                 # Check if dhclient process runs
-                dhclient_pid = process_named_running(dhclient_process_name, cmdline=interface, timeout=10)
+                dhclient_pid = process_named_running(dhclient_process_name, cmdline=interface,
+                                                     timeout=PROCESS_WAIT_TIMEOUT)
                 self.assertTrue(dhclient_pid)
                 # .. inside the appropriate VRF instance
                 vrf_pids = cmd(f'ip vrf pids {vrf_name}')
                 self.assertIn(str(dhclient_pid), vrf_pids)
                 # and the commandline has the appropriate options
-                cmdline = read_file(f'/proc/{dhclient_pid}/cmdline')
+                cmdline = self.get_process_cmdline(dhclient_process_name,
+                                                   interface, dhclient_pid)
                 self.assertIn(f'-e\x00IF_METRIC={cli_default_metric}', cmdline)
 
             # T5103: remove interface from VRF instance and move DHCP client
@@ -330,13 +362,15 @@ class BasicInterfaceTest:
                 tmp = get_interface_vrf(interface)
                 self.assertEqual(tmp, 'default')
                 # Check if dhclient process runs
-                dhclient_pid = process_named_running(dhclient_process_name, cmdline=interface, timeout=10)
+                dhclient_pid = process_named_running(dhclient_process_name, cmdline=interface,
+                                                     timeout=PROCESS_WAIT_TIMEOUT)
                 self.assertTrue(dhclient_pid)
                 # .. inside the appropriate VRF instance
                 vrf_pids = cmd(f'ip vrf pids {vrf_name}')
                 self.assertNotIn(str(dhclient_pid), vrf_pids)
                 # and the commandline has the appropriate options
-                cmdline = read_file(f'/proc/{dhclient_pid}/cmdline')
+                cmdline = self.get_process_cmdline(dhclient_process_name,
+                                                   interface, dhclient_pid)
                 self.assertIn(f'-e\x00IF_METRIC={cli_default_metric}', cmdline)
 
             self.cli_delete(['vrf', 'name', vrf_name])
@@ -365,7 +399,8 @@ class BasicInterfaceTest:
                 self.assertEqual(tmp, vrf_name)
 
                 # Check if dhclient process runs
-                tmp = process_named_running(dhcp6c_process_name, cmdline=interface, timeout=10)
+                tmp = process_named_running(dhcp6c_process_name, cmdline=interface,
+                                            timeout=PROCESS_WAIT_TIMEOUT)
                 self.assertTrue(tmp)
                 # .. inside the appropriate VRF instance
                 vrf_pids = cmd(f'ip vrf pids {vrf_name}')
@@ -384,7 +419,8 @@ class BasicInterfaceTest:
                 self.assertEqual(tmp, 'default')
 
                 # Check if dhclient process runs
-                tmp = process_named_running(dhcp6c_process_name, cmdline=interface, timeout=10)
+                tmp = process_named_running(dhcp6c_process_name, cmdline=interface,
+                                            timeout=PROCESS_WAIT_TIMEOUT)
                 self.assertTrue(tmp)
                 # .. inside the appropriate VRF instance
                 vrf_pids = cmd(f'ip vrf pids {vrf_name}')
@@ -1195,11 +1231,13 @@ class BasicInterfaceTest:
                     self.assertNotIn('syntax error', entry.get('MESSAGE', ''))
 
                 # Better ask the process about it's commandline in the future
-                pid = process_named_running(dhcp6c_process_name, cmdline=interface, timeout=10)
+                pid = process_named_running(dhcp6c_process_name, cmdline=interface,
+                                            timeout=PROCESS_WAIT_TIMEOUT)
                 self.assertTrue(pid)
 
                 # DHCPv6 option "no-release" requires "-n" daemon startup option
-                dhcp6c_options = read_file(f'/proc/{pid}/cmdline')
+                dhcp6c_options = self.get_process_cmdline(dhcp6c_process_name,
+                                                          interface, pid)
                 self.assertIn('-n', dhcp6c_options)
 
         def test_dhcpv6pd_auto_sla_id(self):
@@ -1254,7 +1292,8 @@ class BasicInterfaceTest:
                     address = str(int(address) + 1)
 
                 # Check for running process
-                self.assertTrue(process_named_running(dhcp6c_process_name, cmdline=interface, timeout=10))
+                self.assertTrue(process_named_running(dhcp6c_process_name, cmdline=interface,
+                                                      timeout=PROCESS_WAIT_TIMEOUT))
 
             for delegatee in delegatees:
                 # we can already cleanup the test delegatee interface here
@@ -1319,7 +1358,8 @@ class BasicInterfaceTest:
                     address = str(int(address) + 1)
 
                 # Check for running process
-                self.assertTrue(process_named_running(dhcp6c_process_name, cmdline=interface, timeout=10))
+                self.assertTrue(process_named_running(dhcp6c_process_name, cmdline=interface,
+                                                      timeout=PROCESS_WAIT_TIMEOUT))
 
             for delegatee in delegatees:
                 # we can already cleanup the test delegatee interface here

--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -246,7 +246,9 @@ class BasicInterfaceTest:
                 pid = process_named_running(process_name, cmdline=interface,
                                             timeout=PROCESS_WAIT_TIMEOUT)
                 self.assertTrue(pid)
-                cmdline = read_file(f'/proc/{pid}/cmdline')
+                cmdline = read_file(f'/proc/{pid}/cmdline', defaultonfailure='')
+                self.assertTrue(cmdline,
+                    f'{process_name} cmdline unreadable after PID re-resolve')
             return cmdline
 
         def test_dhcp_disable_interface(self):

--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -16,6 +16,8 @@ import re
 import jmespath
 
 from json import loads
+from time import sleep
+from time import time
 from netifaces import ifaddresses # pylint: disable = no-name-in-module
 from socket import AF_INET
 from socket import AF_INET6
@@ -238,18 +240,26 @@ class BasicInterfaceTest:
         def get_process_cmdline(self, process_name, interface, pid):
             # dhclient re-executes itself while daemonizing - the PID found
             # right after commit may already be gone when /proc is read.
-            # Re-resolve the PID once instead of failing on the transient one.
-            # NB: read_file() re-raises on failure unless defaultonfailure is
-            # set to a non-None value.
+            # Poll PID discovery and the /proc read together until the
+            # deadline instead of failing on a transient PID. Returns the
+            # (pid, cmdline) pair that was actually validated so callers
+            # can assert against the same process.
+            # NB: read_file() re-raises on failure unless defaultonfailure
+            # is set to a non-None value.
+            time_expire = time() + PROCESS_WAIT_TIMEOUT
             cmdline = read_file(f'/proc/{pid}/cmdline', defaultonfailure='')
-            if not cmdline:
-                pid = process_named_running(process_name, cmdline=interface,
-                                            timeout=PROCESS_WAIT_TIMEOUT)
-                self.assertTrue(pid)
+            while not cmdline:
+                if time() > time_expire:
+                    break
+                sleep(0.250)
+                tmp = process_named_running(process_name, cmdline=interface)
+                if not tmp:
+                    continue
+                pid = tmp
                 cmdline = read_file(f'/proc/{pid}/cmdline', defaultonfailure='')
-                self.assertTrue(cmdline,
-                    f'{process_name} cmdline unreadable after PID re-resolve')
-            return cmdline
+            self.assertTrue(cmdline,
+                f'{process_name} cmdline unreadable for interface {interface}')
+            return pid, cmdline
 
         def test_dhcp_disable_interface(self):
             if not self._test_dhcp:
@@ -312,8 +322,8 @@ class BasicInterfaceTest:
                 self.assertIn(f'send user-class "{user_class}";', dhclient_config)
 
                 # and the commandline has the appropriate options
-                cmdline = self.get_process_cmdline(dhclient_process_name,
-                                                   interface, dhclient_pid)
+                dhclient_pid, cmdline = self.get_process_cmdline(
+                    dhclient_process_name, interface, dhclient_pid)
                 self.assertIn(f'-e\x00IF_METRIC={distance}', cmdline)
 
         def test_dhcp_vrf(self):
@@ -344,13 +354,16 @@ class BasicInterfaceTest:
                 dhclient_pid = process_named_running(dhclient_process_name, cmdline=interface,
                                                      timeout=PROCESS_WAIT_TIMEOUT)
                 self.assertTrue(dhclient_pid)
-                # .. inside the appropriate VRF instance
+                # The commandline must carry the appropriate options ..
+                # (get_process_cmdline() may re-resolve the PID, so it runs
+                # first and the VRF check below targets the same process)
+                dhclient_pid, cmdline = self.get_process_cmdline(
+                    dhclient_process_name, interface, dhclient_pid)
+                self.assertIn(f'-e\x00IF_METRIC={cli_default_metric}', cmdline)
+                # .. and the process must run inside the appropriate VRF
+                # instance
                 vrf_pids = cmd(f'ip vrf pids {vrf_name}')
                 self.assertIn(str(dhclient_pid), vrf_pids)
-                # and the commandline has the appropriate options
-                cmdline = self.get_process_cmdline(dhclient_process_name,
-                                                   interface, dhclient_pid)
-                self.assertIn(f'-e\x00IF_METRIC={cli_default_metric}', cmdline)
 
             # T5103: remove interface from VRF instance and move DHCP client
             # back to default VRF. This must restart the DHCP client process
@@ -367,13 +380,16 @@ class BasicInterfaceTest:
                 dhclient_pid = process_named_running(dhclient_process_name, cmdline=interface,
                                                      timeout=PROCESS_WAIT_TIMEOUT)
                 self.assertTrue(dhclient_pid)
-                # .. inside the appropriate VRF instance
+                # The commandline must carry the appropriate options ..
+                # (get_process_cmdline() may re-resolve the PID, so it runs
+                # first and the VRF check below targets the same process)
+                dhclient_pid, cmdline = self.get_process_cmdline(
+                    dhclient_process_name, interface, dhclient_pid)
+                self.assertIn(f'-e\x00IF_METRIC={cli_default_metric}', cmdline)
+                # .. and the process must no longer run inside the VRF
+                # instance
                 vrf_pids = cmd(f'ip vrf pids {vrf_name}')
                 self.assertNotIn(str(dhclient_pid), vrf_pids)
-                # and the commandline has the appropriate options
-                cmdline = self.get_process_cmdline(dhclient_process_name,
-                                                   interface, dhclient_pid)
-                self.assertIn(f'-e\x00IF_METRIC={cli_default_metric}', cmdline)
 
             self.cli_delete(['vrf', 'name', vrf_name])
 
@@ -1238,8 +1254,8 @@ class BasicInterfaceTest:
                 self.assertTrue(pid)
 
                 # DHCPv6 option "no-release" requires "-n" daemon startup option
-                dhcp6c_options = self.get_process_cmdline(dhcp6c_process_name,
-                                                          interface, pid)
+                pid, dhcp6c_options = self.get_process_cmdline(
+                    dhcp6c_process_name, interface, pid)
                 self.assertIn('-n', dhcp6c_options)
 
         def test_dhcpv6pd_auto_sla_id(self):


### PR DESCRIPTION
## Change summary

Interface smoketests fail intermittently in CI on DHCP-related assertions — the `test_interfaces_cli` job of the VyOS ISO Integration Test workflow passed only 42-55% of the last 30 runs, with independent failures near-daily. Three timing hazards in `smoketest/scripts/cli/base_interfaces_test.py`:

1. **PID discovery window too short.** `process_named_running(..., timeout=10)` at all dhclient/dhcp6c call sites — on a loaded runner the client daemon can take longer than 10 s to appear after commit. Raised to a shared `PROCESS_WAIT_TIMEOUT = 60`; the poll returns as soon as the process appears, so the longer window only delays the failure path.

2. **Unguarded `/proc/<pid>/cmdline` read after PID discovery.** `dhclient` re-executes itself while daemonizing, so the PID captured right after commit can be gone by the time `/proc` is read — `read_file()` then raises and the test errors out instead of failing cleanly. New `get_process_cmdline()` helper reads with `defaultonfailure=''` and re-resolves the PID once before asserting.

3. **Instant teardown leak asserts.** `tearDown()` ran `assertFalse(process_named_running(daemon))` immediately after the config removal commit, reporting daemons still in their shutdown path as leaks. Now polls via the existing `wait_for_result()` shim helper with the same 60 s bound; the poll returns on the first clean observation, so passing runs pay no extra wall clock.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Task(s)
* https://vyos.dev/T9048

## Related PR(s)

## How to test / Smoketest result

Test-infrastructure-only change (no product code touched). Validation is the workflow itself: `test_interfaces_cli` / `test_smoketest_cli` jobs on this PR exercise the modified base class on every DHCP-capable interface test. Local validation: `python3 -m py_compile smoketest/scripts/cli/base_interfaces_test.py`.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable

🤖 Generated by [robots](https://vyos.io)