### PR TITLE
ci: T9107: opt in to fork PR checkout after actions/checkout security update

### DIFF
--- a/.github/workflows/package-smoketest.yml
+++ b/.github/workflows/package-smoketest.yml
@@ -26,7 +26,6 @@ permissions:
   contents: read
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   BUILD_BY: autobuild@vyos.net
   DEBIAN_MIRROR: http://deb.debian.org/debian/
   DEBIAN_SECURITY_MIRROR: http://deb.debian.org/debian-security
@@ -158,6 +157,8 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
           token: ${{ needs.set_config.outputs.use_pat == 'true' && secrets.PAT || secrets.GITHUB_TOKEN }}
           submodules: true
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Build vyos-1x package
         run: |


### PR DESCRIPTION
## Problem

Every fork-authored PR currently fails the ISO smoketest at checkout.

`actions/checkout` v6.1.0 (released 2026-07-20) backported a breaking security change — "[BREAKING] backport allow-unsafe-pr-checkout to v6" — implementing safer `pull_request_target` defaults:

https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/

`checkout` now refuses to check out fork PR code from a `pull_request_target` workflow unless the step explicitly opts in. `.github/workflows/package-smoketest.yml` runs on `pull_request_target`, and its `Clone vyos-1x source code` step checks out the PR head — the code actually under test — from `github.event.pull_request.head.repo.full_name`. That step now hard-fails on any fork PR.

Example failing run: https://github.com/vyos/vyos-1x/actions/runs/30221012115/job/89843381954 (fork PR #5353).

Same-repo PRs and `push` builds were unaffected — the guard only trips when the checkout target is a fork.

Phorge task: T9107. A prior partial fix (153b8b6fa) addressed a different checkout step; the fork-head step was still broken.

## Changes

Single file, `.github/workflows/package-smoketest.yml`:

1. **`allow-unsafe-pr-checkout: true`** on the `Clone vyos-1x source code` step — the explicit opt-in the new checkout requires. This restores the pre-v6.1.0 behaviour for the one step that genuinely needs the PR head.

2. **`persist-credentials: false`** on the same step — so the token is not written into the `.git` config of a working tree whose contents later steps execute (`dpkg-buildpackage`, `build-vyos-image`). This matches the sibling `Clone vyos-1x source code into the build directory` step, which already sets it, and directly reduces the exposure the new checkout guard warns about.

3. **Removed the workflow-global `GITHUB_TOKEN` env export.** No step consumes it: the `Determine vyos-build ref` step sets its own `GH_TOKEN`, every `actions/checkout` passes `token:` explicitly, and `mshick/add-pr-comment` defaults its `repo-token` input to `github.token`. Verified there is no `GITHUB_TOKEN` consumer in the vyos-build build scripts. As written, the global export handed the token to every step in every job — including the steps that execute fork-supplied code via `sudo --preserve-env`.

Nothing else changes.

## Out of scope

A deeper hardening of the `pull_request_target` flow — a maintainer `safe-to-test` label gate, or splitting the untrusted build into a secret-free `pull_request` job — is a larger design change and is tracked separately. This PR restores CI for fork contributors and removes the token exposure that made the previous arrangement worse than it needed to be.

🤖 Generated by [robots](https://vyos.io)
