### PR TITLE
qos: T9134: Fix commit crash when classes match different protocols

### DIFF
--- a/python/vyos/qos/base.py
+++ b/python/vyos/qos/base.py
@@ -238,18 +238,52 @@ class QoSBase:
             pprint.pprint(config)
 
         if 'class' in config:
+            # T9134: every class match is installed as its own tc filter, and
+            # tc ties a filter priority ("prio"/"pref") to a single protocol -
+            # two filters with the same priority but different protocols (e.g.
+            # the default "all" and an explicit "arp") are rejected by the
+            # kernel and the commit fails. So every filter needs a priority
+            # that is unique across all classes.
+            #
+            # Rank the matches in evaluation order, then number them 1, 2, 3...:
+            #   - by class id for policies that key the filter on it
+            #     (round-robin, priority-queue), else
+            #   - by an explicit or default class "priority", else
+            #   - by the per-class match index (a shaper class with no priority)
+            # The last fallback orders matches by declaration position, not by
+            # match specificity, and it shares the number space with explicit
+            # priorities. This preserves the historical ordering, but it means
+            # overlapping matches whose relative order matters (e.g. a specific
+            # /32 vs a broad /24 in another class) must be given an explicit
+            # "priority" to be ordered deterministically.
+            #
+            # NOTE: this number is an internal evaluation-order rank, not the
+            # CLI "priority" value. The CLI "priority" still decides the order
+            # (and, on the shaper, the HTB class scheduling priority set in
+            # trafficshaper.py); it is not reused verbatim as the tc priority
+            # because it is not unique across classes.
+            filter_pref = {}
+            ranked = []
+            for cls, cls_config in config['class'].items():
+                for index, match in enumerate(cls_config.get('match', {}), start=1):
+                    if priority:
+                        key = int(cls)
+                    elif 'priority' in cls_config:
+                        key = int(cls_config['priority'])
+                    else:
+                        key = index
+                    ranked.append((key, (int(cls), match)))
+            # stable sort keeps declaration order among matches with equal keys
+            ranked.sort(key=lambda entry: entry[0])
+            for pref, (_, ident) in enumerate(ranked, start=1):
+                filter_pref[ident] = pref
+
             for cls, cls_config in config['class'].items():
                 self._build_base_qdisc(cls_config, int(cls))
 
                 # every match criteria has it's tc instance
                 filter_cmd_base = ['tc', 'filter', 'add', 'dev', self._interface,
                                     'parent', f'{self._parent:x}:']
-
-                if priority:
-                    filter_cmd_base += ['prio', str(cls)]
-                elif 'priority' in cls_config:
-                    prio = cls_config['priority']
-                    filter_cmd_base += ['prio', str(prio)]
 
                 if 'match' in cls_config:
                     has_filter = False
@@ -266,8 +300,7 @@ class QoSBase:
                         tmp = dict_search(f'ether.protocol', match_config) or 'all'
                         filter_cmd += ['protocol', str(tmp)]
 
-                        if self.qostype in ['shaper', 'shaper_hfsc'] and 'prio' not in filter_cmd:
-                            filter_cmd += ['prio', str(index)]
+                        filter_cmd += ['prio', str(filter_pref[(int(cls), match)])]
 
                         if 'mark' in match_config:
                             mark = match_config['mark']

--- a/smoketest/scripts/cli/test_qos.py
+++ b/smoketest/scripts/cli/test_qos.py
@@ -356,9 +356,16 @@ class TestQoS(VyOSUnitTestSHIM.TestCase):
                         self.assertEqual(f'{dport:x}', filter['options']['match']['value'])
 
             tc_details = get_tc_filter_details(interface, 'ingress')
-            self.assertTrue('filter parent ffff: protocol all pref 20 u32 chain 0' in tc_details)
+            # the tc filter pref is a dense evaluation-order rank, not the CLI
+            # priority: class 1 (priority 15) is pref 1, class 2 (priority 20,
+            # the default) is pref 2 - ranked by priority, not equal to it (T9134)
+            self.assertTrue(
+                'filter parent ffff: protocol all pref 2 u32 chain 0' in tc_details
+            )
             self.assertTrue('rate 1Gbit burst 15Kb mtu 2Kb action drop overhead 0b linklayer ethernet' in tc_details)
-            self.assertTrue('filter parent ffff: protocol all pref 15 u32 chain 0' in tc_details)
+            self.assertTrue(
+                'filter parent ffff: protocol all pref 1 u32 chain 0' in tc_details
+            )
             self.assertTrue('rate 3Gbit burst 100Kb mtu 1600b action pipe/continue overhead 0b linklayer ethernet' in tc_details)
             self.assertTrue('rate 500Mbit burst 200Kb mtu 3000b action drop overhead 0b linklayer ethernet' in tc_details)
             self.assertTrue('filter parent ffff: protocol all pref 255 basic chain 0' in tc_details)
@@ -773,8 +780,9 @@ class TestQoS(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         tc_filters = cmdl(['tc', 'filter', 'show', 'dev', self._interfaces[0], 'ingress'])
-        # class 100
-        self.assertIn('filter parent ffff: protocol all pref 20 fw chain 0', tc_filters)
+        # class 100 has priority 20, but the tc filter pref is a dense
+        # evaluation-order rank (1 here), not the CLI priority value (T9134)
+        self.assertIn('filter parent ffff: protocol all pref 1 fw chain 0', tc_filters)
         self.assertIn('action order 1:  police 0x1 rate 20Gbit burst 3760Kb mtu 2Kb action drop overhead 0b', tc_filters)
         # default
         self.assertIn('filter parent ffff: protocol all pref 255 basic chain 0', tc_filters)
@@ -1250,8 +1258,11 @@ class TestQoS(VyOSUnitTestSHIM.TestCase):
         iif = Interface(self._interfaces[0]).get_ifindex()
         tc_filters = cmdl(['tc', 'filter', 'show', 'dev', self._interfaces[0], 'ingress'])
 
-        # class 100
-        self.assertIn('filter parent ffff: protocol all pref 20 basic chain 0', tc_filters)
+        # class 100 has priority 20, but the tc filter pref is a dense
+        # evaluation-order rank (1 here), not the CLI priority value (T9134)
+        self.assertIn(
+            'filter parent ffff: protocol all pref 1 basic chain 0', tc_filters
+        )
         self.assertIn(f'meta(rt_iif eq {iif})', tc_filters)
         self.assertIn('action order 1:  police 0x1 rate 20Gbit burst 3760Kb mtu 2Kb action drop overhead 0b', tc_filters)
         # default
@@ -1323,6 +1334,167 @@ class TestQoS(VyOSUnitTestSHIM.TestCase):
             else:
                 self.assertIn(f'filter parent 1: protocol {proto} pref',
                               get_tc_filter_details(interface))
+
+    def test_25_policy_shaper_mixed_ether_protocol(self):
+        # T9134: a tc filter priority is bound to a single protocol, so two
+        # classes matching on different protocols (here the default "all" and
+        # an explicit "arp") must not share a filter priority - otherwise tc
+        # rejects the second filter and the commit crashes.
+        interface = self._interfaces[0]
+        shaper_name = f'qos-shaper-{interface}'
+        shaper_path = base_path + ['policy', 'shaper', shaper_name]
+        cls10 = shaper_path + ['class', '10']
+        cls20 = shaper_path + ['class', '20']
+
+        self.cli_set(base_path + ['interface', interface, 'egress', shaper_name])
+        self.cli_set(shaper_path + ['bandwidth', '100mbit'])
+        self.cli_set(shaper_path + ['default', 'bandwidth', '50mbit'])
+        self.cli_set(cls10 + ['bandwidth', '50mbit'])
+        self.cli_set(
+            cls10 + ['match', 'RULE-1', 'ip', 'source', 'address', '10.10.0.0/24']
+        )
+        self.cli_set(cls20 + ['bandwidth', '10mbit'])
+        self.cli_set(cls20 + ['match', 'RULE-2', 'ether', 'protocol', 'arp'])
+
+        # commit changes
+        self.cli_commit()
+
+        filters = get_tc_filter_details(interface)
+        # the "all" protocol filter (class 10) and the "arp" protocol filter
+        # (class 20) must both be installed with distinct priorities
+        self.assertIn('filter parent 1: protocol all pref 1 u32', filters)
+        self.assertIn('filter parent 1: protocol arp pref 2 u32', filters)
+
+        # The class "priority" is not reused verbatim as the tc filter priority
+        # (it is not unique): both classes share priority "3" and match
+        # different protocols, yet each still gets a distinct tc filter priority
+        # and the commit succeeds. The class "priority" still drives the HTB
+        # class scheduling priority.
+        self.cli_set(cls10 + ['priority', '3'])
+        self.cli_set(cls20 + ['priority', '3'])
+        self.cli_commit()
+
+        filters = get_tc_filter_details(interface)
+        self.assertIn('filter parent 1: protocol all pref 1 u32', filters)
+        self.assertIn('filter parent 1: protocol arp pref 2 u32', filters)
+        # the class priority is applied to the HTB class scheduling prio
+        self.assertIn('prio 3', cmdl(['tc', 'class', 'show', 'dev', interface]))
+
+    def test_26_policy_shaper_match_order(self):
+        # T9134: giving every match a unique tc filter priority must not change
+        # match evaluation order - neither the default order nor the order set
+        # by the class "priority".
+        interface = self._interfaces[0]
+        shaper_name = f'qos-shaper-{interface}'
+        shaper_path = base_path + ['policy', 'shaper', shaper_name]
+        cls10 = shaper_path + ['class', '10']
+        cls20 = shaper_path + ['class', '20']
+
+        self.cli_set(base_path + ['interface', interface, 'egress', shaper_name])
+        self.cli_set(shaper_path + ['bandwidth', '100mbit'])
+        self.cli_set(shaper_path + ['default', 'bandwidth', '40mbit'])
+        self.cli_set(cls10 + ['bandwidth', '20mbit'])
+        self.cli_set(
+            cls10 + ['match', 'A', 'ip', 'destination', 'address', '10.99.9.0/24']
+        )
+        self.cli_set(
+            cls10 + ['match', 'B', 'ip', 'destination', 'address', '10.99.1.0/24']
+        )
+        self.cli_set(cls20 + ['bandwidth', '20mbit'])
+        self.cli_set(
+            cls20 + ['match', 'C', 'ip', 'destination', 'address', '10.99.1.5/32']
+        )
+        self.cli_commit()
+
+        # Default order follows the per-class match index: A (0a630900) and C
+        # (0a630105) are each the first match in their class, B (0a630100) is
+        # second - so evaluation order is A, C, B. The specific /32 (C) must
+        # precede the overlapping broad /24 (B), and A precedes C.
+        filters = get_tc_filter_details(interface)
+        self.assertLess(filters.index('0a630900'), filters.index('0a630105'))
+        self.assertLess(filters.index('0a630105'), filters.index('0a630100'))
+
+        # The class "priority" reorders evaluation: class 20 (C) gets the
+        # lowest priority number, so C now precedes A as well - which only
+        # happens if the priority is honoured (by default A came first).
+        self.cli_set(cls10 + ['priority', '5'])
+        self.cli_set(cls20 + ['priority', '1'])
+        self.cli_commit()
+
+        filters = get_tc_filter_details(interface)
+        self.assertLess(filters.index('0a630105'), filters.index('0a630900'))
+        self.assertLess(filters.index('0a630105'), filters.index('0a630100'))
+
+    def test_27_policy_limiter_mixed_protocol(self):
+        # T9134: limiter classes default to priority 20, so two classes
+        # matching different protocols (here "arp" and the implicit "all")
+        # would share a tc filter priority and tc would reject the second
+        # filter. Each match must instead get a unique tc filter priority.
+        interface = self._interfaces[0]
+        policy_name = 'smoke_test'
+        limiter_path = ['qos', 'policy', 'limiter', policy_name]
+        cls10 = limiter_path + ['class', '10']
+        cls20 = limiter_path + ['class', '20']
+
+        self.cli_set(['qos', 'interface', interface, 'ingress', policy_name])
+        self.cli_set(limiter_path + ['default', 'bandwidth', '500mbit'])
+        self.cli_set(cls10 + ['bandwidth', '100mbit'])
+        self.cli_set(cls10 + ['match', 'R1', 'ether', 'protocol', 'arp'])
+        self.cli_set(cls20 + ['bandwidth', '50mbit'])
+        self.cli_set(cls20 + ['match', 'R2', 'ip', 'source', 'address', '10.0.0.0/8'])
+
+        # used to crash: both classes default to priority 20 with different
+        # protocols
+        self.cli_commit()
+
+        filters = get_tc_filter_details(interface, 'ingress')
+        self.assertIn('filter parent ffff: protocol arp pref 1 u32', filters)
+        self.assertIn('filter parent ffff: protocol all pref 2 u32', filters)
+
+    def test_28_policy_shaper_match_order_declaration(self):
+        # T9134: without an explicit "priority" the filter order falls back to
+        # the per-class match index, i.e. declaration order - it is not aware of
+        # match specificity. Here the broad /24 is the FIRST match of class 10
+        # and the specific /32 is the SECOND match of class 20, so by default
+        # the broad match is evaluated first; an explicit "priority" is required
+        # to make the specific match win.
+        interface = self._interfaces[0]
+        shaper_name = f'qos-shaper-{interface}'
+        shaper_path = base_path + ['policy', 'shaper', shaper_name]
+        cls10 = shaper_path + ['class', '10']
+        cls20 = shaper_path + ['class', '20']
+
+        self.cli_set(base_path + ['interface', interface, 'egress', shaper_name])
+        self.cli_set(shaper_path + ['bandwidth', '100mbit'])
+        self.cli_set(shaper_path + ['default', 'bandwidth', '40mbit'])
+        self.cli_set(cls10 + ['bandwidth', '20mbit'])
+        # broad /24 (0a630100) is the first match of class 10
+        self.cli_set(
+            cls10 + ['match', 'BROAD', 'ip', 'destination', 'address', '10.99.1.0/24']
+        )
+        self.cli_set(cls20 + ['bandwidth', '20mbit'])
+        # specific /32 (0a630105) is the second match of class 20
+        self.cli_set(
+            cls20 + ['match', 'OTHER', 'ip', 'destination', 'address', '10.99.9.0/24']
+        )
+        self.cli_set(
+            cls20 + ['match', 'SPEC', 'ip', 'destination', 'address', '10.99.1.5/32']
+        )
+        self.cli_commit()
+
+        # default fallback is index-major: the broad /24 (index 1) precedes the
+        # specific /32 (index 2), regardless of specificity
+        filters = get_tc_filter_details(interface)
+        self.assertLess(filters.index('0a630100'), filters.index('0a630105'))
+
+        # an explicit priority on the specific match's class overrides the
+        # declaration-order fallback, so the specific /32 is evaluated first
+        self.cli_set(cls10 + ['priority', '5'])
+        self.cli_set(cls20 + ['priority', '1'])
+        self.cli_commit()
+
+        filters = get_tc_filter_details(interface)
+        self.assertLess(filters.index('0a630105'), filters.index('0a630100'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Every class match is installed as its own tc filter, and tc binds a
filter priority ("prio"/"pref") to a single protocol. Two filters with
the same priority but different protocols are rejected by the kernel, so
the commit crashes - e.g. one class matching "ether protocol arp" and
another matching IP. The filter priority came from the class id, the
class "priority" (which the limiter defaults to 20 for every class),
or the per-class match index - none of which is unique across classes.

Assign every match a unique tc filter priority by ranking the matches in
evaluation order (class id, an explicit or default class "priority", or
the per-class match index) and numbering them 1, 2, 3, ... This keeps the
match evaluation order unchanged across all class-based policies (shaper,
shaper-hfsc, limiter, round-robin, priority-queue). The class "priority"
still drives the HTB class scheduling priority on the shaper; the tc
filter priority is an internal evaluation-order rank, not the CLI
"priority" value.

Add smoketests for mixed-protocol classes (shaper and limiter) and for
match evaluation order.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T9134 
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
set qos interface eth2 egress 'TEST'
set qos policy shaper TEST bandwidth '100mbit'
set qos policy shaper TEST class 10 bandwidth '50mbit'
set qos policy shaper TEST class 10 match RULE-1 ip source address '10.10.0.0/24'
set qos policy shaper TEST class 10 set-dscp 'AF21'
set qos policy shaper TEST class 20 bandwidth '10mbit'
set qos policy shaper TEST class 20 match RULE-2 ether protocol 'arp'
set qos policy shaper TEST class 20 set-dscp 'AF21'
set qos policy shaper TEST default bandwidth '50mbit'
```
Before the fix:
```
vyos@MK2707-2# commit
[ qos ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 109, in run_script
    config_manager.apply(script_name, c)
  File "/usr/lib/python3/dist-packages/vyos/configmanager.py", line 136, in apply
    mod.apply(config_dict)
  File "/usr/libexec/vyos/conf_mode/qos.py", line 391, in apply
    apply_interface(qos, ifname)
  File "/usr/libexec/vyos/conf_mode/qos.py", line 373, in apply_interface
    shaper_type(ifname).update(shaper_config, direction)
  File "/usr/lib/python3/dist-packages/vyos/qos/trafficshaper.py", line 127, in update
    super().update(config, direction)
  File "/usr/lib/python3/dist-packages/vyos/qos/base.py", line 399, in update
    self._cmdl(filter_cmd)
  File "/usr/lib/python3/dist-packages/vyos/qos/base.py", line 78, in _cmdl
    return cmdl(command)
           ^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/utils/process.py", line 217, in cmdl
    raise OSError(code, feedback)
FileNotFoundError: [Errno 2] failed to run command: tc filter add dev eth2 parent 1: protocol arp prio 1 u32 match u32 0 0 action police rate 10000000 burst 15k flowid 1:14
returned:
exit code: 2

[[qos]] failed
Commit failed
```
After the fix:
```
vyos@vyos# commit
[edit]
vyos@vyos# sudo tc filter show dev eth2
filter parent 1: protocol all pref 1 u32 chain 0 
filter parent 1: protocol all pref 1 u32 chain 0 fh 800: ht divisor 1 
filter parent 1: protocol all pref 1 u32 chain 0 fh 800::800 order 2048 key ht 800 bkt 0 flowid 1:a not_in_hw 
  match 0a0a0000/ffffff00 at 12
	action order 1:  police 0x1 rate 50Mbit burst 15Kb mtu 2Kb action reclassify overhead 0b 
	ref 1 bind 1 

filter parent 1: protocol arp pref 2 u32 chain 0 
filter parent 1: protocol arp pref 2 u32 chain 0 fh 801: ht divisor 1 
filter parent 1: protocol arp pref 2 u32 chain 0 fh 801::800 order 2048 key ht 801 bkt 0 flowid 1:14 not_in_hw 
  match 00000000/00000000 at 0
	action order 1:  police 0x2 rate 10Mbit burst 15Kb mtu 2Kb action reclassify overhead 0b 
	ref 1 bind 1 

[edit]
vyos@vyos# sudo tc class show dev eth2
class htb 1:1 root rate 100Mbit ceil 100Mbit burst 1600b cburst 1600b
class htb 1:a parent 1:1 leaf 811f: prio 0 rate 50Mbit ceil 50Mbit burst 15Kb cburst 1600b
class htb 1:15 parent 1:1 leaf 8121: prio 7 rate 50Mbit ceil 50Mbit burst 15Kb cburst 1600b
class htb 1:14 parent 1:1 leaf 8120: prio 0 rate 10Mbit ceil 10Mbit burst 15Kb cburst 1600b
[edit]
vyos@vyos#
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
