### PR TITLE
smoketest: T8940: HYPERV_VTL_MODE must not be enabled; require vPCI

### DIFF
--- a/smoketest/scripts/system/test_kernel_options.py
+++ b/smoketest/scripts/system/test_kernel_options.py
@@ -230,13 +230,20 @@ class TestKernelModules(unittest.TestCase):
 
         options_to_check = ['CONFIG_HYPERV_VSOCKETS', 'CONFIG_HYPERV_STORAGE',
                             'CONFIG_HYPERV_NET', 'CONFIG_HYPERV_KEYBOARD',
-                            'CONFIG_HYPERV_VTL_MODE', 'CONFIG_HYPERV_TIMER',
-                            'CONFIG_HYPERV_UTILS', 'CONFIG_HYPERV_BALLOON',
-                            'CONFIG_HYPERV_VMBUS', 'CONFIG_HYPERV_IOMMU']
+                            'CONFIG_HYPERV_TIMER', 'CONFIG_HYPERV_UTILS',
+                            'CONFIG_HYPERV_BALLOON', 'CONFIG_HYPERV_VMBUS',
+                            'CONFIG_HYPERV_IOMMU', 'CONFIG_PCI_HYPERV',
+                            'CONFIG_PCI_HYPERV_INTERFACE']
 
         for option in options_to_check:
             tmp = re.findall(f'{option}=(y|m)', self._config_data)
             self.assertTrue(tmp)
+
+        # T8940: a kernel built with HYPERV_VTL_MODE "must run at VTL2, and
+        # will not run as a normal guest" - get_vtl() calls BUG() on every
+        # regular Hyper-V VM. This option must never be enabled.
+        tmp = re.findall(r'CONFIG_HYPERV_VTL_MODE=(y|m)', self._config_data)
+        self.assertFalse(tmp)
 
     def test_hypervisor_vmware(self):
         if IS_ARM64:


### PR DESCRIPTION
## Change summary

Update the Hyper-V kernel config smoketest to match the T8940 kernel config fix in vyos-build:

- `CONFIG_HYPERV_VTL_MODE` is no longer required — it must **not** be set. A kernel built with this option "must run at VTL2, and will not run as a normal guest" (kernel Kconfig): it panics in `get_vtl()` on every regular Hyper-V VM before any console output, which is the blank screen reported in T8940. The test now fails if the option is ever enabled again.
- Require `CONFIG_PCI_HYPERV` and `CONFIG_PCI_HYPERV_INTERFACE` (Hyper-V vPCI frontend, needed for SR-IOV / accelerated networking), lost in the kernel 6.18 config migration.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T8940

## Related PR(s)
https://github.com/vyos/vyos-build/pull/1236

## How to test / Smoketest result
Assertions dry-run against the generated config of a kernel built with the fixed defconfig: all required options present, VTL_MODE absent — passes. A config containing `CONFIG_HYPERV_VTL_MODE=y` (current nightly kernel) fails the new assertion, as intended.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly