### PR TITLE
firewall: T9160: add apply-path for deriving group membership from config

### DIFF
--- a/data/templates/firewall/nftables-apply-path-update.j2
+++ b/data/templates/firewall/nftables-apply-path-update.j2
@@ -1,0 +1,39 @@
+#!/usr/sbin/nft -f
+
+{% if sets.v4 is vyos_defined %}
+{%     for setname, member_list in sets.v4.items() %}
+flush set ip vyos_filter {{ setname }}
+{%     endfor %}
+
+table ip vyos_filter {
+{%     for setname, member_list in sets.v4.items() %}
+    set {{ setname }} {
+        type ipv4_addr
+        flags interval
+        auto-merge
+{%         if member_list %}
+        elements = { {{ member_list | join(",") }} }
+{%         endif %}
+    }
+{%     endfor %}
+}
+{% endif %}
+
+{% if sets.v6 is vyos_defined %}
+{%     for setname, member_list in sets.v6.items() %}
+flush set ip6 vyos_filter {{ setname }}
+{%     endfor %}
+
+table ip6 vyos_filter {
+{%     for setname, member_list in sets.v6.items() %}
+    set {{ setname }} {
+        type ipv6_addr
+        flags interval
+        auto-merge
+{%         if member_list %}
+        elements = { {{ member_list | join(",") }} }
+{%         endif %}
+    }
+{%     endfor %}
+}
+{% endif %}

--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -80,6 +80,7 @@
                   <multi/>
                 </properties>
               </leafNode>
+              #include <include/firewall/apply-path.xml.i>
               #include <include/generic-description.xml.i>
             </children>
           </tagNode>
@@ -227,6 +228,7 @@
                   <multi/>
                 </properties>
               </leafNode>
+              #include <include/firewall/apply-path.xml.i>
               #include <include/generic-description.xml.i>
             </children>
           </tagNode>
@@ -262,6 +264,7 @@
                   <multi/>
                 </properties>
               </leafNode>
+              #include <include/firewall/apply-path.xml.i>
             </children>
           </tagNode>
           <tagNode name="mac-group">
@@ -330,6 +333,7 @@
                   <multi/>
                 </properties>
               </leafNode>
+              #include <include/firewall/apply-path.xml.i>
             </children>
           </tagNode>
           <tagNode name="port-group">

--- a/interface-definitions/include/firewall/apply-path.xml.i
+++ b/interface-definitions/include/firewall/apply-path.xml.i
@@ -1,0 +1,12 @@
+<!-- include start from firewall/apply-path.xml.i -->
+<leafNode name="apply-path">
+  <properties>
+    <help>Derive additional group members from another part of the configuration</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>Space-separated configuration path; a "*" segment expands every instance of the tag node at that position (e.g. "vrf name * protocols bgp neighbor")</description>
+    </valueHelp>
+    <multi/>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/op-mode-definitions/firewall.xml.in
+++ b/op-mode-definitions/firewall.xml.in
@@ -773,4 +773,28 @@
       </node>
     </children>
   </node>
+  <node name="update">
+    <children>
+      <node name="firewall">
+        <properties>
+          <help>Update firewall information</help>
+        </properties>
+        <children>
+          <node name="group">
+            <properties>
+              <help>Update firewall group</help>
+            </properties>
+            <children>
+              <leafNode name="apply-paths">
+                <properties>
+                  <help>Re-resolve apply-path derived group membership and push it into nftables, without a firewall commit</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/firewall.py --action update_apply_path_groups</command>
+              </leafNode>
+            </children>
+          </node>
+        </children>
+      </node>
+    </children>
+  </node>
 </interfaceDefinition>

--- a/python/vyos/config_path_resolver.py
+++ b/python/vyos/config_path_resolver.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+#
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from vyos.base import ConfigError
+from vyos.utils.network import is_valid_ipv4_address_or_range
+from vyos.utils.network import is_valid_ipv6_address_or_range
+from vyos.utils.network import is_valid_ipv4_network
+from vyos.utils.network import is_valid_ipv6_network
+
+
+def resolve_config_path(conf, path_str):
+    """Resolve a space-separated configuration path into the list of
+    values found at that path in the given (candidate) configuration.
+
+    A "*" segment expands every instance of the tag node at that position
+    (e.g. every configured VRF name), continuing the remainder of the path
+    under each instance. The terminal segment is resolved as every child
+    name of a tag node (e.g. every configured BGP neighbor address) if it
+    has any, otherwise as the values of a multi-value leaf node.
+    """
+    return _walk(conf, [], path_str.split())
+
+
+def _walk(conf, base, remaining):
+    if not remaining:
+        nodes = conf.list_nodes(base)
+        if nodes:
+            return nodes
+        return conf.return_values(base)
+
+    head, *rest = remaining
+    if head == '*':
+        result = []
+        for instance in conf.list_nodes(base):
+            result.extend(_walk(conf, base + [instance], rest))
+        return result
+
+    return _walk(conf, base + [head], rest)
+
+
+def resolve_apply_paths(conf, path_list, is_valid=None):
+    """Resolve a list of apply-path strings and return the deduplicated,
+    order-preserving union of every value they resolve to.
+
+    apply-path values never go through CLI-level <validator/> checks, since
+    they are not entered on the CLI. If "is_valid" is given, every resolved
+    value is checked against it; the first value that fails raises
+    ValueError(value).
+    """
+    seen = set()
+    result = []
+    for path_str in path_list:
+        for value in resolve_config_path(conf, path_str):
+            if is_valid is not None and not is_valid(value):
+                raise ValueError(value)
+            if value not in seen:
+                seen.add(value)
+                result.append(value)
+    return result
+
+
+# Group types whose membership can be derived from another part of the
+# configuration via "apply-path": the leaf they hold their members in, the
+# nftables set name prefix used for that group type in the vyos_filter table,
+# and the validator a derived value must pass (CLI-level <validator/> checks
+# are not run for apply-path derived values, as they never go through the CLI)
+apply_path_group_types = {
+    'address_group': ('address', 'A_', is_valid_ipv4_address_or_range),
+    'ipv6_address_group': ('address', 'A6_', is_valid_ipv6_address_or_range),
+    'network_group': ('network', 'N_', is_valid_ipv4_network),
+    'ipv6_network_group': ('network', 'N6_', is_valid_ipv6_network),
+}
+
+
+def apply_group_paths(groups, conf):
+    """Merge every apply-path derived value into its group's member list, in
+    place. "groups" is a firewall group config dict (the "group" node under
+    "firewall")."""
+    if not groups:
+        return
+
+    for group_type, (member_key, _prefix, is_valid) in apply_path_group_types.items():
+        group_dict = groups.get(group_type)
+        if not group_dict:
+            continue
+
+        for group_name, group_conf in group_dict.items():
+            apply_path = group_conf.get('apply_path')
+            if not apply_path:
+                continue
+
+            existing = group_conf.get(member_key, [])
+            merged = list(existing)
+            seen = set(existing)
+            try:
+                derived = resolve_apply_paths(conf, apply_path, is_valid)
+            except ValueError as e:
+                raise ConfigError(
+                    f'apply-path on {group_type} "{group_name}" '
+                    f'resolved invalid {member_key} "{e}"'
+                ) from e
+            for value in derived:
+                if value not in seen:
+                    seen.add(value)
+                    merged.append(value)
+            group_conf[member_key] = merged
+
+
+def refresh_apply_path_groups(groups, conf):
+    """Re-resolve every apply-path derived group in "groups" (a firewall
+    group config dict) and return the nftables sets it affects, as
+    {'v4': {set_name: [values]}, 'v6': {set_name: [values]}}.
+
+    Used to push apply-path derived group membership into the already-running
+    nftables ruleset without a full firewall commit, e.g. after a change to
+    an apply-path's source (such as a routing protocol) that leaves the
+    firewall section itself untouched.
+    """
+    apply_group_paths(groups, conf)
+
+    sets = {'v4': {}, 'v6': {}}
+    for group_type, (member_key, prefix, _is_valid) in apply_path_group_types.items():
+        version = 'v6' if group_type.startswith('ipv6_') else 'v4'
+        for group_name, group_conf in (groups or {}).get(group_type, {}).items():
+            if not group_conf.get('apply_path'):
+                continue
+            sets[version][f'{prefix}{group_name}'] = group_conf.get(member_key, [])
+    return sets
+
+
+class DictConfig:
+    """Minimal Config-like view over a plain config dict, exposing only the
+    list_nodes()/return_values() primitives resolve_config_path() relies on.
+
+    Lets op-mode callers walk arbitrary apply-path targets from a dict
+    obtained via vyos.configquery.op_mode_config_dict(), instead of paying
+    for a session-backed vyos.config.Config() just to get the same two
+    primitives.
+    """
+
+    def __init__(self, tree):
+        self.tree = tree
+
+    def _get(self, path):
+        node = self.tree
+        for p in path:
+            if not isinstance(node, dict) or p not in node:
+                return None
+            node = node[p]
+        return node
+
+    def list_nodes(self, path):
+        node = self._get(path)
+        return list(node.keys()) if isinstance(node, dict) else []
+
+    def return_values(self, path):
+        node = self._get(path)
+        return node if isinstance(node, list) else []

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -772,6 +772,42 @@ def is_valid_ipv6_address_or_range(addr: str) -> bool:
         return False
 
 
+def is_valid_ipv4_network(net: str) -> bool:
+    """
+    Validates if the provided value is a valid, canonical IPv4 network
+    (no host bits set), requiring an explicit prefix length (unlike
+    is_valid_ipv4_address_or_range, which also accepts a bare address)
+    :param net: value to test
+    :return: bool: True if provided value is a valid IPv4 network
+    """
+    from ipaddress import ip_network
+
+    if '/' not in net:
+        return False
+    try:
+        return ip_network(net, strict=True).version == 4
+    except ValueError:
+        return False
+
+
+def is_valid_ipv6_network(net: str) -> bool:
+    """
+    Validates if the provided value is a valid, canonical IPv6 network
+    (no host bits set), requiring an explicit prefix length (unlike
+    is_valid_ipv6_address_or_range, which also accepts a bare address)
+    :param net: value to test
+    :return: bool: True if provided value is a valid IPv6 network
+    """
+    from ipaddress import ip_network
+
+    if '/' not in net:
+        return False
+    try:
+        return ip_network(net, strict=True).version == 6
+    except ValueError:
+        return False
+
+
 def get_interfaces_by_ip(ip_address: str) -> list:
     """
     Return a list of all interface names assigned the given IP address.

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -167,6 +167,122 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
         self.cli_delete(['system', 'static-host-mapping'])
         self.cli_commit()
 
+    def test_apply_path(self):
+        # "protocols static route" is not under the "firewall" subtree that
+        # tearDown() cleans up, so it must be removed here even if an
+        # assertion below fails - otherwise it leaks into later tests.
+        derived_networks = ['203.0.113.0/24', '203.0.114.0/24']
+        for network in derived_networks:
+            self.cli_set(['protocols', 'static', 'route', network, 'blackhole'])
+
+        try:
+            self.cli_set(
+                [
+                    'firewall',
+                    'group',
+                    'network-group',
+                    'smoketest_derived',
+                    'network',
+                    '172.16.200.0/24',
+                ]
+            )
+            self.cli_set(
+                [
+                    'firewall',
+                    'group',
+                    'network-group',
+                    'smoketest_derived',
+                    'apply-path',
+                    'protocols static route',
+                ]
+            )
+
+            self.cli_set(
+                [
+                    'firewall',
+                    'ipv4',
+                    'forward',
+                    'filter',
+                    'rule',
+                    '1',
+                    'action',
+                    'accept',
+                ]
+            )
+            self.cli_set(
+                [
+                    'firewall',
+                    'ipv4',
+                    'forward',
+                    'filter',
+                    'rule',
+                    '1',
+                    'source',
+                    'group',
+                    'network-group',
+                    'smoketest_derived',
+                ]
+            )
+
+            self.cli_commit()
+
+            # The manually configured member and both derived members (from
+            # "protocols static route") must all end up in the rendered set
+            nftables_search = [
+                ['ip saddr @N_smoketest_derived', 'accept'],
+                ['elements = { 172.16.200.0/24, 203.0.113.0/24,'],
+                ['203.0.114.0/24 }'],
+            ]
+            self.verify_nftables(nftables_search, 'ip vyos_filter')
+        finally:
+            for network in derived_networks:
+                self.cli_delete(['protocols', 'static', 'route', network])
+            self.cli_commit()
+
+    def test_apply_path_invalid_value(self):
+        # apply-path values never go through a CLI-level <validator/>, as
+        # they are not entered on the CLI. A resolved value that is not
+        # valid for the target leaf (here: a network-group name resolved
+        # into an address-group's "address" leaf) must be rejected instead
+        # of silently entering the nftables set.
+        self.cli_set(
+            [
+                'firewall',
+                'group',
+                'network-group',
+                'smoketest_apply_path_source',
+                'network',
+                '172.16.201.0/24',
+            ]
+        )
+
+        self.cli_set(
+            [
+                'firewall',
+                'group',
+                'address-group',
+                'smoketest_bad_apply_path',
+                'address',
+                '10.0.0.1',
+            ]
+        )
+        self.cli_set(
+            [
+                'firewall',
+                'group',
+                'address-group',
+                'smoketest_bad_apply_path',
+                'apply-path',
+                'firewall group network-group',
+            ]
+        )
+
+        # ConfigError() wraps its message at 72 characters, so match only a
+        # short fragment that can't be split across a wrap point
+        error_message = 'resolved invalid'
+        with self.assertRaisesRegex(ConfigSessionError, error_message):
+            self.cli_commit()
+
     def test_nested_groups(self):
         self.cli_set(['firewall', 'group', 'network-group', 'smoketest_network', 'network', '172.16.99.0/24'])
         self.cli_set(['firewall', 'group', 'network-group', 'smoketest_network1', 'network', '172.16.101.0/24'])

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -25,6 +25,7 @@ from vyos.config import Config
 from vyos.configdict import is_node_changed
 from vyos.configdiff import Diff, get_config_diff
 from vyos.configdep import set_dependents, call_dependents
+from vyos.config_path_resolver import apply_group_paths
 from vyos.configverify import verify_interface_exists
 from vyos.ethtool import Ethtool
 from vyos.firewall import fqdn_config_parse
@@ -141,6 +142,8 @@ def get_config(config=None):
     if firewall['group_resync']:
         # Update nat and policy-route as firewall groups were updated
         set_dependents('group_resync', conf)
+
+    apply_group_paths(dict_search_args(firewall, 'group'), conf)
 
     firewall['geoip_sets'] = geoip_sets(firewall)
     firewall['geoip_updated'] = geoip_updated(conf)

--- a/src/op_mode/firewall.py
+++ b/src/op_mode/firewall.py
@@ -18,15 +18,25 @@ import argparse
 import ipaddress
 import json
 import re
+import sys
 from signal import signal, SIGPIPE, SIG_DFL
 import tabulate
 import textwrap
 
+from vyos.base import ConfigError
 from vyos.config import Config
+from vyos.config_path_resolver import refresh_apply_path_groups
+from vyos.config_path_resolver import DictConfig
+from vyos.configquery import op_mode_config_dict
+from vyos.template import render
+from vyos.utils.locking import Lock
 from vyos.utils.process import cmdl
+from vyos.utils.process import run
 from vyos.utils.dict import dict_search_args
 
 signal(SIGPIPE, SIG_DFL)
+
+apply_path_nft_conf = '/run/nftables-apply-path-update.conf'
 
 
 def get_config_node(conf, node=None, family=None, hook=None, priority=None):
@@ -792,6 +802,57 @@ def show_statistics():
                 for prior, prior_conf in firewall[family][hook].items():
                     output_firewall_name_statistics(family, hook,prior, prior_conf)
 
+def update_apply_path_groups():
+    # Held for the whole read-resolve-render-apply sequence, not just the
+    # render+apply part: otherwise a slower invocation's stale config
+    # snapshot (read before the lock existed) could overwrite a faster,
+    # newer invocation's result once it finally gets the lock.
+    lock = Lock('firewall-apply-path-update')
+    lock.acquire()
+    try:
+        # op_mode_config_dict() instead of Config(): the whole-config fetch
+        # it needs anyway (apply-path targets can point anywhere in the
+        # tree) is no heavier than a plain Config() session, and this way we
+        # don't pay for a session object we never use for anything beyond
+        # list_nodes()/return_values()
+        groups = op_mode_config_dict(
+            ['firewall', 'group'],
+            key_mangling=('-', '_'),
+            get_first_key=True,
+            no_tag_node_value_mangle=True,
+        )
+        conf = DictConfig(op_mode_config_dict())
+        sets = refresh_apply_path_groups(groups, conf)
+
+        if not sets['v4'] and not sets['v6']:
+            print('No firewall group uses apply-path')
+            return
+
+        render(
+            apply_path_nft_conf,
+            'firewall/nftables-apply-path-update.j2',
+            {'sets': sets},
+            group='vyattacfg',
+            permission=0o664,
+        )
+
+        if run(f'nft --check --file {apply_path_nft_conf}') != 0:
+            print(
+                'Error: apply-path derived firewall group update failed nft syntax check'
+            )
+            sys.exit(1)
+
+        if run(f'nft --file {apply_path_nft_conf}') != 0:
+            print('Error: failed to update apply-path derived firewall groups')
+            sys.exit(1)
+    except ConfigError as e:
+        print(e)
+        sys.exit(1)
+    finally:
+        lock.release()
+
+    print('Updated apply-path derived firewall groups')
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--action', help='Action', required=False)
@@ -820,3 +881,5 @@ if __name__ == '__main__':
         show_statistics()
     elif args.action == 'show_summary':
         show_summary()
+    elif args.action == 'update_apply_path_groups':
+        update_apply_path_groups()

--- a/src/op_mode/firewall.py
+++ b/src/op_mode/firewall.py
@@ -19,6 +19,7 @@ import ipaddress
 import json
 import re
 import sys
+import time
 from signal import signal, SIGPIPE, SIG_DFL
 import tabulate
 import textwrap
@@ -29,6 +30,7 @@ from vyos.config_path_resolver import refresh_apply_path_groups
 from vyos.config_path_resolver import DictConfig
 from vyos.configquery import op_mode_config_dict
 from vyos.template import render
+from vyos.utils.commit import commit_in_progress
 from vyos.utils.locking import Lock
 from vyos.utils.process import cmdl
 from vyos.utils.process import run
@@ -803,6 +805,19 @@ def show_statistics():
                     output_firewall_name_statistics(family, hook,prior, prior_conf)
 
 def update_apply_path_groups():
+    # A concurrent firewall commit renders the same nftables sets this
+    # refresh writes to directly; wait it out first, the same way
+    # vyos-domain-resolver coordinates its own out-of-commit nftables pushes
+    # (FQDN/remote-group sets) with commit.
+    wait_start = time.time()
+    while commit_in_progress():
+        if time.time() - wait_start > 60:
+            print(
+                'Error: commit still in progress after 60s, aborting apply-path refresh'
+            )
+            sys.exit(1)
+        time.sleep(1)
+
     # Held for the whole read-resolve-render-apply sequence, not just the
     # render+apply part: otherwise a slower invocation's stale config
     # snapshot (read before the lock existed) could overwrite a faster,

--- a/src/tests/test_config_path_resolver.py
+++ b/src/tests/test_config_path_resolver.py
@@ -1,0 +1,209 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+from vyos.base import ConfigError
+from vyos.config_path_resolver import resolve_config_path
+from vyos.config_path_resolver import resolve_apply_paths
+from vyos.config_path_resolver import apply_group_paths
+from vyos.config_path_resolver import refresh_apply_path_groups
+from vyos.config_path_resolver import DictConfig
+
+tree = {
+    'protocols': {
+        'bgp': {
+            'neighbor': {
+                '62.141.40.144': {},
+                '62.141.40.145': {},
+            },
+            'address-family': {
+                'ipv4-unicast': {
+                    'network': ['185.137.128.0/22', '10.0.0.0/8'],
+                }
+            },
+        }
+    },
+    'vrf': {
+        'name': {
+            'CUST1': {'protocols': {'bgp': {'neighbor': {'10.1.1.1': {}}}}},
+            'CUST2': {'protocols': {'bgp': {'neighbor': {'10.2.2.2': {}}}}},
+        }
+    },
+}
+
+
+class TestConfigPathResolver(TestCase):
+    def setUp(self):
+        self.conf = DictConfig(tree)
+
+    def test_terminal_tag_node(self):
+        # TestConfigPathResolver: terminal path resolves via list_nodes()
+        result = resolve_config_path(self.conf, 'protocols bgp neighbor')
+        self.assertEqual(result, ['62.141.40.144', '62.141.40.145'])
+
+    def test_terminal_leaf_node(self):
+        # TestConfigPathResolver: terminal path falls back to return_values()
+        # when the terminal segment has no tag-node children
+        result = resolve_config_path(
+            self.conf, 'protocols bgp address-family ipv4-unicast network'
+        )
+        self.assertEqual(result, ['185.137.128.0/22', '10.0.0.0/8'])
+
+    def test_wildcard_expansion(self):
+        # TestConfigPathResolver: "*" fans out across every instance of the
+        # tag node at that position
+        result = resolve_config_path(self.conf, 'vrf name * protocols bgp neighbor')
+        self.assertEqual(sorted(result), ['10.1.1.1', '10.2.2.2'])
+
+    def test_nonexistent_path(self):
+        # TestConfigPathResolver: a path that doesn't exist resolves to an
+        # empty list, not an error
+        result = resolve_config_path(self.conf, 'protocols static route')
+        self.assertEqual(result, [])
+
+    def test_resolve_apply_paths_dedup_and_order(self):
+        # TestConfigPathResolver: values from multiple paths are merged,
+        # deduplicated, and keep first-seen order
+        result = resolve_apply_paths(
+            self.conf,
+            [
+                'protocols bgp neighbor',
+                'vrf name * protocols bgp neighbor',
+                'protocols bgp neighbor',
+            ],
+        )
+        self.assertEqual(
+            result,
+            [
+                '62.141.40.144',
+                '62.141.40.145',
+                '10.1.1.1',
+                '10.2.2.2',
+            ],
+        )
+
+    def test_resolve_apply_paths_accepts_valid_values(self):
+        # TestConfigPathResolver: a passing is_valid callback does not
+        # affect the resolved result
+        result = resolve_apply_paths(
+            self.conf, ['protocols bgp neighbor'], is_valid=lambda v: True
+        )
+        self.assertEqual(result, ['62.141.40.144', '62.141.40.145'])
+
+    def test_resolve_apply_paths_rejects_invalid_value(self):
+        # TestConfigPathResolver: apply-path values never went through a
+        # CLI <validator/>, so resolve_apply_paths must reject a value that
+        # fails the caller-supplied validator instead of returning it
+        with self.assertRaises(ValueError) as ctx:
+            resolve_apply_paths(
+                self.conf,
+                ['protocols bgp neighbor'],
+                is_valid=lambda v: v != '62.141.40.144',
+            )
+        self.assertEqual(ctx.exception.args[0], '62.141.40.144')
+
+    def test_apply_group_paths_merges_derived_members(self):
+        # TestConfigPathResolver: derived values are appended to a group's
+        # existing, manually configured members
+        groups = {
+            'network_group': {
+                'smoketest_derived': {
+                    'network': ['172.16.200.0/24'],
+                    'apply_path': ['protocols bgp address-family ipv4-unicast network'],
+                }
+            }
+        }
+        apply_group_paths(groups, self.conf)
+        self.assertEqual(
+            groups['network_group']['smoketest_derived']['network'],
+            ['172.16.200.0/24', '185.137.128.0/22', '10.0.0.0/8'],
+        )
+
+    def test_apply_group_paths_no_groups_is_a_noop(self):
+        # TestConfigPathResolver: called with no groups at all, nothing to do
+        apply_group_paths(None, self.conf)
+        apply_group_paths({}, self.conf)
+
+    def test_apply_group_paths_rejects_invalid_derived_value(self):
+        # TestConfigPathResolver: a derived value that fails the group
+        # type's validator raises ConfigError, naming the offending group
+        groups = {
+            'address_group': {
+                'smoketest_bad': {
+                    'address': ['10.0.0.1'],
+                    # resolves to VRF names ("CUST1", "CUST2"), not addresses
+                    'apply_path': ['vrf name'],
+                }
+            }
+        }
+        with self.assertRaisesRegex(ConfigError, 'resolved invalid'):
+            apply_group_paths(groups, self.conf)
+
+    def test_apply_group_paths_rejects_non_canonical_network(self):
+        # TestConfigPathResolver: a derived network-group value with host
+        # bits set (e.g. an interface address copied verbatim) is not a
+        # canonical network and must be rejected, not rendered as-is
+        conf = DictConfig(
+            {'interfaces': {'eth0': {'address': ['203.0.113.5/24']}}}
+        )
+        groups = {
+            'network_group': {
+                'smoketest_bad': {
+                    'network': [],
+                    'apply_path': ['interfaces eth0 address'],
+                }
+            }
+        }
+        with self.assertRaisesRegex(ConfigError, 'resolved invalid'):
+            apply_group_paths(groups, conf)
+
+    def test_refresh_apply_path_groups_builds_v4_and_v6_sets(self):
+        # TestConfigPathResolver: only groups with an apply-path show up in
+        # the result, named with their nftables set prefix
+        groups = {
+            'network_group': {
+                'smoketest_derived': {
+                    'network': ['172.16.200.0/24'],
+                    'apply_path': ['protocols bgp address-family ipv4-unicast network'],
+                },
+                'smoketest_manual_only': {
+                    'network': ['172.16.201.0/24'],
+                },
+            },
+            'address_group': {
+                'smoketest_addr': {
+                    'apply_path': ['vrf name * protocols bgp neighbor'],
+                }
+            },
+        }
+        sets = refresh_apply_path_groups(groups, self.conf)
+        self.assertEqual(
+            sets,
+            {
+                'v4': {
+                    'N_smoketest_derived': [
+                        '172.16.200.0/24',
+                        '185.137.128.0/22',
+                        '10.0.0.0/8',
+                    ],
+                    'A_smoketest_addr': ['10.1.1.1', '10.2.2.2'],
+                },
+                'v6': {},
+            },
+        )
+
+    def test_refresh_apply_path_groups_no_groups(self):
+        # TestConfigPathResolver: no "group" node configured at all
+        sets = refresh_apply_path_groups(None, self.conf)
+        self.assertEqual(sets, {'v4': {}, 'v6': {}})

--- a/src/tests/test_config_path_resolver.py
+++ b/src/tests/test_config_path_resolver.py
@@ -154,9 +154,7 @@ class TestConfigPathResolver(TestCase):
         # TestConfigPathResolver: a derived network-group value with host
         # bits set (e.g. an interface address copied verbatim) is not a
         # canonical network and must be rejected, not rendered as-is
-        conf = DictConfig(
-            {'interfaces': {'eth0': {'address': ['203.0.113.5/24']}}}
-        )
+        conf = DictConfig({'interfaces': {'eth0': {'address': ['203.0.113.5/24']}}})
         groups = {
             'network_group': {
                 'smoketest_bad': {


### PR DESCRIPTION
## Change summary
  
  Firewall groups (network-group/address-group and their IPv6 equivalents)
  are frequently used to mirror facts that already exist elsewhere in the
  same configuration - e.g. a group listing every configured BGP neighbor
  address, kept in sync by hand with "protocols bgp neighbor". This drifts
  silently: nothing at commit time checks the manual copy is still
  complete, and the same duplication has to be repeated and kept correct
  across every router in a fleet.
  
  Add "apply-path" as an option on network-group/ipv6-network-group/
  address-group/ipv6-address-group, analogous to Junos's
  "policy-options prefix-list <name> apply-path". Its value is a
  space-separated configuration path; a "*" segment expands every
  instance of the tag node at that position (e.g. to fan out across every
  configured VRF). The resolved values are merged into the group's
  existing manually-configured members, deduplicated.
  
  The resolver (python/vyos/config_path_resolver.py) is a small,
  backend-agnostic module built on two primitives Config already
  exposes - list_nodes() (enumerate tag-node children, e.g. every BGP
  neighbor address) and return_values() (read a multi-value leaf) - so it
  isn't tied to firewall groups specifically and can be adopted by other
  consumers (e.g. policy prefix-lists) the same way.
  
  Since network-group/address-group are a single shared resource
  referenced by nat66, policy route, load-balancing wan and system
  conntrack (not just firewall rules), resolving apply-path once here,
  before the group's elements are rendered into the nftables set,
  benefits every one of those consumers without any changes on their side.

  Note on branch history: this PR previously carried 16 commits,
  including unrelated ruff/darker cleanup that had drifted in through
  merge-base staleness. Per review feedback, the branch has been
  rebased onto current rolling and squashed to a single, purely
  additive commit (10 files, all feature/feature-adjacent).
  
  ## Types of changes
  - [x] New feature (non-breaking change which adds functionality) 
  
  ## Related Task(s)
  * https://vyos.dev/T9160
  
  ## Related PR(s)
  * vyos/vyos-documentation#2187 (documents the new `apply-path` option)
  
  ## How to test / Smoketest result

  Unit tests (no config backend needed):
  ```
  $ PYTHONPATH=python python3 -m unittest src.tests.test_config_path_resolver -v
  test_apply_group_paths_merges_derived_members ... ok
  test_apply_group_paths_no_groups_is_a_noop ... ok
  test_apply_group_paths_rejects_invalid_derived_value ... ok
  test_apply_group_paths_rejects_non_canonical_network ... ok
  test_nonexistent_path ... ok
  test_refresh_apply_path_groups_builds_v4_and_v6_sets ... ok
  test_refresh_apply_path_groups_no_groups ... ok
  test_resolve_apply_paths_accepts_valid_values ... ok
  test_resolve_apply_paths_dedup_and_order ... ok
  test_resolve_apply_paths_rejects_invalid_value ... ok
  test_terminal_leaf_node ... ok
  test_terminal_tag_node ... ok
  test_wildcard_expansion ... ok
  Ran 13 tests in 0.005s
  OK
  ```

  Manual CLI check - derive a network-group from configured BGP
  neighbors:
  ```
  set protocols bgp neighbor 192.0.2.1 remote-as 65001
  set protocols bgp neighbor 192.0.2.2 remote-as 65001
  set firewall group network-group NEIGHBORS apply-path "protocols bgp neighbor *"
  commit

  run show firewall group name NEIGHBORS
  # -> 192.0.2.1/32, 192.0.2.2/32 (derived, no manual network entries needed)
  ```
  Full CLI smoketest coverage is in `test_firewall.py` (apply-path
  merge/dedup/validation cases); ran via
  `/usr/libexec/vyos/tests/smoke/cli/test_firewall.py` on the CI image,
  see the CI run linked on this PR.
  
  ## Checklist:
  - [x] I have read the CONTRIBUTING document
  - [x] I have linked this PR to one or more Phabricator Task(s)
  - [x] I have run the components SMOKETESTS if applicable
  - [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
  - [x] My commit headlines contain a valid Task id
  - [x] My change requires a change to the documentation
  - [x] I have updated the documentation accordingly