### PR TITLE
frrender: T9054: keep PPPoE/DHCP default route when "protocols static" is deleted

### DIFF
--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -467,7 +467,9 @@ def get_frrender_dict(conf: Config, argv=None) -> dict:
                                   no_tag_node_value_mangle=True)
         dict.update({'static' : static})
     elif conf.exists_effective(static_cli_path):
-        dict.update({'static' : deleted_protocol})
+        # Use a copy - static.dhcp/static.pppoe below may be merged in,
+        # and deleted_protocol is shared by reference with other protocols
+        dict.update({'static' : deleted_protocol.copy()})
 
     # We need to check the CLI if the NHRP node is present and thus load in all the default
     # values present on the CLI - that's why we have if conf.exists()
@@ -487,6 +489,12 @@ def get_frrender_dict(conf: Config, argv=None) -> dict:
 
     tmp = get_pppoe_interfaces(conf)
     if tmp: dict_set_nested('static.pppoe', tmp, dict)
+
+    # T6991/T9054: "protocols static" may have been deleted while a DHCP or
+    # PPPoE interface still contributes a default route - in that case the
+    # static section must still be rendered, so drop the deletion marker
+    if 'static' in dict and ('dhcp' in dict['static'] or 'pppoe' in dict['static']):
+        dict['static'].pop('deleted', None)
 
     # keep a re-usable list of dependent VRFs
     dependent_vrfs_default = {}
@@ -615,7 +623,9 @@ def get_frrender_dict(conf: Config, argv=None) -> dict:
                                               no_tag_node_value_mangle=True)
                 dict_set_nested(f'{protocol_dict_path}.static', static, vrf)
             elif conf.exists_effective(static_vrf_path):
-                dict_set_nested(f'{protocol_dict_path}.static', deleted_protocol, vrf)
+                # Use a copy - static.dhcp/static.pppoe below may be merged in,
+                # and deleted_protocol is shared by reference with other protocols
+                dict_set_nested(f'{protocol_dict_path}.static', deleted_protocol.copy(), vrf)
 
             # T3680 - get a list of all interfaces currently configured to use DHCP
             tmp = get_dhcp_interfaces(conf, vrf_name)
@@ -623,6 +633,14 @@ def get_frrender_dict(conf: Config, argv=None) -> dict:
 
             tmp = get_pppoe_interfaces(conf, vrf_name)
             if tmp: dict_set_nested(f'name.{vrf_name}.protocols.static.pppoe', tmp, vrf)
+
+            # T6991/T9054: "protocols static" may have been deleted while a
+            # DHCP or PPPoE interface still contributes a default route - in
+            # that case the static section must still be rendered, so drop
+            # the deletion marker
+            static_dict = dict_search(f'{protocol_dict_path}.static', vrf)
+            if static_dict and ('dhcp' in static_dict or 'pppoe' in static_dict):
+                static_dict.pop('deleted', None)
 
             vrf_vni_path = ['vrf', 'name', vrf_name, 'vni']
             if conf.exists(vrf_vni_path):

--- a/smoketest/scripts/cli/test_interfaces_pppoe.py
+++ b/smoketest/scripts/cli/test_interfaces_pppoe.py
@@ -416,5 +416,43 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
             # Validate and verify assigned IP addresses
             self._verify_interface_address(interface)
 
+    def test_pppoe_default_route_survives_static_deletion(self):
+        # T6991/T9054: The PPPoE default route must not be withdrawn from FRR
+        # when "protocols static" is deleted - only the statically configured
+        # routes must disappear, the PPPoE-sourced default route must stay.
+        interface = self._interfaces[0]
+        (user, passwd) = self.u_p_dict[interface]
+        static_base_path = ['protocols', 'static']
+
+        self.cli_set(base_path + [interface, 'authentication', 'username', user])
+        self.cli_set(base_path + [interface, 'authentication', 'password', passwd])
+        self.cli_set(base_path + [interface, 'source-interface', self._source_interface])
+        self.cli_commit()
+
+        self.assertTrue(wait_for_interface(interface),
+                        msg=f'Interface {interface} not found after {connect_timeout} seconds!')
+
+        default_route = rf'ip route 0.0.0.0/0 {interface} tag 210'
+        frrconfig = self.getFRRconfig('')
+        self.assertIn(default_route, frrconfig)
+
+        # Add an unrelated static route - this is what triggers "protocols
+        # static" to exist on the CLI in the first place
+        self.cli_set(static_base_path + ['route', '10.0.0.0/8', 'blackhole'])
+        self.cli_commit()
+
+        frrconfig = self.getFRRconfig('')
+        self.assertIn(default_route, frrconfig)
+        self.assertIn(r'ip route 10.0.0.0/8 blackhole', frrconfig)
+
+        # Now delete "protocols static" entirely - the PPPoE default route
+        # must remain in the FRR configuration (and thus in the RIB/FIB)
+        self.cli_delete(static_base_path)
+        self.cli_commit()
+
+        frrconfig = self.getFRRconfig('')
+        self.assertNotIn(r'ip route 10.0.0.0/8 blackhole', frrconfig)
+        self.assertIn(default_route, frrconfig)
+
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Deleting "protocols static" set config_dict['static'] to a dict object shared by reference across every deleted protocol. Merging the PPPoE/DHCP default-route data into it left the "deleted" marker in place, so the entire staticd section - including the just-merged default route - was skipped during FRR rendering, dropping the default route from the RIB/FIB.

Copy the shared deleted-protocol marker before mutating it, and clear the marker once DHCP/PPPoE content has been merged in so the section is still rendered.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9054

## How to test / Smoketest result

```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_pppoe.py
test_pppoe_authentication (__main__.PPPoEInterfaceTest.test_pppoe_authentication) ... ok
test_pppoe_client (__main__.PPPoEInterfaceTest.test_pppoe_client) ... skipped 'Bug in FRR 10.2 - PPPoE interfaces sometimes carry ifIndex 0 which is invalid'
test_pppoe_client_disabled_interface (__main__.PPPoEInterfaceTest.test_pppoe_client_disabled_interface) ... ok
test_pppoe_default_route_survives_static_deletion (__main__.PPPoEInterfaceTest.test_pppoe_default_route_survives_static_deletion) ... ok
test_pppoe_dhcpv6pd (__main__.PPPoEInterfaceTest.test_pppoe_dhcpv6pd) ... ok
test_pppoe_mtu_mru (__main__.PPPoEInterfaceTest.test_pppoe_mtu_mru) ... ok
test_pppoe_options (__main__.PPPoEInterfaceTest.test_pppoe_options) ... ok

----------------------------------------------------------------------
Ran 7 tests in 35.997s

OK (skipped=1)
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
