### PR TITLE
vpp: T9057: Fix promiscuous mode not disabled on bond member detach

### DIFF
--- a/python/vyos/ifconfig/vpp/bond.py
+++ b/python/vyos/ifconfig/vpp/bond.py
@@ -35,6 +35,7 @@ class VPPBondInterface(Interface, VPPInterface):
         self.mode = config.get('mode')
         self.load_balance = config.get('hash_policy')
         self.mac = config.get('mac')
+        self.vlan_members = config.get('vlan_members')
 
     def _create(self):
         pass
@@ -76,26 +77,30 @@ class VPPBondInterface(Interface, VPPInterface):
         """Add member to Bond interface
         Example:
             from vyos.ifconfig.vpp import VPPBondInterface
-            a = VPPBondInterface(ifname='vppbond0', config)
+            a = VPPBondInterface('vppbond0', config)
             a.add_member(interface='eth0')
         """
-        member_if_index = self.vpp.get_sw_if_index(interface)
         self.vpp.api.bond_add_member(
-            bond_sw_if_index=self.index, sw_if_index=member_if_index
+            bond_sw_if_index=self.index,
+            sw_if_index=self.vpp.get_sw_if_index(interface),
         )
-        self.vpp.api.sw_interface_set_promisc(
-            sw_if_index=member_if_index, promisc_on=True
-        )
+        self.vpp.set_promisc(interface, enable=True)
 
     def detach_member(self, interface):
         """Detach member from Bond interface
         Example:
             from vyos.ifconfig.vpp import VPPBondInterface
-            a = VPPBondInterface(ifname='vppbond0')
+            config = {'vlan_members': []}
+            a = VPPBondInterface('vppbond0', config)
             a.detach_member(interface='eth0')
         """
-        member_if_index = self.vpp.get_sw_if_index(interface)
-        self.vpp.api.bond_detach_member(sw_if_index=member_if_index)
+        self.vpp.api.bond_detach_member(
+            sw_if_index=self.vpp.get_sw_if_index(interface),
+        )
+        # Keep promiscuous mode if the interface still requires it for its
+        # own VLAN (vif/vif-s) sub-interfaces
+        if interface not in self.vlan_members:
+            self.vpp.set_promisc(interface, enable=False)
 
     def get_members(self):
         members = []

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -477,6 +477,10 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
             "Interface BondEthernet23 is not in the expected state 'up'.",
         )
 
+        # promiscuous mode must be enabled on a member interface
+        _, out = rc_cmd(f'sudo vppctl show hardware-interfaces {interface}')
+        self.assertRegex(out, r'flags:.*\bpromisc\b')
+
         self.cli_set(bond_path + [interface_bond, 'description', description])
         for vlan in vlans:
             self.cli_set(
@@ -526,6 +530,29 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
         self.assertFalse(os.path.isdir(f'/sys/class/net/{interface_bond}.{vlan}'))
 
+        # a member with its own VLAN (vif) must keep promiscuous mode
+        # enabled after being detached from the bond
+        member_vlan = '789'
+        self.cli_set(['interfaces', 'ethernet', interface, 'vif', member_vlan])
+        self.cli_commit()
+
+        self.cli_delete(bond_path + [interface_bond, 'member', 'interface', interface])
+        self.cli_commit()
+
+        _, out = rc_cmd(f'sudo vppctl show hardware-interfaces {interface}')
+        self.assertRegex(out, r'flags:.*\bpromisc\b')
+
+        # remove the member's VLAN too: promiscuous mode must now be disabled
+        self.cli_delete(['interfaces', 'ethernet', interface, 'vif', member_vlan])
+        self.cli_commit()
+
+        _, out = rc_cmd(f'sudo vppctl show hardware-interfaces {interface}')
+        self.assertNotRegex(out, r'flags:.*\bpromisc\b')
+
+        # re-add the member for the remaining bond-deletion checks below
+        self.cli_set(bond_path + [interface_bond, 'member', 'interface', interface])
+        self.cli_commit()
+
         # delete bonding interface
         self.cli_delete(bond_path)
         self.cli_commit()
@@ -533,6 +560,11 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         # check deleting bonding interface
         _, out = rc_cmd('sudo vppctl show interface')
         self.assertNotIn('BondEthernet23', out)
+
+        # promiscuous mode must be disabled once the member is
+        # detached from the bond (bond deletion detaches all members)
+        _, out = rc_cmd(f'sudo vppctl show hardware-interfaces {interface}')
+        self.assertNotRegex(out, r'flags:.*\bpromisc\b')
 
     def test_06_vpp_bridge(self):
         bridge_path = interfaces_path + ['bridge']

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -448,6 +448,10 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
             "Interface BondEthernet23 is not in the expected state 'up'.",
         )
 
+        # promiscuous mode must be enabled on a member interface
+        _, out = rc_cmd(f'sudo vppctl show hardware-interfaces {interface}')
+        self.assertRegex(out, r'flags:.*\bpromisc\b')
+
         self.cli_set(bond_path + [interface_bond, 'description', description])
         for vlan in vlans:
             self.cli_set(
@@ -497,6 +501,29 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
         self.assertFalse(os.path.isdir(f'/sys/class/net/{interface_bond}.{vlan}'))
 
+        # a member with its own VLAN (vif) must keep promiscuous mode
+        # enabled after being detached from the bond
+        member_vlan = '789'
+        self.cli_set(['interfaces', 'ethernet', interface, 'vif', member_vlan])
+        self.cli_commit()
+
+        self.cli_delete(bond_path + [interface_bond, 'member', 'interface', interface])
+        self.cli_commit()
+
+        _, out = rc_cmd(f'sudo vppctl show hardware-interfaces {interface}')
+        self.assertRegex(out, r'flags:.*\bpromisc\b')
+
+        # remove the member's VLAN too: promiscuous mode must now be disabled
+        self.cli_delete(['interfaces', 'ethernet', interface, 'vif', member_vlan])
+        self.cli_commit()
+
+        _, out = rc_cmd(f'sudo vppctl show hardware-interfaces {interface}')
+        self.assertNotRegex(out, r'flags:.*\bpromisc\b')
+
+        # re-add the member for the remaining bond-deletion checks below
+        self.cli_set(bond_path + [interface_bond, 'member', 'interface', interface])
+        self.cli_commit()
+
         # delete bonding interface
         self.cli_delete(bond_path)
         self.cli_commit()
@@ -504,6 +531,11 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         # check deleting bonding interface
         _, out = rc_cmd('sudo vppctl show interface')
         self.assertNotIn('BondEthernet23', out)
+
+        # promiscuous mode must be disabled once the member is
+        # detached from the bond (bond deletion detaches all members)
+        _, out = rc_cmd(f'sudo vppctl show hardware-interfaces {interface}')
+        self.assertNotRegex(out, r'flags:.*\bpromisc\b')
 
     def test_06_vpp_bridge(self):
         bridge_path = interfaces_path + ['bridge']

--- a/src/conf_mode/vpp_interfaces_bonding.py
+++ b/src/conf_mode/vpp_interfaces_bonding.py
@@ -18,11 +18,14 @@
 
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
+from vyos.configdict import has_vlan_subinterface_configured
 from vyos.configdict import is_node_changed
+from vyos.configdict import leaf_node_changed
 from vyos.configdep import set_dependents, call_dependents
 from vyos.configverify import verify_mtu_ipv6
 from vyos import ConfigError
 from vyos.utils.assertion import assert_mac
+from vyos.utils.dict import dict_search
 from vyos.utils.process import is_systemd_service_active
 
 from vyos.ifconfig import Interface
@@ -116,6 +119,21 @@ def get_config(config=None) -> dict:
             config.update({'rebuild_required': {}})
 
     config['bond_members'] = deps_bond_dict(conf)
+
+    # Members that get detached (removed from the bond, or temporarily
+    # detached and re-attached during a rebuild) keep promiscuous mode
+    # enabled if they have their own VLAN (vif/vif-s) sub-interfaces
+    # configured
+    removed_members = (
+        leaf_node_changed(conf, iface_path + ['member', 'interface']) or []
+    )
+    current_members = dict_search('member.interface', config, default=[])
+    vlan_candidates = set(removed_members + current_members)
+    config['vlan_members'] = [
+        member
+        for member in vlan_candidates
+        if has_vlan_subinterface_configured(conf, member)
+    ]
 
     # Dependency
     config['xconn_members'] = deps_xconnect_dict(conf)


### PR DESCRIPTION
detach_member() never disabled promiscuous mode when a member left a VPP bond or the bond was deleted, unlike add_member() which always enabled it. Disable it on detach, except for members that still have their own vif/vif-s sub-interfaces configured, since VPP requires promiscuous mode to pass their VLAN-tagged traffic.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T9057
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos#  /usr/libexec/vyos/tests/smoke/cli/test_vpp.py -k test_05_vpp_bonding
test_05_vpp_bonding (__main__.TestVPP.test_05_vpp_bonding) ... ok

----------------------------------------------------------------------
Ran 1 test in 46.005s

OK
[edit]
vyos@vyos# 
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
