### PR TITLE
dhcp: T9167: align Kea HA timer defaults with Kea ARM

### DIFF
--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -904,9 +904,9 @@ def kea_high_availability_json(config):
         'this-server-name': os.uname()[1],
         'mode': ha_mode,
         'heartbeat-delay': 10000,
-        'max-response-delay': 10000,
+        'max-response-delay': 60000,
         'max-ack-delay': 5000,
-        'max-unacked-clients': 0,
+        'max-unacked-clients': 10,
         'peers': [
         {
             'name': os.uname()[1],


### PR DESCRIPTION
## Change summary

`kea_high_availability_json` (used by `service dhcp-server high-availability`) hardcodes Kea HA hook timers that disagree with the **Kea ARM** (`libdhcp_ha.so`):

| Param | Stock VyOS | Kea ARM default / rule |
|-------|------------|------------------------|
| `heartbeat-delay` | 10000 | 10000 (unchanged) |
| `max-response-delay` | **10000** | **60000**; must be **greater than** `heartbeat-delay`, typically a multiple |
| `max-unacked-clients` | **0** | **10**; `0` disables client failure-detection and partner-downs immediately |
| `max-ack-delay` | 5000 | 10000 (left unchanged — prior VyOS value; not in T9167 scope) |

Equal `heartbeat-delay` / `max-response-delay` (both 10s) false-fires `communication-interrupted` every heartbeat cycle on healthy pairs (peer age hits ~10s) while often still `in-touch` and `load-balancing`.

This PR only changes the two values required by T9167:

```diff
-    'max-response-delay': 10000,
+    'max-response-delay': 60000,
     'max-ack-delay': 5000,
-    'max-unacked-clients': 0,
+    'max-unacked-clients': 10,
```

No CLI / interface-definition change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T9167
* Related but distinct: https://vyos.dev/T8392 (peer name / Wontfix — not timer defaults)

## Related PR(s)
N/A

## How to test / Smoketest result

Smoketests: N/A (template constant change only; no CLI path change).

Manual verification (VyOS 1.5 Circinus rolling, dual-node load-balancing HA):

1. Before patch, inspect generated HA block in `/run/kea/kea-dhcp4.conf`:
   ```
   "heartbeat-delay": 10000,
   "max-response-delay": 10000,
   "max-unacked-clients": 0
   ```
2. Poll `status-get` ~0.5s for 30–60s while healthy:
   - `remote.age` cycles 0..10
   - `remote.communication-interrupted` becomes true when age hits 10
   - `remote.in-touch` often remains true; local state stays `load-balancing`
3. After this change + dhcp-server re-apply, same conf shows:
   ```
   "max-response-delay": 60000,
   "max-unacked-clients": 10
   ```
4. Same poll: `communication-interrupted` stays false as age cycles 0–10.
5. Peer control channel down should still mark interrupted after ~60s (max-response-delay).

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
