### PR TITLE
vyos-netlinkd: T9143: seed operstate cache at startup

### DIFF
--- a/src/services/vyos-netlinkd
+++ b/src/services/vyos-netlinkd
@@ -180,6 +180,16 @@ def main():
             'IPRoute.bind() has no groups= support; using default RTNL subscriptions',
         )
         ipr.bind()
+
+    # Establish a baseline so the first UP re-notification is not mistaken
+    # for a real interface transition.
+    for link in ipr.get_links():
+        attrs = dict(link.get('attrs', []))
+        ifname = attrs.get('IFLA_IFNAME')
+        operstate = attrs.get('IFLA_OPERSTATE')
+        if ifname and match_iface(ifname) and operstate in ['UP', 'DOWN']:
+            _iface_prev_operstate[ifname] = operstate
+
     fd = ipr.fileno()
 
     global running


### PR DESCRIPTION
## Change summary

Seed the `vyos-netlinkd` per-interface operstate cache from the kernel link
state when the daemon starts.

The cache added by T8950 currently starts empty. If the first notification for
an already-UP interface is another `RTM_NEWLINK state=UP`, the daemon treats it
as a transition and unnecessarily restarts DHCP. Establishing the baseline
before processing notifications closes that startup and service-restart gap
while preserving real DOWN-to-UP handling.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T9143
* https://vyos.dev/T8950

## Related PR(s)

* https://github.com/vyos/vyos-1x/pull/5242
* https://github.com/vyos/vyos-1x/pull/5333 touches the same daemon for an
  orthogonal commit-time stale-event issue but does not seed startup state.

## How to test / Smoketest result

On a disposable VyOS VM with a DHCP-configured interface:

```bash
sudo systemctl restart vyos-netlinkd.service
systemctl show dhclient@eth0.service -p MainPID -p ActiveEnterTimestamp
sudo ip link set dev eth0 promisc on
sleep 5
systemctl show dhclient@eth0.service -p MainPID -p ActiveEnterTimestamp
sudo ip link set dev eth0 promisc off
sudo journalctl -u vyos-netlinkd.service --since "30 seconds ago"
```

Expected result: both promiscuous-mode changes may produce
`RTM_NEWLINK state=UP`, but the journal reports
`Suppressing DHCP restart for eth0: already UP`, and the DHCP PID and service
activation timestamp remain unchanged.

Validation performed against rolling commit
`b81e435210f499b225b5d27fd16c370c0095da3a`:

- `git diff --check`: passed
- Python compilation of `src/services/vyos-netlinkd`: passed
- `vyos-1x` package build and test suite: 104 passed, 1 skipped
- Custom ISO checksum validation and QEMU/KVM live boot: passed
- End-to-end KVM regression test with DHCP: PID and activation timestamp
  remained unchanged after both UP re-notifications
- 42-minute deployment observation: 2,511 successful WAN probes, zero failed
  probes, zero DHCP or netlinkd restarts, and five successful DHCP renewals

No targeted CLI smoketest exists for `vyos-netlinkd`.

## AI assistance disclosure

This patch and PR text were prepared with OpenCode using OpenAI gpt-5.6-sol. I
reviewed and validated the change, including the package build and tests and an
end-to-end QEMU/KVM regression test. No third-party generated source code was
included.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
