### PR TITLE
T9164: coderabbit: surface NOS Jira project alongside legacy VD

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -36,4 +36,5 @@ knowledge_base:
     # in titles (e.g. `T8849: ...` for Phorge tasks that have VD twins),
     # so the surface area that matters is VD.
     project_keys:
+      - NOS
       - VD


### PR DESCRIPTION
Fleet replication of the adversarially-reviewed canary [vyos/vyos-1x#5379](https://github.com/vyos/vyos-1x/pull/5379) for the VD→NOS Jira project rename ([T9164](https://vyos.dev/T9164)). `.coderabbit.yaml` — `knowledge_base.jira.project_keys` pins `NOS` ahead of the retained legacy `VD`. Byte-identical template application — `skip-adversarial` per the documented escape hatch (2 findings were found and fixed on the canary; regexes ship tightened: ASCII digits + literal-space separators).

Phase 0 (local CodeRabbit CLI, `--base origin/rolling`): clean — 0 findings.

Advances: IS-640

🤖 Generated by [robots](https://vyos.io)

