### PR TITLE
wireguard: T8921: Fix false port-conflict error on qos dependent re-verify

### DIFF
--- a/src/conf_mode/interfaces_wireguard.py
+++ b/src/conf_mode/interfaces_wireguard.py
@@ -26,6 +26,7 @@ from vyos.configdict import is_vrf_changed
 from vyos.configdict import is_source_interface
 from vyos.configdep import set_dependents
 from vyos.configdep import call_dependents
+from vyos.configdep import called_as_dependent
 from vyos.configverify import verify_vrf
 from vyos.configverify import verify_address
 from vyos.configverify import verify_bridge_delete
@@ -114,7 +115,14 @@ def verify(wireguard):
     if 'private_key' not in wireguard:
         raise ConfigError('Wireguard private-key not defined')
 
-    if 'port' in wireguard and 'port_changed' in wireguard:
+    # T8921: Skip the port-availability check on a qos.py-triggered
+    # dependent re-run: by then this interface already holds the port
+    # itself, so the check would always false-positive as busy.
+    if (
+        'port' in wireguard
+        and 'port_changed' in wireguard
+        and not called_as_dependent()
+    ):
         listen_port = int(wireguard['port'])
         if check_port_availability(None, listen_port, protocol='udp') is not True:
             raise ConfigError(f'UDP port {listen_port} is busy or unavailable and '


### PR DESCRIPTION
qos.py re-invokes this script mid-commit after the interface has already bound its port, causing the port-availability check to fail against itself and drop the whole QoS config. This can happen on any commit that sets or changes the port. Skip the check on that dependent re-run only.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8921
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set interfaces input ifb99
set interfaces input ifb99 description "BUG TEST IFB"
set interfaces wireguard wg99 address '10.99.99.1/32'
set interfaces wireguard wg99 description "BUG TEST WG"
set interfaces wireguard wg99 port '51999'
set interfaces wireguard wg99 private-key 'SNXK5Z5VgurzK6FQmfBn+IGhal3vVgcI5Z0sqIJzfHQ='
set interfaces wireguard wg99 redirect ifb99
set qos policy cake my-cake-policy bandwidth '100mbit'
set qos interface ifb99 egress my-cake-policy

vyos@vyos# commit
[edit]
vyos@vyos# tc filter show dev wg99 parent ffff:
filter protocol all pref 10 u32 chain 0 
filter protocol all pref 10 u32 chain 0 fh 800: ht divisor 1 
filter protocol all pref 10 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 flowid 1:1 not_in_hw 
  match 00000000/00000000 at 0
	action order 1: mirred (Egress Redirect to device ifb99) stolen
	index 1 ref 1 bind 1

[edit]
vyos@vyos# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
