### PR TITLE
T8329: Fix interface naming for Azure VF interfaces with Accelerated Networking enabled

### DIFF
--- a/src/etc/udev/rules.d/63-hyperv-vf-net.rules
+++ b/src/etc/udev/rules.d/63-hyperv-vf-net.rules
@@ -1,5 +1,9 @@
 ATTR{[dmi/id]sys_vendor}!="Microsoft Corporation", GOTO="end_hyperv_nic"
 
-ACTION=="add", SUBSYSTEM=="net", DRIVERS=="hv_pci", NAME="vf_%k"
+# Primary rename path for Azure VF.
+# Use helper-based naming so the VFs that reuse eth0,eth1,.. names do not
+# collide with already assigned vf_ethN names. Also, prevent renaming of
+# the interfaces already renamed to vf_ethN
+ACTION=="add", SUBSYSTEM=="net", DRIVERS=="hv_pci", KERNEL=="eth*", PROGRAM="vyos_vf_name %k", NAME="%c"
 
 LABEL="end_hyperv_nic"

--- a/src/etc/udev/rules.d/65-vyos-net.rules
+++ b/src/etc/udev/rules.d/65-vyos-net.rules
@@ -4,20 +4,23 @@
 ACTION!="add", 				GOTO="vyos_net_end"
 SUBSYSTEM!="net",			GOTO="vyos_net_end"
 
-# Fallback path for Azure VFs: if any Azure Mellanox VF still appears as plain
-# ethN, rename it to vf_ethX before persistent synthetic interface naming runs
-# to prevent it from incorrectly being considered as a synthetic interface.
+# Fallback path for Azure VF interfaces: if a VF still appears as plain ethN,
+# rename it to vf_ethX before persistent synthetic interface naming runs to
+# prevent it from incorrectly being considered as a synthetic interface.
 ATTR{[dmi/id]sys_vendor}=="Microsoft Corporation", DRIVERS=="mlx*_core", KERNEL=="eth*", PROGRAM="vyos_vf_name %k", NAME="%c", GOTO="vyos_net_end"
+ATTR{[dmi/id]sys_vendor}=="Microsoft Corporation", DRIVERS=="mana", KERNEL=="eth*", PROGRAM="vyos_vf_name %k", NAME="%c", GOTO="vyos_net_end"
 
 # VF interfaces are not handled by vyos_net_name, so skip them.
-# KERNEL=="vf_*" catches already-renamed VFs.
-# DRIVERS=="mlx*_core" on Azure catches VFs that reached here in an unexpected
-# intermediate state, are still named ethN/eN and must not be remapped
-# by vyos_net_name. This guard is intentionally scoped to Microsoft Azure
-# to avoid excluding bare-metal Mellanox NICs on physical hardware, which do
+# KERNEL=="vf_*" catches already-renamed Mellanox and MANA VFs.
+# DRIVERS=="mlx*_core" and DRIVERS=="mana" on Azure catch VF interfaces
+# in an unexpected intermediate state (still named ethN/eN) that must not
+# be remapped by vyos_net_name.
+# This guard is intentionally scoped to Microsoft Azure to
+# avoid excluding bare-metal Mellanox NICs on physical hardware, which do
 # need persistent naming via vyos_net_name.
 KERNEL=="vf_*", 							GOTO="vyos_net_end"
 ATTR{[dmi/id]sys_vendor}=="Microsoft Corporation", DRIVERS=="mlx*_core",	GOTO="vyos_net_end"
+ATTR{[dmi/id]sys_vendor}=="Microsoft Corporation", DRIVERS=="mana",      	GOTO="vyos_net_end"
 
 # Do name change for ethernet and wireless devices only
 KERNEL!="eth*|wlan*|e*", 			GOTO="vyos_net_end"

--- a/src/etc/udev/rules.d/65-vyos-net.rules
+++ b/src/etc/udev/rules.d/65-vyos-net.rules
@@ -4,6 +4,21 @@
 ACTION!="add", 				GOTO="vyos_net_end"
 SUBSYSTEM!="net",			GOTO="vyos_net_end"
 
+# Fallback path for Azure VFs: if any Azure Mellanox VF still appears as plain
+# ethN, rename it to vf_ethX before persistent synthetic interface naming runs
+# to prevent it from incorrectly being considered as a synthetic interface.
+ATTR{[dmi/id]sys_vendor}=="Microsoft Corporation", DRIVERS=="mlx*_core", KERNEL=="eth*", PROGRAM="vyos_vf_name %k", NAME="%c", GOTO="vyos_net_end"
+
+# VF interfaces are not handled by vyos_net_name, so skip them.
+# KERNEL=="vf_*" catches already-renamed VFs.
+# DRIVERS=="mlx*_core" on Azure catches VFs that reached here in an unexpected
+# intermediate state, are still named ethN/eN and must not be remapped
+# by vyos_net_name. This guard is intentionally scoped to Microsoft Azure
+# to avoid excluding bare-metal Mellanox NICs on physical hardware, which do
+# need persistent naming via vyos_net_name.
+KERNEL=="vf_*", 							GOTO="vyos_net_end"
+ATTR{[dmi/id]sys_vendor}=="Microsoft Corporation", DRIVERS=="mlx*_core",	GOTO="vyos_net_end"
+
 # Do name change for ethernet and wireless devices only
 KERNEL!="eth*|wlan*|e*", 			GOTO="vyos_net_end"
 

--- a/src/system/vyos-net-name-resolve.py
+++ b/src/system/vyos-net-name-resolve.py
@@ -178,6 +178,11 @@ def discover_physical_interfaces(sys_class_net: str = '/sys/class/net') -> dict:
     """Return {kernel_name: mac} for every interface backed by a real bus
     device - excludes lo, bridges, bonds, VLANs, veth, tunnels, etc.
 
+    Also excludes interfaces enslaved to another netdev (master symlink
+    present), which covers Azure VF datapath interfaces bound under their
+    synthetic parent. Those are acceleration children, not independent
+    primary interfaces, and must not be candidates for hw-id naming.
+
     sys_class_net is overridable for testing against a fake sysfs tree.
     """
     interfaces = {}
@@ -187,6 +192,14 @@ def discover_physical_interfaces(sys_class_net: str = '/sys/class/net') -> dict:
 
     for entry in net_dir.iterdir():
         if not (entry / 'device').exists():
+            logger.debug(
+                f"skipping '{entry.name}': no backing device in sysfs"
+            )
+            continue
+        if (entry / 'master').exists():
+            logger.debug(
+                f"skipping '{entry.name}': interface is enslaved via master link"
+            )
             continue
         mac = get_permanent_mac(entry.name, sys_class_net)
         if mac:

--- a/src/udev/vyos_vf_name
+++ b/src/udev/vyos_vf_name
@@ -1,0 +1,88 @@
+#!/bin/sh
+# vyos_vf_name - pick a non-colliding VF interface name.
+# Called by udev rules for VF devices that still have plain ethN names.
+#
+# Written as a POSIX shell script so it works in both initramfs (no Python3)
+# and the normal rootfs udev context.
+#
+# Usage: vyos_vf_name <current_ifname>
+# Prints the target vf_ethN name to stdout.
+
+set -e
+
+if [ -z "$1" ]; then
+    exit 1
+fi
+
+IFNAME="$1"
+LOCK_DIR="/run/udev"
+LOCK_PATH="${LOCK_DIR}/vyos_vf_name.lock"
+
+# Already normalized - return as-is.
+case "$IFNAME" in
+    vf_*)
+        echo "$IFNAME"
+        exit 0
+        ;;
+esac
+
+mkdir -p "$LOCK_DIR"
+
+# Acquire a lock to avoid race conditions when multiple VF devices are being
+# renamed concurrently.
+LOCK_ACQUIRED=0
+I=0
+while [ "$I" -lt 200 ]; do
+    if mkdir "$LOCK_PATH" 2>/dev/null; then
+        LOCK_ACQUIRED=1
+        break
+    fi
+    I=$((I + 1))
+    sleep 0.01
+done
+
+[ "$LOCK_ACQUIRED" -eq 1 ] || exit 1
+
+cleanup() {
+    rmdir "$LOCK_PATH" 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Preferred: preserve the original ethN index when vf_ethN is not yet taken.
+case "$IFNAME" in
+    eth*)
+        PREFERRED="${IFNAME#eth}"
+        # Validate it is a pure integer.
+        case "$PREFERRED" in
+            *[!0-9]*)
+                ;;
+            *)
+                if ! [ -d "/sys/class/net/vf_eth${PREFERRED}" ]; then
+                    echo "vf_eth${PREFERRED}"
+                    exit 0
+                fi
+                ;;
+        esac
+        ;;
+esac
+
+# Fallback: allocate just above the highest ethN synthetic index present to
+# avoid collisions.
+MAX=-1
+for D in /sys/class/net/eth*; do
+    [ -d "$D" ] || continue
+    N="${D##*/eth}"
+    # Skip if not a pure integer (e.g. no match expands to literal path).
+    case "$N" in *[!0-9]*) continue;; esac
+    [ "$N" -gt "$MAX" ] && MAX="$N"
+done
+
+IDX=$((MAX + 1))
+[ "$IDX" -lt 0 ] && IDX=0
+
+# Skip any indices already occupied by existing vf_ethN interfaces.
+while [ -d "/sys/class/net/vf_eth${IDX}" ]; do
+    IDX=$((IDX + 1))
+done
+
+echo "vf_eth${IDX}"


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
ROOT-CAUSE:
Some Azure VF interfaces miss to get renamed leading to errors in the downstream rules and mess up with the interface names. Two main problematic scenarios were found which prohibited the renaming of a VF interface to vf_ethN:
1. Missing udev add event, when change event is received directly
2. A VF interface registering during rootfs stage

BEHAVIOR EXPLANATION (Pre-fix):
- If add event is not received for a VF interface, instead a change event is received directly. The rule 63 would not rename the VF interface to `vf_ethN` because the rule acts on add condition and not a change. So it remained exposed as `ethN`. Once that happened, later handling depended on downstream rules.
- If a VF interfaces registers during initramfs stage, upon receiving the add event, Rule 63 renames it to `vf_ethN`. After that, for rule 65 `vyos_net_name` fails silently to execute as it is not available in initramfs. Hence, `vf_ethN` name becomes the final name. Though the final state is the intended state, the execution included a silent failure of the script `vyos_net_name`.
- If a VF interface registers during rootfs stage, Rule 63 correctly sets candidate `NAME= vf_ethN` for VF interfaces , but rule 65 runs afterwards and overwrites NAME to `ethY` via vyos_net_name which becomes the (unintended) final name. To be noted, `vyos_net_name` executes successfully now as it is available in rootfs.
- VF interfaces were also being recursively prefixed with `vf_` based on just the `drivers` condition in rule 63.

FIX:
Rule 63:
-Azure VF naming is now handled by a dedicated helper - `vyos_vf_name` to provide collision-free names for VF interfaces. The helper `vyos_vf_name` would be packaged into initramfs so the same behavior works in early boot and normal boot (a separate PR). -Rule 63 is now guarded to prevent recursive renaming of VF interfaces.

Rule 65:
-A fallback VF rename path has been added for any leftover VF interfaces that were missed to be renamed due to some unexpected situation. Those VF interfaces are renamed prior to running persistent renaming of synthetic interfaces. This prevents VF interfaces from being considered as synthetic interfaces which may lead to errors in the flow of execution. -Rule 65 is now guarded so generic persistent naming does not override VF names.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8329
https://vyos.dev/T7712
1
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-build/pull/1249

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
[az-fixed-logs.txt](https://github.com/user-attachments/files/30281823/az-fixed-logs.txt)

```
adminuser@VyOS-for-Tests:~$ ip -br link
lo               UNKNOWN        00:00:00:00:00:00 <LOOPBACK,UP,LOWER_UP> 
eth0             UP             7c:ed:8d:5a:f4:6d <BROADCAST,MULTICAST,UP,LOWER_UP> 
eth1             UP             7c:ed:8d:5a:f5:13 <BROADCAST,MULTICAST,UP,LOWER_UP> 
eth3             UP             7c:ed:8d:5a:f7:e3 <BROADCAST,MULTICAST,UP,LOWER_UP> 
eth2             UP             7c:ed:8d:5a:f9:25 <BROADCAST,MULTICAST,UP,LOWER_UP> 
vf_eth0          UP             7c:ed:8d:5a:f5:13 <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> 
vf_eth1          UP             7c:ed:8d:5a:f7:e3 <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> 
vf_eth2          UP             7c:ed:8d:5a:f9:25 <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> 
pim6reg@NONE     UNKNOWN        <NOARP,UP,LOWER_UP> 
adminuser@VyOS-for-Tests:~$ show int
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface    IP Address    MAC                VRF        MTU  S/L    Description
-----------  ------------  -----------------  -------  -----  -----  -------------
eth0         10.0.1.4/24   7c:ed:8d:5a:f4:6d  default   1500  u/u    WAN
eth1         10.0.11.5/24  7c:ed:8d:5a:f5:13  default   1500  u/u    LAN1
eth2         10.0.11.6/24  7c:ed:8d:5a:f9:25  default   1500  u/u    LAN2
eth3         10.0.11.4/24  7c:ed:8d:5a:f7:e3  default   1500  u/u    LAN3
lo           127.0.0.1/8   00:00:00:00:00:00  default  65536  u/u
             ::1/128
             
```

Late appearing VF (second eth0) successfully renamed:
```
[    2.414811] hv_netvsc 7ced8d5a-f513-7ced-8d5a-f5137ced8d5a e3: VF registering: eth0
[    2.416396] mlx5_core 980c:00:02.0 eth0: joined to e3
[    2.417070] mlx5_core 980c:00:02.0 eth0: Disabling LRO, not supported in legacy RQ
[    2.418180] mlx5_core 980c:00:02.0 eth0: Disabling LRO, not supported in legacy RQ
[    2.418849] mlx5_core 980c:00:02.0 eth0: Disabling LRO, not supported in legacy RQ
[    2.419509] mlx5_core 980c:00:02.0: MLX5E: StrdRq(0) RqSz(1024) StrdSz(256) RxCqeCmprss(0 basic)
[    2.455531] hv_netvsc 7ced8d5a-f925-7ced-8d5a-f9257ced8d5a e4: VF registering: eth1
[    2.456231] mlx5_core e546:00:02.0 eth1: joined to e4
[    2.456898] mlx5_core e546:00:02.0 eth1: Disabling LRO, not supported in legacy RQ
[    2.458019] mlx5_core e546:00:02.0 eth1: Disabling LRO, not supported in legacy RQ
[    2.458665] mlx5_core e546:00:02.0 eth1: Disabling LRO, not supported in legacy RQ
[    2.462054] mlx5_core e546:00:02.0: MLX5E: StrdRq(0) RqSz(1024) StrdSz(256) RxCqeCmprss(0 basic)
[    2.476827] mlx5_core e546:00:02.0 vf_eth1: renamed from eth1
[    2.494961] mlx5_core 980c:00:02.0 vf_eth0: renamed from eth0
[    2.494989] mlx5_core 3c2b:00:02.0: enabling device (0000 -> 0002)
[    2.498924] mlx5_core 3c2b:00:02.0: firmware version: 14.30.5026
[    2.633001] mlx5_core 3c2b:00:02.0: Flow counters bulk query buffer size increased, bulk_query_len(8)
[    2.715197] hv_netvsc 7ced8d5a-f7e3-7ced-8d5a-f7e37ced8d5a e5: VF registering: eth0
[    2.717389] mlx5_core 3c2b:00:02.0 eth0: joined to e5
[    2.718067] mlx5_core 3c2b:00:02.0 eth0: Disabling LRO, not supported in legacy RQ
[    2.719224] mlx5_core 3c2b:00:02.0 eth0: Disabling LRO, not supported in legacy RQ
[    2.719910] mlx5_core 3c2b:00:02.0 eth0: Disabling LRO, not supported in legacy RQ
[    2.720547] mlx5_core 3c2b:00:02.0: MLX5E: StrdRq(0) RqSz(1024) StrdSz(256) RxCqeCmprss(0 basic)
[    2.723706] mlx5_core 3c2b:00:02.0 vf_eth2: renamed from eth0

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

Depends-on: https://github.com/vyos/vyos-1x/pull/5350