### PR TITLE
utils: T9144: fix infinite loop in ask_yes_no on EOF

### DIFF
--- a/python/vyos/utils/io.py
+++ b/python/vyos/utils/io.py
@@ -71,7 +71,8 @@ def ask_yes_no(question, default=False) -> bool:
             else:
                 stdout.write("Please respond with yes/y or no/n\n")
         except EOFError:
-            stdout.write("\nPlease respond with yes/y or no/n\n")
+            stdout.write("\n")
+            return default
         except KeyboardInterrupt:
             return False
 


### PR DESCRIPTION
## Change summary

`ask_yes_no()` retries on EOFError. With stdin closed or not a terminal, for example `commit-confirm` run from a script over ssh, `input()` raises EOFError on every retry and the loop never exits. The session appears to hang while repeating "Please respond with yes/y or no/n".

This resolves EOF to the prompt's default answer, identical to an interactive user pressing Enter. Callers already declare the safe default at each call site. All call sites with destructive consequences declare `default=False`, so EOF aborts them; `default=True` sites are commit-confirm/rollback (which arm an automatic revert) and installer conveniences behind a False-gated disk confirmation.

One observable behavior change: a headless `install image` previously hung at its first prompt; it now walks the prompts until the destroy-disk confirmation answers No and exits cleanly.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T9144

## Related PR(s)

A follow-up PR to vyatta-cfg adds `-y` passthrough to the `commit-confirm` configure-mode command (same task).

## How to test / Smoketest result

On VyOS Stream 2026.03:

```
$ cat /tmp/t.sh
source /opt/vyatta/etc/functions/script-template
configure
set interfaces dummy dum99
commit-confirm
exit
$ ssh vyos@router "vbash /tmp/t.sh"
```

Before: the session never returns, output loops "Please respond with yes/y or no/n".
After: commit proceeds with the revert timer armed, and `confirm` works as usual.

Interactive behavior is unchanged except Ctrl-D, which now acts like pressing Enter instead of re-prompting.
