### PR TITLE
dhcp: T9108: restart dhclient when unicast RENEW is overdue

### DIFF
--- a/debian/vyos-1x.install
+++ b/debian/vyos-1x.install
@@ -43,4 +43,5 @@ usr/libexec/vyos/validate-value
 usr/libexec/vyos/vyconf
 usr/libexec/vyos/*.py
 usr/libexec/vyos/*.sh
+usr/libexec/vyos/vyos-dhclient-lease-watch
 usr/share

--- a/debian/vyos-1x.postinst
+++ b/debian/vyos-1x.postinst
@@ -300,8 +300,15 @@ if systemctl is-active --quiet vyos-netlinkd; then
 fi
 
 # DHCPv4 stuck-RENEW watchdog (restart dhclient when unicast RENEW is overdue)
+# Enable always; start may fail during image build (no running systemd) — log it.
 if [ -f /lib/systemd/system/vyos-dhclient-lease-watch.timer ]; then
-    systemctl daemon-reload || true
-    systemctl enable vyos-dhclient-lease-watch.timer || true
-    systemctl start vyos-dhclient-lease-watch.timer || true
+    systemctl daemon-reload || echo "WARNING: systemctl daemon-reload failed" >&2
+    if ! systemctl enable vyos-dhclient-lease-watch.timer; then
+        echo "WARNING: failed to enable vyos-dhclient-lease-watch.timer" >&2
+    fi
+    if ! systemctl start vyos-dhclient-lease-watch.timer 2>/dev/null; then
+        echo "NOTE: vyos-dhclient-lease-watch.timer not started (ok during image build)" >&2
+    elif ! systemctl is-active --quiet vyos-dhclient-lease-watch.timer 2>/dev/null; then
+        echo "WARNING: vyos-dhclient-lease-watch.timer enabled but not active" >&2
+    fi
 fi

--- a/debian/vyos-1x.postinst
+++ b/debian/vyos-1x.postinst
@@ -298,3 +298,10 @@ fi
 if systemctl is-active --quiet vyos-netlinkd; then
     systemctl restart vyos-netlinkd
 fi
+
+# DHCPv4 stuck-RENEW watchdog (restart dhclient when unicast RENEW is overdue)
+if [ -f /lib/systemd/system/vyos-dhclient-lease-watch.timer ]; then
+    systemctl daemon-reload || true
+    systemctl enable vyos-dhclient-lease-watch.timer || true
+    systemctl start vyos-dhclient-lease-watch.timer || true
+fi

--- a/src/helpers/vyos-dhclient-lease-watch
+++ b/src/helpers/vyos-dhclient-lease-watch
@@ -101,7 +101,8 @@ def main() -> int:
         if not base.startswith('dhclient_') or not base.endswith('.conf'):
             continue
         iface = base[len('dhclient_') : -len('.conf')]
-        if not iface or iface.endswith('v6'):
+        # v4 dhclient only — IPv6 uses dhcp6c@<iface>, not a *v6 filename.
+        if not iface:
             continue
 
         unit = f'dhclient@{iface}.service'

--- a/src/helpers/vyos-dhclient-lease-watch
+++ b/src/helpers/vyos-dhclient-lease-watch
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 #
-# Copyright (C) 2026 VyOS maintainers and contributors
+# Copyright (C) VyOS Inc.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License version 2 or later as

--- a/src/helpers/vyos-dhclient-lease-watch
+++ b/src/helpers/vyos-dhclient-lease-watch
@@ -142,14 +142,26 @@ def main() -> int:
         except (OSError, ValueError):
             pass
 
-        if not _restart(iface):
-            # No cooldown on failure — next timer tick can retry.
-            continue
+        # Record cooldown before restart. If the write fails, skip the
+        # restart: a successful restart with no marker would fire again
+        # on the next 5-minute tick and defeat COOLDOWN_SECS.
         try:
             with open(state_file, 'w', encoding='utf-8') as f:
                 f.write(str(now))
-        except OSError:
-            pass
+        except OSError as e:
+            syslog.syslog(
+                syslog.LOG_ERR,
+                f'{state_file}: {e}; skipping restart (cannot honor cooldown)',
+            )
+            continue
+
+        if not _restart(iface):
+            # Release the slot so the next tick can retry.
+            try:
+                os.unlink(state_file)
+            except OSError:
+                pass
+            continue
 
     return 0
 

--- a/src/helpers/vyos-dhclient-lease-watch
+++ b/src/helpers/vyos-dhclient-lease-watch
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2026 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# Restart dhclient@<iface> when a unicast RENEW has been overdue long enough
+# that the client is likely stuck talking to a dead DHCP server (lease still
+# valid locally, renew time long past, no successful lease rewrite).
+#
+# Production: ISP session loss while the modem link stayed up left dhclient in
+# unicast-RENEW for the remainder of a multi-hour lease (T9085 sibling).
+# See also T9085 (RENEW success without reinstalling a missing default).
+
+import glob
+import os
+import re
+import subprocess
+import syslog
+import time
+from datetime import datetime
+
+DHCLIENT_DIR = '/run/dhclient'
+# Wait this long after the ISC "renew" time before declaring RENEW stuck.
+GRACE_SECS = 900  # 15 minutes
+# Do not thrash the client more often than this per interface.
+COOLDOWN_SECS = 1800  # 30 minutes
+STATE_DIR = '/run/vyos-dhclient-lease-watch'
+
+# ISC dhclient lease timestamps: "renew 2 2026/07/21 05:22:11;"
+_TS = re.compile(
+    r'(renew|rebind|expire)\s+\d+\s+'
+    r'(\d{4})/(\d{2})/(\d{2})\s+(\d{2}):(\d{2}):(\d{2})\s*;'
+)
+
+
+def _parse_ts(year, month, day, hour, minute, second) -> float:
+    # Lease file times are written in local time by isc-dhclient.
+    return datetime(
+        int(year), int(month), int(day),
+        int(hour), int(minute), int(second),
+    ).timestamp()
+
+
+def _last_lease_block(text: str) -> str:
+    idx = text.rfind('lease {')
+    return text[idx:] if idx >= 0 else ''
+
+
+def _lease_times(block: str):
+    renew_ts = expire_ts = None
+    for m in _TS.finditer(block):
+        kind = m.group(1)
+        ts = _parse_ts(*m.groups()[1:])
+        if kind == 'renew':
+            renew_ts = ts
+        elif kind == 'expire':
+            expire_ts = ts
+    return renew_ts, expire_ts
+
+
+def _service_active(unit: str) -> bool:
+    r = subprocess.run(
+        ['systemctl', 'is-active', unit],
+        capture_output=True,
+        text=True,
+    )
+    return r.stdout.strip() == 'active'
+
+
+def _restart(iface: str) -> None:
+    unit = f'dhclient@{iface}.service'
+    syslog.syslog(
+        syslog.LOG_WARNING,
+        f'{unit}: DHCPv4 RENEW overdue (likely stuck unicast RENEW); '
+        f'restarting client to force rediscovery',
+    )
+    subprocess.run(['systemctl', 'restart', unit], check=False)
+
+
+def main() -> int:
+    syslog.openlog('vyos-dhclient-lease-watch', syslog.LOG_PID, syslog.LOG_DAEMON)
+    os.makedirs(STATE_DIR, exist_ok=True)
+    now = time.time()
+
+    for conf in sorted(glob.glob(f'{DHCLIENT_DIR}/dhclient_*.conf')):
+        base = os.path.basename(conf)
+        # dhclient_eth0.conf -> eth0
+        if not base.startswith('dhclient_') or not base.endswith('.conf'):
+            continue
+        iface = base[len('dhclient_') : -len('.conf')]
+        if not iface or iface.endswith('v6'):
+            continue
+
+        unit = f'dhclient@{iface}.service'
+        if not _service_active(unit):
+            continue
+
+        leases_path = f'{DHCLIENT_DIR}/dhclient_{iface}.leases'
+        if not os.path.isfile(leases_path):
+            continue
+
+        try:
+            with open(leases_path, encoding='utf-8', errors='replace') as f:
+                text = f.read()
+        except OSError as e:
+            syslog.syslog(syslog.LOG_ERR, f'{leases_path}: {e}')
+            continue
+
+        block = _last_lease_block(text)
+        renew_ts, expire_ts = _lease_times(block)
+        if renew_ts is None or expire_ts is None:
+            continue
+
+        # Still before T1 + grace: RENEW not expected to have completed yet.
+        if now < renew_ts + GRACE_SECS:
+            continue
+        # Past expire: client should already be in INIT/DISCOVER on its own.
+        if now >= expire_ts:
+            continue
+
+        state_file = os.path.join(STATE_DIR, f'{iface}.last_restart')
+        try:
+            if os.path.isfile(state_file):
+                with open(state_file, encoding='utf-8') as f:
+                    last = float(f.read().strip() or '0')
+                if now - last < COOLDOWN_SECS:
+                    continue
+        except (OSError, ValueError):
+            pass
+
+        _restart(iface)
+        try:
+            with open(state_file, 'w', encoding='utf-8') as f:
+                f.write(str(now))
+        except OSError:
+            pass
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/src/helpers/vyos-dhclient-lease-watch
+++ b/src/helpers/vyos-dhclient-lease-watch
@@ -11,7 +11,7 @@
 # valid locally, renew time long past, no successful lease rewrite).
 #
 # Production: ISP session loss while the modem link stayed up left dhclient in
-# unicast-RENEW for the remainder of a multi-hour lease (T9085 sibling).
+# unicast-RENEW for the remainder of a multi-hour lease (T9108 / T9085 sibling).
 # See also T9085 (RENEW success without reinstalling a missing default).
 
 import glob
@@ -20,7 +20,7 @@ import re
 import subprocess
 import syslog
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 DHCLIENT_DIR = '/run/dhclient'
 # Wait this long after the ISC "renew" time before declaring RENEW stuck.
@@ -29,7 +29,8 @@ GRACE_SECS = 900  # 15 minutes
 COOLDOWN_SECS = 1800  # 30 minutes
 STATE_DIR = '/run/vyos-dhclient-lease-watch'
 
-# ISC dhclient lease timestamps: "renew 2 2026/07/21 05:22:11;"
+# ISC dhclient default db-time-format: UTC civil time
+# "renew 2 2026/07/21 05:22:11;"
 _TS = re.compile(
     r'(renew|rebind|expire)\s+\d+\s+'
     r'(\d{4})/(\d{2})/(\d{2})\s+(\d{2}):(\d{2}):(\d{2})\s*;'
@@ -37,10 +38,11 @@ _TS = re.compile(
 
 
 def _parse_ts(year, month, day, hour, minute, second) -> float:
-    # Lease file times are written in local time by isc-dhclient.
+    # ISC default lease format is UTC (db-time-format default).
     return datetime(
         int(year), int(month), int(day),
         int(hour), int(minute), int(second),
+        tzinfo=timezone.utc,
     ).timestamp()
 
 
@@ -70,14 +72,22 @@ def _service_active(unit: str) -> bool:
     return r.stdout.strip() == 'active'
 
 
-def _restart(iface: str) -> None:
+def _restart(iface: str) -> bool:
+    """Restart dhclient@iface. Return True if systemctl succeeded."""
     unit = f'dhclient@{iface}.service'
     syslog.syslog(
         syslog.LOG_WARNING,
         f'{unit}: DHCPv4 RENEW overdue (likely stuck unicast RENEW); '
         f'restarting client to force rediscovery',
     )
-    subprocess.run(['systemctl', 'restart', unit], check=False)
+    r = subprocess.run(['systemctl', 'restart', unit], check=False)
+    if r.returncode != 0:
+        syslog.syslog(
+            syslog.LOG_ERR,
+            f'{unit}: restart failed (rc={r.returncode}); will retry next cycle',
+        )
+        return False
+    return True
 
 
 def main() -> int:
@@ -131,7 +141,9 @@ def main() -> int:
         except (OSError, ValueError):
             pass
 
-        _restart(iface)
+        if not _restart(iface):
+            # No cooldown on failure — next timer tick can retry.
+            continue
         try:
             with open(state_file, 'w', encoding='utf-8') as f:
                 f.write(str(now))

--- a/src/systemd/vyos-dhclient-lease-watch.service
+++ b/src/systemd/vyos-dhclient-lease-watch.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=VyOS DHCPv4 stuck-RENEW watchdog (oneshot)
+Documentation=man:dhclient(8)
+After=vyos-router.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/python3 /usr/libexec/vyos/vyos-dhclient-lease-watch
+SyslogIdentifier=vyos-dhclient-lease-watch
+Nice=10

--- a/src/systemd/vyos-dhclient-lease-watch.timer
+++ b/src/systemd/vyos-dhclient-lease-watch.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Periodically check for stuck DHCPv4 unicast RENEW
+Documentation=man:dhclient(8)
+After=vyos-router.service
+
+[Timer]
+# First run a few minutes after boot (leases need to exist)
+OnBootSec=3min
+# Then every 5 minutes
+OnUnitActiveSec=5min
+AccuracySec=30s
+Persistent=true
+Unit=vyos-dhclient-lease-watch.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Change summary

ISC `dhclient` can remain in **unicast RENEW** toward a DHCP server that has lost the client session for the **rest of the lease lifetime** (often many hours) while the WAN link stays up. The process is still running; no DISCOVER / INIT-REBOOT runs until expire.

This is the production failure mode behind multi-hour single-WAN outages on dual-stack links (v4 wedged, v6 healthy on the same iface). It is **not** [T9085](https://vyos.dev/T9085) (RENEW succeeds but does not reinstall a missing default — that is [vyos-1x#5340](https://github.com/vyos/vyos-1x/pull/5340)).

### Fix

| Component | Behavior |
|-----------|----------|
| `vyos-dhclient-lease-watch` | For each active `dhclient@<iface>`, read last ISC lease record under `/run/dhclient/` |
| Stuck heuristic | `renew` time **+ 15m** is past, but `expire` is still in the future → restart `dhclient@<iface>` |
| Cooldown | 30 minutes per interface (no thrash) |
| Timer | `OnBootSec=3min`, then every `5min` |
| Package | `postinst` enables/starts the timer |

Restart forces a clean client start (INIT / INIT-REBOOT with the existing `-lf` DB) instead of sitting on a dead unicast target until expire.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T9108
* Related but separate: https://vyos.dev/T9085

## Related PR(s)
* https://github.com/vyos/vyos-1x/pull/5340 (T9085 RENEW default reinstall — different path)

## How to test / Smoketest result

No CLI smoketest for dhclient lifecycle. Manual:

1. BOUND on a DHCP WAN; note `renew` / `expire` in `/run/dhclient/dhclient_<iface>.leases`.
2. After `renew + 15m` with a still-future `expire` and a non-advancing renew timestamp (simulate by freezing updates / dead server), run:
   ```bash
   python3 /usr/libexec/vyos/vyos-dhclient-lease-watch
   journalctl -t vyos-dhclient-lease-watch -n 20
   systemctl status dhclient@<iface>
   ```
3. Confirm restart logged once; second run within 30m does not restart again.
4. Healthy client with future `renew` time: helper no-ops.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly