### PR TITLE
firewall: T8247: Normalize protocol values to protocol names

### DIFF
--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -1687,5 +1687,34 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         ]
         self.verify_nftables(nftables_search, 'ip vyos_filter')
 
+    def test_protocol_normalization(self):
+        # Protocol cannot be ipv6-icmp on IPv4
+        self.cli_set(['firewall', 'ipv4', 'input', 'filter', 'rule', '1', 'action', 'accept'])
+        self.cli_set(['firewall', 'ipv4', 'input', 'filter', 'rule', '1', 'protocol', '58'])
+
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_discard()
+
+        # Protocol must be TCP if flags are set
+        self.cli_set(['firewall', 'ipv4', 'input', 'filter', 'rule', '1', 'action', 'accept'])
+        self.cli_set(['firewall', 'ipv4', 'input', 'filter', 'rule', '1', 'protocol', '6'])
+        self.cli_set(['firewall', 'ipv4', 'input', 'filter', 'rule', '1', 'tcp', 'flags', 'syn'])
+
+        # Protocol must be GRE if GRE specific fields are set
+        self.cli_set(['firewall', 'ipv4', 'input', 'filter', 'rule', '2', 'action', 'accept'])
+        self.cli_set(['firewall', 'ipv4', 'input', 'filter', 'rule', '2', 'protocol', '47'])
+        self.cli_set(['firewall', 'ipv4', 'input', 'filter', 'rule', '2', 'gre', 'flags', 'key', 'unset'])
+
+        self.cli_commit()
+
+        nftables_search = [
+            ['tcp flags & syn == syn'],
+            ['gre flags & 4 == 0'],
+        ]
+        self.verify_nftables(nftables_search, 'ip vyos_filter')
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -106,6 +106,24 @@ def geoip_updated(conf):
     return any(any(dict_search_recursive(diff.get(section, {}), 'geoip'))
                for section in ('add', 'delete'))
 
+def generate_inet_proto_keymap(firewall):
+    """
+    Build a keymap of IP protocol numbers to protocol names from
+    `nft describe inet_proto`.
+
+    Returns:
+        dict[int, str]: Mapping of protocol number -> protocol name.
+    """
+    keymap = {}
+
+    for line in cmdl(['nft', 'describe', 'inet_proto']).splitlines():
+        match = re.match(r'^\s*([A-Za-z0-9_.-]+)\s+(\d+)\s*$', line)
+        if match:
+            name, number = match.groups()
+            keymap[number] = name
+
+    firewall['inet_proto_map'] = keymap
+
 def get_config(config=None):
     if config:
         conf = config
@@ -261,6 +279,17 @@ def verify_rule(firewall, family, hook, priority, rule_id, rule_conf):
     elif 'offload_target' in rule_conf:
         Warning(f'{rule_num}offload-target is specified but action is not set to "offload"')
 
+    if 'protocol' in rule_conf:
+        if rule_conf['protocol'].isdigit():
+            if not dict_search('inet_proto_map', firewall):
+                generate_inet_proto_keymap(firewall)
+            rule_conf['protocol'] = dict_search(rule_conf['protocol'], firewall['inet_proto_map'], "")
+
+        if rule_conf['protocol'] == 'icmp' and family == 'ipv6':
+            raise ConfigError(f'{rule_num}Cannot match IPv4 ICMP protocol on IPv6, use ipv6-icmp')
+        if rule_conf['protocol'] == 'ipv6-icmp' and family == 'ipv4':
+            raise ConfigError(f'{rule_num}Cannot match IPv6 ICMP protocol on IPv4, use icmp')
+
     if rule_conf['action'] != 'synproxy' and 'synproxy' in rule_conf:
         raise ConfigError(f'{rule_num}"synproxy" option allowed only for action synproxy')
     if rule_conf['action'] == 'synproxy':
@@ -363,12 +392,6 @@ def verify_rule(firewall, family, hook, priority, rule_id, rule_conf):
             duplicates = [flag for flag in tcp_flags if flag in not_flags]
             if duplicates:
                 raise ConfigError(f'{rule_num}Cannot match a tcp flag as set and not set')
-
-    if 'protocol' in rule_conf:
-        if rule_conf['protocol'] == 'icmp' and family == 'ipv6':
-            raise ConfigError(f'{rule_num}Cannot match IPv4 ICMP protocol on IPv6, use ipv6-icmp')
-        if rule_conf['protocol'] == 'ipv6-icmp' and family == 'ipv4':
-            raise ConfigError(f'{rule_num}Cannot match IPv6 ICMP protocol on IPv4, use icmp')
 
     for side in ['destination', 'source']:
         if side in rule_conf:

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -283,7 +283,7 @@ def verify_rule(firewall, family, hook, priority, rule_id, rule_conf):
         if rule_conf['protocol'].isdigit():
             if not dict_search('inet_proto_map', firewall):
                 generate_inet_proto_keymap(firewall)
-            rule_conf['protocol'] = dict_search(rule_conf['protocol'], firewall['inet_proto_map'], "")
+            rule_conf['protocol'] = dict_search(rule_conf['protocol'], firewall['inet_proto_map'], rule_conf['protocol'])
 
         if rule_conf['protocol'] == 'icmp' and family == 'ipv6':
             raise ConfigError(f'{rule_num}Cannot match IPv4 ICMP protocol on IPv6, use ipv6-icmp')


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
A previous PR for this issue has stalled. This PR normalizes protocol numbers to their corresponding names. This prevents errors being raised during verify() checks that expect a protocol name rather than a number.
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8247
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/vyos/vyos-1x/pull/4978
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
#### Configure rules with protocol numbers and observe expected behavior:
TCP and GRE flags cannot be set without the protocol being 'tcp' or  'gre' respectively
```
vyos@vyos# set firewall ipv4 forward filter rule 1 action accept
vyos@vyos# set firewall ipv4 forward filter rule 1 protocol 6
vyos@vyos# set firewall ipv4 forward filter rule 1 tcp flags syn

vyos@vyos# set firewall ipv4 forward filter rule 2 action accept
vyos@vyos# set firewall ipv4 forward filter rule 2 protocol 47
vyos@vyos# set firewall ipv4 forward filter rule 2 gre flags key unset
vyos@vyos# commit
vyos@vyos# <-- No errors
```
`ipv6-icmp` cannot be set for the `ipv4` address family
```
vyos@vyos# set firewall ipv4 forward filter rule 3 action accept
vyos@vyos# set firewall ipv4 forward filter rule 3 protocol 58
vyos@vyos# commit
[ firewall ]
Cannot match IPv6 ICMP protocol on IPv4, use icmp
[[firewall]] failed
Commit failed
```
```
test_bridge_firewall (__main__.TestFirewall.test_bridge_firewall) ... ok
test_cyclic_jump_validation (__main__.TestFirewall.test_cyclic_jump_validation) ... ok
test_disable_conntrack_per_chain (__main__.TestFirewall.test_disable_conntrack_per_chain) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
test_geoip (__main__.TestFirewall.test_geoip) ... ok
test_gre_match (__main__.TestFirewall.test_gre_match) ... ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipsec_metadata_match (__main__.TestFirewall.test_ipsec_metadata_match) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_dynamic_groups (__main__.TestFirewall.test_ipv4_dynamic_groups) ... ok
test_ipv4_global_state (__main__.TestFirewall.test_ipv4_global_state) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_remote_group (__main__.TestFirewall.test_ipv4_remote_group) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... ok
test_ipv4_time_weekdays (__main__.TestFirewall.test_ipv4_time_weekdays) ... ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_dynamic_groups (__main__.TestFirewall.test_ipv6_dynamic_groups) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_ipv6_remote_group (__main__.TestFirewall.test_ipv6_remote_group) ... ok
test_ipv6_time_weekdays (__main__.TestFirewall.test_ipv6_time_weekdays) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
test_protocol_normalization (__main__.TestFirewall.test_protocol_normalization) ... ok
test_remote_group (__main__.TestFirewall.test_remote_group) ... ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_timeout_sysctl (__main__.TestFirewall.test_timeout_sysctl) ... ok
test_wildcard_interfaces (__main__.TestFirewall.test_wildcard_interfaces) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... ok
test_zone_with_default_firewall (__main__.TestFirewall.test_zone_with_default_firewall) ... ok
test_zone_with_vrf (__main__.TestFirewall.test_zone_with_vrf) ... ok
test_zone_without_member (__main__.TestFirewall.test_zone_without_member) ... ok

----------------------------------------------------------------------
Ran 35 tests in 84.072s

OK
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
