### PR TITLE
flow-accounting: T9122: bind NetFlow export to the configured VRF

### DIFF
--- a/data/templates/ipt-netflow/ipt_NETFLOW.conf.j2
+++ b/data/templates/ipt-netflow/ipt_NETFLOW.conf.j2
@@ -12,8 +12,17 @@ options ipt_NETFLOW sampler=random:{{ netflow.sampling_rate }}
 {%     for server in netflow.server %}
 {%         set d = netflow.server[server] %}
 {%         set s = (server | bracketize_ipv6) ~ ':' ~ d['port'] %}
-{%         set s = s ~ ('%' ~ d['source_interface'] if d['source_interface'] is vyos_defined else '') %}
+{#         The ipt_NETFLOW destination grammar is "ip:port[@address][%device]" and #}
+{#         the module parses "@" before "%", so the source-address is rendered #}
+{#         first. The socket is then bound to a device to select the egress path: #}
+{#         a per-server source-interface takes precedence, else the global VRF is #}
+{#         used so flows are exported within that VRF (T9122). #}
 {%         set s = s ~ ('@' ~ d['source_address'] if d['source_address'] is vyos_defined else '') %}
+{%         if d['source_interface'] is vyos_defined %}
+{%             set s = s ~ '%' ~ d['source_interface'] %}
+{%         elif vrf is vyos_defined %}
+{%             set s = s ~ '%' ~ vrf %}
+{%         endif %}
 {%         set _ = servers_list.append(s) %}
 {%     endfor %}
 options ipt_NETFLOW destination={{ servers_list | join(",") }}

--- a/smoketest/scripts/cli/test_system_flow-accounting.py
+++ b/smoketest/scripts/cli/test_system_flow-accounting.py
@@ -213,6 +213,71 @@ class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
 
         self.cli_delete(['interfaces', 'dummy', dummy_if])
 
+    def test_netflow_vrf(self):
+        # T9122: NetFlow export must be routed via the configured VRF. The
+        # export socket is bound to a device - a per-server source-interface
+        # takes precedence, otherwise the global VRF device is used - so that
+        # collectors reachable only inside the VRF actually receive flows.
+        vrf_name = 'vyos-test-mgmt'
+        table = '1010'
+        source_address = '192.0.2.1'
+        dummy_if = 'dum2096'
+
+        server_vrf = '198.51.100.1'
+        server_vrf_address = '198.51.100.2'
+        server_vrf_interface = '198.51.100.3'
+
+        # Create a VRF and a member interface that holds the source address
+        self.cli_set(['vrf', 'name', vrf_name, 'table', table])
+        self.cli_set(['interfaces', 'dummy', dummy_if, 'vrf', vrf_name])
+        self.cli_set(
+            ['interfaces', 'dummy', dummy_if, 'address', source_address + '/32']
+        )
+
+        for interface in Section.interfaces('ethernet'):
+            self.cli_set(base_path + ['netflow', 'interface', interface])
+
+        self.cli_set(base_path + ['vrf', vrf_name])
+
+        # No per-server source - bind to the VRF device
+        self.cli_set(base_path + ['netflow', 'server', server_vrf])
+        # source-address inside the VRF - rendered as @address%vrf
+        self.cli_set(
+            base_path
+            + ['netflow', 'server', server_vrf_address]
+            + ['source-address', source_address]
+        )
+        # source-interface inside the VRF - takes precedence over the VRF device
+        self.cli_set(
+            base_path
+            + ['netflow', 'server', server_vrf_interface]
+            + ['source-interface', dummy_if]
+        )
+
+        self.cli_commit()
+
+        module_data = get_module_data(module_name)
+        destinations = set(module_data['parameters']['destination'].split(','))
+        self.assertEqual(
+            destinations,
+            {
+                f'{server_vrf}:2055%{vrf_name}',
+                f'{server_vrf_address}:2055@{source_address}%{vrf_name}',
+                f'{server_vrf_interface}:2055%{dummy_if}',
+            },
+        )
+
+        # A source-interface that is not a member of the VRF must be rejected
+        eth = Section.interfaces('ethernet')[0]
+        self.cli_set(
+            base_path + ['netflow', 'server', '198.51.100.9', 'source-interface', eth]
+        )
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(base_path + ['netflow', 'server', '198.51.100.9'])
+
+        self.cli_delete(['interfaces', 'dummy', dummy_if])
+        self.cli_delete(['vrf', 'name', vrf_name])
 
     def test_iptables(self):
         netflow_server = '11.22.33.44'

--- a/smoketest/scripts/cli/test_system_flow-accounting.py
+++ b/smoketest/scripts/cli/test_system_flow-accounting.py
@@ -276,6 +276,16 @@ class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
             self.cli_commit()
         self.cli_delete(base_path + ['netflow', 'server', '198.51.100.9'])
 
+        # A source-interface that names a VRF is not an interface and must be
+        # rejected
+        self.cli_set(
+            base_path
+            + ['netflow', 'server', '198.51.100.9', 'source-interface', vrf_name]
+        )
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(base_path + ['netflow', 'server', '198.51.100.9'])
+
         self.cli_delete(['interfaces', 'dummy', dummy_if])
         self.cli_delete(['vrf', 'name', vrf_name])
 

--- a/src/conf_mode/system_flow-accounting.py
+++ b/src/conf_mode/system_flow-accounting.py
@@ -25,7 +25,9 @@ from vyos.config import config_dict_merge
 from vyos.configverify import verify_vrf
 from vyos.configverify import verify_interface_exists
 from vyos.template import render
+from vyos.utils.dict import dict_search
 from vyos.utils.file import read_file
+from vyos.utils.network import get_interface_config
 from vyos.utils.network import get_interface_vrf
 from vyos.utils.network import interface_exists
 from vyos.utils.network import is_addr_assigned
@@ -119,6 +121,16 @@ def verify(flow_config):
             verify_interface_exists(
                 flow_config, data['source_interface'], warning_only=True
             )
+            # A VRF is not an interface. Cisco and Juniper both source a flow
+            # exporter from a routed interface and never from a VRF, and VRF
+            # export is already selected with "system flow-accounting vrf", so
+            # reject a source-interface that names a VRF device.
+            source_interface_config = get_interface_config(data['source_interface'])
+            if dict_search('linkinfo.info_kind', source_interface_config) == 'vrf':
+                raise ConfigError(
+                    f'Configured "netflow server {server} source-interface '
+                    f'{data["source_interface"]}" is a VRF, not an interface!'
+                )
             # A source-interface used together with a VRF must be a member of
             # that VRF, otherwise the exported flows would silently leave via a
             # different routing table. Due to the VyOS priorities the interface

--- a/src/conf_mode/system_flow-accounting.py
+++ b/src/conf_mode/system_flow-accounting.py
@@ -26,6 +26,8 @@ from vyos.configverify import verify_vrf
 from vyos.configverify import verify_interface_exists
 from vyos.template import render
 from vyos.utils.file import read_file
+from vyos.utils.network import get_interface_vrf
+from vyos.utils.network import interface_exists
 from vyos.utils.network import is_addr_assigned
 from vyos import ConfigError
 from vyos import airbag
@@ -117,6 +119,18 @@ def verify(flow_config):
             verify_interface_exists(
                 flow_config, data['source_interface'], warning_only=True
             )
+            # A source-interface used together with a VRF must be a member of
+            # that VRF, otherwise the exported flows would silently leave via a
+            # different routing table. Due to the VyOS priorities the interface
+            # is bound to the VRF before flow-accounting is configured, so the
+            # running state can be relied upon here.
+            if netflow_vrf and interface_exists(data['source_interface']):
+                if get_interface_vrf(data['source_interface']) != netflow_vrf:
+                    raise ConfigError(
+                        f'Configured "netflow server {server} source-interface '
+                        f'{data["source_interface"]}" is not a member of '
+                        f'VRF "{netflow_vrf}"!'
+                    )
 
     # Check if engine-id compatible with selected protocol version
     if 'engine_id' in flow_config['netflow']:


### PR DESCRIPTION
## Change summary

Since the migration from pmacct to the `ipt_NETFLOW` kernel module (T75),
`set system flow-accounting vrf <name>` has had no effect on the NetFlow export
path. NetFlow is now emitted by the kernel module, so there is no `uacctd`
daemon left to wrap in `ip vrf exec`, and nothing bound the module's export
socket to the VRF. A collector reachable only inside a VRF therefore never
received any flows when the export was configured with `source-address`.

This binds the export socket to a device using the ipt_NETFLOW `%device`
destination suffix:

- a per-server `source-interface` takes precedence (`%<interface>`);
- otherwise the global `vrf` device is used (`%<vrf>`), reproducing the old
  `ip vrf exec` behaviour;
- `source-address` is rendered independently as `@<address>`.

The module parses `@source-address` before `%device`, so the source-address is
now rendered first. The previous template emitted them in the opposite order,
which only worked because `source-address` and `source-interface` are mutually
exclusive per server — combining a VRF bind with a source-address needs the
correct order.

Example — `vrf OOB-Management` + `server 10.0.0.24 source-address 10.0.0.64` now
renders:

```
options ipt_NETFLOW destination=10.0.0.24:2055@10.0.0.64%OOB-Management
```

The commit is rejected when a `source-interface` used together with a `vrf` is
not a member of that VRF (mirroring the existing OSPF/OSPFv3/IS-IS/BGP checks),
since the flows would otherwise silently leave via a different routing table.

**Upgrade impact (behaviour change):** no CLI syntax change and no migration is
required. Configs that set `vrf` now export within that VRF — this fixes broken
setups (including anything the flow-accounting 2-to-3 migration produced), but
also means a config that set `vrf X` while its collector was actually reachable
via the default table (working today only because `vrf` was ignored) will now be
bound into VRF X. Full analysis in T9122.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other (please describe): restores intended VRF behaviour; classified on
  Phabricator as a *behaviour change* for existing `vrf` configs — see the
  Upgrade impact note above.

## Related Task(s)

* https://vyos.dev/T9122

## Related PR(s)

* Documentation update to follow in `vyos/vyos-documentation` (flow-accounting
  `vrf` / `source-interface` / `source-address` export behaviour).

## How to test / Smoketest result

Reproduction (collector `10.0.0.24` reachable only inside VRF `OOB-Management`,
OOB interface `bond0.500` with `10.0.0.64/xx` enslaved to that VRF):

```
set system flow-accounting netflow interface 'bond0.500'
set system flow-accounting netflow server 10.0.0.24 source-address '10.0.0.64'
set system flow-accounting vrf 'OOB-Management'
```

Before this change `/etc/modprobe.d/ipt_NETFLOW.conf` renders
`destination=10.0.0.24:2055@10.0.0.64` and no flows reach the collector. After
this change it renders `destination=10.0.0.24:2055@10.0.0.64%OOB-Management` and
the export is routed via the VRF.

A smoketest case `test_netflow_vrf` is added covering the three combinations
(`vrf` only, `vrf` + `source-address`, `vrf` + `source-interface`), asserting the
resulting `ipt_NETFLOW` `destination=` string via `get_module_data()`, and
asserting that a `source-interface` outside the VRF is rejected. It is exercised
by the CI smoketest job; I do not have a live router to paste output here. The
template rendering was validated locally for all cases and the darker + ruff lint
passes on the changed lines.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
