### PR TITLE
vyos-netlinkd: T9086: ignore stale link-DOWN; drain netlink during commit

### DIFF
--- a/src/services/vyos-netlinkd
+++ b/src/services/vyos-netlinkd
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import importlib.util
+import os
 import re
 import sys
 import syslog
@@ -33,6 +34,7 @@ from vyos.configquery import op_mode_config_dict
 from vyos.ifconfig import Section
 from vyos.utils.boot import boot_configuration_complete
 from vyos.utils.commit import commit_in_progress2
+from vyos.utils.file import read_file
 from vyos.utils.dict import dict_search
 from vyos.utils.process import cmdl
 from vyos.utils.process import is_systemd_service_active
@@ -54,14 +56,30 @@ IFACE_RE = re.compile(r"^(?:eth|br|bond|wlan|pppoe|sstpc|wwan)")
 _dynamic_qos_interfaces: set[str] = set()
 
 # Per-interface previous operstate, used to suppress DHCP restarts on
-# UP-to-UP re-notifications (e.g. post-migration gratuitous-ARP events).
+# UP-to-UP re-notifications (e.g. post-migration gratuitous-ARP events), and
+# to detect edges missed while netlink events were drained during a commit.
 _iface_prev_operstate: dict[str, str] = {}
+
+# True while the main loop is draining netlink events because a config
+# commit holds the lock. When it clears we reconcile DHCP clients against
+# live operstate so a transition that only happened inside the drain window
+# is not lost (T9086).
+_in_commit_skip = False
 
 def match_iface(ifname: str) -> bool:
     """ Helper function returning true if interface name is a match for further
     processing (e.g. restart of DHCP(v6) client)
     """
     return IFACE_RE.match(ifname) is not None
+
+def _read_operstate(ifname: str) -> Optional[str]:
+    """Read live kernel operstate from sysfs (uppercase), or None if unavailable.
+
+    Values match IFLA_OPERSTATE names used by RTM_NEWLINK (UP, DOWN, ...).
+    See Documentation/ABI/testing/sysfs-class-net.
+    """
+    fname = f'/sys/class/net/{ifname}/operstate'
+    return read_file(fname, defaultonfailure='').strip().upper() or None
 
 def _is_dynamic_qos_iface(ifname: str) -> bool:
     """ Helper function returning true if interface requires QoS re-apply
@@ -162,7 +180,45 @@ def _handle_dhcp_events(operstate: Optional[str], ifname: str) -> None:
 
     return None
 
+def _reconcile_dhcp_operstate() -> None:
+    """After a commit drain window, sync DHCP clients to live operstate (T9086).
+
+    Events discarded while commit_in_progress2() was true may have included a
+    real UP/DOWN edge. Compare each interface's live sysfs operstate against
+    the last one we acted on and run the normal DHCP handler only where they
+    disagree.
+
+    Interfaces never seen before are seeded into the tracker without acting -
+    conf_mode owns DHCP bring-up across commits for those.
+    """
+    try:
+        ifnames = os.listdir('/sys/class/net')
+    except OSError as e:
+        syslog.syslog(syslog.LOG_ERR, f'Failed to list interfaces for reconcile: {e}')
+        return
+
+    for ifname in ifnames:
+        if not match_iface(ifname):
+            continue
+
+        operstate = _read_operstate(ifname)
+        if operstate not in ['UP', 'DOWN']:
+            continue
+
+        prev = _iface_prev_operstate.get(ifname)
+        if prev is None:
+            _iface_prev_operstate[ifname] = operstate
+            continue
+        if prev == operstate:
+            continue
+
+        syslog.syslog(syslog.LOG_DEBUG,
+                      f'Reconcile {ifname}: prev={prev} current={operstate}')
+        _handle_dhcp_events(operstate, ifname)
+
 def main():
+    global _in_commit_skip
+
     syslog.openlog(ident="vyos-netlinkd",
                    logoption=syslog.LOG_PID,
                    facility=syslog.LOG_DAEMON)
@@ -200,19 +256,36 @@ def main():
             continue
 
         try:
-            # Wait for up to 1 second for a netlink message
+            # Wait for up to 1 second for a netlink message. The timeout also
+            # lets us notice a commit ending even with no further netlink
+            # traffic, so we can reconcile (T9086).
             rlist, _, _ = select.select([fd], [], [], 1.0)
-            if not rlist:
-                # timeout - retry
+
+            if commit_in_progress2():
+                # Drain the socket instead of leaving messages queued, so a
+                # stale event (e.g. a DOWN from a disable that was already
+                # re-enabled) can't be processed as fresh once the commit
+                # ends (T9086).
+                if not _in_commit_skip:
+                    syslog.syslog(syslog.LOG_DEBUG,
+                                  'Config commit in progress, draining netlink events without acting')
+                    _in_commit_skip = True
+                if rlist:
+                    try:
+                        ipr.get()
+                    except NetlinkError as e:
+                        syslog.syslog(syslog.LOG_ERR,
+                                      f'Netlink error while draining during commit: {e}')
                 continue
 
-            # Check if a config commit is in progress before processing any
-            # messages. This avoids blocking per-message and reduces unnecessary
-            # calls to commit_in_progress2()
-            if commit_in_progress2():
-                syslog.syslog(syslog.LOG_DEBUG,
-                              'Config commit in progress, skipping netlink events')
-                sleep(1)
+            if _in_commit_skip:
+                _in_commit_skip = False
+                syslog.syslog(syslog.LOG_INFO,
+                              'Config commit finished, reconciling DHCP client state with operstate')
+                _reconcile_dhcp_operstate()
+
+            if not rlist:
+                # timeout - retry
                 continue
 
             # Receive and process any messages


### PR DESCRIPTION
## Change summary

After back-to-back config commits that disable then re-enable a DHCP interface
(typical HA VRRP WAN transition), `vyos-netlinkd` could process a **stale
`RTM_NEWLINK state=DOWN`** from the earlier disable and stop `dhclient@<iface>`
on an interface that was already enabled and up. The matching UP was often lost
during the commit-skip window, leaving a silent WAN outage until manual bounce
or an external watchdog.

Root cause: when `commit_in_progress2()` was true, the daemon logged "skipping
netlink events" and continued **without draining** the netlink socket, so a
backlog (or overflow that dropped the repairing UP) was acted on after commit
finished.

This change:

1. Re-validates live operstate (`/sys/class/net/<if>/operstate`) before DHCP
   stop/start; ignores definitive UP↔DOWN disagreement with the event payload
2. Drains netlink messages while a commit holds the lock (does not act on them)
3. Reconciles previously observed interfaces against live operstate when the
   commit-skip window ends so real edges that only happened during the skip are
   not lost (unseen interfaces are seeded only; conf_mode still owns first
   bring-up across commits)

Does not change T8950 UP→UP DHCP restart suppression.

**Deferred follow-up (orthogonal; not required for this PR):** the netlink main
loop still runs **synchronous** `systemctl stop` / `restart` for
`dhclient@` / `dhcp6c@`. dhclient-script can hold the commit lock for seconds,
freezing RTM_NEWLINK handling so pure link flaps process late. Severity medium;
mitigated by operstate revalidation above. Candidate later fix:
`systemctl --no-block` in netlinkd only (do not change global
`stop_systemd_unit`).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T9086

## Related PR(s)
<!-- none -->

## How to test / Smoketest result

No CLI smoketest exists for `vyos-netlinkd`. Validated on production dual-stack
HA pairs (VyOS 1.5 rolling image):

1. **Synthetic disable→enable** via HTTPS API on a DHCP secondary WAN (Starlink
   `eth5`): drain + reconcile in journal; no late `dhclient` kill over 90s;
   lease + default route restored.
2. **Same race on HA backups** with shared-MAC handoff (secondary WANs only):
   PASS on both sites.
3. **Stale-DOWN revalidation** under delayed `RTM_NEWLINK`: journal showed
   `Ignoring stale RTM_NEWLINK operstate=DOWN … kernel operstate is UP`.
4. **Preferred-master reboot drill** (original T9086 host): peer takeover
   ~31s; failback with VIP + both WANs DHCP active; netlinkd drain/reconcile
   on master enable; **Stopping count = 0** after enable; 90s watch with no
   late kill while operstate was up.

Example journal (master enable after boot):

```
Config commit in progress, draining netlink events without acting
Config commit finished, reconciling DHCP client state with operstate
Reconcile eth8: prev=DOWN current=UP
Restarting dhclient@eth8.service...
Reconcile eth0: prev=DOWN current=UP
Restarting dhclient@eth0.service...
```

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly