### PR TITLE
vpp: T9062: Enable DHCP/DHCPv6 client detection on VLAN sub-interfaces

### DIFF
--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -210,6 +210,59 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
             )
             self.assertTrue(icmpv6_ra_punt_feature.is_enabled)
 
+        # DHCP/DHCPv6 must also work on VLAN sub-interfaces
+        vlan = '10'
+        vif_interface = f'{interface}.{vlan}'
+        self.cli_set(
+            ['interfaces', 'ethernet', interface, 'vif', vlan, 'address', 'dhcp']
+        )
+        self.cli_set(
+            ['interfaces', 'ethernet', interface, 'vif', vlan, 'address', 'dhcpv6']
+        )
+        self.cli_commit()
+
+        # check 'ip4-dhcp-client-detect' feature is enabled
+        vif_client_detect_feature = vpp.api.feature_is_enabled(
+            sw_if_index=vpp.get_sw_if_index(vif_interface),
+            feature_name='ip4-dhcp-client-detect',
+            arc_name='ip4-unicast',
+        )
+        self.assertTrue(vif_client_detect_feature.is_enabled)
+
+        # check 'ip6-icmp-ra-punt' feature is enabled
+        # for ip6-unicast and ip6-multicast arcs
+        for arc_name in ['ip6-unicast', 'ip6-multicast']:
+            vif_icmpv6_ra_punt_feature = vpp.api.feature_is_enabled(
+                sw_if_index=vpp.get_sw_if_index(vif_interface),
+                feature_name='ip6-icmp-ra-punt',
+                arc_name=arc_name,
+            )
+            self.assertTrue(vif_icmpv6_ra_punt_feature.is_enabled)
+
+        # remove DHCP/DHCPv6 from the VLAN sub-interface
+        self.cli_delete(['interfaces', 'ethernet', interface, 'vif', vlan, 'address'])
+        self.cli_commit()
+
+        # check 'ip4-dhcp-client-detect' feature is disabled
+        vif_client_detect_feature = vpp.api.feature_is_enabled(
+            sw_if_index=vpp.get_sw_if_index(vif_interface),
+            feature_name='ip4-dhcp-client-detect',
+            arc_name='ip4-unicast',
+        )
+        self.assertFalse(vif_client_detect_feature.is_enabled)
+
+        # check 'ip6-icmp-ra-punt' feature is disabled
+        for arc_name in ['ip6-unicast', 'ip6-multicast']:
+            vif_icmpv6_ra_punt_feature = vpp.api.feature_is_enabled(
+                sw_if_index=vpp.get_sw_if_index(vif_interface),
+                feature_name='ip6-icmp-ra-punt',
+                arc_name=arc_name,
+            )
+            self.assertFalse(vif_icmpv6_ra_punt_feature.is_enabled)
+
+        # cleanup: delete the VLAN sub-interface
+        self.cli_delete(['interfaces', 'ethernet', interface, 'vif', vlan])
+
     def test_02_vpp_vxlan(self):
         vxlan_path = interfaces_path + ['vxlan']
         vni = '23'

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -455,20 +455,32 @@ def apply(ethernet):
     if vpp_iface_config is not None and is_systemd_service_running('vpp.service'):
         vpp_api = VPPControl()
 
-        # Enable ip4-dhcp-client-detect feature for DHCP-configured interfaces.
-        # This feature is required for VPP to process DHCP packets and assign addresses.
-        if 'dhcp' in ethernet.get('address', []):
-            vpp_api.enable_dhcp_client(ifname)
-        else:
-            vpp_api.disable_dhcp_client(ifname)
+        # Enable ip4-dhcp-client-detect/ip6-icmp-ra-punt features for
+        # DHCP/DHCPv6/autoconf-configured interfaces. These features are
+        # required for VPP to process DHCP(v6) packets and assign addresses.
+        # Applies to the interface itself and its VLAN sub-interfaces
+        # (vif, vif_s).vif-c (Q-in-Q) is intentionally excluded, as it is
+        # not currently functional under VPP.
+        dhcp_targets = [(ifname, ethernet)]
+        dhcp_targets += [
+            (vif['ifname'], vif) for vif in ethernet.get('vif', {}).values()
+        ]
+        dhcp_targets += [
+            (vif_s['ifname'], vif_s) for vif_s in ethernet.get('vif_s', {}).values()
+        ]
 
-        # Enable ip6-icmp-ra-punt feature for DHCPv6-configured interfaces.
-        if 'dhcpv6' in ethernet.get('address', []) or (
-            'autoconf' in ethernet.get('ipv6', {}).get('address', {})
-        ):
-            vpp_api.enable_icmpv6_ra_punt(ifname)
-        else:
-            vpp_api.disable_icmpv6_ra_punt(ifname)
+        for dhcp_ifname, dhcp_config in dhcp_targets:
+            if 'dhcp' in dhcp_config.get('address', []):
+                vpp_api.enable_dhcp_client(dhcp_ifname)
+            else:
+                vpp_api.disable_dhcp_client(dhcp_ifname)
+
+            if 'dhcpv6' in dhcp_config.get('address', []) or (
+                'autoconf' in dhcp_config.get('ipv6', {}).get('address', {})
+            ):
+                vpp_api.enable_icmpv6_ra_punt(dhcp_ifname)
+            else:
+                vpp_api.disable_icmpv6_ra_punt(dhcp_ifname)
 
         # If the interface is managed by the VPP DPDK driver, synchronize runtime
         # parameters between Linux and the corresponding VPP LCP interface


### PR DESCRIPTION
The 'ip4-dhcp-client-detect' and 'ip6-icmp-ra-punt' VPP features were only ever enabled on the base ethernet interface, so DHCP and DHCPv6 clients never worked on VLAN sub-interfaces (vif/vif-s) of a VPP-managed interface. Apply the same feature toggles to each vif/vif-s using its own address configuration. vif-c is intentionally excluded, as Q-in-Q sub-interfaces are not currently functional under VPP.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T9062
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
on server side:
```
set interfaces ethernet eth1 vif 100 address '192.168.100.1/24'
set service dhcp-server shared-network-name LAN100 subnet 192.168.100.0/24 option default-router '192.168.100.1'
set service dhcp-server shared-network-name LAN100 subnet 192.168.100.0/24 range 0 start '192.168.100.10'
set service dhcp-server shared-network-name LAN100 subnet 192.168.100.0/24 range 0 stop '192.168.100.100'
set service dhcp-server shared-network-name LAN100 subnet 192.168.100.0/24 subnet-id '1'
commit
```
on client side:
```
set vpp settings interface eth1
set interfaces ethernet eth1 vif 100 address dhcp
commit

vyos@vyos# run show interfaces 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address         MAC                VRF        MTU  S/L    Description
-----------  -----------------  -----------------  -------  -----  -----  -------------
eth0         -                  0c:ab:05:09:00:00  default   1500  u/D
eth1         -                  0c:ab:05:09:00:01  default   1500  u/u
eth1.100     192.168.100.45/24  0c:ab:05:09:00:01  default   1500  u/u
eth2         -                  0c:ab:05:09:00:02  default   1500  u/D
eth3         10.217.32.105/24   0c:ab:05:09:00:03  default   1500  u/u
lo           127.0.0.1/8        00:00:00:00:00:00  default  65536  u/u
             ::1/128
[edit]
vyos@vyos# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
