### PR TITLE
container: T7736: give container veths a deterministic host_interface_name

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -334,7 +334,7 @@ Depends:
 # For "container"
   podman (>=5.8),
   netavark (>=1.14.0),
-  aardvark-dns,
+  aardvark-dns (>=1.14.0),
 # iptables is only used for containers now, not the the firewall CLI
   iptables,
 # End container

--- a/debian/control
+++ b/debian/control
@@ -332,8 +332,8 @@ Depends:
   kbd,
 # End "system option keyboard-layout"
 # For "container"
-  podman (>=4.9.5),
-  netavark,
+  podman (>=5.8),
+  netavark (>=1.14.0),
   aardvark-dns,
 # iptables is only used for containers now, not the the firewall CLI
   iptables,

--- a/op-mode-definitions/container.xml.in
+++ b/op-mode-definitions/container.xml.in
@@ -133,6 +133,22 @@
               </node>
             </children>
           </node>
+          <node name="interface">
+            <properties>
+              <help>Show host-side network interface used by each container</help>
+            </properties>
+            <!-- no admin check -->
+            <command>${vyos_op_scripts_dir}/container.py show_interface</command>
+            <children>
+              <node name="json">
+                <properties>
+                  <help>Show host-side network interface used by each container in JSON format</help>
+                </properties>
+                <!-- no admin check -->
+                <command>${vyos_op_scripts_dir}/container.py show_interface --raw</command>
+              </node>
+            </children>
+          </node>
           <tagNode name="log">
             <properties>
               <help>Show logs from a given container</help>

--- a/python/vyos/container.py
+++ b/python/vyos/container.py
@@ -12,10 +12,26 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from hashlib import sha256
+
 from vyos.config import Config
 from vyos.ifconfig import Interface
 from vyos.utils.dict import dict_search
 from vyos.utils.network import interface_exists
+
+def get_container_host_ifname(name: str) -> str:
+    """
+    Deterministic host-side veth interface name for a container's network
+    attachment (verify() only allows one network per container). Kept within
+    IFNAMSIZ and - thanks to the leading "veth-" (a hyphen can never appear in
+    a VyOS "vethN" interface name) - guaranteed to never collide with the
+    "virtual-ethernet" naming scheme..
+    """
+    prefix = f'veth-{name}'
+    if len(prefix) <= 15:
+        return prefix
+    digest = sha256(name.encode()).hexdigest()[:4]
+    return f'veth-{name[:5]}-{digest}'
 
 def restart_network(config: Config) -> None:
     """

--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -264,6 +264,58 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         n = cmd_to_json(['container', 'inspect', 'test2'])
         self.assertEqual(n['NetworkSettings']['Networks']['bridge1']['MacAddress'], '02:00:00:00:00:02')
 
+    def test_long_name_host_interface_uniqueness(self):
+        # T7736: the deterministic host-side veth interface name derived
+        # from a container name is truncated to fit IFNAMSIZ. Two distinct
+        # but similarly-prefixed long names must not truncate to the same
+        # interface name - Podman would then refuse to attach the second
+        # container's network, and its systemd unit would fail to start.
+        net_name = 'longiftest'
+        prefix = '192.0.2.0/24'
+        name_1 = 'abcdefghij-1'
+        name_2 = 'abcdefghij-2'
+
+        self.cli_set(base_path + ['network', net_name, 'prefix', prefix])
+        self.cli_set(base_path + ['name', name_1, 'image', busybox_image])
+        self.cli_set(base_path + ['name', name_1, 'network', net_name, 'address', str(ip_interface(prefix).ip + 2)])
+        self.cli_set(base_path + ['name', name_2, 'image', busybox_image])
+        self.cli_set(base_path + ['name', name_2, 'network', net_name, 'address', str(ip_interface(prefix).ip + 3)])
+        self.cli_commit()
+
+        # Both containers run a "conmon" process at once, so checking by
+        # process name alone can't distinguish which container it belongs
+        # to - verify each container's own recorded PID is still alive
+        for name in (name_1, name_2):
+            pid = 0
+            with open(PROCESS_PIDFILE.format(name)) as f:
+                pid = int(f.read())
+            self.assertTrue(os.path.exists(f'/proc/{pid}'))
+
+    def test_colliding_host_interface_names(self):
+        # T7736: the host-side veth name is "veth-<name[:5]>-<hash[:4]>" for
+        # long container names - two distinct names can still (rarely) hash
+        # to the same result. These two are a confirmed real collision
+        # (both produce "veth-aaaa9-4ded") - verify() must reject the
+        # commit with a clear error instead of leaving it to Podman to fail
+        # obscurely when the second container's network attachment clashes
+        # with the first's interface name.
+        net_name = 'collidetest'
+        prefix = '192.0.2.0/24'
+        name_1 = 'aaaa9000005'
+        name_2 = 'aaaa9000336'
+
+        self.cli_set(base_path + ['network', net_name, 'prefix', prefix])
+        self.cli_set(base_path + ['name', name_1, 'image', busybox_image])
+        self.cli_set(base_path + ['name', name_1, 'network', net_name, 'address', str(ip_interface(prefix).ip + 2)])
+        self.cli_set(base_path + ['name', name_2, 'image', busybox_image])
+        self.cli_set(base_path + ['name', name_2, 'network', net_name, 'address', str(ip_interface(prefix).ip + 3)])
+
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_delete(base_path + ['name', name_2])
+        self.cli_commit()
+
     def test_ipv4_network(self):
         prefix = '192.0.2.0/24'
         base_name = 'ipv4'

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -29,6 +29,7 @@ from vyos.configdict import dict_merge
 from vyos.configdict import node_changed
 from vyos.configdict import is_node_changed
 from vyos.configverify import verify_vrf
+from vyos.container import get_container_host_ifname
 from vyos.container import restart_network
 from vyos.utils.configfs import delete_cli_node
 from vyos.utils.configfs import add_cli_node
@@ -122,6 +123,7 @@ def verify(container):
         net_dict = {}
         net_dict['mac'] = {}
         net_dict['address'] = {}
+        net_dict['host_ifname'] = {}
 
         for name, container_config in container['name'].items():
             # Container image is a mandatory option
@@ -157,6 +159,19 @@ def verify(container):
                 network_name = list(container_config['network'])[0]
                 if network_name not in container.get('network', {}):
                     raise ConfigError(f'Container network "{network_name}" does not exist!')
+
+                # T7736: two distinct (long) container names could truncate to
+                # the same host_interface_name - not applicable to macvlan networks,
+                # they attach without a paired host veth
+                network_type = dict_search(f'{network_name}.type', container['network'])
+                if dict_search('macvlan', network_type) is None:
+                    host_ifname = get_container_host_ifname(name)
+                    if host_ifname in net_dict['host_ifname']:
+                        raise ConfigError(
+                            f'Container "{name}" and "{net_dict["host_ifname"][host_ifname]}" '
+                            f'both generate the host interface name "{host_ifname}" - please '
+                            f'use less similar container names!')
+                    net_dict['host_ifname'][host_ifname] = name
 
                 if 'name_server' in container_config and 'no_name_server' not in container['network'][network_name]:
                     raise ConfigError(f'Setting name server has no effect when attached container network has DNS enabled!')
@@ -361,7 +376,7 @@ def verify(container):
     return None
 
 
-def generate_run_arguments(name, container_config, host_ident):
+def generate_run_arguments(name, container_config, host_ident, network_config):
     image = container_config['image']
     cpu_quota = container_config['cpu_quota']
     memory = container_config['memory']
@@ -511,9 +526,19 @@ def generate_run_arguments(name, container_config, host_ident):
     else:
         ip_param = ''
         addr_info = ''
-        networks = ",".join(container_config['network'])
+        network_opts = []
         for network in container_config['network']:
             network_name = network
+            # T7736: give the host-side veth a name that can never collide
+            # with a VyOS "virtual-ethernet vethN" interface.
+            type_config = dict_search(f'{network}.type', network_config)
+            is_macvlan = dict_search('macvlan', type_config) is not None
+            net_opt = network
+            if not is_macvlan:
+                ifname = get_container_host_ifname(name)
+                net_opt += f':host_interface_name={ifname}'
+            network_opts.append(net_opt)
+
             if 'address' not in container_config['network'][network]:
                 continue
             for address in container_config['network'][network]['address']:
@@ -523,6 +548,8 @@ def generate_run_arguments(name, container_config, host_ident):
                     ip_param += f' --ip {address}'
 
             addr_info = ''.join(container_config['network'][network]['address'])
+
+        networks = ' '.join(f'--network {opt}' for opt in network_opts)
 
         get_mac = dict_search(f'network.{network_name}.mac', container_config)
         if get_mac == 'auto' or get_mac is None:
@@ -546,7 +573,7 @@ def generate_run_arguments(name, container_config, host_ident):
             delete_cli_node(mac_config_path)
             add_cli_node(mac_config_path, value=mac_add)
 
-        net = f'--net {networks} {ip_param} {mac_address}'
+        net = f'{networks} {ip_param} {mac_address}'
 
     return f'{container_base_cmd} {healthcheck} {net} {entrypoint} {image} {command} {command_arguments}'.strip()
 
@@ -626,12 +653,13 @@ def generate(container):
 
     if 'name' in container:
         host_ident = get_host_identity()
+        network_config = container.get('network', {})
         for name, container_config in container['name'].items():
             if 'disable' in container_config:
                 continue
 
             file_path = os.path.join(systemd_unit_path, f'vyos-container-{name}.service')
-            run_args = generate_run_arguments(name, container_config, host_ident)
+            run_args = generate_run_arguments(name, container_config, host_ident, network_config)
             render(file_path, 'container/systemd-unit.j2', {'name': name, 'run_args': run_args, },
                    formatter=lambda _: _.replace("&quot;", '"').replace("&apos;", "'"))
 

--- a/src/op_mode/container.py
+++ b/src/op_mode/container.py
@@ -21,6 +21,8 @@ import sys
 import subprocess
 
 from pathlib import Path
+from tabulate import tabulate
+
 from vyos.defaults import directories
 from vyos.utils.process import cmdl
 from vyos.utils.process import rc_cmd
@@ -162,6 +164,43 @@ def show_network(raw: bool):
         return container_data
     else:
         return cmdl(command.split())
+
+def show_interface(raw: bool):
+    """ Show the deterministic host-side veth interface name (T7736) VyOS
+    assigns to each configured container's network attachment """
+    from vyos.configquery import ConfigTreeQuery
+    from vyos.container import get_container_host_ifname
+    from vyos.utils.dict import dict_search
+
+    conf = ConfigTreeQuery()
+    container = conf.get_config_dict(['container'], key_mangling=('-', '_'),
+                                      no_tag_node_value_mangle=True,
+                                      get_first_key=True,
+                                      with_recursive_defaults=True)
+
+    data = []
+    for name, container_config in container.get('name', {}).items():
+        if 'allow_host_networks' in container_config:
+            data.append({'name': name, 'network': None, 'interface': None})
+            continue
+        if 'network' not in container_config:
+            continue
+
+        network_name = list(container_config['network'])[0]
+        network_type = dict_search(f'network.{network_name}.type', container)
+        is_macvlan = dict_search('macvlan', network_type) is not None
+        interface = None if is_macvlan else get_container_host_ifname(name)
+        data.append({'name': name, 'network': network_name, 'interface': interface})
+
+    if raw:
+        return data
+
+    if not data:
+        return 'No containers configured!'
+
+    headers = ['Container', 'Network', 'Host Interface']
+    rows = [[d['name'], d['network'] or 'host', d['interface'] or 'n/a'] for d in data]
+    return tabulate(rows, headers)
 
 def restart(name: str):
     from vyos.utils.process import rc_cmd


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Podman's default `vethN` auto-naming for a container's host-side veth can collide with VyOS's own `virtual-ethernet vethN` interfaces.

Bump the minimum Podman dependency to 5.8 (which supports the "host_interface_name" network connect option) and use it to name every non-macvlan container network attachment `veth-<container name>` instead, eliminating the collision by construction.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
https://vyos.dev/T7736

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/1259

## How to test / Smoketest result

```
 INFO - Executing VyOS smoketests
DEBUG - vyos@vyos:~$ /usr/bin/vyos-smoketest
DEBUG - /usr/bin/vyos-smoketest
DEBUG - Running Testcase (1/1): /usr/libexec/vyos/tests/smoke/cli/test_container.py
DEBUG - test_api_socket (__main__.TestContainer.test_api_socket) ... ok
DEBUG - test_basic (__main__.TestContainer.test_basic) ... ok
DEBUG - test_cpu_limit (__main__.TestContainer.test_cpu_limit) ... ok
DEBUG - test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... ok
DEBUG - test_healthcheck (__main__.TestContainer.test_healthcheck) ... ok
DEBUG - test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... ok
DEBUG - test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... ok
DEBUG - test_long_name_host_interface_uniqueness (__main__.TestContainer.test_long_name_host_interface_uniqueness) ... ok
DEBUG - test_name_server (__main__.TestContainer.test_name_server) ... ok
DEBUG - test_network_mtu (__main__.TestContainer.test_network_mtu) ... ok
DEBUG - test_network_types (__main__.TestContainer.test_network_types) ... ok
DEBUG - test_network_vrf (__main__.TestContainer.test_network_vrf) ... ok
DEBUG - test_no_name_server (__main__.TestContainer.test_no_name_server) ... ok
DEBUG - test_uid_gid (__main__.TestContainer.test_uid_gid) ... ok
DEBUG - test_user_defined_mac (__main__.TestContainer.test_user_defined_mac) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 15 tests in 209.184s
DEBUG -
DEBUG - OK
DEBUG - SUCCESS! All 1 tests passed.
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
