### PR TITLE
ci: T9082: scan C code with CodeQL (add c-cpp, build-mode none)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,4 +33,5 @@ jobs:
     uses: vyos/.github/.github/workflows/codeql-analysis.yml@production
     secrets: inherit
     with:
-      languages: "['python']"
+      languages: "['python', 'c-cpp']"
+      build-mode: "none"


### PR DESCRIPTION
The CodeQL caller previously scanned only Python, leaving this repo's C sources unanalyzed. Adds `c-cpp` to the language matrix with `build-mode: "none"` (codeql-action v4 no-build extraction — validated on the T9082 cpp canary with coverage parity against autobuild).

Part of the vyos-org CodeQL rollout ([T9082](https://vyos.dev/T9082), [IS-610](https://vyos.atlassian.net/browse/IS-610)).

Advances: IS-610

🤖 Generated by [robots](https://vyos.io)

[IS-610]: https://vyos.atlassian.net/browse/IS-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ