### PR TITLE
vpp: T9018: Auto-enable promiscuous mode for interfaces with VLANs

### DIFF
--- a/python/vyos/vpp/control_vpp.py
+++ b/python/vyos/vpp/control_vpp.py
@@ -688,3 +688,16 @@ class VPPControl:
                 arc_name=arc_name,
                 feature_name='ip6-icmp-ra-punt',
             )
+
+    @_Decorators.api_call
+    def set_promisc(self, ifname: str, enable: bool = True) -> None:
+        """Set promiscuous mode for interface
+
+        Args:
+            ifname (str): name of an interface
+            enable (bool): enable or disable promiscuous mode
+        """
+        self.__vpp_api_client.api.sw_interface_set_promisc(
+            sw_if_index=self.get_sw_if_index(ifname),
+            promisc_on=enable,
+        )

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -1474,6 +1474,9 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         # Ensure that VPP process is active
         self.assertTrue(process_named_running(PROCESS_NAME))
 
+        # Cleanup
+        self.cli_delete(['interfaces', 'ethernet', interface, 'vif', vlan])
+
     def test_23_1_vpp_acl_subinterface(self):
         base_acl = base_path + ['acl', 'ip']
         vlan = '200'
@@ -1513,6 +1516,9 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.assertEqual(
             list(acl_interfaces[0].acls)[: acl_interfaces[0].count], [acl_index]
         )
+
+        # Cleanup
+        self.cli_delete(['interfaces', 'ethernet', interface, 'vif', vlan])
 
     def test_23_2_vpp_acl_bond_with_vif(self):
         base_acl = base_path + ['acl', 'ip']
@@ -1664,6 +1670,36 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(['vrf', 'name', test_vrf])
         self.cli_delete(['vrf', 'name', mgmt_vrf])
         self.cli_commit()
+
+    def test_25_vpp_promisc_vlan(self):
+        # T9018: promiscuous mode must be enabled automatically when VLANs
+        # are configured on a VPP interface and disabled when removed.
+        vlan = '100'
+        address = '192.168.10.1/24'
+
+        self.cli_commit()
+
+        # Verify promisc is off initially
+        _, out = rc_cmd(f'sudo vppctl show hardware-interfaces {interface}')
+        self.assertNotRegex(out, r'flags:.*\bpromisc\b')
+
+        # Add VLAN sub-interface
+        self.cli_set(
+            ['interfaces', 'ethernet', interface, 'vif', vlan, 'address', address]
+        )
+        self.cli_commit()
+
+        # Verify promisc is enabled
+        _, out = rc_cmd(f'sudo vppctl show hardware-interfaces {interface}')
+        self.assertRegex(out, r'flags:.*\bpromisc\b')
+
+        # Remove VLAN sub-interface
+        self.cli_delete(['interfaces', 'ethernet', interface, 'vif'])
+        self.cli_commit()
+
+        # Verify promisc is disabled
+        _, out = rc_cmd(f'sudo vppctl show hardware-interfaces {interface}')
+        self.assertNotRegex(out, r'flags:.*\bpromisc\b')
 
 
 if __name__ == '__main__':

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -48,6 +48,7 @@ from vyos.utils.dict import dict_set
 from vyos.utils.dict import dict_delete
 from vyos.utils.network import get_vrf_tableid
 from vyos.utils.process import is_systemd_service_running
+from vyos.vpp.config_deps import deps_bond_dict
 from vyos.vpp.config_verify import verify_vpp_remove_interface
 from vyos.vpp.control_vpp import VPPControl
 from vyos import ConfigError
@@ -192,6 +193,7 @@ def get_config(config=None):
             get_first_key=True,
             no_tag_node_value_mangle=True,
         )
+        ethernet['vpp_bond_members'] = deps_bond_dict(conf)
 
     # Protocols static arp dependency
     if 'static_arp' in ethernet:
@@ -481,6 +483,15 @@ def apply(ethernet):
             vpp_api.set_iface_mtu(lcp_name, mtu)
 
         sync_vpp_lcp_vrf_tables(ethernet, vpp_api)
+
+        # VPP requires promiscuous mode to pass VLAN-tagged traffic;
+        # also keep it enabled for VPP bond members
+        needs_promisc = (
+            'vif' in ethernet
+            or 'vif_s' in ethernet
+            or ifname in ethernet.get('vpp_bond_members')
+        )
+        vpp_api.set_promisc(ifname, enable=needs_promisc)
 
     return None
 


### PR DESCRIPTION
VPP drops VLAN-tagged frames unless the parent interface has promiscuous mode enabled, causing VLAN sub-interfaces to lose connectivity. Automatically enable promiscuous mode on VPP interfaces that have VLAN sub-interfaces (vif/vif-s) configured.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T9018
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos# /usr/libexec/vyos/tests/smoke/cli/test_vpp.py  -k test_25_vpp_promisc_vlan
test_25_vpp_promisc_vlan (__main__.TestVPP.test_25_vpp_promisc_vlan) ... ok

----------------------------------------------------------------------
Ran 1 test in 34.530s

OK
[edit]
vyos@vyos# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
