### PR TITLE
utils: T9177: fix _are_same_ip() using wrong address family

### DIFF
--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -131,7 +131,7 @@ def get_vrf_members(vrf: str) -> list:
                 # Skip PIM interfaces which appears in VRF
                 if 'pim' not in data.get('ifname'):
                     interfaces.append(data.get('ifname'))
-    except:
+    except Exception:
         pass
     return interfaces
 
@@ -219,7 +219,8 @@ def get_interface_namespace(interface: str):
     """
     # Bail out early if netns does not exist
     tmp = cmdl(['ip', '--json', 'netns', 'ls'])
-    if not tmp: return None
+    if not tmp:
+        return None
 
     for ns in loads(tmp):
         netns = f'{ns["name"]}'
@@ -339,7 +340,7 @@ def mac2eui64(mac, prefix=None):
             net = ip_network(prefix, strict=False)
             euil = int('0x{0}'.format(eui64), 16)
             return str(net[euil])
-        except:  # pylint: disable=bare-except
+        except Exception:
             return
 
 
@@ -381,7 +382,7 @@ def check_port_availability(address: str = None, port: int = 0,
     protocol = socket.SOCK_STREAM if protocol == 'tcp' else socket.SOCK_DGRAM
     try:
         addr_info = socket.getaddrinfo(address, port, socket.AF_UNSPEC, protocol)
-    except socket.gaierror as e:
+    except socket.gaierror:
         print(f'Invalid address: {address}')
         return False
 
@@ -500,7 +501,6 @@ def is_intf_addr_assigned(ifname: str, addr: str, netns: str=None) -> bool:
         json_out = loads(out)
         addresses = jmespath.search("[].addr_info[].{family: family, address: local, prefixlen: prefixlen}", json_out)
         for address_info in addresses:
-            family = address_info['family']
             address = address_info['address']
             prefixlen = address_info['prefixlen']
             # Remove the interface name if present in the given address
@@ -688,7 +688,7 @@ def ipv6_prefix_length(low, high):
     try:
         lo = bytearray(socket.inet_pton(socket.AF_INET6, low))
         hi = bytearray(socket.inet_pton(socket.AF_INET6, high))
-    except:
+    except Exception:
         return None
 
     xor = bytearray(a ^ b for a, b in zip(lo, hi))
@@ -752,7 +752,7 @@ def is_valid_ipv4_address_or_range(addr: str) -> bool:
             return is_valid_ipv4_address_or_range(split[0]) and is_valid_ipv4_address_or_range(split[1])
         else:
             return ip_network(addr).version == 4
-    except:
+    except Exception:
         return False
 
 def is_valid_ipv6_address_or_range(addr: str) -> bool:
@@ -768,7 +768,7 @@ def is_valid_ipv6_address_or_range(addr: str) -> bool:
             return is_valid_ipv6_address_or_range(split[0]) and is_valid_ipv6_address_or_range(split[1])
         else:
             return ip_network(addr).version == 6
-    except:
+    except Exception:
         return False
 
 

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -121,9 +121,9 @@ def get_vrf_members(vrf: str) -> list:
     :return: list
     """
     interfaces = []
+    if not interface_exists(vrf):
+        return interfaces
     try:
-        if not interface_exists(vrf):
-            raise ValueError(f'VRF "{vrf}" does not exist!')
         output = cmdl(['ip', '--json', '--brief', 'link', 'show', 'vrf', vrf])
         answer = loads(output)
         for data in answer:

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -25,8 +25,10 @@ def _are_same_ip(one, two):
     from vyos.template import is_ipv4
     # compare the binary representation of the IP
     f_one = AF_INET if is_ipv4(one) else AF_INET6
-    s_two = AF_INET if is_ipv4(two) else AF_INET6
-    return inet_pton(f_one, one) == inet_pton(f_one, two)
+    f_two = AF_INET if is_ipv4(two) else AF_INET6
+    if f_one != f_two:
+        return False
+    return inet_pton(f_one, one) == inet_pton(f_two, two)
 
 def get_protocol_by_name(protocol_name):
     """Get protocol number by protocol name

--- a/src/tests/test_utils_network.py
+++ b/src/tests/test_utils_network.py
@@ -44,6 +44,15 @@ class TestVyOSUtilsNetwork(TestCase):
         self.assertFalse(vyos.utils.network.is_loopback_addr('::2'))
         self.assertFalse(vyos.utils.network.is_loopback_addr('192.0.2.1'))
 
+    def test_are_same_ip(self):
+        self.assertTrue(vyos.utils.network._are_same_ip('192.0.2.1', '192.0.2.1'))
+        self.assertFalse(vyos.utils.network._are_same_ip('192.0.2.1', '192.0.2.2'))
+        self.assertTrue(vyos.utils.network._are_same_ip('::1', '::1'))
+        self.assertFalse(vyos.utils.network._are_same_ip('::1', '::2'))
+        # mixed address families must never compare equal, and must not raise
+        self.assertFalse(vyos.utils.network._are_same_ip('192.0.2.1', '::1'))
+        self.assertFalse(vyos.utils.network._are_same_ip('::1', '192.0.2.1'))
+
     def test_check_port_availability(self):
         self.assertTrue(vyos.utils.network.check_port_availability('::1', 8080))
         self.assertTrue(vyos.utils.network.check_port_availability('127.0.0.1', 8080))

--- a/src/tests/test_utils_network.py
+++ b/src/tests/test_utils_network.py
@@ -35,7 +35,7 @@ class TestVyOSUtilsNetwork(TestCase):
         self.assertFalse(vyos.utils.network.is_ipv6_link_local('::1'))
         self.assertFalse(vyos.utils.network.is_ipv6_link_local('::1%lo'))
 
-    def test_is_ipv6_link_local(self):
+    def test_is_loopback_addr(self):
         self.assertTrue(vyos.utils.network.is_loopback_addr('127.0.0.1'))
         self.assertTrue(vyos.utils.network.is_loopback_addr('127.0.1.1'))
         self.assertTrue(vyos.utils.network.is_loopback_addr('127.1.1.1'))


### PR DESCRIPTION
# Change summary

Fixes `_are_same_ip()` in `python/vyos/utils/network.py`, which computed
the address family of both arguments but only ever passed the first
one's family to `inet_pton()` for both — the second argument's computed
family was assigned to an unused local and never used. Comparing
addresses of different families (e.g. one IPv4, one IPv6) raised
instead of cleanly returning `False`.

Found via `ruff` flagging the unused local during unrelated review work
on #5374; the function currently has no callers in the tree. Also
includes a small ruff cleanup of the rest of the touched files (bare
`except:`, one unused loop variable, one multi-statement `if`, and a
duplicate test method name that was silently shadowing another test) —
no behavior changes there.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T9177

## Related PR(s)

None.

## How to test / Smoketest result

`_are_same_ip()` is a private, unexported helper with no current
callers, so there is no CLI-level smoketest for it. Added/ran a unit
test covering same-family match/mismatch and the mixed-family case
that previously raised instead of returning `False`:

```
$ python3 -m pytest src/tests/test_utils_network.py -v
test_are_same_ip PASSED
test_check_port_availability PASSED
test_is_addr_assigned PASSED
test_is_ipv6_link_local PASSED
test_is_loopback_addr PASSED
5 passed in 0.53s
```

Also verified `ruff`, `darker`, and `pylint --enable=W0611` are clean
on both touched files, and confirmed via `py_compile` that the module
still imports correctly.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
