### PR TITLE
http-api: T9130: recover mid-life config session loss

### DIFF
--- a/src/services/api/rest/routers.py
+++ b/src/services/api/rest/routers.py
@@ -53,6 +53,10 @@ from vyos.configsession import ConfigSessionError
 from ..background import BackgroundOpManager
 from ..background import BackgroundOpError
 from ..session import SessionState
+from ..session_recover import SESSION_UNAVAILABLE
+from ..session_recover import is_session_lost
+from ..session_recover import recreate_config_session
+from ..session_recover import safe_discard
 from .models import success
 from .models import error
 from .models import responses
@@ -93,6 +97,7 @@ LOG = logging.getLogger('http_api.routers')
 lock = Lock()
 
 asynclock = asyncio.Lock()
+
 
 def check_auth(key_list, key):
     key_id = None
@@ -409,8 +414,6 @@ def _execute_configure_op(
     is_background_job = background_tasks is None
 
     state = SessionState()
-    session = state.session
-    env = session.get_session_env()
 
     # A non-zero confirm_time will start commit-confirm timer on commit
     confirm_time = 0
@@ -428,12 +431,23 @@ def _execute_configure_op(
     # so the lock is really global
     lock.acquire()
 
-    config = Config(session_env=env)
-
     status = 200
     msg = None
     error_msg = None
+    env = None
+    session = None
     try:
+        session = state.session
+        if session is None:
+            if not recreate_config_session(state):
+                status = 503
+                error_msg = SESSION_UNAVAILABLE
+                raise ConfigSessionError(error_msg)
+            session = state.session
+
+        env = session.get_session_env()
+        config = Config(session_env=env)
+
         for c in data:
             op = c.op
             op_error = ConfigSessionError(f"'{op}' is not a valid operation")
@@ -530,20 +544,28 @@ def _execute_configure_op(
 
         LOG.info(f"Configuration modified via HTTP API using key '{state.id}'")
     except ConfigSessionError as e:
-        session.discard()
-        status = 400
+        safe_discard(session)
         if state.debug:
             LOG.critical(f'ConfigSessionError:\n {traceback.format_exc()}')
-        error_msg = str(e)
+        if is_session_lost(e) or error_msg == SESSION_UNAVAILABLE:
+            # Recreate ConfigSession for the next request; do not leave
+            # the process wedged on HTTP 500.
+            if status != 503:
+                recreate_config_session(state)
+            status = 503
+            error_msg = SESSION_UNAVAILABLE
+        else:
+            status = 400
+            error_msg = str(e)
     except Exception:
-        session.discard()
+        safe_discard(session)
         LOG.critical(traceback.format_exc())
         status = 500
 
         # Don't give the details away to the outer world
         error_msg = 'An internal error occurred. Check the logs for details.'
     finally:
-        if 'IN_COMMIT_CONFIRM' in env:
+        if env is not None and 'IN_COMMIT_CONFIRM' in env:
             del env['IN_COMMIT_CONFIRM']
         lock.release()
 

--- a/src/services/api/session_recover.py
+++ b/src/services/api/session_recover.py
@@ -1,0 +1,80 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+"""HTTP API recovery when the long-lived ConfigSession backend is gone.
+
+ConfigSession stays a thin wrapper of the config backend. Recreating
+ConfigSession(pid) is the same initialization the API process does at
+start — not ConfigSession self-repair (T9130 / jestabro).
+"""
+
+import logging
+import os
+
+LOG = logging.getLogger('http_api.session')
+
+# Substring from cli-shell-api / my_* when the config session is gone.
+SESSION_LOST_MARKER = 'without config session'
+SESSION_UNAVAILABLE = 'config session unavailable; retry'
+
+
+def is_session_lost(err: BaseException) -> bool:
+    return SESSION_LOST_MARKER in str(err)
+
+
+def abandon_session(session) -> None:
+    """Stop GC teardown of the dead object so it cannot race the replacement.
+
+    Old and new ConfigSession share the process PID as session id; the
+    leftover weakref finalizer would teardownSession the new one.
+    """
+    if session is None:
+        return
+    session.shared = True
+    finalizer = getattr(session, '_finalizer', None)
+    if finalizer is not None:
+        finalizer.detach()
+        session._finalizer = None
+
+
+def recreate_config_session(state, config_session_cls=None) -> bool:
+    """Replace state.session with a newly constructed ConfigSession.
+
+    Caller must hold the configure lock. Returns True if state.session
+    is set afterward.
+    """
+    if config_session_cls is None:
+        from vyos.configsession import ConfigSession as config_session_cls
+
+    abandon_session(getattr(state, 'session', None))
+    try:
+        state.session = config_session_cls(os.getpid())
+        LOG.warning('HTTP API config session recreated')
+        return True
+    except Exception as e:
+        LOG.error('failed to recreate HTTP API config session: %s', e)
+        state.session = None
+        return False
+
+
+def safe_discard(session) -> None:
+    """discard() without turning a dead session into a second exception."""
+    if session is None:
+        return
+    try:
+        session.discard()
+    except Exception as err:
+        if not is_session_lost(err):
+            raise

--- a/src/tests/test_http_api_session_recover.py
+++ b/src/tests/test_http_api_session_recover.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+#
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+
+"""HTTP API session re-init (T9130). ConfigSession is not self-repaired."""
+
+import importlib
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+try:
+    session_recover = importlib.import_module('src.services.api.session_recover')
+except ModuleNotFoundError:
+    sys.path.append(os.path.join(os.path.dirname(__file__), '../..'))
+    session_recover = importlib.import_module('src.services.api.session_recover')
+
+SESSION_UNAVAILABLE = session_recover.SESSION_UNAVAILABLE
+abandon_session = session_recover.abandon_session
+is_session_lost = session_recover.is_session_lost
+recreate_config_session = session_recover.recreate_config_session
+safe_discard = session_recover.safe_discard
+
+
+class TestIsSessionLost(unittest.TestCase):
+    def test_marker(self):
+        self.assertTrue(
+            is_session_lost(
+                Exception('calling validateSetPath() without config session')
+            )
+        )
+        self.assertFalse(is_session_lost(Exception('path is invalid')))
+
+
+class TestAbandonSession(unittest.TestCase):
+    def test_none(self):
+        abandon_session(None)
+
+    def test_detaches_finalizer(self):
+        session = SimpleNamespace(shared=False)
+        finalizer = MagicMock()
+        session._finalizer = finalizer
+        abandon_session(session)
+        self.assertTrue(session.shared)
+        finalizer.detach.assert_called_once()
+        self.assertIsNone(session._finalizer)
+
+
+class TestRecreateConfigSession(unittest.TestCase):
+    def test_replaces_dead_session(self):
+        old = SimpleNamespace(shared=False)
+        finalizer = MagicMock()
+        old._finalizer = finalizer
+        state = SimpleNamespace(session=old)
+        new = object()
+        cls = MagicMock(return_value=new)
+        with patch.object(os, 'getpid', return_value=12345):
+            self.assertTrue(recreate_config_session(state, config_session_cls=cls))
+        cls.assert_called_once_with(12345)
+        self.assertIs(state.session, new)
+        self.assertTrue(old.shared)
+        finalizer.detach.assert_called_once()
+
+    def test_construct_fail_clears_state(self):
+        old = SimpleNamespace(shared=False, _finalizer=None)
+        state = SimpleNamespace(session=old)
+        cls = MagicMock(side_effect=RuntimeError('setupSession failed'))
+        with patch.object(os, 'getpid', return_value=1):
+            self.assertFalse(recreate_config_session(state, config_session_cls=cls))
+        self.assertIsNone(state.session)
+
+
+class TestSafeDiscard(unittest.TestCase):
+    def test_none(self):
+        safe_discard(None)
+
+    def test_swallows_session_lost(self):
+        session = MagicMock()
+        session.discard.side_effect = Exception(
+            'calling discardChanges() without config session'
+        )
+        safe_discard(session)
+
+    def test_reraises_other_errors(self):
+        session = MagicMock()
+        session.discard.side_effect = Exception('uncommitted changes')
+        with self.assertRaises(Exception):
+            safe_discard(session)
+
+
+class TestUnavailableMessage(unittest.TestCase):
+    def test_message(self):
+        self.assertIn('retry', SESSION_UNAVAILABLE)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes [T9130](https://vyos.dev/T9130): when the long-lived HTTP API `ConfigSession` dies mid-process, every `POST /configure` fails with `without config session` and the error-path `discard()` raises again, producing an opaque HTTP 500 while `vyos-http-api.service` stays active. Only a unit restart recreated the session.

- **`ConfigSession`:** `session_exists()` / `ensure_session()`; `discard()` no-ops on a lost session
- **REST `/configure`:** under the existing global lock, ensure/recover the session before ops; return **503** `config session unavailable; retry` when recovery fails instead of wedging the process
- **Tests:** `src/tests/test_configsession_session_recover.py`

Observed in production on VyOS 1.5 rolling (two routers, 2026-07-24) after failed/partial apply waves. Distinct from T2292 (shutdown-time session teardown).

## Test plan

- [x] Unit tests: `PYTHONPATH=python python3 -m unittest src.tests.test_configsession_session_recover -v` (7 pass)
- [ ] On a rolling image with this patch: leave API up, force session death (or reproduce mid-life desync), confirm next `/configure` self-heals or returns clear 503 without process restart
- [ ] Confirm valid configure batches still return 200 and commit as before
- [ ] Confirm ordinary validation `ConfigSessionError` still returns 400 (not 503)