### PR TITLE
vpp: T8367: Fix identical default MAC on bridged loopback interfaces

### DIFF
--- a/interface-definitions/vpp_interface_loopback.xml.in
+++ b/interface-definitions/vpp_interface_loopback.xml.in
@@ -21,6 +21,7 @@
               #include <include/generic-description.xml.i>
               #include <include/interface/disable.xml.i>
               #include <include/interface/address-ipv4-ipv6.xml.i>
+              #include <include/interface/mac.xml.i>
               #include <include/interface/mtu-68-16000.xml.i>
               #include <include/vpp/vif.xml.i>
             </children>

--- a/python/vyos/ifconfig/vpp/loopback.py
+++ b/python/vyos/ifconfig/vpp/loopback.py
@@ -18,6 +18,8 @@
 
 from vyos.ifconfig import Interface
 from vyos.ifconfig.vpp.interface import VPPInterface
+from vyos.utils.network import gen_mac
+from vyos.utils.network import get_host_identity
 
 
 class VPPLoopbackInterface(Interface, VPPInterface):
@@ -34,6 +36,7 @@ class VPPLoopbackInterface(Interface, VPPInterface):
 
         self.index = self.vpp.get_sw_if_index(self.vpp_ifname)
         self.state = 'up' if 'disable' not in config else 'down'
+        self.mac = config.get('mac')
 
     def _create(self):
         pass
@@ -49,6 +52,13 @@ class VPPLoopbackInterface(Interface, VPPInterface):
         self.vpp.api.create_loopback_instance(
             is_specified=True, user_instance=self.instance
         )
+        # VPP's default loopback MAC is based only on the instance
+        # number (de:ad:00:00:00:<instance>), so two nodes configuring the
+        # same instance always conflict. Otherwise, use a host-unique MAC
+        # so bridging a loopback as a BVI across nodes never conflicts.
+        if not self.mac:
+            self.mac = gen_mac(self.ifname, '', get_host_identity())
+        self.vpp.set_iface_mac(self.vpp_ifname, self.mac)
         # Add LCP pair (kernel) interface
         self.kernel_add()
         # Set interface state

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -34,6 +34,7 @@ from vyos.utils.process import rc_cmd
 from vyos.utils.system import sysctl_read
 from vyos.utils.network import interface_exists
 from vyos.system import image
+from vyos.ifconfig import Interface
 from vyos.vpp import VPPControl
 from vyos.vpp.utils import vpp_ip_addresses_by_index
 from vyos.vpp.utils import vpp_iface_name_transform
@@ -401,6 +402,7 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         loopback_path = interfaces_path + ['loopback']
         interface_loopback = 'vpplo11'
         address = '192.0.2.54'
+        mac = '00:50:00:00:00:11'
 
         self.cli_set(loopback_path + [interface_loopback])
         self.cli_set(loopback_path + [interface_loopback, 'address', f'{address}/25'])
@@ -417,6 +419,14 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         _, out = rc_cmd('sudo vppctl show interface loop11')
         required_str = 'loop11'
         self.assertIn(required_str, out)
+
+        # check explicit MAC
+        self.cli_set(loopback_path + [interface_loopback, 'mac', mac])
+        self.cli_commit()
+
+        _, out = rc_cmd('sudo vppctl show hardware-interfaces loop11')
+        self.assertIn(f'Ethernet address {mac}', out)
+        self.assertEqual(mac, Interface(interface_loopback).get_mac())
 
         # delete loopback interface
         self.cli_delete(loopback_path + [interface_loopback])
@@ -623,6 +633,25 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
 
         self.assertRegex(normalized_out, r'10 1 \d+ off')
         self.assertRegex(out, r'\bloop23\s+\d+\s+\d+\s+\d+\s+\*\s+')
+
+        # A loopback is fully deleted and recreated in VPP on every apply,
+        # getting a new sw_if_index - reconfiguring it must reattach it to
+        # the bridge as BVI rather than leaving the bridge pointing at the
+        # stale, now-deleted interface
+        self.cli_set(
+            interfaces_path + ['loopback', f'vpplo{vni}', 'mac', '00:50:00:00:00:23']
+        )
+        self.cli_commit()
+
+        _, out = rc_cmd('sudo vppctl show bridge-domain 10 detail')
+        normalized_out = re.sub(r'\s+', ' ', out)
+        self.assertRegex(normalized_out, r'10 1 \d+ off')
+        self.assertRegex(out, r'\bloop23\s+\d+\s+\d+\s+\d+\s+\*\s+')
+
+        # cannot remove loopback interface while it is used as BVI
+        self.cli_delete(interfaces_path + ['loopback', f'vpplo{vni}'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
 
     def test_07_vpp_ipip(self):
         ipip_path = interfaces_path + ['ipip']

--- a/src/conf_mode/vpp_interfaces_loopback.py
+++ b/src/conf_mode/vpp_interfaces_loopback.py
@@ -24,6 +24,8 @@ from vyos.configdep import set_dependents, call_dependents
 from vyos.utils.process import is_systemd_service_active
 
 from vyos.ifconfig.vpp import VPPLoopbackInterface
+from vyos.vpp.config_deps import deps_bridge_dict
+from vyos.vpp.config_verify import verify_vpp_remove_bridge_interface
 
 
 def get_config(config=None) -> dict:
@@ -55,6 +57,12 @@ def get_config(config=None) -> dict:
         no_tag_node_value_mangle=True,
     )
 
+    # Bridge dependency - reattach as BVI after this loopback is recreated
+    config['bridge_members'] = deps_bridge_dict(conf)
+    if ifname in config['bridge_members']:
+        for bridge_iface in config['bridge_members'][ifname]:
+            set_dependents('vpp_interfaces_bridge', conf, bridge_iface)
+
     # NAT dependency
     if conf.exists(['vpp', 'nat', 'nat44']):
         set_dependents('vpp_nat_nat44', conf)
@@ -72,6 +80,8 @@ def verify(config):
     # No need to verify anything if vpp is removed
     if 'remove_vpp' in config:
         return None
+
+    verify_vpp_remove_bridge_interface(config)
 
     if not is_systemd_service_active('vpp.service'):
         raise ConfigError(


### PR DESCRIPTION
VPP assigns loopback interfaces a default MAC address derived only from
the interface instance number (de:ad:00:00:00:<instance>), with no
host-specific entropy. Two independent VPP nodes configuring the same
loopback instance (e.g. as a bridge BVI over VXLAN) therefore end up with
an identical MAC address.
When that MAC arrives from a peer over the shared L2 segment, VPP's L2
learning logic rejects it as a `mac move violation` - it's statically
pinned to the local BVI and cannot legitimately appear on another port.
This silently drops ARP traffic between the loopbacks while ordinary
bridged client traffic (unique MACs) is unaffected, breaking
loopback-to-loopback connectivity.
Add a mac-address option to the VPP loopback interface, and fall back to
a deterministic, host-unique MAC (derived from host UUID/hostname, same
scheme already used for container interfaces) whenever none is
configured, so the collision can no longer occur by default.
Also fix a related bug found while reproducing the above: a loopback is
fully deleted and recreated in VPP on every apply, receiving a new
`sw_if_index` each time. The loopback conf_mode script never registered
the bridge it's a BVI member of as a dependent, so the bridge kept its
L2 membership bound to the stale, deleted index instead of reattaching
the current one. Register the bridge dependency and reuse the existing
`verify_vpp_remove_bridge_interface()` check to block deleting a
loopback still in use as a BVI.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T8367
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
R1:
```
set vpp settings interface eth1
set interfaces ethernet eth1 address '10.0.0.1/24'
set interfaces vpp vxlan vppvxlan123456 source-address '10.0.0.1'
set interfaces vpp vxlan vppvxlan123456 remote '10.0.0.2'
set interfaces vpp vxlan vppvxlan123456 vni '123456'
set interfaces vpp loopback vpplo1 address '100.64.0.1/24'
set interfaces vpp bridge vppbr1 member interface vppvxlan123456
set interfaces vpp bridge vppbr1 member interface vpplo1 bvi
commit
```
R2:
```
set vpp settings interface eth1
set interfaces ethernet eth1 address '10.0.0.2/24'
set interfaces vpp vxlan vppvxlan123456 source-address '10.0.0.2'
set interfaces vpp vxlan vppvxlan123456 remote '10.0.0.1'
set interfaces vpp vxlan vppvxlan123456 vni '123456'
set interfaces vpp loopback vpplo1 address '100.64.0.2/24'
set interfaces vpp bridge vppbr1 member interface vppvxlan123456
set interfaces vpp bridge vppbr1 member interface vpplo1 bvi
commit
```
Before the fix:
Without an explicit `mac`, both loopbacks got VPP's default, which is derived only from the instance number (`de:ad:00:00:00:<instance>`) - identical on both nodes. 
Ping between the loopbacks fails, and ARP never resolves:
```
vpp# show trace
------------------- Start of thread 0 vpp_main -------------------
Packet 1

00:37:45:163322: dpdk-input
eth1 rx queue 0
...
00:37:45:165647: vxlan4-input
VXLAN decap from vxlan_tunnel0 vni 123456 next 1 error 0
00:37:45:165649: l2-input
l2-input: sw_if_index 7 dst ff:ff:ff:ff:ff:ff src de:ad:00:00:00:0a [l2-learn l2-flood ]
00:37:45:165650: l2-learn
l2-learn: sw_if_index 7 dst ff:ff:ff:ff:ff:ff src de:ad:00:00:00:0a bd_index 1
00:37:45:165651: error-drop
rx:vxlan_tunnel10
00:37:45:165653: drop
l2-learn: L2 mac move violations
```
After the fix:
With no `mac` configured, each router now generates its own host-unique MAC instead of the colliding default:
```
vyos@vyos# sudo vppctl show hardware-interfaces loop1
              Name                Idx   Link  Hardware
loop1                              5     up   loop1
  Link speed: unknown
  Ethernet address 02:2f:7b:3f:d1:88
[edit]
vyos@vyos# ping 100.64.0.2
PING 100.64.0.2 (100.64.0.2) 56(84) bytes of data.
64 bytes from 100.64.0.2: icmp_seq=1 ttl=64 time=9.48 ms
64 bytes from 100.64.0.2: icmp_seq=2 ttl=64 time=1.53 ms
64 bytes from 100.64.0.2: icmp_seq=3 ttl=64 time=1.15 ms
64 bytes from 100.64.0.2: icmp_seq=4 ttl=64 time=1.29 ms
^C
--- 100.64.0.2 ping statistics ---
4 packets transmitted, 4 received, 0% packet loss, time 3005ms
rtt min/avg/max/mdev = 1.152/3.363/9.480/3.534 ms
[edit]
vyos@vyos# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
