### PR TITLE
T9073: frr-exporter: add CLI support for optional collectors and collector options

### DIFF
--- a/data/templates/prometheus/frr_exporter.service.j2
+++ b/data/templates/prometheus/frr_exporter.service.j2
@@ -9,7 +9,41 @@ After=network.target
 User=frr
 {% endif %}
 ExecStart={{ vrf_command }}/usr/sbin/frr_exporter \
-          --collector.bgp6 \
+        --collector.bgp6 \
+{% if optional_collectors is vyos_defined %}
+{%     for collector in optional_collectors %}
+        --collector.{{ collector }} \
+{%     endfor %}
+{% endif %}
+{% if collector is vyos_defined %}
+{%     if collector.bgp.accept_filtered_prefixes is vyos_defined %}
+        --collector.bgp.accepted-filtered-prefixes \
+{%     endif %}
+{%     if collector.bgp.advertised_prefixes is vyos_defined %}
+        --collector.bgp.advertised-prefixes \
+{%     endif %}
+{%     if collector.bgp.peer_description is vyos_defined %}
+        --collector.bgp.peer-descriptions \
+{%         if collector.bgp.peer_description is vyos_defined('plain-text') %}
+        --collector.bgp.peer-descriptions.plain-text \
+{%         endif %}
+{%     endif %}
+{%     if collector.bgp.peer_group is vyos_defined %}
+        --collector.bgp.peer-groups \
+{%     endif %}
+{%     if collector.bgp.peer_hostname is vyos_defined %}
+        --collector.bgp.peer-hostnames \
+{%     endif %}
+{%     if collector.bgp.peer_type is vyos_defined %}
+        --collector.bgp.peer-types \
+{%     endif %}
+{%     if collector.ospf_instance is vyos_defined %}
+        --collector.ospf.instances={{ collector.ospf_instance | join(',') }} \
+{%     endif %}
+{%     if collector.detailed_routes is vyos_defined %}
+        --collector.route.detailed-routes \
+{%     endif %}
+{% endif %}
 {% if listen_address is vyos_defined %}
 {%     for address in listen_address %}
         --web.listen-address={{ address | bracketize_ipv6 }}:{{ port }}

--- a/interface-definitions/service_monitoring_prometheus.xml.in
+++ b/interface-definitions/service_monitoring_prometheus.xml.in
@@ -47,6 +47,101 @@
                     <defaultValue>9342</defaultValue>
                   </leafNode>
                   #include <include/interface/vrf.xml.i>
+                  <node name="collector">
+                    <properties>
+                      <help>Collector specific configuration</help>
+                    </properties>
+                    <children>
+                      <node name="bgp">
+                        <properties>
+                          <help>BGP collector specific options</help>
+                        </properties>
+                        <children>
+                          <leafNode name="accept-filtered-prefixes">
+                            <properties>
+                              <help>Enable retrieval of accepted and filtered BGP prefix counts</help>
+                              <valueless/>
+                            </properties>
+                          </leafNode>
+                          <leafNode name="advertised-prefixes">
+                            <properties>
+                              <help>Enable count of advertised prefixes to a BGP peer (for FRR versions without PfxSnt field)</help>
+                              <valueless/>
+                            </properties>
+                          </leafNode>
+                          <leafNode name="peer-description">
+                            <properties>
+                              <help>Add the BGP peer description as a label to peer metrics</help>
+                              <completionHelp>
+                                <list>json plain-text</list>
+                              </completionHelp>
+                              <valueHelp>
+                                <format>json</format>
+                                <description>Use the value of the desc key from the JSON formatted BGP peer description</description>
+                              </valueHelp>
+                              <valueHelp>
+                                <format>plain-text</format>
+                                <description>Use the full text of the BGP peer description</description>
+                              </valueHelp>
+                              <constraint>
+                                <regex>(json|plain-text)</regex>
+                              </constraint>
+                            </properties>
+                            <defaultValue>json</defaultValue>
+                          </leafNode>
+                          <leafNode name="peer-group">
+                            <properties>
+                              <help>Add the peer group name of the BGP peer as a label to peer metrics</help>
+                              <valueless/>
+                            </properties>
+                          </leafNode>
+                          <leafNode name="peer-hostname">
+                            <properties>
+                              <help>Add the hostname of the BGP peer as a label to peer metrics</help>
+                              <valueless/>
+                            </properties>
+                          </leafNode>
+                          <leafNode name="peer-type">
+                            <properties>
+                              <help>Enable metrics for the number of established BGP peers per type, defined by the type key in the JSON formatted peer description</help>
+                              <valueless/>
+                            </properties>
+                          </leafNode>
+                        </children>
+                      </node>
+                      <leafNode name="bgp-l2-vpn">
+                        <properties>
+                          <help>Enable BGP L2VPN collector</help>
+                          <valueless/>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="ospf-instance">
+                        <properties>
+                          <help>OSPF instance ID when using multiple OSPF instances</help>
+                          <valueHelp>
+                            <format>u32:1-65535</format>
+                            <description>OSPF instance ID</description>
+                          </valueHelp>
+                          <constraint>
+                            <validator name="numeric" argument="--range 1-65535"/>
+                          </constraint>
+                          <multi/>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="pim">
+                        <properties>
+                          <help>Enable PIM collector</help>
+                          <valueless/>
+                        </properties>
+                      </leafNode>
+                      <leafNode name="detailed-routes">
+                        <properties>
+                          <help>Enable detailed route count of each route type</help>
+                          <valueless/>
+                        </properties>
+                      </leafNode>
+                    </children>
+                  </node>
                 </children>
               </node>
               <node name="blackbox-exporter">

--- a/smoketest/scripts/cli/test_service_monitoring_prometheus.py
+++ b/smoketest/scripts/cli/test_service_monitoring_prometheus.py
@@ -75,13 +75,54 @@ class TestMonitoringPrometheus(VyOSUnitTestSHIM.TestCase):
         self.assertTrue(process_named_running(NODE_EXPORTER_PROCESS_NAME))
 
     def test_02_frr_exporter(self):
+        optional_collectors = ['bgp-l2-vpn', 'pim']
+        collector_base = base_path + ['frr-exporter', 'collector']
         self.cli_set(base_path + ['frr-exporter', 'listen-address', listen_ip])
+
+        # commit changes
+        self.cli_commit()
+
+        # optional collectors and collector options are opt-in
+        file_content = read_file(frr_exporter_service_file)
+        self.assertNotIn('--collector.bgp.peer-descriptions', file_content)
+
+        for collector in optional_collectors:
+            self.cli_set(collector_base + [collector])
+
+        # BGP collector options
+        self.cli_set(collector_base + ['bgp', 'accept-filtered-prefixes'])
+        self.cli_set(collector_base + ['bgp', 'advertised-prefixes'])
+        self.cli_set(collector_base + ['bgp', 'peer-description', 'plain-text'])
+        self.cli_set(collector_base + ['bgp', 'peer-group'])
+        self.cli_set(collector_base + ['bgp', 'peer-hostname'])
+        self.cli_set(collector_base + ['bgp', 'peer-type'])
+        # OSPF collector options
+        self.cli_set(collector_base + ['ospf-instance', '1'])
+        self.cli_set(collector_base + ['ospf-instance', '2'])
+        # Route collector options
+        self.cli_set(collector_base + ['detailed-routes'])
 
         # commit changes
         self.cli_commit()
 
         file_content = read_file(frr_exporter_service_file)
         self.assertIn(f'{listen_ip}:9342', file_content)
+        # bgp6 collector is always enabled
+        self.assertIn('--collector.bgp6', file_content)
+        for collector in ['bgpl2vpn', 'pim']:
+            self.assertIn(f'--collector.{collector}', file_content)
+        for flag in [
+            '--collector.bgp.accepted-filtered-prefixes',
+            '--collector.bgp.advertised-prefixes',
+            '--collector.bgp.peer-descriptions',
+            '--collector.bgp.peer-descriptions.plain-text',
+            '--collector.bgp.peer-groups',
+            '--collector.bgp.peer-hostnames',
+            '--collector.bgp.peer-types',
+            '--collector.ospf.instances=1,2',
+            '--collector.route.detailed-routes',
+        ]:
+            self.assertIn(flag, file_content)
 
         # Check for running process
         self.assertTrue(process_named_running(FRR_EXPORTER_PROCESS_NAME))

--- a/src/conf_mode/service_monitoring_prometheus.py
+++ b/src/conf_mode/service_monitoring_prometheus.py
@@ -65,6 +65,22 @@ def get_config(config=None):
                 with_recursive_defaults=True,
             )
 
+    if 'frr_exporter' in monitoring:
+        # Optional collectors to enable, translated from the CLI node name
+        # to the upstream frr_exporter collector flag
+        collector_flags = {'bgp_l2_vpn': 'bgpl2vpn', 'pim': 'pim'}
+        collector = monitoring['frr_exporter'].get('collector', {})
+        monitoring['frr_exporter']['optional_collectors'] = [
+            flag for node, flag in collector_flags.items() if node in collector
+        ]
+        # peer-description carries a default value (json) which is merged into
+        # the config dict by with_recursive_defaults - the BGP peer description
+        # collector option is opt-in, so drop the default if it was never set
+        if not conf.exists(
+            base + ['frr-exporter', 'collector', 'bgp', 'peer-description']
+        ):
+            collector.get('bgp', {}).pop('peer_description', None)
+
     tmp = is_node_changed(conf, base + ['node-exporter', 'vrf'])
     if tmp:
         monitoring.update({'node_exporter_restart_required': {}})


### PR DESCRIPTION
## Change summary

frr_exporter only enables the bgp, ospf, bfd and route collectors by default; VyOS provided no CLI to enable the optional ones. This PR exposes them under `service monitoring prometheus frr-exporter collector`:

- `collector bgp-l2-vpn | pim` — enable optional collectors (valueless, opt-in). The upstream vrrp collector is intentionally not exposed: VyOS implements VRRP with keepalived and FRR's vrrpd is never started (`vrrpd=no`).
- `collector bgp accept-filtered-prefixes | advertised-prefixes | peer-description <json|plain-text> | peer-group | peer-hostname | peer-type` — BGP collector options (labels on per-peer metrics, peer-type aggregation). `peer-description` takes the description format (default `json`, which uses the `desc` key of a JSON formatted peer description). `peer-type` is valueless and relies on the upstream default `type` JSON key in the peer description.
- `collector ospf-instance <1-65535>` (multi) — for multi-instance OSPF
- `collector detailed-routes` — per-route-type counts

Per review feedback, CLI node names are singular (`collector`, `peer-group`, `peer-hostname`, ...) while the rendered flags keep the upstream plural spelling (`--collector.bgp.peer-groups`, `--collector.ospf.instances`, ...).

All exposed flags exist in frr_exporter v1.5.0 as packaged by vyos-build. The `collector.bgp.*` options are shared upstream by the bgp, bgp6 and bgpl2vpn collectors. The bgp6 collector stays unconditionally enabled (as introduced by T7851), so existing configurations render an identical systemd unit and no migration is required. The two value-carrying nodes (`peer-description`, `ospf-instance`) are constrained (fixed value list / numeric range) so no arbitrary text can reach the rendered `ExecStart`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T9073

## Related PR(s)

## How to test / Smoketest result

```
set service monitoring prometheus frr-exporter listen-address 192.0.2.1
set service monitoring prometheus frr-exporter collector bgp-l2-vpn
set service monitoring prometheus frr-exporter collector pim
set service monitoring prometheus frr-exporter collector bgp peer-description plain-text
set service monitoring prometheus frr-exporter collector bgp peer-type
set service monitoring prometheus frr-exporter collector ospf-instance 1
set service monitoring prometheus frr-exporter collector detailed-routes
commit
```

Verify the rendered unit and the exporter:

```
grep collector /etc/systemd/system/frr_exporter.service
curl -s http://192.0.2.1:9342/metrics | grep frr_
```

Smoketest:

```
$ /usr/libexec/vyos/tests/smoke/cli/test_service_monitoring_prometheus.py
```

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
