### PR TITLE
ipsec: T9154: count connection entries in the vti-up-down state DB

### DIFF
--- a/python/vyos/utils/vti_updown_db.py
+++ b/python/vyos/utils/vti_updown_db.py
@@ -92,6 +92,21 @@ class VTIUpDownDB:
     # indicates the named interface wants to be up due to an established
     # connection <connection name> using the <protocol> protocol.
     #
+    # Connection entries are a multiset: the same ifspec is stored once per
+    # established CHILD_SA, because a connection can transiently have more
+    # than one -- when the peer establishes a new SA before the old one has
+    # timed out. The interface must stay up until the last of them is gone.
+    # Persistent entries remain unique.
+    #
+    # The count is exact only while every up-client is eventually matched by a
+    # down-client, which holds because the updown plugin implements child_updown
+    # and is not invoked for rekeys of either the IKE_SA or the CHILD_SA. Should
+    # a teardown be lost anyway - e.g., charon killed outright - the leaked
+    # occurrence holds the interface up rather than dropping one that is still
+    # carrying traffic, and it does not outlive the daemon: this file lives in
+    # /tmp, and remove_vti_updown_db() discards it when the IPsec configuration
+    # goes away.
+    #
     # The configuration tree and ipsec daemon connection up-down hook
     # modify this file as needed and use it to determine when a
     # particular event or configuration change should lead to changing
@@ -99,7 +114,11 @@ class VTIUpDownDB:
 
     def __init__(self, f):
         self._fileHandle = f
-        self._ifspecs = set([entry.strip() for entry in f.read().split(" ") if entry and not entry.isspace()])
+        self._ifspecs = [
+            entry.strip()
+            for entry in f.read().split(" ")
+            if entry and not entry.isspace()
+        ]
         self._ifsUp = set()
         self._ifsDown = set()
 
@@ -108,20 +127,26 @@ class VTIUpDownDB:
         Adds a new entry to the DB.
 
         If an interface name, connection name, and protocol are supplied,
-        creates a connection entry.
+        creates a connection entry. Connection entries are counted, so one is
+        stored per established CHILD_SA even when they share an ifspec.
 
         If only an interface name is specified, creates a persistent entry
-        for the given interface.
+        for the given interface. Persistent entries are not counted.
         """
         ifspec = f"{interface}:{connection}:{protocol}" if (connection is not None and protocol is not None) else interface
-        if ifspec not in self._ifspecs:
-            self._ifspecs.add(ifspec)
-            self._ifsUp.add(interface)
-            self._ifsDown.discard(interface)
+        if ':' not in ifspec and ifspec in self._ifspecs:
+            return
+
+        self._ifspecs.append(ifspec)
+        self._ifsUp.add(interface)
+        self._ifsDown.discard(interface)
 
     def remove(self, interface, connection = None, protocol = None):
         """
         Removes a matching entry from the DB.
+
+        For a connection entry a single occurrence is removed, so the interface
+        is only brought down once the last CHILD_SA using it has gone away.
 
         If no matching entry can be found, the operation returns successfully.
         """
@@ -147,8 +172,14 @@ class VTIUpDownDB:
 
     def removeAllOtherInterfaces(self, interface_list):
         """ Removes all interfaces not included in the given list from the DB """
-        updated_ifspecs = set([ifspec for ifspec in self._ifspecs if ifspec.split(':')[0] in interface_list])
-        removed_ifspecs = self._ifspecs - updated_ifspecs
+        updated_ifspecs = [
+            ifspec for ifspec in self._ifspecs if ifspec.split(':')[0] in interface_list
+        ]
+        removed_ifspecs = [
+            ifspec
+            for ifspec in self._ifspecs
+            if ifspec.split(':')[0] not in interface_list
+        ]
         self._ifspecs = updated_ifspecs
         interfaces_to_bring_down = [ifspec.split(':')[0] for ifspec in removed_ifspecs]
         self._ifsDown.update(interfaces_to_bring_down)

--- a/src/tests/test_vti_updown_db.py
+++ b/src/tests/test_vti_updown_db.py
@@ -71,6 +71,57 @@ class TestVTIUpDownDBLogic(unittest.TestCase):
                 db.remove('vti0', 'conn-b', 'IKEv2')
                 self.assertFalse(db.wantsInterfaceUp('vti0'))
 
+    def test_concurrent_sas_same_connection(self):
+        """Connection entries are counted, not deduplicated.
+
+        A peer that re-establishes a tunnel before the local side has timed the
+        old IKE_SA out leaves two CHILD_SAs of the same connection installed at
+        once, and the hook fires up-client twice with identical arguments. The
+        teardown of the first must not bring down an interface the second is
+        still carrying.
+        """
+        from vyos.utils.vti_updown_db import open_vti_updown_db_for_create_or_update
+
+        with patch('vyos.utils.vti_updown_db.Lock', MagicMock()):
+            with open_vti_updown_db_for_create_or_update() as db:
+                db.add('vti0', 'conn-a', 'IKEv2')
+                db.add('vti0', 'conn-a', 'IKEv2')
+                db.remove('vti0', 'conn-a', 'IKEv2')
+                # the second CHILD_SA is still installed
+                self.assertTrue(db.wantsInterfaceUp('vti0'))
+                db.remove('vti0', 'conn-a', 'IKEv2')
+                self.assertFalse(db.wantsInterfaceUp('vti0'))
+
+    def test_duplicate_entries_survive_a_reload(self):
+        """Occurrences are preserved across a file round-trip.
+
+        The two CHILD_SAs that produce them are rarely torn down in the same DB
+        session, so the count has to survive being written out and read back --
+        reading into a set would silently collapse it.
+        """
+        with open(self.tmpfile.name, 'w') as f:
+            f.write('vti0:conn-a:IKEv2 vti0:conn-a:IKEv2')
+
+        from vyos.utils.vti_updown_db import open_vti_updown_db_for_create_or_update
+
+        with patch('vyos.utils.vti_updown_db.Lock', MagicMock()):
+            with open_vti_updown_db_for_create_or_update() as db:
+                db.remove('vti0', 'conn-a', 'IKEv2')
+                self.assertTrue(db.wantsInterfaceUp('vti0'))
+                db.remove('vti0', 'conn-a', 'IKEv2')
+                self.assertFalse(db.wantsInterfaceUp('vti0'))
+
+    def test_persistent_entries_are_not_counted(self):
+        """Persistent entries stay unique, so one remove() always clears them."""
+        from vyos.utils.vti_updown_db import open_vti_updown_db_for_create_or_update
+
+        with patch('vyos.utils.vti_updown_db.Lock', MagicMock()):
+            with open_vti_updown_db_for_create_or_update() as db:
+                db.add('vti0')
+                db.add('vti0')
+                db.remove('vti0')
+                self.assertFalse(db.wantsInterfaceUp('vti0'))
+
     def test_remove_all_other_interfaces(self):
         """removeAllOtherInterfaces() drops entries for interfaces not in the keep list."""
         from vyos.utils.vti_updown_db import open_vti_updown_db_for_create_or_update


### PR DESCRIPTION
The up-down hook identifies a connection entry by PLUTO_CONNECTION alone, so VTIUpDownDB stores it as
"<interface>:<connection>:<protocol>" in a set. Two concurrent IKE_SAs of the same connection therefore produce a byte-identical key and cannot be represented separately.

That situation is routine: when a peer restarts its VPN headend it initiates a fresh IKE_SA while the local side is still working through the DPD retransmit sequence for the old one, leaving both installed for as long as it takes the old SA to give up. In that window add() for the new SA is a no-op -- the interface is never even placed in _ifsUp -- and the subsequent remove() for the dying old SA empties the set and brings the interface down while the new SA is still INSTALLED and rekeying normally. Nothing re-adds the entry afterwards, so the VTI stays admin-down and everything routed over it is silently blackholed until an operator intervenes.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Connection entries become a multiset: one occurrence is stored per established
CHILD_SA, and a single occurrence is dropped per teardown, so the interface
goes down only once the last one is gone. Persistent entries have no
counterpart to pair with and stay unique. The file format is unchanged -- an
ifspec may simply now appear more than once; an older reader collapses
duplicates into a set, which just restores the bug this fixes, so a downgrade
is no worse than not having it.

**An earlier revision of this PR keyed entries on PLUTO_UNIQUEID.**
`@alexk37` found that this is unworkable: strongSwan allocates `unique_id` per
IKE_SA from a global counter, and `inherit_post()` does not carry it across an
in-place IKE_SA rekey, while the updown plugin registers only `child_updown`
and fires no event at rekey time. With the default `rekey_time`, the stored id
goes stale about eight hours after establishment, the next down-client carries
a different id, remove() matches nothing, and the interface is never brought
down at all. An exported PLUTO_* value does not avoid it: the only CHILD_SA-derived
identifier is PLUTO_REQID, which is allocated per CHILD_SA *configuration* and is
identical across concurrent SAs of one connection. Counting needs no identity at all
and is unaffected by the rotation.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/TT9154

## Related PR(s)
None.

## How to test / Smoketest result
### Unit test

`src/tests/test_vti_updown_db.py` gains `test_concurrent_sas_same_connection`, which fails on `rolling` today and passes with this change, plus `test_missing_uniqueid_is_self_consistent` covering the degraded path. The existing cases are unaffected - note that `test_multiple_connections_same_interface` only ever covered *distinct* connection names, which is why this went unnoticed.

### Observed in production

Encountered on a router with two IKEv2 site-to-site tunnels to Oracle Cloud, route-based over `vti0`/`vti1`
with eBGP on top. Oracle restarted a VPN headend; the two SAs overlapped for 107 seconds. Addresses below
are sanitised.

```
10:26:10  OCI-T2|1802  sending DPD request                      # old SA, peer has gone away
10:26:14  OCI-T2|1802  retransmit 1 of request with message ID 12
...
10:27:08  203.0.113.22 is initiating an IKE_SA                  # peer builds a NEW SA
10:27:08  IKE_SA OCI-T2[1813] established
10:27:08  CHILD_SA OCI-T2-vti{2888} established with SPIs cefa7470_i 63bf7620_o
10:27:08  vti-up-down: Interface vti1 up-client OCI-T2-vti      # add() is a no-op; no "is admin up"
10:28:55  OCI-T2|1802  giving up after 5 retransmits            # OLD SA finally dies
10:28:55  vti-up-down: Interface vti1 down-client OCI-T2-vti
10:28:55  vti-up-down: Interface vti1 is admin down             # kills the LIVE SA's interface
```

The result is a state in which every status command reports health while nothing passes:

```
$ show vpn ipsec sa
Connection    State    Uptime    Bytes In/Out    Packets In/Out
------------  -------  --------  --------------  ----------------
OCI-T1-vti    up       1m51s     0B/0B           0/0
OCI-T2-vti    up       2m4s      0B/0B           0/0

$ show interfaces vti
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
vti0             169.254.150.122/30                A/D  OCI-T1
vti1             169.254.189.46/30                 A/D  OCI-T2
```

IPsec is genuinely healthy throughout - DPD every 10 s, CHILD_SA rekeys succeeding on schedule. Successive
rekeys show the signature of an admin-down interface, inbound bytes arriving and zero outbound:

```
14:18:34  closing CHILD_SA OCI-T1-vti{2897} with SPIs ce69c190_i (4140 bytes) de0b68c9_o (0 bytes)
15:02:42  closing CHILD_SA OCI-T2-vti{2898} with SPIs ca6336f9_i (3780 bytes) ab06cd8d_o (0 bytes)
```

The outage lasted 4.5 hours and required manual intervention. `sudo ip link set vti0 up` is enough to
recover, since the SA is already installed.

### To reproduce on hardware

Bring up a route-based site-to-site tunnel, then make the peer initiate a new IKE_SA while the local side is
mid-DPD-timeout on the old one - blackholing the peer's return path for ~30 s and letting it reconnect is
sufficient. The VTI drops when the old SA expires and stays down.

### `PLUTO_UNIQUEID` verified on hardware (bare metal, x86_64)

Confirmed on the affected system that the updown plugin exports the variable and that its value actually
distinguishes SAs. A temporary `syslog(f'DEBUG uniqueid={os.getenv("PLUTO_UNIQUEID")!r}')` was added to the
hook path, and one CHILD_SA was torn down with `swanctl --terminate`:

```
Aug 03 19:21:11 gw vti-up-down[6558]: Interface vti0 down-client OCI-T1-vti
Aug 03 19:21:11 gw vti-up-down[6558]: Interface vti0 is admin down ...
Aug 03 19:21:11 gw vti-up-down[6558]: DEBUG uniqueid='1'
Aug 03 19:21:12 gw vti-up-down[6566]: Interface vti0 up-client OCI-T1-vti
Aug 03 19:21:12 gw vti-up-down[6566]: Interface vti0 is admin up ...
Aug 03 19:21:12 gw vti-up-down[6566]: DEBUG uniqueid='4'
```

The down event for the outgoing SA and the up event for its replacement carry **different** unique ids
while sharing the same `PLUTO_CONNECTION`. Under the current code both collapse to
`vti0:OCI-T1-vti:v4`; with this change they become `vti0:OCI-T1-vti:v4:1` and `vti0:OCI-T1-vti:v4:4`.

The patched code itself has not been exercised on hardware - the only available system is a production
router - so hardware verification covers the premise of the fix, not the fix.

### Smoketests

Not run locally: `test_vpn_ipsec.py` and `test_interfaces_vti.py` reconfigure the system under test, and the
only hardware available herea is a production router. Relying on CI for these.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
