### PR TITLE
pppoe: T9060: expose no-default-link-local for IPv6 address configuration

### DIFF
--- a/interface-definitions/interfaces_pppoe.xml.in
+++ b/interface-definitions/interfaces_pppoe.xml.in
@@ -105,6 +105,7 @@
                 <children>
                   #include <include/interface/ipv6-address-autoconf.xml.i>
                   #include <include/interface/ipv6-address-interface-identifier.xml.i>
+                  #include <include/interface/ipv6-address-no-default-link-local.xml.i>
                 </children>
               </node>
               #include <include/interface/adjust-mss.xml.i>

--- a/smoketest/scripts/cli/test_interfaces_pppoe.py
+++ b/smoketest/scripts/cli/test_interfaces_pppoe.py
@@ -416,5 +416,41 @@ class PPPoEInterfaceTest(VyOSUnitTestSHIM.TestCase):
             # Validate and verify assigned IP addresses
             self._verify_interface_address(interface)
 
+    def test_pppoe_no_default_link_local(self):
+        # Verify no synthetic EUI64 /64 link-local is added when no-default-link-local is set
+        interface = self._interfaces[0]
+        (user, passwd) = self.u_p_dict[interface]
+
+        self.cli_set(base_path + [interface, 'authentication', 'username', user])
+        self.cli_set(base_path + [interface, 'authentication', 'password', passwd])
+        self.cli_set(base_path + [interface, 'source-interface', self._source_interface])
+        self.cli_set(base_path + [interface, 'no-peer-dns'])
+        self.cli_set(base_path + [interface, 'ipv6', 'address', 'no-default-link-local'])
+
+        # commit changes
+        self.cli_commit()
+
+        self.assertTrue(wait_for_interface(interface),
+                        msg=f'Interface {interface} not found after {connect_timeout} seconds!')
+
+        tmp = get_interface_address(interface)
+        self.assertIn('addr_info', tmp)
+
+        link_locals = [
+            a for a in tmp['addr_info']
+            if a.get('family') == 'inet6'
+            and IPv6Address(a['local']).is_link_local
+        ]
+
+        # IPv6CP must have negotiated a link-local with the peer
+        self.assertTrue(link_locals,
+                        'No IPv6 link-local found: IPv6CP negotiation may have failed')
+
+        # No synthetic EUI64 /64 must be present on top of the IPv6CP-negotiated link-local
+        for addr in link_locals:
+            self.assertNotEqual(addr['prefixlen'], 64,
+                                'Synthetic EUI64 /64 link-local must not be present '
+                                'when no-default-link-local is configured')
+
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())


### PR DESCRIPTION
## Change summary

Expose no-default-link-local for IPv6 address configuration on PPPoE interfaces. When IPv6 is enabled on a PPPoE interface, VyOS currently adds a synthetic EUI64-derived /64 link-local address on top of the link-local already negotiated by pppd via IPv6CP. Under RFC 6724 Rule 8 (longest prefix match), the kernel prefers the synthetic /64 over the IPv6CP-negotiated address when selecting a source address, causing DHCPv6 PD to send Solicit/Request packets from the wrong link-local. ISPs that validate the source link-local against the IPv6CP-negotiated one silently drop these packets, stalling prefix delegation indefinitely.

The fix adds the missing `#include <include/interface/ipv6-address-no-default-link-local.xml.i>` to the PPPoE interface definition. The synthetic link-local remains the default; affected users opt out explicitly with set interfaces pppoe pppoe0 ipv6 address no-default-link-local.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T9060

## How to test / Smoketest result
Set up a PPPoE interface with IPv6 and no-default-link-local:

```bash
set interfaces pppoe pppoe0 source-interface eth0.20
set interfaces pppoe pppoe0 authentication username <user>
set interfaces pppoe pppoe0 authentication password <pass>
set interfaces pppoe pppoe0 ipv6 address no-default-link-local
commit
```

Verify only one link-local is present (the IPv6CP-negotiated peer address, no synthetic /64):

```bash
$ ip -6 addr show pppoe0
inet6 fe80::bd27:a8d:ab4a:60af peer fe80::1/128 scope link
     valid_lft forever preferred_lft forever
```

A smoketest covering this case was added to `test_interfaces_pppoe.py`

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation (addition of no-default-link-local to the ppp API documentation)
- [ ] I have updated the documentation accordingly