### PR TITLE
nhrp: T9128: fix duplicate nftables meter name for multiple redirect tunnels

### DIFF
--- a/data/templates/frr/nhrpd_nftables.conf.j2
+++ b/data/templates/frr/nhrpd_nftables.conf.j2
@@ -37,7 +37,7 @@ table ip vyos_nhrp_redirect {
 {%     if tunnel is vyos_defined %}
 {%         for tun, tunnel_conf in tunnel.items() %}
 {%             if tunnel_conf.redirect is vyos_defined %}
-                iifname "{{ tun }}" oifname "{{ tun }}" meter loglimit-0 size 65535 { ip daddr & 255.255.255.0 . ip saddr & 255.255.255.0 timeout 1m limit rate 4/minute burst 1 packets } counter log group {{ redirect }}
+                iifname "{{ tun }}" oifname "{{ tun }}" meter loglimit-{{ loop.index0 }} size 65535 { ip daddr & 255.255.255.0 . ip saddr & 255.255.255.0 timeout 1m limit rate 4/minute burst 1 packets } counter log group {{ redirect }}
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/smoketest/scripts/cli/test_protocols_nhrp.py
+++ b/smoketest/scripts/cli/test_protocols_nhrp.py
@@ -37,6 +37,7 @@ class TestProtocolsNHRP(VyOSUnitTestSHIM.TestCase):
     def tearDown(self):
         self.cli_delete(nhrp_path)
         self.cli_delete(tunnel_path)
+        self.cli_delete(vpn_path)
         self.cli_commit()
         # always forward to base class
         super().tearDown()
@@ -137,6 +138,82 @@ class TestProtocolsNHRP(VyOSUnitTestSHIM.TestCase):
         ]
         self.verify_nftables(nftables_search_multicast, 'ip vyos_nhrp_multicast')
         self.verify_nftables(nftables_search_redirect, 'ip vyos_nhrp_redirect')
+
+        self.assertTrue(process_named_running(PROCESS_NAME))
+
+    def test_02_nhrp_multiple_tunnels(self):
+        # Multiple NHRP tunnels with 'redirect' enabled must each receive a
+        # uniquely named nftables meter. The meter name used to be hardcoded
+        # ('loglimit-0'), so a second redirect-enabled tunnel produced a
+        # duplicate set, 'nft' rejected the whole ruleset, and the commit failed
+        # with "Failed to apply NHRP tunnel firewall rules".
+        redirect_log_group = '1'
+        multicast_log_group = '2'
+        tunnels = {
+            'tun100': {
+                'address': '172.16.253.134/32',
+                'source': '192.0.2.134',
+                'key': '1',
+                'network_id': '1',
+                'meter': 'loglimit-0',
+            },
+            'tun101': {
+                'address': '172.16.254.134/32',
+                'source': '192.0.2.135',
+                'key': '2',
+                'network_id': '2',
+                'meter': 'loglimit-1',
+            },
+        }
+
+        for tunnel_if, tunnel_conf in tunnels.items():
+            # Tunnel interface (mGRE)
+            self.cli_set(tunnel_path + [tunnel_if, 'address', tunnel_conf['address']])
+            self.cli_set(tunnel_path + [tunnel_if, 'encapsulation', 'gre'])
+            self.cli_set(
+                tunnel_path + [tunnel_if, 'source-address', tunnel_conf['source']]
+            )
+            self.cli_set(tunnel_path + [tunnel_if, 'enable-multicast'])
+            self.cli_set(
+                tunnel_path + [tunnel_if, 'parameters', 'ip', 'key', tunnel_conf['key']]
+            )
+
+            # NHRP - 'redirect' and 'multicast' are the options that render
+            # nftables rules for the tunnel
+            self.cli_set(
+                nhrp_path
+                + ['tunnel', tunnel_if, 'network-id', tunnel_conf['network_id']]
+            )
+            self.cli_set(nhrp_path + ['tunnel', tunnel_if, 'redirect'])
+            self.cli_set(nhrp_path + ['tunnel', tunnel_if, 'multicast', 'dynamic'])
+
+        # Must not raise "Failed to apply NHRP tunnel firewall rules"
+        self.cli_commit()
+
+        # Each redirect-enabled tunnel gets its own meter (loglimit-0,
+        # loglimit-1, ...) and each multicast-enabled tunnel its own log rule.
+        nftables_search_redirect = [['chain VYOS_NHRP_REDIRECT_FORWARD']]
+        nftables_search_multicast = [['chain VYOS_NHRP_MULTICAST_OUTPUT']]
+        for tunnel_if, tunnel_conf in tunnels.items():
+            nftables_search_redirect.append(
+                [
+                    f'iifname "{tunnel_if}" oifname "{tunnel_if}"',
+                    f'meter {tunnel_conf["meter"]} size 65535',
+                    'counter',
+                    f'log group {redirect_log_group}',
+                ]
+            )
+            nftables_search_multicast.append(
+                [
+                    f'oifname "{tunnel_if}"',
+                    'ip daddr 224.0.0.0/24',
+                    'counter',
+                    f'log group {multicast_log_group}',
+                ]
+            )
+
+        self.verify_nftables(nftables_search_redirect, 'ip vyos_nhrp_redirect')
+        self.verify_nftables(nftables_search_multicast, 'ip vyos_nhrp_multicast')
 
         self.assertTrue(process_named_running(PROCESS_NAME))
 


### PR DESCRIPTION
## Change summary

Adding a second `protocols nhrp tunnel` with `redirect` enabled made `commit` fail with `Failed to apply NHRP tunnel firewall rules`; a single tunnel worked fine.

The redirect chain in `data/templates/frr/nhrpd_nftables.conf.j2` is rendered in a per-tunnel loop but hardcoded the nftables meter name `loglimit-0`. With two redirect-enabled tunnels the loop declares the named set `loglimit-0` twice in table `vyos_nhrp_redirect`; `nft` rejects the duplicate set and aborts the atomic ruleset load, so `apply()` in `src/conf_mode/protocols_nhrp.py` raises the error.

The fix derives the meter name from the loop index (`loglimit-0`, `loglimit-1`, ...) so every redirect-enabled tunnel gets a unique meter. The first tunnel keeps the name `loglimit-0`, so single-tunnel setups render byte-for-byte identically. This matches the per-item set-naming convention already used across the firewall templates (`RECENT_{{ set_name }}`, `A_{{ group_name }}`, ...).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T9128

## Related PR(s)

## How to test / Smoketest result

Before the fix, a second `redirect`-enabled tunnel fails to commit:

```
set interfaces tunnel tun100 address '172.16.253.134/32'
set interfaces tunnel tun100 encapsulation 'gre'
set interfaces tunnel tun100 source-address '192.0.2.134'
set interfaces tunnel tun100 parameters ip key '1'
set protocols nhrp tunnel tun100 network-id '1'
set protocols nhrp tunnel tun100 redirect
set protocols nhrp tunnel tun100 multicast 'dynamic'
commit                     # OK

set interfaces tunnel tun101 address '172.16.254.134/32'
set interfaces tunnel tun101 encapsulation 'gre'
set interfaces tunnel tun101 source-address '192.0.2.135'
set interfaces tunnel tun101 parameters ip key '2'
set protocols nhrp tunnel tun101 network-id '2'
set protocols nhrp tunnel tun101 redirect
set protocols nhrp tunnel tun101 multicast 'dynamic'
commit
# [ protocols nhrp ]
# Failed to apply NHRP tunnel firewall rules
```

With the fix the second commit succeeds and `nft list table ip vyos_nhrp_redirect` shows a distinct meter per tunnel:

```
iifname "tun100" oifname "tun100" meter loglimit-0 size 65535 { ... } counter log group 1
iifname "tun101" oifname "tun101" meter loglimit-1 size 65535 { ... } counter log group 1
```

`smoketest/scripts/cli/test_protocols_nhrp.py` gains `test_02_nhrp_multiple_tunnels`: it configures two tunnels with `redirect` + `multicast`, asserts the commit succeeds, and asserts both `loglimit-0` and `loglimit-1` rules are present. The existing `test_01` is unaffected (a single tunnel still renders `loglimit-0`).

Validated locally: `darker`/black, `ruff check`, and `j2lint` are all clean on the diff, and the template output above was confirmed by rendering `nhrpd_nftables.conf.j2` standalone for one vs. two tunnels. The `test_02` case exercises the CLI smoketest harness under CI (it needs a running VyOS instance).

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
