### PR TITLE
cli: T9077: insert literal '?' inside quoted values instead of triggering help

### DIFF
--- a/src/etc/bash_completion.d/vyatta-op
+++ b/src/etc/bash_completion.d/vyatta-op
@@ -42,10 +42,10 @@ test -z "$VYATTA_PAGER" && \
 #   set firewall group remote-group X url 'https://example.com/list?key=abc'
 _vyatta_question_mark ()
 {
-  local head=${READLINE_LINE:0:READLINE_POINT}
+  local head="${READLINE_LINE:0:READLINE_POINT}"
   local i c in_sq='' in_dq='' esc=''
   for (( i=0; i<${#head}; i++ )); do
-    c=${head:i:1}
+    c="${head:i:1}"
     if [[ -n $esc ]]; then
       esc=''
       continue
@@ -57,14 +57,15 @@ _vyatta_question_mark ()
     esac
   done
   if [[ -n $in_sq || -n $in_dq || -n $esc ]]; then
-    READLINE_LINE=${READLINE_LINE:0:READLINE_POINT}\?${READLINE_LINE:READLINE_POINT}
+    READLINE_LINE="${READLINE_LINE:0:READLINE_POINT}?${READLINE_LINE:READLINE_POINT}"
     (( READLINE_POINT++ ))
   else
     # 'bind -x' handlers cannot invoke readline functions directly, so
     # ask the terminal for a Device Status Report (DSR); the terminal's
     # reply (ESC [ 0 n) is bound to possible-completions below, which
     # re-enters the standard help path with the line unchanged.
-    printf '\e[5n'
+    # Write to /dev/tty so help still works if stdout is redirected.
+    printf '\e[5n' > /dev/tty
   fi
 }
 

--- a/src/etc/bash_completion.d/vyatta-op
+++ b/src/etc/bash_completion.d/vyatta-op
@@ -35,6 +35,39 @@ test -z "$_vyatta_default_pager" && \
 test -z "$VYATTA_PAGER" && \
     declare -x VYATTA_PAGER=$_vyatta_default_pager
 
+# Handler for the '?' key. Outside of a quoted string, '?' shows the
+# completion help as before. Inside a quoted string (or after a
+# backslash), it self-inserts, so values like URLs with query strings
+# can be typed without Ctrl-V:
+#   set firewall group remote-group X url 'https://example.com/list?key=abc'
+_vyatta_question_mark ()
+{
+  local head=${READLINE_LINE:0:READLINE_POINT}
+  local i c in_sq='' in_dq='' esc=''
+  for (( i=0; i<${#head}; i++ )); do
+    c=${head:i:1}
+    if [[ -n $esc ]]; then
+      esc=''
+      continue
+    fi
+    case $c in
+      \\) [[ -z $in_sq ]] && esc=1 ;;
+      \') [[ -z $in_dq ]] && { [[ -n $in_sq ]] && in_sq='' || in_sq=1; } ;;
+      \") [[ -z $in_sq ]] && { [[ -n $in_dq ]] && in_dq='' || in_dq=1; } ;;
+    esac
+  done
+  if [[ -n $in_sq || -n $in_dq || -n $esc ]]; then
+    READLINE_LINE=${READLINE_LINE:0:READLINE_POINT}\?${READLINE_LINE:READLINE_POINT}
+    (( READLINE_POINT++ ))
+  else
+    # 'bind -x' handlers cannot invoke readline functions directly, so
+    # ask the terminal for a Device Status Report (DSR); the terminal's
+    # reply (ESC [ 0 n) is bound to possible-completions below, which
+    # re-enters the standard help path with the line unchanged.
+    printf '\e[5n'
+  fi
+}
+
 _vyatta_op_do_key_bindings ()
 {
   if [[ "$SHELL" != "/bin/vbash" && "$SHELL" != "/sbin/radius_shell" ]]; then
@@ -45,7 +78,8 @@ _vyatta_op_do_key_bindings ()
   shopt -u nullglob
   case "$-" in
     *i*)
-      bind '"?": possible-completions'
+      bind -x '"?": _vyatta_question_mark'
+      bind '"\e[0n": possible-completions'
       bind 'set show-all-if-ambiguous on'
       bind_cmds=$(grep '^bind .* # vyatta key binding$' $HOME/.bashrc)
       eval $bind_cmds

--- a/src/op_mode/toggle_help_binding.sh
+++ b/src/op_mode/toggle_help_binding.sh
@@ -21,5 +21,6 @@ if [ "$1" == 'disable' ]; then
   bind '"?": self-insert'
 else
   sed -i "/^bind '\"?\": .* # vyatta key binding$/d" $HOME/.bashrc
-  bind '"?": possible-completions'
+  # default binding: quote-aware help handler from bash_completion.d/vyatta-op
+  bind -x '"?": _vyatta_question_mark'
 fi


### PR DESCRIPTION
## Change Summary

In the interactive CLI, `?` is a raw readline binding (`bind '"?": possible-completions'`), so a literal question mark can never be typed into a value — readline intercepts the keystroke before bash parsing begins, and quoting cannot protect it. Values like remote-group URLs with query strings are silently corrupted (`'.../blacklist?key=x'` is stored as `.../blacklistkey=x`) with no error at any stage.

This PR rebinds `?` to a quote-aware `bind -x` handler: inside an open single/double quote (or after a backslash) the key self-inserts; everywhere else it shows the completion help exactly as before.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T9077

## Related PR(s)

* https://github.com/vyos/vyos-documentation/pull/2149 (documentation)

## Component(s) name

op-mode, CLI completion (`bash_completion.d/vyatta-op`)

## Proposed changes

- `src/etc/bash_completion.d/vyatta-op`: add `_vyatta_question_mark`, a `bind -x` handler that scans `READLINE_LINE` left of the cursor tracking single-quote, double-quote and backslash-escape state. Inside a quote/escape it inserts a literal `?` at the cursor; otherwise it triggers the standard help via a DSR round-trip (`printf '\e[5n'`, with the terminal's reply `ESC [ 0 n` bound to `possible-completions`), so the help path and output remain the stock readline behavior. A `bind -x` handler cannot invoke readline functions directly, hence the DSR indirection.
- `src/op_mode/toggle_help_binding.sh`: `set terminal key query-help enable` now restores the quote-aware handler instead of the raw `possible-completions` binding. `disable` keeps its existing `self-insert` override, which continues to take precedence at login via the existing `.bashrc` mechanism.

Known limitation: on a terminal that does not answer DSR (a VT100-era feature supported by all common terminal emulators and serial terminals), `?`-help would not fire; `Ctrl-V ?` and TAB completion are unaffected either way.

## How to test

On a live system, replace `/etc/bash_completion.d/vyatta-op` with the patched file and start a new login shell:

```
configure
set firewall group remote-group TEST url 'https://api.example.com/v2/blacklist?ipVersion=4&key=SECRET'
show firewall group remote-group TEST url
discard
```

Before the patch, the `?` keystroke pops the help table and the stored value is `.../blacklistipVersion=4&key=SECRET`. With the patch, the URL is stored intact.

Also verified on VyOS 2026.07.10-1446-rolling:
- `?` help still works at top level and mid-command in both op and config mode (over ssh)
- `Ctrl-V ?` still inserts a literal `?`
- `set terminal key query-help disable` / `enable` round-trip
- quote-state unit cases (open `'`/`"` → insert; unquoted/closed-quotes/empty line → help; trailing backslash → insert; escaped `\"` inside double quotes → still inside; cursor mid-line positions)

## Smoketest result

Not applicable — interactive readline behavior has no smoketest coverage; `bash -n` passes on both changed files and behavior was verified manually as described above.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

