### PR TITLE
interfaces: T9158: add option to enable/disable rx offload

### DIFF
--- a/interface-definitions/interfaces_ethernet.xml.in
+++ b/interface-definitions/interfaces_ethernet.xml.in
@@ -113,6 +113,12 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <leafNode name="rx">
+                <properties>
+                  <help>Enable Receive Checksum Offload</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
               <leafNode name="rfs">
                 <properties>
                   <help>Enable Receive Flow Steering</help>

--- a/python/vyos/ethtool.py
+++ b/python/vyos/ethtool.py
@@ -159,6 +159,9 @@ class Ethtool:
             fixed = bool(self._features[feature]['fixed'])
         return active, fixed
 
+    def get_rx_checksumming(self):
+        return self._get_generic('rx-checksumming')
+
     def get_generic_receive_offload(self):
         return self._get_generic('generic-receive-offload')
 

--- a/python/vyos/ifconfig/ethernet.py
+++ b/python/vyos/ifconfig/ethernet.py
@@ -58,6 +58,10 @@ class EthernetIf(Interface):
                 'validate': lambda v: assert_list(v, ['on', 'off']),
                 'possible': lambda i, v: EthernetIf.feature(i, 'gro', v),
             },
+            'rx': {
+                'validate': lambda v: assert_list(v, ['on', 'off']),
+                'possible': lambda i, v: EthernetIf.feature(i, 'rx', v),
+            },
             'gso': {
                 'validate': lambda v: assert_list(v, ['on', 'off']),
                 'possible': lambda i, v: EthernetIf.feature(i, 'gso', v),
@@ -105,6 +109,7 @@ class EthernetIf(Interface):
             'offload.lro',
             'offload.rfs',
             'offload.rps',
+            'offload.rx',
             'offload.sg',
             'offload.tso',
             'redirect',
@@ -272,6 +277,22 @@ class EthernetIf(Interface):
                 print(
                     'Adapter does not support changing generic-receive-offload settings!'
                 )
+        return False
+
+    def set_rx(self, state):
+        """
+        Enable/Disable Receive Checksum Offload.
+        State can be either True or False.
+        """
+        if not isinstance(state, bool):
+            raise ValueError('Value out of range')
+
+        enabled, fixed = self.ethtool.get_rx_checksumming()
+        if enabled != state:
+            if not fixed:
+                return self.set_interface('rx', 'on' if state else 'off')
+            else:
+                print('Adapter does not support changing rx-checksumming settings!')
         return False
 
     def set_gso(self, state):
@@ -576,6 +597,9 @@ class EthernetIf(Interface):
 
         # RFS - Receive Flow Steering
         self.set_rfs(dict_search('offload.rfs', config) is not None)
+
+        # RX (receive checksum offload)
+        self.set_rx(dict_search('offload.rx', config) is not None)
 
         # scatter-gather option
         self.set_sg(dict_search('offload.sg', config) is not None)

--- a/smoketest/scripts/cli/test_interfaces_ethernet.py
+++ b/smoketest/scripts/cli/test_interfaces_ethernet.py
@@ -319,6 +319,31 @@ class EthernetInterfaceTest(BasicInterfaceTest.TestCase):
             frrconfig = self.getFRRconfig(f'interface {interface}', stop_section='^exit')
             self.assertIn(' evpn mh uplink', frrconfig)
 
+    def test_ethtool_offload_rx(self):
+        for interface in self._interfaces:
+            ethtool = Ethtool(interface)
+            active, fixed = ethtool.get_rx_checksumming()
+            
+            # Skip if adapter does not support changing rx checksumming
+            if fixed:
+                continue
+
+            # Enable rx offload
+            self.cli_set(self._base_path + [interface, 'offload', 'rx'])
+            self.cli_commit()
+
+            ethtool = Ethtool(interface)
+            active, _ = ethtool.get_rx_checksumming()
+            self.assertTrue(active)
+
+            # Disable rx offload
+            self.cli_delete(self._base_path + [interface, 'offload', 'rx'])
+            self.cli_commit()
+
+            ethtool = Ethtool(interface)
+            active, _ = ethtool.get_rx_checksumming()
+            self.assertFalse(active)
+
     def test_switchdev(self):
         interface = self._interfaces[0]
         self.cli_set(self._base_path + [interface, 'switchdev'])

--- a/src/activation-scripts/20-ethernet-offload.py
+++ b/src/activation-scripts/20-ethernet-offload.py
@@ -63,6 +63,15 @@ def activate(config: ConfigTree):
         elif enabled and not fixed:
             config.set(base + [ifname, 'offload', 'lro'])
 
+        # If RX is enabled by the Kernel - we reflect this on the CLI. If RX is
+        # enabled via CLI but not supported by the NIC - we remove it from the CLI
+        configured = config.exists(base + [ifname, 'offload', 'rx'])
+        enabled, fixed = eth.get_rx_checksumming()
+        if configured and fixed:
+            config.delete(base + [ifname, 'offload', 'rx'])
+        elif enabled and not fixed:
+            config.set(base + [ifname, 'offload', 'rx'])
+
         # If SG is enabled by the Kernel - we reflect this on the CLI. If SG is
         # enabled via CLI but not supported by the NIC - we remove it from the CLI
         configured = config.exists(base + [ifname, 'offload', 'sg'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Add support for toggling the receive checksum offload on ethernet interfaces. The existing valueless offload options in VyOS disable their respective offloads by default if unconfigured. To avoid turning off rx-checksumming for all users who have not explicitly configured it, the rx option takes a boolean value (on|off) instead. This ensures it remains in its default hardware state when omitted.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T9158
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

```
$ /usr/libexec/vyos/tests/smoke/cli/test_interfaces_ethernet.py
test_ethtool_offload_rx (__main__.EthernetInterfaceTest.test_ethtool_offload_rx) ... ok
```


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
