### PR TITLE
qos: T9080: only delete ingress qdisc when interface has an ingress policy

### DIFF
--- a/src/conf_mode/qos.py
+++ b/src/conf_mode/qos.py
@@ -37,6 +37,7 @@ from vyos.qos import RateLimiter
 from vyos.qos import RoundRobin
 from vyos.qos import TrafficShaper
 from vyos.qos import TrafficShaperHFSC
+from vyos.utils.dict import dict_search_args
 from vyos.utils.dict import dict_search_recursive
 from vyos.utils.process import run
 from vyos import ConfigError
@@ -351,13 +352,23 @@ def generate(qos):
 
 def apply_interface(qos, ifname):
     """ Clear and re-apply QoS for a single interface only. """
-    run(f'tc qdisc del dev {ifname} parent ffff:')
+    interface_config = dict_search_args(qos, 'interface', ifname)
+    if not interface_config:
+        interface_config = {}
+
+    # Only tear down the ingress qdisc if this interface actually has an
+    # ingress QoS policy bound. Otherwise this would remove an unrelated
+    # ingress redirect/mirror configuration (see set_mirror_redirect())
+    # that call_dependents() just re-created, and it would never come
+    # back as only directions present in interface_config are re-applied
+    # below.
+    if 'ingress' in interface_config:
+        run(f'tc qdisc del dev {ifname} parent ffff:')
     run(f'tc qdisc del dev {ifname} root')
 
-    if not qos or 'interface' not in qos or ifname not in qos['interface']:
+    if not interface_config:
         return None
 
-    interface_config = qos['interface'][ifname]
     if not verify_interface_exists(qos, ifname, state_required=True, warning_only=True):
         # When shaper is bound to a dialup (e.g. PPPoE) interface it is
         # possible that it is yet not available when the QoS code runs.


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

`apply_interface()` unconditionally deleted the `parent ffff:` ingress qdisc before re-applying QoS, even for interfaces with an egress-only policy.

Since `call_dependents()` had already restored an unrelated ingress redirect/mirror qdisc on that handle just before, and only directions present in the interface's QoS config get re-applied, the redirect was silently lost and never recreated.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9080

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/5220

## How to test / Smoketest result
All Smoketests pass

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
