### PR TITLE
wireless: T9104: fix CLI/OS race on interface removal

### DIFF
--- a/src/conf_mode/interfaces_wireless.py
+++ b/src/conf_mode/interfaces_wireless.py
@@ -322,7 +322,8 @@ def apply(wifi):
     call(f'systemctl stop wpa_supplicant@{interface}.service')
 
     if 'deleted' in wifi:
-        WiFiIf(**wifi).remove()
+        if interface_exists(interface):
+            WiFiIf(**wifi).remove()
 
         # run the dependents and return
         call_dependents()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

A classical race condition detected depending on host system CPU load while executing smoketests.

Removal of the Wireless/Wifi interfaces can cause a KeyError.

```
DEBUG -
DEBUG - Traceback (most recent call last):
DEBUG -   File "/usr/libexec/vyos/conf_mode/interfaces_wireless.py", line 414, in <module>
DEBUG -     apply(c)
DEBUG -   File "/usr/libexec/vyos/conf_mode/interfaces_wireless.py", line 325, in apply
DEBUG -     WiFiIf(**wifi).remove()
DEBUG -     ^^^^^^^^^^^^^^
DEBUG -   File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 358, in __init__
DEBUG -     self._create()
DEBUG -   File "/usr/lib/python3/dist-packages/vyos/ifconfig/wireless.py", line 33, in _create
DEBUG -     cmd = ['iw', 'phy', self.config['physical_device'], 'interface', 'add',
DEBUG -                         ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
DEBUG - KeyError: 'physical_device'
DEBUG -
DEBUG - noteworthy:
DEBUG - cmd 'ip link show dev wlan1'
DEBUG - returned (out):
DEBUG -
DEBUG - returned (err):
DEBUG - Device "wlan1" does not exist.
DEBUG -
DEBUG - delete [ interfaces wireless wlan1 ] failed
DEBUG - Commit failed
```

In `src/conf_mode/interfaces_wireless.py:apply()`, the delete path unconditionally does `WiFiIf(**wifi).remove()`.
Since the `wifi` dict for a deleted node never contains `physical_device`, and `Interface.__init__` calls `self._create()` whenever the kernel interface doesn't already exist, `WiFiIf._create()` crashes with `KeyError: 'physical_device'` when the interface never actually got created (or already vanished) before deletion.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9104

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
Integrated smoketests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
