### PR TITLE
T8382: Add VPP Prometheus exporter

### DIFF
--- a/data/templates/prometheus/vpp_exporter.service.j2
+++ b/data/templates/prometheus/vpp_exporter.service.j2
@@ -1,0 +1,15 @@
+{% set vrf_command = 'ip vrf exec ' ~ vrf ~ ' ' if vrf is vyos_defined else '' %}
+[Unit]
+Description=VPP Prometheus Exporter
+After=network.target vpp.service
+Wants=vpp.service
+PartOf=vpp.service
+BindsTo=vpp.service
+
+[Service]
+ExecStart={{ vrf_command }}/usr/bin/vpp_prometheus_export v2 socket-name /run/vpp/stats.sock port {{ port }} {{ patterns | join(' ') }}
+Restart=always
+RestartSec=2s
+
+[Install]
+WantedBy=vpp.service

--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -131,6 +131,9 @@ linux-nl {
 
 {% if resource_allocation.memory.stats is vyos_defined %}
 statseg {
+{%     if resource_allocation.memory.stats.per_node_counters is vyos_defined %}
+    per-node-counters on
+{%     endif %}
 {%     if resource_allocation.memory.stats.size is vyos_defined %}
     size {{ resource_allocation.memory.stats.size }}
 {%     endif %}

--- a/interface-definitions/service_monitoring_prometheus.xml.in
+++ b/interface-definitions/service_monitoring_prometheus.xml.in
@@ -220,6 +220,62 @@
                   </node>
                 </children>
               </node>
+              <node name="vpp-exporter">
+                <properties>
+                  <help>Prometheus exporter for VPP metrics</help>
+                </properties>
+                <children>
+                  #include <include/port-number.xml.i>
+                  <leafNode name="port">
+                    <defaultValue>9482</defaultValue>
+                  </leafNode>
+                  #include <include/interface/vrf.xml.i>
+                  <leafNode name="stat-group">
+                    <properties>
+                      <help>VPP stat groups to be exported</help>
+                      <valueHelp>
+                        <format>interfaces</format>
+                        <description>Interface counters</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>err</format>
+                        <description>Error counters</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>buffer-pools</format>
+                        <description>Buffer pool counters</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>system</format>
+                        <description>System counters</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>workers</format>
+                        <description>Worker counters</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>nodes</format>
+                        <description>Node counters</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>memory</format>
+                        <description>Memory counters</description>
+                      </valueHelp>
+                      <constraint>
+                        <regex>(interfaces|err|buffer-pools|system|workers|nodes|memory)</regex>
+                      </constraint>
+                      <constraintErrorMessage>Invalid stat-group. Allowed values: interfaces, err, buffer-pools, system, workers, nodes, memory</constraintErrorMessage>
+                      <multi/>
+                    </properties>
+                  </leafNode>
+                  <leafNode name="stat-pattern">
+                    <properties>
+                      <help>Regex pattern to export filtered VPP stats. Examples: ^/interfaces, ^/interfaces/.*/rx$</help>
+                      <multi/>
+                    </properties>
+                  </leafNode>
+                </children>
+              </node>
             </children>
           </node>
         </children>

--- a/interface-definitions/service_monitoring_prometheus.xml.in
+++ b/interface-definitions/service_monitoring_prometheus.xml.in
@@ -261,16 +261,18 @@
                         <format>memory</format>
                         <description>Memory counters</description>
                       </valueHelp>
+                      <valueHelp>
+                        <format>nat44</format>
+                        <description>NAT44 counters</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>acl</format>
+                        <description>ACL match counters</description>
+                      </valueHelp>
                       <constraint>
-                        <regex>(interfaces|err|buffer-pools|system|workers|nodes|memory)</regex>
+                        <regex>(interfaces|err|buffer-pools|system|workers|nodes|memory|nat44|acl)</regex>
                       </constraint>
-                      <constraintErrorMessage>Invalid stat-group. Allowed values: interfaces, err, buffer-pools, system, workers, nodes, memory</constraintErrorMessage>
-                      <multi/>
-                    </properties>
-                  </leafNode>
-                  <leafNode name="stat-pattern">
-                    <properties>
-                      <help>Regex pattern to export filtered VPP stats. Examples: ^/interfaces, ^/interfaces/.*/rx$</help>
+                      <constraintErrorMessage>Invalid stat-group. Allowed values: interfaces, err, buffer-pools, system, workers, nodes, memory, nat44, acl</constraintErrorMessage>
                       <multi/>
                     </properties>
                   </leafNode>

--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -323,6 +323,12 @@
                       <help>Stats settings</help>
                     </properties>
                     <children>
+                      <leafNode name="per-node-counters">
+                        <properties>
+                          <help>Enable per-node counters within the statistics segment</help>
+                          <valueless/>
+                        </properties>
+                      </leafNode>
                       <leafNode name="size">
                         <properties>
                           <help>Size of stats segment</help>

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -62,6 +62,16 @@ vpp_system_stat_patterns = (
     '^/sys/last_update$',
     '^/sys/input_rate$',
 )
+vpp_nat44_stat_patterns = (
+    '^/nat44-.*/total-sessions$',
+    '^/nat44-ed/max-cfg-sessions$',
+    '^/nat44-ed/in2out/fastpath/.*$',
+    '^/nat44-ed/out2in/fastpath/.*$',
+    '^/nat44-ed/in2out/slowpath/.*$',
+    '^/nat44-ed/out2in/slowpath/.*$',
+    '^/nat44-ed/hairpinning$',
+)
+vpp_acl_stat_patterns = ('^/acl/.*/matches$',)
 
 
 def get_vpp_config():
@@ -1842,6 +1852,10 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.assertIn('^/workers', file_content)
         self.assertIn('^/mem', file_content)
         self.assertNotIn('^/nodes', file_content)
+        for pattern in vpp_nat44_stat_patterns:
+            self.assertNotIn(pattern, file_content)
+        for pattern in vpp_acl_stat_patterns:
+            self.assertNotIn(pattern, file_content)
         self.assertIn('PartOf=vpp.service', file_content)
         self.assertIn('BindsTo=vpp.service', file_content)
         self.assertIn('WantedBy=vpp.service', file_content)
@@ -1855,24 +1869,30 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.assertFalse(os.path.exists(vpp_exporter_service_file))
         self.assertFalse(os.path.lexists(vpp_exporter_enable_link))
 
-    def test_26_2_vpp_exporter_groups_and_custom_patterns(self):
+    def test_26_2_vpp_exporter_selected_groups(self):
         exporter_path = prometheus_base_path + ['vpp-exporter']
         self.cli_set(resource_path + ['memory', 'stats', 'per-node-counters'])
         self.cli_set(exporter_path)
         self.cli_set(exporter_path + ['stat-group', 'interfaces'])
+        self.cli_set(exporter_path + ['stat-group', 'buffer-pools'])
         self.cli_set(exporter_path + ['stat-group', 'system'])
         self.cli_set(exporter_path + ['stat-group', 'nodes'])
         self.cli_set(exporter_path + ['stat-group', 'memory'])
-        self.cli_set(exporter_path + ['stat-pattern', '^/buffer-pools/.*/used$'])
+        self.cli_set(exporter_path + ['stat-group', 'nat44'])
+        self.cli_set(exporter_path + ['stat-group', 'acl'])
         self.cli_commit()
 
         file_content = read_file(vpp_exporter_service_file)
         self.assertIn('^/interfaces', file_content)
+        self.assertIn('^/buffer-pools', file_content)
         for pattern in vpp_system_stat_patterns:
             self.assertIn(pattern, file_content)
         self.assertIn('^/nodes', file_content)
         self.assertIn('^/mem', file_content)
-        self.assertIn('^/buffer-pools/.*/used$', file_content)
+        for pattern in vpp_nat44_stat_patterns:
+            self.assertIn(pattern, file_content)
+        for pattern in vpp_acl_stat_patterns:
+            self.assertIn(pattern, file_content)
         self.assertNotIn('^/err', file_content)
         self.assertTrue(process_named_running(VPP_EXPORTER_PROCESS_NAME))
 

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -41,11 +41,16 @@ from vyos.vpp.utils import vpp_iface_name_transform
 from vyos.vpp.config_resource_checks.resource_defaults import default_resource_map
 
 PROCESS_NAME = 'vpp_main'
+VPP_EXPORTER_PROCESS_NAME = 'vpp_prometheus_export'
 VPP_CONF = '/run/vpp/vpp.conf'
 base_path = ['vpp']
+prometheus_base_path = ['service', 'monitoring', 'prometheus']
 resource_path = base_path + ['settings', 'resource-allocation']
 interfaces_path = ['interfaces', 'vpp']
 interface = 'eth1'
+vpp_exporter_service_file = '/etc/systemd/system/vpp_exporter.service'
+vpp_exporter_enable_link = '/etc/systemd/system/vpp.service.wants/vpp_exporter.service'
+vpp_exporter_vrf = 'vpp-exporter'
 
 
 def get_vpp_config():
@@ -122,6 +127,8 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
             # Ensure these cleanup operations always run
             self.cli_delete(base_path)
             self.cli_delete(interfaces_path)
+            self.cli_delete(prometheus_base_path)
+            self.cli_delete(['vrf', 'name', vpp_exporter_vrf])
             self.cli_commit()
 
             # delete address and any custom MAC for the Ethernet interface
@@ -875,6 +882,13 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
 
             conf = get_vpp_config()
             self.assertEqual(conf['memory']['main-heap-page-size'], size)
+
+    def test_11_4_statseg_per_node_counters(self):
+        self.cli_set(resource_path + ['memory', 'stats', 'per-node-counters'])
+        self.cli_commit()
+
+        conf = get_vpp_config()
+        self.assertEqual(conf['statseg']['per-node-counters'], 'on')
 
     def test_12_vpp_ipsec_xfrm_nl(self):
         rx_buffer_zise = default_resource_map.get('netlink_rx_buffer_size')
@@ -1801,6 +1815,71 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         # Verify promisc is disabled
         _, out = rc_cmd(f'sudo vppctl show hardware-interfaces {interface}')
         self.assertNotRegex(out, r'flags:.*\bpromisc\b')
+
+    def test_26_1_vpp_exporter_default_groups(self):
+        self.cli_set(prometheus_base_path + ['vpp-exporter'])
+        self.cli_commit()
+
+        file_content = read_file(vpp_exporter_service_file)
+        self.assertIn('port 9482', file_content)
+        self.assertIn('socket-name /run/vpp/stats.sock', file_content)
+        self.assertIn('^/interfaces', file_content)
+        self.assertIn('^/err', file_content)
+        self.assertIn('^/buffer-pools', file_content)
+        self.assertIn('^/sys', file_content)
+        self.assertIn('^/workers', file_content)
+        self.assertIn('^/mem', file_content)
+        self.assertNotIn('^/nodes', file_content)
+        self.assertIn('PartOf=vpp.service', file_content)
+        self.assertIn('BindsTo=vpp.service', file_content)
+        self.assertIn('WantedBy=vpp.service', file_content)
+        self.assertTrue(os.path.islink(vpp_exporter_enable_link))
+        self.assertTrue(process_named_running(VPP_EXPORTER_PROCESS_NAME))
+
+        self.cli_delete(prometheus_base_path)
+        self.cli_commit()
+
+        self.assertFalse(process_named_running(VPP_EXPORTER_PROCESS_NAME))
+        self.assertFalse(os.path.exists(vpp_exporter_service_file))
+        self.assertFalse(os.path.lexists(vpp_exporter_enable_link))
+
+    def test_26_2_vpp_exporter_groups_and_custom_patterns(self):
+        exporter_path = prometheus_base_path + ['vpp-exporter']
+        self.cli_set(resource_path + ['memory', 'stats', 'per-node-counters'])
+        self.cli_set(exporter_path)
+        self.cli_set(exporter_path + ['stat-group', 'interfaces'])
+        self.cli_set(exporter_path + ['stat-group', 'system'])
+        self.cli_set(exporter_path + ['stat-group', 'nodes'])
+        self.cli_set(exporter_path + ['stat-group', 'memory'])
+        self.cli_set(exporter_path + ['stat-pattern', '^/buffer-pools/.*/used$'])
+        self.cli_commit()
+
+        file_content = read_file(vpp_exporter_service_file)
+        self.assertIn('^/interfaces', file_content)
+        self.assertIn('^/sys', file_content)
+        self.assertIn('^/nodes', file_content)
+        self.assertIn('^/mem', file_content)
+        self.assertIn('^/buffer-pools/.*/used$', file_content)
+        self.assertNotIn('^/err', file_content)
+        self.assertTrue(process_named_running(VPP_EXPORTER_PROCESS_NAME))
+
+    def test_26_3_vpp_exporter_vrf(self):
+        self.cli_set(['vrf', 'name', vpp_exporter_vrf, 'table', '1001'])
+        self.cli_set(prometheus_base_path + ['vpp-exporter', 'vrf', vpp_exporter_vrf])
+        self.cli_commit()
+
+        file_content = read_file(vpp_exporter_service_file)
+        self.assertIn(
+            f'ExecStart=ip vrf exec {vpp_exporter_vrf} '
+            '/usr/bin/vpp_prometheus_export',
+            file_content,
+        )
+        self.assertTrue(process_named_running(VPP_EXPORTER_PROCESS_NAME))
+
+        self.cli_delete(prometheus_base_path)
+        self.cli_commit()
+        self.cli_delete(['vrf', 'name', vpp_exporter_vrf])
+        self.cli_commit()
 
 
 if __name__ == '__main__':

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -51,6 +51,17 @@ interface = 'eth1'
 vpp_exporter_service_file = '/etc/systemd/system/vpp_exporter.service'
 vpp_exporter_enable_link = '/etc/systemd/system/vpp.service.wants/vpp_exporter.service'
 vpp_exporter_vrf = 'vpp-exporter'
+vpp_system_stat_patterns = (
+    '^/sys/heartbeat$',
+    '^/sys/last_stats_clear$',
+    '^/sys/boottime$',
+    '^/sys/vector_rate$',
+    '^/sys/vector_rate_per_worker$',
+    '^/sys/loops_per_worker$',
+    '^/sys/num_worker_threads$',
+    '^/sys/last_update$',
+    '^/sys/input_rate$',
+)
 
 
 def get_vpp_config():
@@ -1826,7 +1837,8 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.assertIn('^/interfaces', file_content)
         self.assertIn('^/err', file_content)
         self.assertIn('^/buffer-pools', file_content)
-        self.assertIn('^/sys', file_content)
+        for pattern in vpp_system_stat_patterns:
+            self.assertIn(pattern, file_content)
         self.assertIn('^/workers', file_content)
         self.assertIn('^/mem', file_content)
         self.assertNotIn('^/nodes', file_content)
@@ -1856,12 +1868,21 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
 
         file_content = read_file(vpp_exporter_service_file)
         self.assertIn('^/interfaces', file_content)
-        self.assertIn('^/sys', file_content)
+        for pattern in vpp_system_stat_patterns:
+            self.assertIn(pattern, file_content)
         self.assertIn('^/nodes', file_content)
         self.assertIn('^/mem', file_content)
         self.assertIn('^/buffer-pools/.*/used$', file_content)
         self.assertNotIn('^/err', file_content)
         self.assertTrue(process_named_running(VPP_EXPORTER_PROCESS_NAME))
+
+        rc, output = rc_cmd(
+            'curl --silent --show-error --connect-timeout 2 --max-time 15 '
+            'http://127.0.0.1:9482/metrics'
+        )
+        self.assertEqual(rc, 0)
+        self.assertIn('nodes_calls{', output)
+        self.assertIn('sys_num_worker_threads', output)
 
     def test_26_3_vpp_exporter_vrf(self):
         self.cli_set(['vrf', 'name', vpp_exporter_vrf, 'table', '1001'])

--- a/src/conf_mode/service_monitoring_prometheus.py
+++ b/src/conf_mode/service_monitoring_prometheus.py
@@ -18,12 +18,15 @@ import os
 
 from sys import exit
 
+from vyos.base import Warning
 from vyos.config import Config
 from vyos.configdict import is_node_changed
 from vyos.configdict import node_changed
 from vyos.configdiff import Diff
 from vyos.configverify import verify_vrf
 from vyos.template import render
+from vyos.utils.network import check_port_availability
+from vyos.utils.network import is_listen_port_bind_service
 from vyos.utils.process import call
 from vyos.utils.process import is_systemd_service_active
 from vyos import ConfigError
@@ -41,6 +44,50 @@ frr_exporter_systemd_service = 'frr_exporter.service'
 blackbox_exporter_service_file = '/etc/systemd/system/blackbox_exporter.service'
 blackbox_exporter_systemd_service = 'blackbox_exporter.service'
 
+vpp_exporter_service_file = '/etc/systemd/system/vpp_exporter.service'
+vpp_exporter_systemd_service = 'vpp_exporter.service'
+vpp_exporter_enable_link = '/etc/systemd/system/vpp.service.wants/vpp_exporter.service'
+vpp_exporter_process_name = 'vpp_prometheus_export'
+
+vpp_stat_group_patterns = {
+    'interfaces': '^/interfaces',
+    'err': '^/err',
+    'buffer-pools': '^/buffer-pools',
+    'system': '^/sys',
+    'workers': '^/workers',
+    'nodes': '^/nodes',
+    'memory': '^/mem',
+}
+vpp_default_stat_groups = [
+    'interfaces',
+    'err',
+    'buffer-pools',
+    'system',
+    'workers',
+    'memory',
+]
+
+
+def build_vpp_stat_patterns(vpp_exporter):
+    selected_groups = vpp_exporter.get('stat_group', [])
+    custom_patterns = vpp_exporter.get('stat_pattern', [])
+
+    if not selected_groups and not custom_patterns:
+        selected_groups = vpp_default_stat_groups
+
+    selected_groups = set(selected_groups)
+    patterns = [
+        pattern
+        for group_name, pattern in vpp_stat_group_patterns.items()
+        if group_name in selected_groups
+    ]
+
+    for pattern in custom_patterns:
+        if pattern not in patterns:
+            patterns.append(pattern)
+
+    return patterns
+
 
 def get_config(config=None):
     if config:
@@ -56,6 +103,7 @@ def get_config(config=None):
         'node_exporter': base + ['node-exporter'],
         'frr_exporter': base + ['frr-exporter'],
         'blackbox_exporter': base + ['blackbox-exporter'],
+        'vpp_exporter': base + ['vpp-exporter'],
     }
 
     for exporter_name, exporter_base in exporters.items():
@@ -82,6 +130,41 @@ def get_config(config=None):
             base + ['frr-exporter', 'collector', 'bgp', 'peer-description']
         ):
             collector.get('bgp', {}).pop('peer_description', None)
+    if 'vpp_exporter' in monitoring:
+        vpp_exporter = monitoring['vpp_exporter']
+        vpp_exporter['patterns'] = build_vpp_stat_patterns(vpp_exporter)
+        vpp_exporter['vpp_per_node_counters_enabled'] = conf.exists(
+            [
+                'vpp',
+                'settings',
+                'resource-allocation',
+                'memory',
+                'stats',
+                'per-node-counters',
+            ]
+        )
+        vpp_exporter['vpp_configured'] = conf.exists(['vpp'])
+
+        configured_groups = conf.return_values(base + ['vpp-exporter', 'stat-group'])
+        configured_patterns = conf.return_values(
+            base + ['vpp-exporter', 'stat-pattern']
+        )
+        effective_groups = conf.return_effective_values(
+            base + ['vpp-exporter', 'stat-group']
+        )
+        effective_patterns = conf.return_effective_values(
+            base + ['vpp-exporter', 'stat-pattern']
+        )
+
+        nodes_requested = 'nodes' in configured_groups or any(
+            pattern.startswith('^/nodes') for pattern in configured_patterns
+        )
+        nodes_requested_effective = 'nodes' in effective_groups or any(
+            pattern.startswith('^/nodes') for pattern in effective_patterns
+        )
+        vpp_exporter['nodes_selection_newly_enabled'] = (
+            nodes_requested and not nodes_requested_effective
+        )
 
     tmp = is_node_changed(conf, base + ['node-exporter', 'vrf'])
     if tmp:
@@ -102,6 +185,9 @@ def get_config(config=None):
     tmp = tmp or 'icmp' in modules_changed
     if tmp:
         monitoring.update({'blackbox_exporter_restart_required': {}})
+
+    if is_node_changed(conf, base + ['vpp-exporter']):
+        monitoring.update({'vpp_exporter_restart_required': {}})
 
     return monitoring
 
@@ -132,6 +218,43 @@ def verify(monitoring):
                         f'query name not specified in dns module {mod_name}'
                     )
 
+    if 'vpp_exporter' in monitoring:
+        vpp_exporter = monitoring['vpp_exporter']
+        verify_vrf(vpp_exporter)
+
+        if not vpp_exporter.get('vpp_configured'):
+            raise ConfigError(
+                'No VPP configuration exists. Configure VPP before configuring '
+                'VPP-exporter.'
+            )
+
+        port = int(vpp_exporter['port'])
+        if not check_port_availability(
+            None, port, 'tcp', vrf=vpp_exporter.get('vrf')
+        ) and not is_listen_port_bind_service(port, vpp_exporter_process_name):
+            raise ConfigError(f'TCP port "{port}" is used by another service!')
+
+        for group_name in vpp_exporter.get('stat_group', []):
+            if group_name not in vpp_stat_group_patterns:
+                raise ConfigError(f'Invalid stat-group "{group_name}"')
+
+        for pattern in vpp_exporter.get('stat_pattern', []):
+            if not pattern.startswith('^/'):
+                raise ConfigError(
+                    f'Invalid stat-pattern "{pattern}". Pattern must start with "^/"'
+                )
+
+        if vpp_exporter.get('nodes_selection_newly_enabled') and not vpp_exporter.get(
+            'vpp_per_node_counters_enabled'
+        ):
+            Warning(
+                'VPP node metrics requested but per-node-counters setting is not '
+                'enabled. Enable it using the following command for "nodes" metrics '
+                'to be available:\n'
+                '"set vpp settings resource-allocation memory stats '
+                'per-node-counters".'
+            )
+
     return None
 
 
@@ -150,6 +273,13 @@ def generate(monitoring):
         # Delete systemd files
         if os.path.isfile(blackbox_exporter_service_file):
             os.unlink(blackbox_exporter_service_file)
+
+    if not monitoring or 'vpp_exporter' not in monitoring:
+        # Delete systemd files
+        if os.path.isfile(vpp_exporter_service_file):
+            os.unlink(vpp_exporter_service_file)
+        if os.path.islink(vpp_exporter_enable_link):
+            os.unlink(vpp_exporter_enable_link)
 
     if not monitoring:
         return None
@@ -191,6 +321,14 @@ def generate(monitoring):
             monitoring['blackbox_exporter'],
         )
 
+    if 'vpp_exporter' in monitoring:
+        # Render vpp_exporter service_file
+        render(
+            vpp_exporter_service_file,
+            'prometheus/vpp_exporter.service.j2',
+            monitoring['vpp_exporter'],
+        )
+
     return None
 
 
@@ -206,6 +344,9 @@ def apply(monitoring):
     if not monitoring or 'blackbox_exporter' not in monitoring:
         if is_systemd_service_active(blackbox_exporter_systemd_service):
             call(f'systemctl stop {blackbox_exporter_systemd_service}')
+    if not monitoring or 'vpp_exporter' not in monitoring:
+        if is_systemd_service_active(vpp_exporter_systemd_service):
+            call(f'systemctl stop {vpp_exporter_systemd_service}')
 
     if not monitoring:
         return
@@ -233,6 +374,15 @@ def apply(monitoring):
             systemd_action = 'restart'
 
         call(f'systemctl {systemd_action} {blackbox_exporter_systemd_service}')
+
+    if 'vpp_exporter' in monitoring:
+        call(f'systemctl enable {vpp_exporter_systemd_service}')
+
+        systemd_action = 'reload-or-restart'
+        if 'vpp_exporter_restart_required' in monitoring:
+            systemd_action = 'restart'
+
+        call(f'systemctl {systemd_action} {vpp_exporter_systemd_service}')
 
 
 if __name__ == '__main__':

--- a/src/conf_mode/service_monitoring_prometheus.py
+++ b/src/conf_mode/service_monitoring_prometheus.py
@@ -49,14 +49,25 @@ vpp_exporter_systemd_service = 'vpp_exporter.service'
 vpp_exporter_enable_link = '/etc/systemd/system/vpp.service.wants/vpp_exporter.service'
 vpp_exporter_process_name = 'vpp_prometheus_export'
 
+vpp_system_stat_patterns = (
+    '^/sys/heartbeat$',
+    '^/sys/last_stats_clear$',
+    '^/sys/boottime$',
+    '^/sys/vector_rate$',
+    '^/sys/vector_rate_per_worker$',
+    '^/sys/loops_per_worker$',
+    '^/sys/num_worker_threads$',
+    '^/sys/last_update$',
+    '^/sys/input_rate$',
+)
 vpp_stat_group_patterns = {
-    'interfaces': '^/interfaces',
-    'err': '^/err',
-    'buffer-pools': '^/buffer-pools',
-    'system': '^/sys',
-    'workers': '^/workers',
-    'nodes': '^/nodes',
-    'memory': '^/mem',
+    'interfaces': ('^/interfaces',),
+    'err': ('^/err',),
+    'buffer-pools': ('^/buffer-pools',),
+    'system': vpp_system_stat_patterns,
+    'workers': ('^/workers',),
+    'nodes': ('^/nodes',),
+    'memory': ('^/mem',),
 }
 vpp_default_stat_groups = [
     'interfaces',
@@ -78,8 +89,9 @@ def build_vpp_stat_patterns(vpp_exporter):
     selected_groups = set(selected_groups)
     patterns = [
         pattern
-        for group_name, pattern in vpp_stat_group_patterns.items()
+        for group_name, group_patterns in vpp_stat_group_patterns.items()
         if group_name in selected_groups
+        for pattern in group_patterns
     ]
 
     for pattern in custom_patterns:

--- a/src/conf_mode/service_monitoring_prometheus.py
+++ b/src/conf_mode/service_monitoring_prometheus.py
@@ -60,6 +60,16 @@ vpp_system_stat_patterns = (
     '^/sys/last_update$',
     '^/sys/input_rate$',
 )
+vpp_nat44_stat_patterns = (
+    '^/nat44-.*/total-sessions$',
+    '^/nat44-ed/max-cfg-sessions$',
+    '^/nat44-ed/in2out/fastpath/.*$',
+    '^/nat44-ed/out2in/fastpath/.*$',
+    '^/nat44-ed/in2out/slowpath/.*$',
+    '^/nat44-ed/out2in/slowpath/.*$',
+    '^/nat44-ed/hairpinning$',
+)
+vpp_acl_stat_patterns = ('^/acl/.*/matches$',)
 vpp_stat_group_patterns = {
     'interfaces': ('^/interfaces',),
     'err': ('^/err',),
@@ -68,6 +78,8 @@ vpp_stat_group_patterns = {
     'workers': ('^/workers',),
     'nodes': ('^/nodes',),
     'memory': ('^/mem',),
+    'nat44': vpp_nat44_stat_patterns,
+    'acl': vpp_acl_stat_patterns,
 }
 vpp_default_stat_groups = [
     'interfaces',
@@ -81,24 +93,17 @@ vpp_default_stat_groups = [
 
 def build_vpp_stat_patterns(vpp_exporter):
     selected_groups = vpp_exporter.get('stat_group', [])
-    custom_patterns = vpp_exporter.get('stat_pattern', [])
 
-    if not selected_groups and not custom_patterns:
+    if not selected_groups:
         selected_groups = vpp_default_stat_groups
 
     selected_groups = set(selected_groups)
-    patterns = [
+    return [
         pattern
         for group_name, group_patterns in vpp_stat_group_patterns.items()
         if group_name in selected_groups
         for pattern in group_patterns
     ]
-
-    for pattern in custom_patterns:
-        if pattern not in patterns:
-            patterns.append(pattern)
-
-    return patterns
 
 
 def get_config(config=None):
@@ -158,22 +163,12 @@ def get_config(config=None):
         vpp_exporter['vpp_configured'] = conf.exists(['vpp'])
 
         configured_groups = conf.return_values(base + ['vpp-exporter', 'stat-group'])
-        configured_patterns = conf.return_values(
-            base + ['vpp-exporter', 'stat-pattern']
-        )
         effective_groups = conf.return_effective_values(
             base + ['vpp-exporter', 'stat-group']
         )
-        effective_patterns = conf.return_effective_values(
-            base + ['vpp-exporter', 'stat-pattern']
-        )
 
-        nodes_requested = 'nodes' in configured_groups or any(
-            pattern.startswith('^/nodes') for pattern in configured_patterns
-        )
-        nodes_requested_effective = 'nodes' in effective_groups or any(
-            pattern.startswith('^/nodes') for pattern in effective_patterns
-        )
+        nodes_requested = 'nodes' in configured_groups
+        nodes_requested_effective = 'nodes' in effective_groups
         vpp_exporter['nodes_selection_newly_enabled'] = (
             nodes_requested and not nodes_requested_effective
         )
@@ -249,12 +244,6 @@ def verify(monitoring):
         for group_name in vpp_exporter.get('stat_group', []):
             if group_name not in vpp_stat_group_patterns:
                 raise ConfigError(f'Invalid stat-group "{group_name}"')
-
-        for pattern in vpp_exporter.get('stat_pattern', []):
-            if not pattern.startswith('^/'):
-                raise ConfigError(
-                    f'Invalid stat-pattern "{pattern}". Pattern must start with "^/"'
-                )
 
         if vpp_exporter.get('nodes_selection_newly_enabled') and not vpp_exporter.get(
             'vpp_per_node_counters_enabled'


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## In advance

This PR is based on draft: https://github.com/vyos/vyos-1x/pull/5048

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Vyos VPP exporter implementation added to facilitate the VPP stats/metrics to be available via Prometheus. Vyos VPP exporter integrates with the VPP-exposed prometheus exporter binary and can be configured using the Vyos CLIs to fetch the stats/metrics selectively from VPP. 

Following functionalities have been implemented:
- Stat-groups stats are available on Prometheus web UI
- Regex pattern based filtered stats are available on Prometheus web UI
- vpp-exporter service restarts automatically upon:
	any change in vpp-exporter config
	VPP service restart
	system reboot	
- vpp-exporter service cannot be started until VPP service exists
- vpp-exporter service stops if VPP service becomes unavailable
- vpp-exporter service can co-exist with node-exporter (both independently) to provide VPP and kernel stats respectively.
- Added CLI support for enabling VPP per-node-counters, which is required to export node-level statistics.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8382 

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Testing done:
- Verified stat-group stats and regex pattern based filtered stats on Prometheus web UI against the VPP CLI output
- Verified VPP service restarts automatically upon below actions and correct/updated stats are available again on Prometheus. 
	any change in vpp-exporter config
	VPP service restart
	system reboot	

- Verified changing the node_exporter config only restarts node_exporter. Same for vpp_exporter.
- Verified vpp-exporter vrf endpoint option

CONFIGURE METRICS FOR BUFFER-POOL AND SYS GROUPS & CUSTOM STAT-PATTERN FOR INTERFACES
```
set service monitoring prometheus vpp-exporter port '9482'
set service monitoring prometheus vpp-exporter stat-group 'interfaces'
set service monitoring prometheus vpp-exporter stat-group 'buffer-pools'
set service monitoring prometheus vpp-exporter stat-group 'system'
set service monitoring prometheus vpp-exporter stat-group 'workers'
set service monitoring prometheus vpp-exporter stat-group 'memory'
set service monitoring prometheus vpp-exporter stat-group 'nodes'
set service monitoring prometheus vpp-exporter stat-pattern '^/nat44-.*/total-sessions$'
set service monitoring prometheus vpp-exporter vrf 'mgmt'

➜  ~ curl http://10.42.80.247:9482/metrics
sys_heartbeat 7900.00
sys_last_stats_clear 0.00
sys_boottime 1784567321.00
sys_uptime 78996.00
mem{heap="stat segment",index="0",thread="0"} 134213584
mem{heap="stat segment",index="1",thread="0"} 1315568
mem{heap="stat segment",index="2",thread="0"} 132898016
mem{heap="stat segment",index="3",thread="0"} 0
mem{heap="stat segment",index="4",thread="0"} 134213584
mem{heap="stat segment",index="5",thread="0"} 55
mem{heap="stat segment",index="6",thread="0"} 132145424
mem_used{heap="stat segment",index="0",thread="0"} 1315568
mem_total{heap="stat segment",index="0",thread="0"} 134213584
mem_free{heap="stat segment",index="0",thread="0"} 132898016
[...]

vyos@gns3-vyos-7:~$ sudo vpp_get_stats dump '^/buffer-pools'
42.00 /buffer-pools/default-numa-0/cached
2070.00 /buffer-pools/default-numa-0/used
14672.00 /buffer-pools/default-numa-0/available

vyos@gns3-vyos-7:~$ sudo vpp_get_stats dump '^/interfaces/.*/rx$'
[0 @ 0]: 0 packets, 0 bytes /interfaces/local0/rx
[0 @ 0]: 0 packets, 0 bytes /interfaces/eth1/rx
[0 @ 0]: 0 packets, 0 bytes /interfaces/eth2/rx
[0 @ 0]: 107548 packets, 152328117 bytes /interfaces/eth3/rx
[0 @ 0]: 1 packets, 90 bytes /interfaces/tap4096/rx
[0 @ 0]: 0 packets, 0 bytes /interfaces/tap4097/rx
[0 @ 0]: 107328 packets, 152315644 bytes /interfaces/tap4098/rx
[0 @ 0]: 107318 packets, 152314628 bytes /interfaces/tap4098.20/rx
[0 @ 0]: 107487 packets, 152321711 bytes /interfaces/eth3.20/rx
[0 @ 0]: 0 packets, 0 bytes /interfaces/loop1/rx
[0 @ 0]: 8 packets, 836 bytes /interfaces/tap4099/rx
```

VRF TESTING
```
set vrf name mgmt table '1000'
set interfaces ethernet eth0 address '10.42.80.247/26'
set interfaces ethernet eth0 vrf 'mgmt'

gns3-vyos-7:~$ sudo ip vrf exec mgmt curl -s http://127.0.0.1:9482/metrics | head
sys_heartbeat 7911.00
sys_last_stats_clear 0.00
sys_boottime 1784567321.00
sys_uptime 79113.00
mem{heap="stat segment",index="0",thread="0"} 134213584
mem{heap="stat segment",index="1",thread="0"} 1315568
mem{heap="stat segment",index="2",thread="0"} 132898016
mem{heap="stat segment",index="3",thread="0"} 0
mem{heap="stat segment",index="4",thread="0"} 134213584
mem{heap="stat segment",index="5",thread="0"} 55
```

CLI VALIDATION
- No VPP
```
vyos@vyos# set serv moni prom vpp stat-group nodes
[edit]
vyos@vyos# commit
[ service monitoring prometheus ]
No VPP configuration exists!  Configure VPP before VPP-exporter
configuration.
[[service monitoring prometheus]] failed
Commit failed
```

- Invalid Stat-group
```
vyos@gns3-vyos-7# set service monitoring prometheus vpp-exporter stat-group abd



  Invalid stat-group. Allowed values: interfaces, err, buffer-pools, system, workers, nodes, memory
  Value validation failed
  Set failed

```

- Invalid regex pattern
```
vyos@gns3-vyos-7# set service monitoring prometheus vpp-exporter stat-pattern mem
[edit]
vyos@gns3-vyos-7# compare
[service monitoring prometheus vpp-exporter]
+ stat-pattern "mem"

[edit]
vyos@gns3-vyos-7# commit
[ service monitoring prometheus ]
Invalid stat-pattern "mem". Pattern must start with "^/"

[[service monitoring prometheus]] failed
Commit failed
```

- Per-node-counters not enabled triggers a one-time warning while configuring nodes stats
```
vyos@gns3-vyos-7# set serv moni prom vpp stat-group nodes
[edit]
vyos@gns3-vyos-7# commit
[ service monitoring prometheus ]

WARNING: VPP node metrics requested but per-node-counters setting is
not enabled. Enable it using below cmd for "nodes" metrics to be 
available:
"set vpp settings resource-allocation memory stats per-node-counters".
```


SMOKETESTS:
```
vyos@gns3-vyos-7:~$ sudo su
rsudo /usr/libexec/vyos/tests/smoke/cli/test_vpp.py TestVPP.test_11_4_statseg_per_node_counters_4_statseg_per_node_counters

test_11_4_statseg_per_node_counters (__main__.TestVPP.test_11_4_statseg_per_node_counters) ... ok


----------------------------------------------------------------------
Ran 1 test in 82.326s

OK
root@gns3-vyos-7:/home/vyos# sudo /usr/libexec/vyos/tests/smoke/cli/test_service_monitoring_prometheus.py
test_01_node_exporter (__main__.TestMonitoringPrometheus.test_01_node_exporter) ... ok
test_02_frr_exporter (__main__.TestMonitoringPrometheus.test_02_frr_exporter) ... ok
test_03_blackbox_exporter (__main__.TestMonitoringPrometheus.test_03_blackbox_exporter) ... ok
test_04_blackbox_exporter_with_config (__main__.TestMonitoringPrometheus.test_04_blackbox_exporter_with_config) ... ok
test_05_blackbox_exporter_with_icmp (__main__.TestMonitoringPrometheus.test_05_blackbox_exporter_with_icmp) ... ok

----------------------------------------------------------------------
Ran 5 tests in 99.652s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
