### PR TITLE
sflow: T9065: Always set psample group even when egress sampling is disabled

### DIFF
--- a/data/templates/sflow/hsflowd.conf.j2
+++ b/data/templates/sflow/hsflowd.conf.j2
@@ -25,9 +25,7 @@ sflow {
   pcap { dev={{ iface }} }
 {%     endfor %}
 {% endif %}
-{% if enable_egress is vyos_defined %}
-  psample { group=1 egress=on }
-{% endif %}
+  psample { group=1{{ ' egress=on' if enable_egress is vyos_defined }} }
 {% if drop_monitor_limit is vyos_defined %}
   dropmon { limit={{ drop_monitor_limit }} start=on sw=on hw=off }
 {% endif %}

--- a/smoketest/scripts/cli/test_system_sflow.py
+++ b/smoketest/scripts/cli/test_system_sflow.py
@@ -151,5 +151,25 @@ class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
         tmp = cmd(f'ip vrf pids {vrf}')
         self.assertIn(PROCESS_NAME, tmp)
 
+    def test_sflow_egress(self):
+        interface = 'eth0'
+        server = '192.0.2.254'
+
+        self.cli_set(base_path + ['interface', interface])
+        self.cli_set(base_path + ['server', server])
+        self.cli_commit()
+
+        # ingress sampling must work even without enable-egress configured
+        hsflowd = read_file(hsflowd_conf)
+        self.assertIn('psample { group=1 }', hsflowd)
+
+        # enable-egress only appends "egress=on", it must not gate the group
+        self.cli_set(base_path + ['enable-egress'])
+        self.cli_commit()
+
+        hsflowd = read_file(hsflowd_conf)
+        self.assertIn('psample { group=1 egress=on }', hsflowd)
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T9065
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set vpp interfaces eth0
set system sflow vpp
set system sflow server 192.0.2.100 port 6343
set vpp sflow interface eth0
commit

vyos@vyos# cat /run/sflow/hsflowd.conf 
# Generated by /usr/libexec/vyos/conf_mode/system_sflow.py
# Parameters http://sflow.net/host-sflow-linux-config.php

sflow {
  polling=30
  sampling=1000
  sampling.bps_ratio=0
  collector { ip = 192.0.2.100 udpport = 6343 }
  psample { group=1 }
  dbus { }
  vpp { }
}
[edit]
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
