### PR TITLE
vpp: T9139: Check interface not referenced by a feature before removal

### DIFF
--- a/src/conf_mode/vpp_interfaces_gre.py
+++ b/src/conf_mode/vpp_interfaces_gre.py
@@ -30,6 +30,7 @@ from vyos.vpp.config_deps import deps_xconnect_dict
 from vyos.vpp.config_verify import verify_vpp_remove_bridge_interface
 from vyos.vpp.config_verify import verify_vpp_remove_xconnect_interface
 from vyos.vpp.config_verify import verify_vpp_tunnel_source_address
+from vyos.vpp.config_verify import verify_vpp_remove_interface
 from vyos.vpp.utils import cli_ethernet_with_vifs_ifaces
 
 
@@ -76,6 +77,14 @@ def get_config(config=None) -> dict:
         no_tag_node_value_mangle=True,
     )
 
+    # VPP config for member-in-feature checks
+    config['vpp'] = conf.get_config_dict(
+        ['vpp'],
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+    )
+
     # Get all gre interfaces config
     config['gre_interfaces'] = conf.get_config_dict(
         base,
@@ -109,6 +118,7 @@ def verify(config):
 
     # config removed
     if 'deleted' in config:
+        verify_vpp_remove_interface(config['ifname'], config['vpp'])
         return None
 
     if not is_systemd_service_active('vpp.service'):

--- a/src/conf_mode/vpp_interfaces_ipip.py
+++ b/src/conf_mode/vpp_interfaces_ipip.py
@@ -29,6 +29,7 @@ from vyos.vpp.config_deps import deps_xconnect_dict
 from vyos.vpp.config_verify import (
     verify_vpp_remove_xconnect_interface,
     verify_vpp_tunnel_source_address,
+    verify_vpp_remove_interface,
 )
 from vyos.vpp.utils import cli_ethernet_with_vifs_ifaces
 
@@ -71,6 +72,14 @@ def get_config(config=None) -> dict:
         no_tag_node_value_mangle=True,
     )
 
+    # VPP config for member-in-feature checks
+    config['vpp'] = conf.get_config_dict(
+        ['vpp'],
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+    )
+
     # ACL dependency
     if conf.exists(['vpp', 'acl']):
         set_dependents('vpp_acl', conf)
@@ -87,6 +96,7 @@ def verify(config):
 
     # config removed
     if 'deleted' in config:
+        verify_vpp_remove_interface(config['ifname'], config['vpp'])
         return None
 
     if not is_systemd_service_active('vpp.service'):

--- a/src/conf_mode/vpp_interfaces_loopback.py
+++ b/src/conf_mode/vpp_interfaces_loopback.py
@@ -26,6 +26,7 @@ from vyos.utils.process import is_systemd_service_active
 from vyos.ifconfig.vpp import VPPLoopbackInterface
 from vyos.vpp.config_deps import deps_bridge_dict
 from vyos.vpp.config_verify import verify_vpp_remove_bridge_interface
+from vyos.vpp.config_verify import verify_vpp_remove_interface
 
 
 def get_config(config=None) -> dict:
@@ -57,6 +58,14 @@ def get_config(config=None) -> dict:
         no_tag_node_value_mangle=True,
     )
 
+    # VPP config for member-in-feature checks
+    config['vpp'] = conf.get_config_dict(
+        ['vpp'],
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+    )
+
     # Bridge dependency - reattach as BVI after this loopback is recreated
     config['bridge_members'] = deps_bridge_dict(conf)
     if ifname in config['bridge_members']:
@@ -83,10 +92,20 @@ def verify(config):
 
     verify_vpp_remove_bridge_interface(config)
 
+    if 'deleted' in config:
+        verify_vpp_remove_interface(config['ifname'], config['vpp'], match_vlans=True)
+        return None
+
     if not is_systemd_service_active('vpp.service'):
         raise ConfigError(
             'Cannot configure VPP loopback interface: vpp.service is not running'
         )
+
+    for vif_remove in config.get('vif_remove', []):
+        vif_iface = f'{config["ifname"]}.{vif_remove}'
+        verify_vpp_remove_interface(vif_iface, config['vpp'])
+
+    return None
 
 
 def generate(config):

--- a/src/conf_mode/vpp_interfaces_vxlan.py
+++ b/src/conf_mode/vpp_interfaces_vxlan.py
@@ -34,6 +34,7 @@ from vyos.vpp.config_deps import deps_xconnect_dict
 from vyos.vpp.config_verify import verify_vpp_remove_bridge_interface
 from vyos.vpp.config_verify import verify_vpp_remove_xconnect_interface
 from vyos.vpp.config_verify import verify_vpp_tunnel_source_address
+from vyos.vpp.config_verify import verify_vpp_remove_interface
 from vyos.vpp.utils import cli_ethernet_with_vifs_ifaces
 
 
@@ -81,6 +82,14 @@ def get_config(config=None) -> dict:
         with_defaults=True,
     )
 
+    # VPP config for member-in-feature checks
+    config['vpp'] = conf.get_config_dict(
+        ['vpp'],
+        key_mangling=('-', '_'),
+        get_first_key=True,
+        no_tag_node_value_mangle=True,
+    )
+
     # NAT dependency
     if conf.exists(['vpp', 'nat', 'nat44']):
         set_dependents('vpp_nat_nat44', conf)
@@ -103,6 +112,7 @@ def verify(config):
     verify_vpp_remove_bridge_interface(config)
 
     if 'deleted' in config:
+        verify_vpp_remove_interface(config['ifname'], config['vpp'])
         return None
 
     if not is_systemd_service_active('vpp.service'):


### PR DESCRIPTION
Reject deletion of a gre, ipip, vxlan or loopback interface that is still used by a feature.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
 * https://vyos.dev/T9139
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set interfaces ethernet eth0 address '200.0.0.1/24'
set vpp settings interface eth0
set interfaces vpp ipip vppipip1 remote '200.0.0.2'
set interfaces vpp ipip vppipip1 source-address '200.0.0.1'

set vpp acl ip tag-name TEST_ACL rule 10 action 'permit'
set vpp acl ip tag-name TEST_ACL rule 10 source prefix '10.0.0.10/32'
set vpp acl ip interface vppipip1 input acl-tag 10 tag-name 'TEST_ACL'
commit

vyos@vyos# run show vpp acl ip interface 
Interface    Input ACLs    Output ACLs
-----------  ------------  -------------
ipip1        TEST_ACL
[edit]
vyos@vyos# del interfaces vpp ipip 
[edit]
vyos@vyos# commit
[ interfaces vpp ipip vppipip1 ]
Cannot remove interface "vppipip1", it is still configured as VPP IP ACL
interface

delete [ interfaces vpp ipip vppipip1 ] failed
Commit failed
[edit]
vyos@vyos#
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
