### PR TITLE
vpp: T9146: Enable DPDK no-multi-seg when a full frame fits the buffer

### DIFF
--- a/data/templates/vpp/startup.conf.j2
+++ b/data/templates/vpp/startup.conf.j2
@@ -178,6 +178,9 @@ dpdk {
 {%     endif %}
 {% endfor %}
     uio-bind-force
+{% if no_multi_seg is vyos_defined %}
+    no-multi-seg
+{% endif %}
 }
 
 {% if ipsec_acceleration is vyos_defined %}

--- a/python/vyos/vpp/config_resource_checks/memory.py
+++ b/python/vyos/vpp/config_resource_checks/memory.py
@@ -106,6 +106,22 @@ def buffer_size(settings: dict) -> int:
     return buffers_memory
 
 
+def no_multi_seg_fits(max_mtu, data_size) -> bool:
+    """Whether 'no-multi-seg' can be enabled for the given MTU and buffer size.
+
+    With multi-segment buffers disabled a received frame must fit a single
+    buffer, so the largest interface MTU plus its L2 framing overhead must fit
+    within the buffer 'data-size' (T9146).
+    """
+    # Bytes a full L2 frame carries on top of the L3 MTU: Ethernet header (14),
+    # up to two QinQ VLAN tags (8) and the FCS (4). Matches VPP's DPDK frame
+    # overhead (RTE_ETHER_HDR_LEN + 2 * RTE_VLAN_HLEN + RTE_ETHER_CRC_LEN)
+    # https://github.com/FDio/vpp/blob/stable/2506/src/plugins/dpdk/device/init.c
+    # constants: https://github.com/DPDK/dpdk/blob/main/lib/net/rte_ether.h
+    l2_frame_overhead = 14 + 8 + 4
+    return int(data_size) >= int(max_mtu) + l2_frame_overhead
+
+
 def main_heap_page_size(settings: dict) -> int:
     heap_page_size = settings['resource_allocation']['memory']['main_heap_page_size']
     return human_memory_to_bytes(heap_page_size)

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -1834,6 +1834,40 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         _, out = rc_cmd(f'sudo vppctl show hardware-interfaces {interface}')
         self.assertNotRegex(out, r'flags:.*\bpromisc\b')
 
+    def test_26_vpp_no_multi_seg(self):
+        # 'no-multi-seg' is auto-computed (T9146): enabled while the largest
+        # VPP-interface MTU fits the buffer data-size, dropped otherwise (VPP
+        # falls back to multi-seg so Jumbo frames still work)
+        mtu = '2500'
+
+        self.cli_commit()
+
+        # Check no-multi-seg option
+        # Default 1500 MTU fits the default 2048 buffer -> enabled
+        config = read_file(VPP_CONF)
+        self.assertIn('no-multi-seg', config)
+
+        # Raising the MTU beyond the buffer drops it; the interface change
+        # triggers a VPP reconfigure on its own
+        self.cli_set(['interfaces', 'ethernet', interface, 'mtu', mtu])
+        self.cli_commit()
+
+        config = read_file(VPP_CONF)
+        self.assertNotIn('no-multi-seg', config)
+
+        # Sizing the buffer to fit the MTU brings it back
+        self.cli_set(
+            base_path
+            + ['settings', 'resource-allocation', 'buffers', 'data-size', '4096']
+        )
+        self.cli_commit()
+
+        config = read_file(VPP_CONF)
+        self.assertIn('no-multi-seg', config)
+
+        # Cleanup
+        self.cli_delete(['interfaces', 'ethernet', interface, 'mtu'])
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -22,6 +22,8 @@ from vyos.base import Warning
 from vyos.config import Config
 from vyos.configdep import set_dependents
 from vyos.configdep import call_dependents
+from vyos.configdep import set_dependents_initial
+from vyos.configdep import call_dependents_initial
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
 from vyos.configdict import is_vrf_changed
@@ -48,7 +50,9 @@ from vyos.utils.dict import dict_set
 from vyos.utils.dict import dict_delete
 from vyos.utils.network import get_vrf_tableid
 from vyos.utils.process import is_systemd_service_running
+from vyos.utils.file import read_file
 from vyos.vpp.config_deps import deps_bond_dict
+from vyos.vpp.config_resource_checks.memory import no_multi_seg_fits
 from vyos.vpp.config_verify import verify_vpp_remove_interface
 from vyos.vpp.config_verify import verify_vpp_mac_change_supported
 from vyos.vpp.control_vpp import VPPControl
@@ -140,6 +144,51 @@ def update_bond_options(conf: Config, eth_conf: dict) -> list:
     eth_conf['bond_blocked_changes'] = blocked_list
     return None
 
+def _vpp_no_multi_seg_change(conf: Config) -> bool:
+    """Whether VPP must be reconfigured to flip 'no-multi-seg' (T9146)
+
+    True only when the flag the current config requires differs from the one VPP
+    is running with
+    """
+    # VPP is down: nothing to reconfigure now; the flag is recomputed the next
+    # time vpp.py runs (a 'vpp' commit or boot).
+    if not is_systemd_service_running('vpp.service'):
+        return False
+
+    # Largest MTU across all VPP-bound interfaces - the flag depends on the max,
+    # not just the interface being changed, so a change that leaves a bigger
+    # interface in place does not needlessly flip it.
+    vpp_ifaces = conf.list_nodes(['vpp', 'settings', 'interface'], default=[])
+    max_mtu = max(
+        (
+            int(conf.return_value(['interfaces', 'ethernet', iface, 'mtu']) or 1500)
+            for iface in vpp_ifaces
+        ),
+        default=1500,
+    )
+    # buffer data-size (default 2048) that the frame must fit under 'no-multi-seg'
+    data_size = int(
+        conf.return_value(
+            ['vpp', 'settings', 'resource-allocation', 'buffers', 'data-size']
+        )
+        or 2048
+    )
+    # what the new config requires after MTU change
+    desired = no_multi_seg_fits(max_mtu, data_size)
+
+    # read the flag VPP is actually running with from its generated startup.conf
+    try:
+        current = 'no-multi-seg' in read_file('/run/vpp/vpp.conf')
+    except OSError:
+        # Running state unknown: reconfigure only when 'no-multi-seg' must be
+        # off (an oversized frame would drop otherwise). When it should be on,
+        # multi-seg is a safe fallback, so skip the restart.
+        return not desired
+
+    # reconfigure VPP only when the flag actually flips
+    return current != desired
+
+
 def get_config(config=None):
     """
     Retrieve CLI config as dictionary. Dictionary can never be empty, as at least the
@@ -203,6 +252,14 @@ def get_config(config=None):
     # Check vrf membership, to ensure firewall is updated
     if is_vrf_changed(conf, ifname):
         set_dependents('firewall', conf)
+
+    # T9146: An MTU change on a VPP-bound interface can flip 'no-multi-seg';
+    # reconfigure VPP only when it actually flips. An initial dependency is
+    # used because a normal ethernet -> vpp one would cycle with the existing
+    # vpp -> ethernet dependency.
+    if vpp_config and is_node_changed(conf, base + [ifname, 'mtu']):
+        if _vpp_no_multi_seg_change(conf):
+            set_dependents_initial('vpp', conf)
 
     return ethernet
 
@@ -458,6 +515,7 @@ def apply(ethernet):
 
     # run the dependents
     call_dependents()
+    call_dependents_initial()
 
     vpp_iface_config = dict_search(f'vpp.settings.interface.{ifname}', ethernet)
     if vpp_iface_config is not None and is_systemd_service_running('vpp.service'):

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -76,9 +76,16 @@ service_name = 'vpp'
 service_conf = Path(f'/run/vpp/{service_name}.conf')
 systemd_override = '/run/systemd/system/vpp.service.d/10-override.conf'
 
-vpp_log = getLogger(
-    service_name, format='%(filename)s[%(process)d]: %(message)s', address='/dev/log'
-)
+try:
+    vpp_log = getLogger(
+        service_name,
+        format='%(filename)s[%(process)d]: %(message)s',
+        address='/dev/log',
+    )
+except ValueError:
+    # vpp.py is re-executed when run as a config dependency (T9146); the named
+    # logger is created only once, so reuse the existing instance on re-import.
+    vpp_log = getLogger(service_name)
 
 dependency_interface_type_map = {
     'vpp_interfaces_bonding': 'bonding',
@@ -207,6 +214,24 @@ def _normalize_buffers(config: dict):
         config['settings']['resource_allocation']['buffers']['buffers_per_numa'] = str(
             buffers
         )
+
+
+def _set_no_multi_seg(config: dict):
+    """Enable 'no-multi-seg' when the largest VPP interface MTU fits one buffer.
+
+    Disabling multi-segment buffers boosts throughput, but a received frame must
+    then fit a single buffer - i.e. the largest interface MTU (plus L2 framing)
+    must fit within the buffer 'data-size'. When it does, set the flag so the
+    template emits 'no-multi-seg'; otherwise leave it unset so VPP keeps
+    multi-seg and can still carry Jumbo frames without a bigger buffer (T9146).
+    """
+    max_mtu = max(
+        (int(c['mtu']) for c in config['settings'].get('interface', {}).values()),
+        default=1500,
+    )
+    data_size = config['settings']['resource_allocation']['buffers']['data_size']
+    if memory.no_multi_seg_fits(max_mtu, data_size):
+        config['settings']['no_multi_seg'] = True
 
 
 def _get_max_xdp_rx_queues(config: dict):
@@ -381,6 +406,11 @@ def get_config(config=None):
 
             for iface, iface_config in config['settings']['interface'].items():
                 iface_config['driver'] = 'dpdk'
+                # configured MTU, used to set no_multi_seg option
+                iface_config['mtu'] = (
+                    conf.return_value(['interfaces', 'ethernet', iface, 'mtu'])
+                    or '1500'
+                )
 
                 # old_driver = leaf_node_changed(
                 #     conf, base_settings + ['interface', iface, 'driver']
@@ -477,6 +507,11 @@ def get_config(config=None):
                     ):
                         xdp_api_params['flags'] = 'no_syscall_lock'
                     iface_config['xdp_api_params'] = xdp_api_params
+
+        # Enable 'no-multi-seg' only when the buffer data-size can hold the
+        # largest interface MTU in a single segment (T9146); otherwise VPP keeps
+        # multi-seg so Jumbo frames still work.
+        _set_no_multi_seg(config)
 
         # Buffer normalization (auto → computed)
         _normalize_buffers(config)


### PR DESCRIPTION
Disabling DPDK multi-segment buffers (no-multi-seg) lets VPP receive each
frame into a single buffer, increasing forwarding throughput. The frame
must then fit the buffer 'data-size', so 'no-multi-seg' is computed: it is
enabled only while the largest MTU across all VPP-bound interfaces, plus
its L2 framing overhead (26 bytes), fits 'data-size'. Otherwise VPP keeps
multi-seg and Jumbo frames still work without a larger buffer.

Changing the MTU of a VPP-bound interface can flip the flag, so
interfaces_ethernet reconfigures VPP when it changes, via an initial
dependency (set_dependents_initial) to avoid a cycle with the existing
vpp -> ethernet dependency.

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T9146
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
# eth1 with the default MTU (1500)
vyos@vyos# set vpp settings interface eth1
[edit]
vyos@vyos# commit
[ vpp ]

WARNING: NOTE: Current dataplane capacity (estimated): 2.1 M IPv4
routes. Exceeding these values will lead to a dataplane out-of-memory
condition and a crash. Extensive use of features like ACLs, NAT and
others may reduce the numbers above. Please read the documentation for
details: https://docs.vyos.io/


[edit]
# no-multi-seg IS enabled
vyos@vyos# grep no-multi-seg /run/vpp/vpp.conf
    no-multi-seg
[edit]
# Raise eth1 MTU beyond what the buffer can hold
vyos@vyos# set interfaces ethernet eth1 mtu 2500
[edit]
vyos@vyos# commit
[ interfaces ethernet eth1 ]

WARNING: NOTE: Current dataplane capacity (estimated): 2.1 M IPv4
routes. Exceeding these values will lead to a dataplane out-of-memory
condition and a crash. Extensive use of features like ACLs, NAT and
others may reduce the numbers above. Please read the documentation for
details: https://docs.vyos.io/


[edit]
# no-multi-seg is now GONE
vyos@vyos# grep no-multi-seg /run/vpp/vpp.conf
[edit]
vyos@vyos# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
