### PR TITLE
container: T7736: fix smoketest failures caused by netavark/aardvark-dns IPv6 DAD race

### DIFF
--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -78,6 +78,12 @@ class VyOSUnitTestSHIM:
                 # restore previous configuration before the test
                 cls._session.migrate_and_load_config(save_config)
                 cls._session.commit()
+                # Remove the saved config snapshot once the test is done
+                # with it - a leftover file here is owned by whichever user
+                # ran this test, and blocks a different user from running
+                # it later ("Permission denied" on save_config)
+                if os.path.exists(save_config):
+                    os.remove(save_config)
 
         def setUp(self):
             pass

--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -77,26 +77,15 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         cont_name = 'c1'
 
         self.cli_set(['interfaces', 'ethernet', 'eth0', 'address', '10.0.2.15/24'])
-        self.cli_set(
-            ['protocols', 'static', 'route', '0.0.0.0/0', 'next-hop', '10.0.2.2']
-        )
+        self.cli_set(['protocols', 'static', 'route', '0.0.0.0/0',
+                      'next-hop', '10.0.2.2', 'distance', '230'])
         self.cli_set(['system', 'name-server', '1.1.1.1'])
         self.cli_set(['system', 'name-server', '8.8.8.8'])
 
         self.cli_set(base_path + ['name', cont_name, 'image', busybox_image])
         self.cli_set(base_path + ['name', cont_name, 'allow-host-networks'])
-        self.cli_set(
-            base_path
-            + [
-                'name',
-                cont_name,
-                'sysctl',
-                'parameter',
-                'kernel.msgmax',
-                'value',
-                '4096',
-            ]
-        )
+        self.cli_set(base_path + ['name', cont_name, 'sysctl', 'parameter',
+                                  'kernel.msgmax', 'value', '4096'])
         self.cli_set(base_path + ['name', cont_name, 'log-driver', 'journald'])
         # commit changes
         self.cli_commit()

--- a/smoketest/scripts/cli/test_system_ipv6.py
+++ b/smoketest/scripts/cli/test_system_ipv6.py
@@ -56,8 +56,12 @@ class TestSystemIPv6(VyOSUnitTestSHIM.TestCase):
         self.assertNotIn('no ipv6 forwarding', frrconfig)
 
     def test_system_ipv6_strict_dad(self):
-        # This defaults to 1
-        self.assertEqual(sysctl_read(['net', 'ipv6', 'conf', 'all', 'accept_dad']), '1')
+        # T7736: "all" defaults to 0 (see 32-vyos-podman.conf) so that
+        # newly created interfaces outside VyOS's interface model (e.g.
+        # netavark's container bridges) skip DAD; VyOS-managed interface
+        # types always write their own explicit accept_dad on commit
+        # (XML defaultValue 1), so this does not affect them.
+        self.assertEqual(sysctl_read(['net', 'ipv6', 'conf', 'all', 'accept_dad']), '0')
 
         # Do not assign any IPv6 address on interfaces, this requires a reboot
         # which cannot be tested, but we can read the config file :)

--- a/src/conf_mode/system_ipv6.py
+++ b/src/conf_mode/system_ipv6.py
@@ -83,8 +83,14 @@ def apply(config_dict):
     sysctl_write(['net', 'ipv6', 'neigh', 'default', 'gc_thresh1'], size // 8)
 
     # configure IPv6 strict-dad
+    # T7736: DAD is off by default (see 32-vyos-podman.conf) so that
+    # interfaces outside VyOS's interface model (e.g. netavark's
+    # container bridges) skip it; VyOS-managed interface types always
+    # write their own explicit accept_dad on their own next commit
+    # regardless of what this sets here, so this only has a lasting
+    # effect on interfaces nothing else manages.
     tmp = dict_search('strict_dad', opt)
-    value = '2' if (tmp != None) else '1'
+    value = '2' if (tmp != None) else '0'
     for root, dirs, files in os.walk('/proc/sys/net/ipv6/conf'):
         for name in files:
             if name == 'accept_dad':

--- a/src/etc/sysctl.d/32-vyos-podman.conf
+++ b/src/etc/sysctl.d/32-vyos-podman.conf
@@ -3,3 +3,14 @@ fs.inotify.max_queued_events = 1048576
 fs.inotify.max_user_instances = 1048576
 fs.inotify.max_user_watches = 1048576
 
+# T7736: netavark assigns the IPv6 gateway address to a container "pod-*"
+# bridge and immediately invokes aardvark-dns to bind its DNS listener to
+# it; while the address is "tentative" during Duplicate Address Detection,
+# that bind() fails with EADDRNOTAVAIL and container startup fails for any
+# IPv6-enabled network.
+# The kernel only skips DAD for an address if BOTH "all" and the specific
+# interface's own accept_dad are disabled at the moment the interface is
+# created.
+net.ipv6.conf.all.accept_dad=0
+net.ipv6.conf.default.accept_dad=0
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

netavark assigns the IPv6 gateway address to a container's pod-* bridge and immediately hands off to aardvark-dns to bind its DNS listener, which fails with EADDRNOTAVAIL while the address is still "tentative" during Duplicate Address Detection.

Fixed by disabling DAD globally via all/default accept_dad sysctls - the only combination the kernel honors race-free, since a per-interface override always arrives too late for a network's first container.

Also fixes a smoketest hygiene bug where a stale `/tmp/vyos-smoketest-save` file blocked other users from running tests, and raises the container test's default-route distance to avoid clobbering dynamically learned routes.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T7736

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
```
DEBUG - /usr/bin/vyos-smoketest
DEBUG - Running Testcase (1/1): /usr/libexec/vyos/tests/smoke/cli/test_container.py
DEBUG - test_api_socket (__main__.TestContainer.test_api_socket) ... ok
DEBUG - test_basic (__main__.TestContainer.test_basic) ... ok
DEBUG - test_colliding_host_interface_names (__main__.TestContainer.test_colliding_host_interface_names) ... ok
DEBUG - test_cpu_limit (__main__.TestContainer.test_cpu_limit) ... ok
DEBUG - test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... ok
DEBUG - test_healthcheck (__main__.TestContainer.test_healthcheck) ... ok
DEBUG - test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... ok
DEBUG - test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... ok
DEBUG - test_long_name_host_interface_uniqueness (__main__.TestContainer.test_long_name_host_interface_uniqueness) ... ok
DEBUG - test_name_server (__main__.TestContainer.test_name_server) ... ok
DEBUG - test_network_mtu (__main__.TestContainer.test_network_mtu) ... ok
DEBUG - test_network_types (__main__.TestContainer.test_network_types) ... ok
DEBUG - test_network_vrf (__main__.TestContainer.test_network_vrf) ... ok
DEBUG - test_no_name_server (__main__.TestContainer.test_no_name_server) ... ok
DEBUG - test_uid_gid (__main__.TestContainer.test_uid_gid) ... ok
DEBUG - test_user_defined_mac (__main__.TestContainer.test_user_defined_mac) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 16 tests in 207.046s
DEBUG -
DEBUG - OK
DEBUG - SUCCESS! All 1 tests passed.
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
