### PR TITLE
interfaces: T9152: Refactor source-validation to use vmaps

### DIFF
--- a/data/templates/firewall/nftables-source-validation.j2
+++ b/data/templates/firewall/nftables-source-validation.j2
@@ -1,0 +1,25 @@
+{% if strict_delete is vyos_defined %}
+destroy rule {{ family }} raw vyos_rpfilter handle {{ strict_handle }}
+{% endif %}
+{% if loose_delete is vyos_defined %}
+destroy rule {{ family }} raw vyos_rpfilter handle {{ loose_handle }}
+{% endif %}
+
+destroy element {{ family }} raw rpfilter_strict_ifaces { "{{ iface }}" }
+destroy element {{ family }} raw rpfilter_loose_ifaces { "{{ iface }}" }
+destroy element {{ family }} raw rpfilter_strict { "{{ iface }}" }
+destroy element {{ family }} raw rpfilter_loose { "{{ iface }}" }
+
+{% if mode is vyos_defined('strict') %}
+add element {{ family }} raw rpfilter_strict_ifaces { "{{ iface }}" }
+add element {{ family }} raw rpfilter_strict { "{{ iface }}" : accept }
+{%     if strict_add is vyos_defined %}
+insert rule {{ family }} raw vyos_rpfilter iifname @rpfilter_strict_ifaces fib saddr . iif oif vmap @rpfilter_strict
+{%     endif %}
+{% elif mode is vyos_defined('loose') %}
+add element {{ family }} raw rpfilter_loose_ifaces { "{{ iface }}" }
+add element {{ family }} raw rpfilter_loose { "{{ iface }}" : accept }
+{%     if loose_add is vyos_defined %}
+insert rule {{ family }} raw vyos_rpfilter iifname @rpfilter_loose_ifaces fib saddr oif vmap @rpfilter_loose
+{%     endif %}
+{% endif %}

--- a/data/templates/firewall/nftables-source-validation.j2
+++ b/data/templates/firewall/nftables-source-validation.j2
@@ -1,14 +1,17 @@
-{% if strict_delete is vyos_defined %}
-destroy rule {{ family }} raw vyos_rpfilter handle {{ strict_handle }}
+{% if strict_handles is vyos_defined %}
+{%     for handle in strict_handles %}
+destroy rule {{ family }} raw vyos_rpfilter handle {{ handle }}
+{%     endfor %}
 {% endif %}
-{% if loose_delete is vyos_defined %}
-destroy rule {{ family }} raw vyos_rpfilter handle {{ loose_handle }}
+{% if loose_handles is vyos_defined %}
+{%     for handle in loose_handles %}
+destroy rule {{ family }} raw vyos_rpfilter handle {{ handle }}
+{%     endfor %}
 {% endif %}
 
 destroy element {{ family }} raw rpfilter_strict_ifaces { "{{ iface }}" }
 destroy element {{ family }} raw rpfilter_loose_ifaces { "{{ iface }}" }
 destroy element {{ family }} raw rpfilter_strict { "{{ iface }}" }
-destroy element {{ family }} raw rpfilter_loose { "{{ iface }}" }
 
 {% if mode is vyos_defined('strict') %}
 add element {{ family }} raw rpfilter_strict_ifaces { "{{ iface }}" }
@@ -18,8 +21,8 @@ insert rule {{ family }} raw vyos_rpfilter iifname @rpfilter_strict_ifaces fib s
 {%     endif %}
 {% elif mode is vyos_defined('loose') %}
 add element {{ family }} raw rpfilter_loose_ifaces { "{{ iface }}" }
-add element {{ family }} raw rpfilter_loose { "{{ iface }}" : accept }
 {%     if loose_add is vyos_defined %}
-insert rule {{ family }} raw vyos_rpfilter iifname @rpfilter_loose_ifaces fib saddr oif vmap @rpfilter_loose
+insert rule {{ family }} raw vyos_rpfilter iifname @rpfilter_loose_ifaces counter drop
+insert rule {{ family }} raw vyos_rpfilter iifname @rpfilter_loose_ifaces fib saddr oif != 0 counter accept
 {%     endif %}
 {% endif %}

--- a/data/vyos-firewall-init.conf
+++ b/data/vyos-firewall-init.conf
@@ -16,12 +16,31 @@ table inet mangle {
 }
 
 table raw {
+    map rpfilter_strict {
+            typeof fib saddr . iif oif : verdict
+            counter
+            elements = { 0 : drop }
+    }
+
+    map rpfilter_loose {
+            typeof fib saddr oif : verdict
+            counter
+            elements = { 0 : drop }
+    }
+
+    set rpfilter_strict_ifaces {
+            type ifname
+    }
+
+    set rpfilter_loose_ifaces {
+            type ifname
+    }
+
     chain VYOS_TCP_MSS {
         type filter hook postrouting priority -300; policy accept;
     }
 
     chain vyos_global_rpfilter {
-        return
     }
 
     chain vyos_rpfilter {
@@ -36,12 +55,31 @@ table raw {
 }
 
 table ip6 raw {
+    map rpfilter_strict {
+            typeof fib saddr . iif oif : verdict
+            counter
+            elements = { 0 : drop }
+    }
+
+    map rpfilter_loose {
+            typeof fib saddr oif : verdict
+            counter
+            elements = { 0 : drop }
+    }
+
+    set rpfilter_strict_ifaces {
+            type ifname
+    }
+
+    set rpfilter_loose_ifaces {
+            type ifname
+    }
+
     chain VYOS_TCP_MSS {
         type filter hook postrouting priority -300; policy accept;
     }
 
     chain vyos_global_rpfilter {
-        return
     }
 
     chain vyos_rpfilter {

--- a/data/vyos-firewall-init.conf
+++ b/data/vyos-firewall-init.conf
@@ -22,12 +22,6 @@ table raw {
             elements = { 0 : drop }
     }
 
-    map rpfilter_loose {
-            typeof fib saddr oif : verdict
-            counter
-            elements = { 0 : drop }
-    }
-
     set rpfilter_strict_ifaces {
             type ifname
     }
@@ -57,12 +51,6 @@ table raw {
 table ip6 raw {
     map rpfilter_strict {
             typeof fib saddr . iif oif : verdict
-            counter
-            elements = { 0 : drop }
-    }
-
-    map rpfilter_loose {
-            typeof fib saddr oif : verdict
             counter
             elements = { 0 : drop }
     }

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -896,12 +896,23 @@ class Interface(Control):
                 rpf_dict['loose_handle'] = handle
 
     def _apply_rpf_nft_config(self, rpf_dict):
+        from subprocess import STDOUT
+
         rpf_template = '/run/nftables-source-validation.conf'
         render(rpf_template, 'firewall/nftables-source-validation.j2', rpf_dict)
-        tmp = run(['nft', '-c', '-f', rpf_template])
-        if tmp > 0:
-            raise ConfigError('Source validation configuration file errors encountered!')
-        run(['nft', '-f', rpf_template])
+
+        cmdl(
+            ['nft', '-c', '--file', rpf_template],
+            stderr=STDOUT,
+            raising=ConfigError,
+            message='Source validation nftables check failed',
+        )
+        cmdl(
+            ['nft', '-f', rpf_template],
+            stderr=STDOUT,
+            raising=ConfigError,
+            message='Failed to apply source validation nftables config',
+        )
 
     def set_ipv4_source_validation(self, mode):
         """

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -868,32 +868,36 @@ class Interface(Control):
     def _get_nft_set_elements(self, family, table, set_name):
         """Return elements of an nftables set, or [] if none are present."""
         tmp = json.loads(self._cmdl(['nft', '-j', 'list', 'set', family, table, set_name]))
-        return dict_search('set.elem', tmp['nftables'][1], [])
+        elems = dict_search('set.elem', tmp['nftables'][1], []) or []
+        # nft may return a bare value for a single element instead of a list
+        if not isinstance(elems, list):
+            elems = [elems]
+        return elems
 
-    def _get_nft_rule_handle(self, family, table, chain, match):
-        """Return handle of first rule matching match, or None if not found."""
-        results = self._cmdl(['nft', '-a', 'list', 'chain', family, table, chain]).split('\n')
-        for line in results:
-            if match in line:
-                handle_search = re.search(r'handle (\d+)', line)
-                if handle_search:
-                    return handle_search[1]
-        return None
+    def _get_nft_rule_handles(self, family, table, chain, set_name):
+        """Return handles of all rules referencing set_name."""
+        handles = []
+        tmp = json.loads(self._cmdl(['nft', '-j', 'list', 'chain', family, table, chain]))
+        for entry in tmp.get('nftables', []):
+            rule = entry.get('rule')
+            if not rule:
+                continue
+            if set_name in json.dumps(rule.get('expr', [])):
+                handles.append(str(rule['handle']))
+        return handles
 
     def _get_rpf_interface_rules(self, family):
         return self._get_nft_set_elements(family, 'raw', 'rpfilter_strict_ifaces'), self._get_nft_set_elements(family, 'raw', 'rpfilter_loose_ifaces')
 
     def _set_rpf_rule_deletes(self, family, rpf_dict, strict_needs_rule, loose_needs_rule):
         if strict_needs_rule:
-            handle = self._get_nft_rule_handle(family, 'raw', 'vyos_rpfilter', '@rpfilter_strict_ifaces')
-            if handle:
-                rpf_dict['strict_delete'] = True
-                rpf_dict['strict_handle'] = handle
+            handles = self._get_nft_rule_handles(family, 'raw', 'vyos_rpfilter', 'rpfilter_strict_ifaces')
+            if handles:
+                rpf_dict['strict_handles'] = handles
         if loose_needs_rule:
-            handle = self._get_nft_rule_handle(family, 'raw', 'vyos_rpfilter', '@rpfilter_loose_ifaces')
-            if handle:
-                rpf_dict['loose_delete'] = True
-                rpf_dict['loose_handle'] = handle
+            handles = self._get_nft_rule_handles(family, 'raw', 'vyos_rpfilter', 'rpfilter_loose_ifaces')
+            if handles:
+                rpf_dict['loose_handles'] = handles
 
     def _apply_rpf_nft_config(self, rpf_dict):
         from subprocess import STDOUT

--- a/python/vyos/ifconfig/interface.py
+++ b/python/vyos/ifconfig/interface.py
@@ -65,6 +65,7 @@ from vyos.ifconfig.control import Control
 from vyos.ifconfig.vrrp import VRRP
 from vyos.ifconfig.operational import Operational
 from vyos.ifconfig import Section
+from vyos import ConfigError
 
 link_local_prefix = 'fe80::/64'
 
@@ -398,6 +399,12 @@ class Interface(Control):
         #
         # This will internally stop DHCP(v6) if running
         self.flush_addrs()
+
+        # Remove reverse-path filter entries before the interface is deleted.
+        # Map keys are interface indexes resolved from ifname, so this must
+        # happen while the interface still exists.
+        self.set_ipv4_source_validation('disable')
+        self.set_ipv6_source_validation('disable')
 
         # remove interface from conntrack VRF interface map
         self._del_interface_from_ct_iface_map()
@@ -858,13 +865,43 @@ class Interface(Control):
             return None
         return self.set_interface('ipv4_directed_broadcast', forwarding)
 
-    def _cleanup_ipv4_source_validation_rules(self, ifname):
-        results = self._cmdl(['nft', '-a', 'list', 'chain', 'ip', 'raw', 'vyos_rpfilter']).split("\n")
+    def _get_nft_set_elements(self, family, table, set_name):
+        """Return elements of an nftables set, or [] if none are present."""
+        tmp = json.loads(self._cmdl(['nft', '-j', 'list', 'set', family, table, set_name]))
+        return dict_search('set.elem', tmp['nftables'][1], [])
+
+    def _get_nft_rule_handle(self, family, table, chain, match):
+        """Return handle of first rule matching match, or None if not found."""
+        results = self._cmdl(['nft', '-a', 'list', 'chain', family, table, chain]).split('\n')
         for line in results:
-            if f'iifname "{ifname}"' in line:
-                handle_search = re.search('handle (\d+)', line)
+            if match in line:
+                handle_search = re.search(r'handle (\d+)', line)
                 if handle_search:
-                    self._cmdl(['nft', 'delete', 'rule', 'ip', 'raw', 'vyos_rpfilter', 'handle', handle_search[1]])
+                    return handle_search[1]
+        return None
+
+    def _get_rpf_interface_rules(self, family):
+        return self._get_nft_set_elements(family, 'raw', 'rpfilter_strict_ifaces'), self._get_nft_set_elements(family, 'raw', 'rpfilter_loose_ifaces')
+
+    def _set_rpf_rule_deletes(self, family, rpf_dict, strict_needs_rule, loose_needs_rule):
+        if strict_needs_rule:
+            handle = self._get_nft_rule_handle(family, 'raw', 'vyos_rpfilter', '@rpfilter_strict_ifaces')
+            if handle:
+                rpf_dict['strict_delete'] = True
+                rpf_dict['strict_handle'] = handle
+        if loose_needs_rule:
+            handle = self._get_nft_rule_handle(family, 'raw', 'vyos_rpfilter', '@rpfilter_loose_ifaces')
+            if handle:
+                rpf_dict['loose_delete'] = True
+                rpf_dict['loose_handle'] = handle
+
+    def _apply_rpf_nft_config(self, rpf_dict):
+        rpf_template = '/run/nftables-source-validation.conf'
+        render(rpf_template, 'firewall/nftables-source-validation.j2', rpf_dict)
+        tmp = run(['nft', '-c', '-f', rpf_template])
+        if tmp > 0:
+            raise ConfigError('Source validation configuration file errors encountered!')
+        run(['nft', '-f', rpf_template])
 
     def set_ipv4_source_validation(self, mode):
         """
@@ -878,23 +915,27 @@ class Interface(Control):
         if 'netns' in self.config:
             return None
 
-        self._cleanup_ipv4_source_validation_rules(self.ifname)
-        nft_prefix = ['nft', 'insert', 'rule', 'ip', 'raw', 'vyos_rpfilter',
-                      'iifname', f'"{self.ifname}"']
-        if mode in ['strict', 'loose']:
-            self._cmdl(nft_prefix + ['counter', 'return'])
-        if mode == 'strict':
-            self._cmdl(nft_prefix + ['fib', 'saddr', '.', 'iif', 'oif', '0', 'counter', 'drop'])
-        elif mode == 'loose':
-            self._cmdl(nft_prefix + ['fib', 'saddr', 'oif', '0', 'counter', 'drop'])
+        strict_ifaces, loose_ifaces = self._get_rpf_interface_rules('ip')
 
-    def _cleanup_ipv6_source_validation_rules(self, ifname):
-        results = self._cmdl(['nft', '-a', 'list', 'chain', 'ip6', 'raw', 'vyos_rpfilter']).split("\n")
-        for line in results:
-            if f'iifname "{ifname}"' in line:
-                handle_search = re.search('handle (\d+)', line)
-                if handle_search:
-                    self._cmdl(['nft', 'delete', 'rule', 'ip6', 'raw', 'vyos_rpfilter', 'handle', handle_search[1]])
+        rpf_dict = {
+            'family': 'ip',
+            'iface': self.ifname,
+            'mode': mode
+        }
+
+        strict_needs_rule = (len(strict_ifaces) == 0 or
+                             (len(strict_ifaces) == 1 and self.ifname in strict_ifaces))
+        loose_needs_rule = (len(loose_ifaces) == 0 or
+                            (len(loose_ifaces) == 1 and self.ifname in loose_ifaces))
+
+        self._set_rpf_rule_deletes('ip', rpf_dict, strict_needs_rule, loose_needs_rule)
+
+        if mode == 'strict' and strict_needs_rule:
+            rpf_dict['strict_add'] = True
+        if mode == 'loose' and loose_needs_rule:
+            rpf_dict['loose_add'] = True
+
+        self._apply_rpf_nft_config(rpf_dict)
 
     def set_ipv6_source_validation(self, mode):
         """
@@ -908,15 +949,27 @@ class Interface(Control):
         if 'netns' in self.config:
             return None
 
-        self._cleanup_ipv6_source_validation_rules(self.ifname)
-        nft_prefix = ['nft', 'insert', 'rule', 'ip6', 'raw', 'vyos_rpfilter',
-                      'iifname', f'"{self.ifname}"']
-        if mode in ['strict', 'loose']:
-            self._cmdl(nft_prefix + ['counter', 'return'])
-        if mode == 'strict':
-            self._cmdl(nft_prefix + ['fib', 'saddr', '.', 'iif', 'oif', '0', 'counter', 'drop'])
-        elif mode == 'loose':
-            self._cmdl(nft_prefix + ['fib', 'saddr', 'oif', '0', 'counter', 'drop'])
+        strict_ifaces, loose_ifaces = self._get_rpf_interface_rules('ip6')
+
+        rpf_dict = {
+            'family': 'ip6',
+            'iface': self.ifname,
+            'mode': mode
+        }
+
+        strict_needs_rule = (len(strict_ifaces) == 0 or
+                             (len(strict_ifaces) == 1 and self.ifname in strict_ifaces))
+        loose_needs_rule = (len(loose_ifaces) == 0 or
+                            (len(loose_ifaces) == 1 and self.ifname in loose_ifaces))
+
+        self._set_rpf_rule_deletes('ip6', rpf_dict, strict_needs_rule, loose_needs_rule)
+
+        if mode == 'strict' and strict_needs_rule:
+            rpf_dict['strict_add'] = True
+        if mode == 'loose' and loose_needs_rule:
+            rpf_dict['loose_add'] = True
+
+        self._apply_rpf_nft_config(rpf_dict)
 
     def set_ipv6_accept_ra(self, accept_ra):
         """
@@ -1909,12 +1962,12 @@ class Interface(Control):
 
         # IPv4 source-validation
         tmp = dict_search('ip.source_validation', config)
-        value = tmp if (tmp != None) else '0'
+        value = tmp if (tmp != None) else 'disable'
         self.set_ipv4_source_validation(value)
 
         # IPv6 source-validation
         tmp = dict_search('ipv6.source_validation', config)
-        value = tmp if (tmp != None) else '0'
+        value = tmp if (tmp != None) else 'disable'
         self.set_ipv6_source_validation(value)
 
         # MTU - Maximum Transfer Unit has a default value. It must ALWAYS be set

--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -1126,12 +1126,11 @@ class BasicInterfaceTest:
                     self.assertEqual('1', tmp)
 
                 if cli_defined(self._base_path + ['ip'], 'source-validation'):
-                    base_options = f'iifname "{interface}"'
+                    base_options = f'iifname @rpfilter_loose_ifaces'
                     out = cmdl(['nft', 'list', 'chain', 'ip', 'raw', 'vyos_rpfilter'], sudo=True)
                     for line in out.splitlines():
-                        if line.startswith(base_options):
-                            self.assertIn('fib saddr oif 0', line)
-                            self.assertIn('drop', line)
+                        if base_options in line:
+                            self.assertIn('iifname @rpfilter_loose_ifaces fib saddr oif vmap @rpfilter_loose', line)
 
         def test_interface_ipv6_options(self):
             if not self._test_ipv6:
@@ -1191,12 +1190,11 @@ class BasicInterfaceTest:
                     self.assertEqual('0', tmp)
 
                 if cli_defined(self._base_path + ['ipv6'], 'source-validation'):
-                    base_options = f'iifname "{interface}"'
+                    base_options = f'iifname @rpfilter_strict_ifaces'
                     out = cmdl(['nft', 'list', 'chain', 'ip6', 'raw', 'vyos_rpfilter'], sudo=True)
                     for line in out.splitlines():
-                        if line.startswith(base_options):
-                            self.assertIn('fib saddr . iif oif 0', line)
-                            self.assertIn('drop', line)
+                        if base_options in line:
+                            self.assertIn('iifname @rpfilter_strict_ifaces fib saddr . iif oif vmap @rpfilter_strict', line)
 
                 if cli_defined(self._base_path + ['ipv6', 'address'], 'interface-identifier'):
                     tmp = cmdl(['ip', '-j', 'token', 'show', 'dev', interface])

--- a/smoketest/scripts/cli/base_interfaces_test.py
+++ b/smoketest/scripts/cli/base_interfaces_test.py
@@ -1126,11 +1126,11 @@ class BasicInterfaceTest:
                     self.assertEqual('1', tmp)
 
                 if cli_defined(self._base_path + ['ip'], 'source-validation'):
-                    base_options = f'iifname @rpfilter_loose_ifaces'
-                    out = cmdl(['nft', 'list', 'chain', 'ip', 'raw', 'vyos_rpfilter'], sudo=True)
+                    base_options = f'iifname @rpfilter_loose_ifaces fib saddr oif'
+                    out = cmdl(['nft', '-s', 'list', 'chain', 'ip', 'raw', 'vyos_rpfilter'], sudo=True)
                     for line in out.splitlines():
                         if base_options in line:
-                            self.assertIn('iifname @rpfilter_loose_ifaces fib saddr oif vmap @rpfilter_loose', line)
+                            self.assertIn('iifname @rpfilter_loose_ifaces fib saddr oif != 0 counter accept', line)
 
         def test_interface_ipv6_options(self):
             if not self._test_ipv6:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
This changes the inefficient 2 rules per interface implementation of `source-validation` to use vmaps instead. This will generally mean 1 rule lookup regardless of the number of interfaces configured for source-validation.

Additionally, 2 more issues were corrected:

1. source-validation smoketests were never being tested since they were checking `startswith`, but nftables output has whitespace to the left that wasn't accounted for.
2. If interfaces were removed before the `ip` or `ipv6` sections were, the source-validation failed to get removed, leaving it present for non-existent interfaces. This is tracked in T9153
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T9152
https://vyos.dev/T9153
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
### Configure source validation for one or more interfaces:
```
set interfaces ethernet eth2 vif 201 ip source-validation 'strict'
set interfaces ethernet eth2 vif 202 ip source-validation 'strict'
set interfaces ethernet eth2 vif 203 ip source-validation 'loose'
set interfaces ethernet eth2 vif 204 ip source-validation 'loose'
```
### Verify nftables output:
```
vyos@vyos# sudo nft list table ip raw
table ip raw {
        map rpfilter_strict {
                typeof fib saddr . iif oif : verdict
                counter
                elements = { 0 counter packets 0 bytes 0 : drop, "eth2.201" counter packets 0 bytes 0 : accept, "eth2.202" counter packets 0 bytes 0 : accept }
        }

        set rpfilter_strict_ifaces {
                type ifname
                elements = { "eth2.201",
                             "eth2.202" }
        }

        set rpfilter_loose_ifaces {
                type ifname
                elements = { "eth2.203",
                             "eth2.204" }
        }

        chain VYOS_TCP_MSS {
                type filter hook postrouting priority raw; policy accept;
        }

        chain vyos_global_rpfilter {
        }

        chain vyos_rpfilter {
                type filter hook prerouting priority raw; policy accept;
                iifname @rpfilter_loose_ifaces fib saddr oif != 0 counter packets 0 bytes 0 accept
                iifname @rpfilter_loose_ifaces counter packets 0 bytes 0 drop
                iifname @rpfilter_strict_ifaces fib saddr . iif oif vmap @rpfilter_strict
                counter packets 113 bytes 8312 jump vyos_global_rpfilter
        }

        chain VYOS_PREROUTING_HOOK {
                type filter hook prerouting priority raw; policy accept;
        }
}
```
### Delete interfaces:
```
delete interfaces ethernet eth2 vif 202
delete interfaces ethernet eth2 vif 204
```
### Verify config was removed from nftables:
```
sudo nft list table ip raw
table ip raw {
        map rpfilter_strict {
                typeof fib saddr . iif oif : verdict
                counter
                elements = { 0 counter packets 0 bytes 0 : drop, "eth2.201" counter packets 0 bytes 0 : accept }
        }

        set rpfilter_strict_ifaces {
                type ifname
                elements = { "eth2.201" }
        }

        set rpfilter_loose_ifaces {
                type ifname
                elements = { "eth2.203" }
        }

        chain VYOS_TCP_MSS {
                type filter hook postrouting priority raw; policy accept;
        }

        chain vyos_global_rpfilter {
        }

        chain vyos_rpfilter {
                type filter hook prerouting priority raw; policy accept;
                iifname @rpfilter_loose_ifaces fib saddr oif != 0 counter packets 0 bytes 0 accept
                iifname @rpfilter_loose_ifaces counter packets 0 bytes 0 drop
                iifname @rpfilter_strict_ifaces fib saddr . iif oif vmap @rpfilter_strict
                counter packets 120 bytes 8732 jump vyos_global_rpfilter
        }

        chain VYOS_PREROUTING_HOOK {
                type filter hook prerouting priority raw; policy accept;
        }
}
```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
