### PR TITLE
router-advert: T9084: allow name-server-lifetime 0 in CLI validator

### DIFF
--- a/interface-definitions/service_router-advert.xml.in
+++ b/interface-definitions/service_router-advert.xml.in
@@ -149,9 +149,9 @@
                     <description>Maximum interval in seconds</description>
                   </valueHelp>
                   <constraint>
-                    <validator name="numeric" argument="--range 1-7200"/>
+                    <validator name="numeric" argument="--range 0-0 --range 1-7200"/>
                   </constraint>
-                  <constraintErrorMessage>Maximum interval must be between 1 and 7200 seconds</constraintErrorMessage>
+                  <constraintErrorMessage>RDNSS lifetime must be 0 or between 1 and 7200 seconds</constraintErrorMessage>
                 </properties>
               </leafNode>
               <leafNode name="other-config-flag">

--- a/interface-definitions/service_router-advert.xml.in
+++ b/interface-definitions/service_router-advert.xml.in
@@ -149,7 +149,7 @@
                     <description>Maximum interval in seconds</description>
                   </valueHelp>
                   <constraint>
-                    <validator name="numeric" argument="--range 0-0 --range 1-7200"/>
+                    <validator name="numeric" argument="--range 0-7200"/>
                   </constraint>
                   <constraintErrorMessage>RDNSS lifetime must be 0 or between 1 and 7200 seconds</constraintErrorMessage>
                 </properties>

--- a/smoketest/scripts/cli/test_service_router-advert.py
+++ b/smoketest/scripts/cli/test_service_router-advert.py
@@ -148,6 +148,15 @@ class TestServiceRADVD(VyOSUnitTestSHIM.TestCase):
         tmp = 'DNSSL ' + ' '.join(dnssl) + ' {'
         self.assertIn(tmp, config)
 
+        # Lifetime 0 withdraws RDNSS (RFC 8106); CLI must accept it (T9084).
+        ns_lifetime = '0'
+        self.cli_set(base_path + ['name-server-lifetime', ns_lifetime])
+        self.cli_commit()
+
+        config = read_file(RADVD_CONF)
+        tmp = f'AdvRDNSSLifetime {ns_lifetime};'
+        self.assertIn(tmp, config)
+
     def test_deprecate_prefix(self):
         self.cli_set(base_path + ['prefix', prefix, 'valid-lifetime', 'infinity'])
         self.cli_set(base_path + ['prefix', prefix, 'deprecate-prefix'])


### PR DESCRIPTION
## Summary

Fixes [T9084](https://vyos.dev/T9084): CLI rejected `name-server-lifetime 0` even though:

- `valueHelp` documents `u32:0` as "Name-servers should no longer be used"
- conf-mode (`service_router-advert.py`) already skips MaxRtrAdvInterval checks when `lifetime > 0` is false
- RFC 8106 / radvd treat RDNSS lifetime 0 as "resolvers must no longer be used"

The XML constraint only allowed `1-7200`. Align with the existing `default-lifetime` pattern in the same file (`--range 0-0 --range …`).

## Changes

- `interface-definitions/service_router-advert.xml.in`: constraint `--range 0-0 --range 1-7200`; clearer error message
- `smoketest/scripts/cli/test_service_router-advert.py`: assert `name-server-lifetime 0` commits and renders `AdvRDNSSLifetime 0`

## How to test

```
configure
set interfaces ethernet eth1 address 2001:db8::1/64
set service router-advert interface eth1 prefix ::/64
set service router-advert interface eth1 name-server 2001:db8::53
set service router-advert interface eth1 name-server-lifetime 0
commit
```

Expect success. Generated `/run/radvd/radvd.conf` should contain `AdvRDNSSLifetime 0`.

Smoketest: `test_service_router-advert.py` (`test_dns`).

## Checklist

- [x] Commit message references Phabricator task (`T9084`)
- [x] Single issue / self-contained change
- [x] Component prefix in commit subject (`router-advert:`)
- [x] Smoke test updated

Closes / refs: https://vyos.dev/T9084