### PR TITLE
T9164: mergify: accept NOS- and legacy VD- Jira keys in task-id check

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -33,10 +33,12 @@ pull_request_rules:
   - name: Flag product T-ID format violation in PR title or commit messages
     description: >
       Product-repo convention: PR title and every commit's first line must
-      match `T<digits>: <text>` (optional `scope: ` prefix). Relocated from
-      the central config (T8966) so the T-ID convention is opt-in per product
-      repo. Name is intentionally distinct from any central rule name so this
-      stays additive (not an `extends:` override).
+      match a `T<digits>:`, `NOS-<digits>:` or legacy `VD-<digits>:` task key
+      followed by text (optional `scope: ` prefix). NOS is the renamed VD Jira
+      project (2026-07). Relocated from the central config (T8966) so the T-ID
+      convention is opt-in per product repo. Name is intentionally distinct
+      from any central rule name so this stays additive (not an `extends:`
+      override).
     conditions:
       - '-closed'
       - '-merged'
@@ -44,10 +46,10 @@ pull_request_rules:
       - 'author!=copilot-swe-agent'
       - 'author!=vyosbot'
       - or:
-          - '-title~=^(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+.*'
+          - '-title~=^(([a-zA-Z0-9\-_.]+:[ ])?)(T[0-9]+|NOS-[0-9]+|VD-[0-9]+):[ ]+[^\s]+.*'
           - and:
               - 'label!=legacy'
-              - 'commits[*].commit_message~=^(?!(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+).*'
+              - 'commits[*].commit_message~=^(?!(([a-zA-Z0-9\-_.]+:[ ])?)(T[0-9]+|NOS-[0-9]+|VD-[0-9]+):[ ]+[^\s]+).*'
     actions:
       label:
         toggle:


### PR DESCRIPTION
## What

Extends the per-repo `invalid-task-id` Mergify rule so a PR title or commit headline may carry a `NOS-<digits>:` or legacy `VD-<digits>:` task key in addition to the existing `T<digits>:` key.

Exactly three strings change in `.github/mergify.yml` (two regexes + the rule's `description`). The rule **name** is byte-identical, so this stays additive and does not become an `extends:` override of any central rule. No other file is touched.

## Why

The `VD` tracker project was renamed to `NOS` (2026-07). Under the current rule only `T<digits>:` is accepted, so any PR or commit using the new `NOS-` key gets labelled `invalid-task-id` and blocked at merge.

Legacy `VD-<digits>:` is accepted as well, for two reasons:

1. `VD-` keys already exist in this repo's history — e.g. `VD-277: use YYYY.MM.DD-HHMM-integration version scheme for builds` and `VD-279: Use common IPv6 naming for CLI`. Those headlines are malformed under today's rule.
2. Long-lived branches and backports that predate the rename should not start failing.

`T<digits>:` behaviour is unchanged, and it remains overwhelmingly the dominant convention here — 3,866 commit headlines since 2023 match `T<digits>:` versus 2 matching `VD-`.

## The change

```diff
-          - '-title~=^(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+.*'
+          - '-title~=^(([a-zA-Z0-9\-_.]+:\s)?)(T\d+|NOS-\d+|VD-\d+):\s+[^\s]+.*'
           - and:
               - 'label!=legacy'
-              - 'commits[*].commit_message~=^(?!(([a-zA-Z0-9\-_.]+:\s)?)T\d+:\s+[^\s]+).*'
+              - 'commits[*].commit_message~=^(?!(([a-zA-Z0-9\-_.]+:\s)?)(T\d+|NOS-\d+|VD-\d+):\s+[^\s]+).*'
```

Plus the matching `description:` update documenting the three accepted key forms.

## Evidence — regex vectors

Both patterns were extracted programmatically from the committed `.github/mergify.yml` (not retyped by hand) and exercised under Python `re`. `re` is the right fidelity check here: the commit condition uses a negative lookahead `(?!...)`, which RE2 does not support, so a backtracking engine is in play.

Note the title condition ships **negated** (`-title~=`) and the commit condition is a **negative lookahead** — in both cases the rule fires (labels the PR) when the task key is *absent*. The `labels?` column is the user-visible outcome.

| vector | expected | title-re | commit-inner | labels? | result |
|---|---|---|---|---|---|
| `T9043: fix x` | MATCH | True | True | False | PASS |
| `vpp: T9062: fix y` | MATCH | True | True | False | PASS |
| `NOS-4709: Fix GitHub actions publishing` | MATCH | True | True | False | PASS |
| `VD-4696: legacy title` | MATCH | True | True | False | PASS |
| `smoketest: NOS-12: z` | MATCH | True | True | False | PASS |
| `fix stuff` | no-match | False | False | True | PASS |
| `NOS4709: x` | no-match | False | False | True | PASS |
| `nos-1: x` | no-match | False | False | True | PASS |
| `T: x` | no-match | False | False | True | PASS |
| `NOS-: x` | no-match | False | False | True | PASS |

10/10 vectors passed. Missing hyphen (`NOS4709:`), lowercase (`nos-1:`), and digit-less (`T:`, `NOS-:`) forms are all still correctly rejected — the alternation did not loosen the check beyond the intended keys.

Schema lint: checked against the known Mergify schema/keyword traps. No `merge_protections:` block, no `dequeue` action, no `rebase` action, no `queue_rules`, no `commands_restrictions` in this file; `merge_protections_settings.reporting_method: check-runs` remains explicitly declared (pre-existing, and required ahead of the upstream default flip). `yaml.safe_load` parses clean.

## Scope

This is the canary for an operator-approved sweep across the remaining product repos that carry this rule. Only `vyos/vyos-1x` is changed here; the fleet sweep follows separately once this bakes.

Tracker: [T9164](https://vyos.dev/T9164)

Advances: IS-640

🤖 Generated by [robots](https://vyos.io)

