### PR TITLE
firewall: T9716: Implement nftables concatenation support for firewall groups

### DIFF
--- a/data/templates/firewall/nftables-defines.j2
+++ b/data/templates/firewall/nftables-defines.j2
@@ -124,6 +124,9 @@
         typeof {{ group_conf.parameter | nft_flow_group_typeof('ipv4') }}
         flags interval
         counter
+{%                 if group_conf.description is vyos_defined %}
+        {{ group_conf.description | nft_flow_group_comment }}
+{%                 endif %}
 {%                 set fg_elements = group_conf | nft_flow_group_elements('ipv4') %}
 {%                 if fg_elements %}
         elements = { {{ fg_elements }} }
@@ -140,6 +143,9 @@
         typeof {{ group_conf.parameter | nft_flow_group_typeof('ipv6') }}
         flags interval
         counter
+{%                 if group_conf.description is vyos_defined %}
+        {{ group_conf.description | nft_flow_group_comment }}
+{%                 endif %}
 {%                 set fg_elements = group_conf | nft_flow_group_elements('ipv6') %}
 {%                 if fg_elements %}
         elements = { {{ fg_elements }} }

--- a/data/templates/firewall/nftables-defines.j2
+++ b/data/templates/firewall/nftables-defines.j2
@@ -117,6 +117,38 @@
 {%         endfor %}
 {%     endif %}
 
+{%     if group.ipv4_flow_group is vyos_defined and not is_ipv6 and is_l3 %}
+{%         for group_name, group_conf in group.ipv4_flow_group.items() %}
+{%             if group_conf.parameter is vyos_defined %}
+    set FG4_{{ group_name }} {
+        typeof {{ group_conf.parameter | nft_flow_group_typeof('ipv4') }}
+        flags interval
+        counter
+{%                 set fg_elements = group_conf | nft_flow_group_elements('ipv4') %}
+{%                 if fg_elements %}
+        elements = { {{ fg_elements }} }
+{%                 endif %}
+    }
+{%             endif %}
+{%         endfor %}
+{%     endif %}
+
+{%     if group.ipv6_flow_group is vyos_defined and is_ipv6 and is_l3 %}
+{%         for group_name, group_conf in group.ipv6_flow_group.items() %}
+{%             if group_conf.parameter is vyos_defined %}
+    set FG6_{{ group_name }} {
+        typeof {{ group_conf.parameter | nft_flow_group_typeof('ipv6') }}
+        flags interval
+        counter
+{%                 set fg_elements = group_conf | nft_flow_group_elements('ipv6') %}
+{%                 if fg_elements %}
+        elements = { {{ fg_elements }} }
+{%                 endif %}
+    }
+{%             endif %}
+{%         endfor %}
+{%     endif %}
+
 {%     if group.dynamic_group is vyos_defined %}
 {%         if group.dynamic_group.address_group is vyos_defined and not is_ipv6 and is_l3 %}
 {%             for group_name, group_conf in group.dynamic_group.address_group.items() %}

--- a/data/templates/firewall/nftables.j2
+++ b/data/templates/firewall/nftables.j2
@@ -35,6 +35,7 @@ delete table ip vyos_filter
 {% endif %}
 table ip vyos_filter {
 {% if ipv4 is vyos_defined %}
+{%     set ipv4_flow_groups = group.ipv4_flow_group if group is vyos_defined and group.ipv4_flow_group is vyos_defined else none %}
 {%     if flowtable is vyos_defined %}
 {%         for name, flowtable_conf in flowtable.items() %}
 {{ offload_tmpl.flowtable(name, flowtable_conf) }}
@@ -51,7 +52,7 @@ table ip vyos_filter {
 {%             endif %}
 {%             if conf.rule is vyos_defined %}
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
-        {{ rule_conf | nft_rule('FWD', prior, rule_id) }}
+        {{ rule_conf | nft_rule('FWD', prior, rule_id, flow_groups=ipv4_flow_groups) }}
 {%                     if rule_conf.recent is vyos_defined %}
 {%                         set ns.sets = ns.sets + ['FWD_' + prior + '_' + rule_id] %}
 {%                     endif %}
@@ -71,7 +72,7 @@ table ip vyos_filter {
 {%             endif %}
 {%             if conf.rule is vyos_defined %}
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
-        {{ rule_conf | nft_rule('INP',prior, rule_id) }}
+        {{ rule_conf | nft_rule('INP', prior, rule_id, flow_groups=ipv4_flow_groups) }}
 {%                     if rule_conf.recent is vyos_defined %}
 {%                         set ns.sets = ns.sets + ['INP_' + prior + '_' + rule_id] %}
 {%                     endif %}
@@ -91,7 +92,7 @@ table ip vyos_filter {
 {%             endif %}
 {%             if conf.rule is vyos_defined %}
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
-        {{ rule_conf | nft_rule('OUT', prior, rule_id) }}
+        {{ rule_conf | nft_rule('OUT', prior, rule_id, flow_groups=ipv4_flow_groups) }}
 {%                     if rule_conf.recent is vyos_defined %}
 {%                         set ns.sets = ns.sets + ['OUT_' + prior + '_' + rule_id] %}
 {%                     endif %}
@@ -108,7 +109,7 @@ table ip vyos_filter {
         type filter hook prerouting priority {{ prior }}; policy accept;
 {%             if conf.rule is vyos_defined %}
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
-        {{ rule_conf | nft_rule('PRE', prior, rule_id) }}
+        {{ rule_conf | nft_rule('PRE', prior, rule_id, flow_groups=ipv4_flow_groups) }}
 {%                     if rule_conf.recent is vyos_defined %}
 {%                         set ns.sets = ns.sets + ['PRE_' + prior + '_' + rule_id] %}
 {%                     endif %}
@@ -129,7 +130,7 @@ table ip vyos_filter {
     chain NAME_{{ name_text }} {
 {%             if conf.rule is vyos_defined %}
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
-        {{ rule_conf | nft_rule('NAM', name_text, rule_id) }}
+        {{ rule_conf | nft_rule('NAM', name_text, rule_id, flow_groups=ipv4_flow_groups) }}
 {%                     if rule_conf.recent is vyos_defined %}
 {%                         set ns.sets = ns.sets + ['NAM_' + name_text + '_' + rule_id] %}
 {%                     endif %}
@@ -223,6 +224,7 @@ delete table ip6 vyos_filter
 {% endif %}
 table ip6 vyos_filter {
 {% if ipv6 is vyos_defined %}
+{%     set ipv6_flow_groups = group.ipv6_flow_group if group is vyos_defined and group.ipv6_flow_group is vyos_defined else none %}
 {%     if flowtable is vyos_defined %}
 {%         for name, flowtable_conf in flowtable.items() %}
 {{ offload_tmpl.flowtable(name, flowtable_conf) }}
@@ -239,7 +241,7 @@ table ip6 vyos_filter {
 {%             endif %}
 {%             if conf.rule is vyos_defined %}
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
-        {{ rule_conf | nft_rule('FWD', prior, rule_id, 'ip6') }}
+        {{ rule_conf | nft_rule('FWD', prior, rule_id, 'ip6', flow_groups=ipv6_flow_groups) }}
 {%                     if rule_conf.recent is vyos_defined %}
 {%                         set ns.sets = ns.sets + ['FWD_' + prior + '_' + rule_id] %}
 {%                     endif %}
@@ -259,7 +261,7 @@ table ip6 vyos_filter {
 {%             endif %}
 {%             if conf.rule is vyos_defined %}
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
-        {{ rule_conf | nft_rule('INP', prior, rule_id, 'ip6') }}
+        {{ rule_conf | nft_rule('INP', prior, rule_id, 'ip6', flow_groups=ipv6_flow_groups) }}
 {%                     if rule_conf.recent is vyos_defined %}
 {%                         set ns.sets = ns.sets + ['INP_' + prior + '_' + rule_id] %}
 {%                     endif %}
@@ -279,7 +281,7 @@ table ip6 vyos_filter {
 {%             endif %}
 {%             if conf.rule is vyos_defined %}
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
-        {{ rule_conf | nft_rule('OUT', prior, rule_id, 'ip6') }}
+        {{ rule_conf | nft_rule('OUT', prior, rule_id, 'ip6', flow_groups=ipv6_flow_groups) }}
 {%                     if rule_conf.recent is vyos_defined %}
 {%                         set ns.sets = ns.sets + ['OUT_' + prior + '_' + rule_id] %}
 {%                     endif %}
@@ -296,7 +298,7 @@ table ip6 vyos_filter {
         type filter hook prerouting priority {{ prior }}; policy accept;
 {%             if conf.rule is vyos_defined %}
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
-        {{ rule_conf | nft_rule('PRE', prior, rule_id, 'ip6') }}
+        {{ rule_conf | nft_rule('PRE', prior, rule_id, 'ip6', flow_groups=ipv6_flow_groups) }}
 {%                     if rule_conf.recent is vyos_defined %}
 {%                         set ns.sets = ns.sets + ['PRE_' + prior + '_' + rule_id] %}
 {%                     endif %}
@@ -316,7 +318,7 @@ table ip6 vyos_filter {
     chain NAME6_{{ name_text }} {
 {%             if conf.rule is vyos_defined %}
 {%                 for rule_id, rule_conf in conf.rule.items() if rule_conf.disable is not vyos_defined %}
-        {{ rule_conf | nft_rule('NAM', name_text, rule_id, 'ip6') }}
+        {{ rule_conf | nft_rule('NAM', name_text, rule_id, 'ip6', flow_groups=ipv6_flow_groups) }}
 {%                     if rule_conf.recent is vyos_defined %}
 {%                         set ns.sets = ns.sets + ['NAM_' + name_text + '_' + rule_id] %}
 {%                     endif %}

--- a/interface-definitions/firewall.xml.in
+++ b/interface-definitions/firewall.xml.in
@@ -169,6 +169,8 @@
               #include <include/generic-description.xml.i>
             </children>
           </tagNode>
+          #include <include/firewall/ipv4-flow-group.xml.i>
+          #include <include/firewall/ipv6-flow-group.xml.i>
           <tagNode name="interface-group">
             <properties>
               <help>Firewall interface-group</help>

--- a/interface-definitions/include/firewall/common-rule-ipv4-raw.xml.i
+++ b/interface-definitions/include/firewall/common-rule-ipv4-raw.xml.i
@@ -3,6 +3,7 @@
 #include <include/firewall/action-and-notrack.xml.i>
 #include <include/generic-description.xml.i>
 #include <include/firewall/dscp.xml.i>
+#include <include/firewall/flow-group-ipv4.xml.i>
 #include <include/firewall/fragment.xml.i>
 #include <include/generic-disable-node.xml.i>
 #include <include/firewall/icmp.xml.i>

--- a/interface-definitions/include/firewall/common-rule-ipv4.xml.i
+++ b/interface-definitions/include/firewall/common-rule-ipv4.xml.i
@@ -1,6 +1,7 @@
 <!-- include start from firewall/common-rule-ipv4.xml.i -->
 #include <include/firewall/add-addr-to-group-ipv4.xml.i>
 #include <include/firewall/common-rule-inet.xml.i>
+#include <include/firewall/flow-group-ipv4.xml.i>
 #include <include/firewall/icmp.xml.i>
 #include <include/firewall/ttl.xml.i>
 <node name="destination">

--- a/interface-definitions/include/firewall/common-rule-ipv6-raw.xml.i
+++ b/interface-definitions/include/firewall/common-rule-ipv6-raw.xml.i
@@ -3,6 +3,7 @@
 #include <include/firewall/action-and-notrack.xml.i>
 #include <include/generic-description.xml.i>
 #include <include/firewall/dscp.xml.i>
+#include <include/firewall/flow-group-ipv6.xml.i>
 #include <include/firewall/fragment.xml.i>
 #include <include/generic-disable-node.xml.i>
 #include <include/firewall/icmpv6.xml.i>

--- a/interface-definitions/include/firewall/common-rule-ipv6.xml.i
+++ b/interface-definitions/include/firewall/common-rule-ipv6.xml.i
@@ -1,6 +1,7 @@
 <!-- include start from firewall/common-rule-ipv6.xml.i -->
 #include <include/firewall/add-addr-to-group-ipv6.xml.i>
 #include <include/firewall/common-rule-inet.xml.i>
+#include <include/firewall/flow-group-ipv6.xml.i>
 #include <include/firewall/hop-limit.xml.i>
 #include <include/firewall/icmpv6.xml.i>
 <node name="destination">

--- a/interface-definitions/include/firewall/flow-group-ipv4.xml.i
+++ b/interface-definitions/include/firewall/flow-group-ipv4.xml.i
@@ -1,0 +1,18 @@
+<!-- include start from firewall/flow-group-ipv4.xml.i -->
+<leafNode name="flow-group">
+  <properties>
+    <help>Match IPv4 flow-group (nftables concatenated set)</help>
+    <completionHelp>
+      <path>firewall group ipv4-flow-group</path>
+    </completionHelp>
+    <valueHelp>
+      <format>txt</format>
+      <description>Flow-group name</description>
+    </valueHelp>
+    <valueHelp>
+      <format>!txt</format>
+      <description>Inverted flow-group name</description>
+    </valueHelp>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/firewall/flow-group-ipv6.xml.i
+++ b/interface-definitions/include/firewall/flow-group-ipv6.xml.i
@@ -1,0 +1,18 @@
+<!-- include start from firewall/flow-group-ipv6.xml.i -->
+<leafNode name="flow-group">
+  <properties>
+    <help>Match IPv6 flow-group (nftables concatenated set)</help>
+    <completionHelp>
+      <path>firewall group ipv6-flow-group</path>
+    </completionHelp>
+    <valueHelp>
+      <format>txt</format>
+      <description>Flow-group name</description>
+    </valueHelp>
+    <valueHelp>
+      <format>!txt</format>
+      <description>Inverted flow-group name</description>
+    </valueHelp>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/firewall/ipv4-flow-group.xml.i
+++ b/interface-definitions/include/firewall/ipv4-flow-group.xml.i
@@ -1,0 +1,292 @@
+<!-- include start from firewall/ipv4-flow-group.xml.i -->
+<tagNode name="ipv4-flow-group">
+  <properties>
+    <help>Firewall IPv4 flow-group (nftables concatenated set)</help>
+    <constraint>
+      #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+    </constraint>
+    <constraintErrorMessage>Name of firewall group can only contain alphanumeric letters, hyphen, underscores and dot</constraintErrorMessage>
+  </properties>
+  <children>
+    #include <include/generic-description.xml.i>
+    <leafNode name="parameter">
+      <properties>
+        <help>Packet field included in the concatenated set key</help>
+        <completionHelp>
+          <list>inbound-interface outbound-interface ipv4-source-address ipv4-destination-address source-port destination-port protocol mark connection-mark dscp icmp-type icmp-code</list>
+        </completionHelp>
+        <valueHelp>
+          <format>inbound-interface</format>
+          <description>Inbound interface name</description>
+        </valueHelp>
+        <valueHelp>
+          <format>outbound-interface</format>
+          <description>Outbound interface name</description>
+        </valueHelp>
+        <valueHelp>
+          <format>ipv4-source-address</format>
+          <description>IPv4 source address</description>
+        </valueHelp>
+        <valueHelp>
+          <format>ipv4-destination-address</format>
+          <description>IPv4 destination address</description>
+        </valueHelp>
+        <valueHelp>
+          <format>source-port</format>
+          <description>Transport source port</description>
+        </valueHelp>
+        <valueHelp>
+          <format>destination-port</format>
+          <description>Transport destination port</description>
+        </valueHelp>
+        <valueHelp>
+          <format>protocol</format>
+          <description>IP protocol</description>
+        </valueHelp>
+        <valueHelp>
+          <format>mark</format>
+          <description>Packet mark</description>
+        </valueHelp>
+        <valueHelp>
+          <format>connection-mark</format>
+          <description>Connection mark</description>
+        </valueHelp>
+        <valueHelp>
+          <format>dscp</format>
+          <description>DSCP value</description>
+        </valueHelp>
+        <valueHelp>
+          <format>icmp-type</format>
+          <description>ICMP type</description>
+        </valueHelp>
+        <valueHelp>
+          <format>icmp-code</format>
+          <description>ICMP code</description>
+        </valueHelp>
+        <constraint>
+          <regex>(inbound-interface|outbound-interface|ipv4-source-address|ipv4-destination-address|source-port|destination-port|protocol|mark|connection-mark|dscp|icmp-type|icmp-code)</regex>
+        </constraint>
+        <multi/>
+      </properties>
+    </leafNode>
+    <tagNode name="match">
+      <properties>
+        <help>Concatenated set element (identifier is informational only)</help>
+        <constraint>
+          #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+        </constraint>
+        <constraintErrorMessage>Match name can only contain alphanumeric letters, hyphen, underscores and dot</constraintErrorMessage>
+      </properties>
+      <children>
+        #include <include/generic-description.xml.i>
+        #include <include/generic-disable-node.xml.i>
+        <leafNode name="inbound-interface">
+          <properties>
+            <help>Inbound interface name</help>
+            <completionHelp>
+              <script>${vyos_completion_dir}/list_interfaces</script>
+            </completionHelp>
+            <valueHelp>
+              <format>txt</format>
+              <description>Interface name</description>
+            </valueHelp>
+            <constraint>
+              #include <include/constraint/interface-name.xml.i>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="outbound-interface">
+          <properties>
+            <help>Outbound interface name</help>
+            <completionHelp>
+              <script>${vyos_completion_dir}/list_interfaces</script>
+            </completionHelp>
+            <valueHelp>
+              <format>txt</format>
+              <description>Interface name</description>
+            </valueHelp>
+            <constraint>
+              #include <include/constraint/interface-name.xml.i>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="ipv4-source-address">
+          <properties>
+            <help>IPv4 source address</help>
+            <valueHelp>
+              <format>ipv4</format>
+              <description>IPv4 address to match</description>
+            </valueHelp>
+            <valueHelp>
+              <format>ipv4net</format>
+              <description>IPv4 prefix to match</description>
+            </valueHelp>
+            <valueHelp>
+              <format>ipv4range</format>
+              <description>IPv4 range to match (e.g. 10.0.0.1-10.0.0.200)</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ipv4-address"/>
+              <validator name="ipv4-prefix"/>
+              <validator name="ipv4-range"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="ipv4-destination-address">
+          <properties>
+            <help>IPv4 destination address</help>
+            <valueHelp>
+              <format>ipv4</format>
+              <description>IPv4 address to match</description>
+            </valueHelp>
+            <valueHelp>
+              <format>ipv4net</format>
+              <description>IPv4 prefix to match</description>
+            </valueHelp>
+            <valueHelp>
+              <format>ipv4range</format>
+              <description>IPv4 range to match (e.g. 10.0.0.1-10.0.0.200)</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ipv4-address"/>
+              <validator name="ipv4-prefix"/>
+              <validator name="ipv4-range"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="source-port">
+          <properties>
+            <help>Transport source port</help>
+            <valueHelp>
+              <format>txt</format>
+              <description>Named port (any name in /etc/services, e.g., http)</description>
+            </valueHelp>
+            <valueHelp>
+              <format>u32:1-65535</format>
+              <description>Numbered port</description>
+            </valueHelp>
+            <valueHelp>
+              <format>start-end</format>
+              <description>Numbered port range (e.g. 1001-1050)</description>
+            </valueHelp>
+            <constraint>
+              <validator name="port-range"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="destination-port">
+          <properties>
+            <help>Transport destination port</help>
+            <valueHelp>
+              <format>txt</format>
+              <description>Named port (any name in /etc/services, e.g., http)</description>
+            </valueHelp>
+            <valueHelp>
+              <format>u32:1-65535</format>
+              <description>Numbered port</description>
+            </valueHelp>
+            <valueHelp>
+              <format>start-end</format>
+              <description>Numbered port range (e.g. 1001-1050)</description>
+            </valueHelp>
+            <constraint>
+              <validator name="port-range"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="protocol">
+          <properties>
+            <help>IP protocol</help>
+            <completionHelp>
+              <script>${vyos_completion_dir}/list_protocols.sh</script>
+            </completionHelp>
+            <valueHelp>
+              <format>u32:0-255</format>
+              <description>IP protocol number</description>
+            </valueHelp>
+            <valueHelp>
+              <format>&lt;protocol&gt;</format>
+              <description>IP protocol name</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ip-protocol"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="mark">
+          <properties>
+            <help>Packet mark</help>
+            <valueHelp>
+              <format>u32:0-2147483647</format>
+              <description>Firewall mark to match</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 0-2147483647"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="connection-mark">
+          <properties>
+            <help>Connection mark</help>
+            <valueHelp>
+              <format>u32:0-2147483647</format>
+              <description>Connection mark to match</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 0-2147483647"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="dscp">
+          <properties>
+            <help>DSCP value</help>
+            <valueHelp>
+              <format>u32:0-63</format>
+              <description>DSCP value to match</description>
+            </valueHelp>
+            <valueHelp>
+              <format>&lt;start-end&gt;</format>
+              <description>DSCP range to match</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--allow-range --range 0-63"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="icmp-type">
+          <properties>
+            <help>ICMP type</help>
+            <completionHelp>
+              <list>echo-reply destination-unreachable source-quench redirect echo-request router-advertisement router-solicitation time-exceeded parameter-problem timestamp-request timestamp-reply info-request info-reply address-mask-request address-mask-reply</list>
+            </completionHelp>
+            <valueHelp>
+              <format>u32:0-255</format>
+              <description>ICMP type number</description>
+            </valueHelp>
+            <valueHelp>
+              <format>txt</format>
+              <description>ICMP type name (e.g. echo-request)</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 0-255"/>
+              <regex>(echo-reply|destination-unreachable|source-quench|redirect|echo-request|router-advertisement|router-solicitation|time-exceeded|parameter-problem|timestamp-request|timestamp-reply|info-request|info-reply|address-mask-request|address-mask-reply)</regex>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="icmp-code">
+          <properties>
+            <help>ICMP code</help>
+            <valueHelp>
+              <format>u32:0-255</format>
+              <description>ICMP code (must be valid for the selected icmp-type)</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 0-255"/>
+            </constraint>
+          </properties>
+        </leafNode>
+      </children>
+    </tagNode>
+  </children>
+</tagNode>
+<!-- include end -->

--- a/interface-definitions/include/firewall/ipv6-flow-group.xml.i
+++ b/interface-definitions/include/firewall/ipv6-flow-group.xml.i
@@ -1,0 +1,292 @@
+<!-- include start from firewall/ipv6-flow-group.xml.i -->
+<tagNode name="ipv6-flow-group">
+  <properties>
+    <help>Firewall IPv6 flow-group (nftables concatenated set)</help>
+    <constraint>
+      #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+    </constraint>
+    <constraintErrorMessage>Name of firewall group can only contain alphanumeric letters, hyphen, underscores and dot</constraintErrorMessage>
+  </properties>
+  <children>
+    #include <include/generic-description.xml.i>
+    <leafNode name="parameter">
+      <properties>
+        <help>Packet field included in the concatenated set key</help>
+        <completionHelp>
+          <list>inbound-interface outbound-interface ipv6-source-address ipv6-destination-address source-port destination-port protocol mark connection-mark dscp icmpv6-type icmpv6-code</list>
+        </completionHelp>
+        <valueHelp>
+          <format>inbound-interface</format>
+          <description>Inbound interface name</description>
+        </valueHelp>
+        <valueHelp>
+          <format>outbound-interface</format>
+          <description>Outbound interface name</description>
+        </valueHelp>
+        <valueHelp>
+          <format>ipv6-source-address</format>
+          <description>IPv6 source address</description>
+        </valueHelp>
+        <valueHelp>
+          <format>ipv6-destination-address</format>
+          <description>IPv6 destination address</description>
+        </valueHelp>
+        <valueHelp>
+          <format>source-port</format>
+          <description>Transport source port</description>
+        </valueHelp>
+        <valueHelp>
+          <format>destination-port</format>
+          <description>Transport destination port</description>
+        </valueHelp>
+        <valueHelp>
+          <format>protocol</format>
+          <description>IP protocol</description>
+        </valueHelp>
+        <valueHelp>
+          <format>mark</format>
+          <description>Packet mark</description>
+        </valueHelp>
+        <valueHelp>
+          <format>connection-mark</format>
+          <description>Connection mark</description>
+        </valueHelp>
+        <valueHelp>
+          <format>dscp</format>
+          <description>DSCP value</description>
+        </valueHelp>
+        <valueHelp>
+          <format>icmpv6-type</format>
+          <description>ICMPv6 type</description>
+        </valueHelp>
+        <valueHelp>
+          <format>icmpv6-code</format>
+          <description>ICMPv6 code</description>
+        </valueHelp>
+        <constraint>
+          <regex>(inbound-interface|outbound-interface|ipv6-source-address|ipv6-destination-address|source-port|destination-port|protocol|mark|connection-mark|dscp|icmpv6-type|icmpv6-code)</regex>
+        </constraint>
+        <multi/>
+      </properties>
+    </leafNode>
+    <tagNode name="match">
+      <properties>
+        <help>Concatenated set element (identifier is informational only)</help>
+        <constraint>
+          #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+        </constraint>
+        <constraintErrorMessage>Match name can only contain alphanumeric letters, hyphen, underscores and dot</constraintErrorMessage>
+      </properties>
+      <children>
+        #include <include/generic-description.xml.i>
+        #include <include/generic-disable-node.xml.i>
+        <leafNode name="inbound-interface">
+          <properties>
+            <help>Inbound interface name</help>
+            <completionHelp>
+              <script>${vyos_completion_dir}/list_interfaces</script>
+            </completionHelp>
+            <valueHelp>
+              <format>txt</format>
+              <description>Interface name</description>
+            </valueHelp>
+            <constraint>
+              #include <include/constraint/interface-name.xml.i>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="outbound-interface">
+          <properties>
+            <help>Outbound interface name</help>
+            <completionHelp>
+              <script>${vyos_completion_dir}/list_interfaces</script>
+            </completionHelp>
+            <valueHelp>
+              <format>txt</format>
+              <description>Interface name</description>
+            </valueHelp>
+            <constraint>
+              #include <include/constraint/interface-name.xml.i>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="ipv6-source-address">
+          <properties>
+            <help>IPv6 source address</help>
+            <valueHelp>
+              <format>ipv6</format>
+              <description>IPv6 address to match</description>
+            </valueHelp>
+            <valueHelp>
+              <format>ipv6net</format>
+              <description>IPv6 prefix to match</description>
+            </valueHelp>
+            <valueHelp>
+              <format>ipv6range</format>
+              <description>IPv6 range to match (e.g. 2002::1-2002::ff)</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ipv6-address"/>
+              <validator name="ipv6-prefix"/>
+              <validator name="ipv6-range"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="ipv6-destination-address">
+          <properties>
+            <help>IPv6 destination address</help>
+            <valueHelp>
+              <format>ipv6</format>
+              <description>IPv6 address to match</description>
+            </valueHelp>
+            <valueHelp>
+              <format>ipv6net</format>
+              <description>IPv6 prefix to match</description>
+            </valueHelp>
+            <valueHelp>
+              <format>ipv6range</format>
+              <description>IPv6 range to match (e.g. 2002::1-2002::ff)</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ipv6-address"/>
+              <validator name="ipv6-prefix"/>
+              <validator name="ipv6-range"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="source-port">
+          <properties>
+            <help>Transport source port</help>
+            <valueHelp>
+              <format>txt</format>
+              <description>Named port (any name in /etc/services, e.g., http)</description>
+            </valueHelp>
+            <valueHelp>
+              <format>u32:1-65535</format>
+              <description>Numbered port</description>
+            </valueHelp>
+            <valueHelp>
+              <format>start-end</format>
+              <description>Numbered port range (e.g. 1001-1050)</description>
+            </valueHelp>
+            <constraint>
+              <validator name="port-range"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="destination-port">
+          <properties>
+            <help>Transport destination port</help>
+            <valueHelp>
+              <format>txt</format>
+              <description>Named port (any name in /etc/services, e.g., http)</description>
+            </valueHelp>
+            <valueHelp>
+              <format>u32:1-65535</format>
+              <description>Numbered port</description>
+            </valueHelp>
+            <valueHelp>
+              <format>start-end</format>
+              <description>Numbered port range (e.g. 1001-1050)</description>
+            </valueHelp>
+            <constraint>
+              <validator name="port-range"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="protocol">
+          <properties>
+            <help>IP protocol</help>
+            <completionHelp>
+              <script>${vyos_completion_dir}/list_protocols.sh</script>
+            </completionHelp>
+            <valueHelp>
+              <format>u32:0-255</format>
+              <description>IP protocol number</description>
+            </valueHelp>
+            <valueHelp>
+              <format>&lt;protocol&gt;</format>
+              <description>IP protocol name</description>
+            </valueHelp>
+            <constraint>
+              <validator name="ip-protocol"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="mark">
+          <properties>
+            <help>Packet mark</help>
+            <valueHelp>
+              <format>u32:0-2147483647</format>
+              <description>Firewall mark to match</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 0-2147483647"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="connection-mark">
+          <properties>
+            <help>Connection mark</help>
+            <valueHelp>
+              <format>u32:0-2147483647</format>
+              <description>Connection mark to match</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 0-2147483647"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="dscp">
+          <properties>
+            <help>DSCP value</help>
+            <valueHelp>
+              <format>u32:0-63</format>
+              <description>DSCP value to match</description>
+            </valueHelp>
+            <valueHelp>
+              <format>&lt;start-end&gt;</format>
+              <description>DSCP range to match</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--allow-range --range 0-63"/>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="icmpv6-type">
+          <properties>
+            <help>ICMPv6 type</help>
+            <completionHelp>
+              <list>destination-unreachable packet-too-big time-exceeded parameter-problem echo-request echo-reply mld-listener-query mld-listener-report mld-listener-done mld-listener-reduction nd-router-solicit nd-router-advert nd-neighbor-solicit nd-neighbor-advert nd-redirect router-renumbering ind-neighbor-solicit ind-neighbor-advert mld2-listener-report</list>
+            </completionHelp>
+            <valueHelp>
+              <format>u32:0-255</format>
+              <description>ICMPv6 type number</description>
+            </valueHelp>
+            <valueHelp>
+              <format>txt</format>
+              <description>ICMPv6 type name (e.g. echo-request)</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 0-255"/>
+              <regex>(destination-unreachable|packet-too-big|time-exceeded|parameter-problem|echo-request|echo-reply|mld-listener-query|mld-listener-report|mld-listener-done|mld-listener-reduction|nd-router-solicit|nd-router-advert|nd-neighbor-solicit|nd-neighbor-advert|nd-redirect|router-renumbering|ind-neighbor-solicit|ind-neighbor-advert|mld2-listener-report)</regex>
+            </constraint>
+          </properties>
+        </leafNode>
+        <leafNode name="icmpv6-code">
+          <properties>
+            <help>ICMPv6 code</help>
+            <valueHelp>
+              <format>u32:0-255</format>
+              <description>ICMPv6 code (must be valid for the selected icmpv6-type)</description>
+            </valueHelp>
+            <constraint>
+              <validator name="numeric" argument="--range 0-255"/>
+            </constraint>
+          </properties>
+        </leafNode>
+      </children>
+    </tagNode>
+  </children>
+</tagNode>
+<!-- include end -->

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -467,11 +467,26 @@ def flow_group_typeof(parameters, family):
     param_meta = FLOW_GROUP_PARAMS[family]
     return ' . '.join(param_meta[p]['expr'] for p in parameters)
 
+# nftables limits user comments to NFT_USERDATA_MAXLEN (128 bytes).
+# CLI descriptions allow up to 255 characters; truncate before emitting.
+NFT_COMMENT_MAX_LEN = 128
+
+def flow_group_nft_comment(text):
+    """Format a CLI description as an nftables ``comment "..."`` clause.
+
+    Descriptions are truncated to ``NFT_COMMENT_MAX_LEN`` to match the
+    nftables userdata limit, then quotes/backslashes are escaped.
+    """
+    truncated = str(text)[:NFT_COMMENT_MAX_LEN]
+    escaped = truncated.replace('\\', '\\\\').replace('"', '\\"')
+    return f'comment "{escaped}"'
+
 def flow_group_format_element(match_conf, parameters, family):
     """Format one match as an nftables concatenated set element.
 
     Values follow parameter order. ICMP types are rendered as symbolic names
-    when possible; interface names are quoted.
+    when possible; interface names are quoted. Match ``description`` becomes a
+    per-element comment when present.
     """
     param_meta = FLOW_GROUP_PARAMS[family]
     parts = []
@@ -486,7 +501,10 @@ def flow_group_format_element(match_conf, parameters, family):
         if param_meta[param].get('quote'):
             value = f'"{value}"'
         parts.append(str(value))
-    return ' . '.join(parts)
+    element = ' . '.join(parts)
+    if 'description' in match_conf:
+        element = f'{element} {flow_group_nft_comment(match_conf["description"])}'
+    return element
 
 def flow_group_elements(group_conf, family):
     """Build the comma-separated elements string for a flow-group set.

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -95,6 +95,416 @@ def find_nftables_rule(table, chain, rule_matches=[]):
 def remove_nftables_rule(table, chain, handle):
     cmdl(['nft', 'delete', 'rule', table, chain, 'handle', str(handle)], sudo=True)
 
+# Flow-group (nftables concatenations)
+#
+# Flow-groups map to concatenated nftables sets so related packet fields are
+# matched together (e.g. source address . destination port) rather than as
+# independent criteria.
+#
+# nftables limits concatenated set keys to NFT_DATA_VALUE_MAXLEN (64 bytes).
+# See: https://git.netfilter.org/nftables/tree/include/linux/netfilter/nf_tables.h
+#      (#define NFT_DATA_VALUE_MAXLEN 64)
+NFT_CONCAT_MAX_KEY_SIZE = 64
+
+# ICMP type numbers -> symbolic names from `nft describe icmp_type`
+ICMP_TYPE_NUM_TO_NAME = {
+    0: 'echo-reply',
+    3: 'destination-unreachable',
+    4: 'source-quench',
+    5: 'redirect',
+    8: 'echo-request',
+    9: 'router-advertisement',
+    10: 'router-solicitation',
+    11: 'time-exceeded',
+    12: 'parameter-problem',
+    13: 'timestamp-request',
+    14: 'timestamp-reply',
+    15: 'info-request',
+    16: 'info-reply',
+    17: 'address-mask-request',
+    18: 'address-mask-reply',
+}
+
+# ICMPv6 type numbers -> symbolic names from `nft describe icmpv6_type`
+# (132 has two aliases; prefer mld-listener-reduction to match existing CLI)
+ICMPV6_TYPE_NUM_TO_NAME = {
+    1: 'destination-unreachable',
+    2: 'packet-too-big',
+    3: 'time-exceeded',
+    4: 'parameter-problem',
+    128: 'echo-request',
+    129: 'echo-reply',
+    130: 'mld-listener-query',
+    131: 'mld-listener-report',
+    132: 'mld-listener-reduction',
+    133: 'nd-router-solicit',
+    134: 'nd-router-advert',
+    135: 'nd-neighbor-solicit',
+    136: 'nd-neighbor-advert',
+    137: 'nd-redirect',
+    138: 'router-renumbering',
+    141: 'ind-neighbor-solicit',
+    142: 'ind-neighbor-advert',
+    143: 'mld2-listener-report',
+}
+
+# Valid ICMP codes keyed by type name (IANA / RFC792+)
+ICMP_CODE_BY_TYPE = {
+    'echo-reply': {0},
+    'destination-unreachable': set(range(0, 16)),
+    'source-quench': {0},
+    'redirect': {0, 1, 2, 3},
+    'echo-request': {0},
+    'router-advertisement': {0},
+    'router-solicitation': {0},
+    'time-exceeded': {0, 1},
+    'parameter-problem': {0, 1, 2},
+    'timestamp-request': {0},
+    'timestamp-reply': {0},
+    'info-request': {0},
+    'info-reply': {0},
+    'address-mask-request': {0},
+    'address-mask-reply': {0},
+}
+
+# Valid ICMPv6 codes keyed by type name (IANA / RFC4443+)
+ICMPV6_CODE_BY_TYPE = {
+    'destination-unreachable': set(range(0, 10)),
+    'packet-too-big': {0},
+    'time-exceeded': {0, 1},
+    'parameter-problem': set(range(0, 11)),
+    'echo-request': {0},
+    'echo-reply': {0},
+    'mld-listener-query': {0},
+    'mld-listener-report': {0},
+    'mld-listener-done': {0},
+    'mld-listener-reduction': {0},
+    'nd-router-solicit': {0},
+    'nd-router-advert': {0},
+    'nd-neighbor-solicit': {0},
+    'nd-neighbor-advert': {0},
+    'nd-redirect': {0},
+    'router-renumbering': {0, 1, 255},
+    'ind-neighbor-solicit': {0},
+    'ind-neighbor-advert': {0},
+    'mld2-listener-report': {0},
+}
+
+def icmp_type_to_name(value, family='ipv4'):
+    """Resolve an ICMP/ICMPv6 type number or name to its symbolic name.
+
+    Numeric values are looked up in the ``nft describe`` type map. Symbolic
+    names are accepted as-is when they appear in the code-by-type map.
+
+    Args:
+        value: Type as configured (e.g. ``8`` or ``echo-request``).
+        family: ``ipv4`` for ICMP, ``ipv6`` for ICMPv6.
+
+    Returns:
+        The symbolic type name, or None if ``value`` is not a known type.
+    """
+    type_map = ICMP_TYPE_NUM_TO_NAME if family == 'ipv4' else ICMPV6_TYPE_NUM_TO_NAME
+    code_map = ICMP_CODE_BY_TYPE if family == 'ipv4' else ICMPV6_CODE_BY_TYPE
+    value = str(value)
+
+    if value.isdigit():
+        return type_map.get(int(value))
+
+    if value in code_map:
+        return value
+
+    return None
+
+def icmp_codes_for_type(type_name, family='ipv4'):
+    """Return the set of valid ICMP/ICMPv6 codes for a type name, or None."""
+    code_map = ICMP_CODE_BY_TYPE if family == 'ipv4' else ICMPV6_CODE_BY_TYPE
+    return code_map.get(type_name)
+
+# Maps CLI flow-group parameters to nftables match expressions and key sizes.
+# ``expr`` is used in typeof / rule matches; ``size`` feeds the 64-byte key check;
+# ``quote`` marks values that must be quoted in set elements (e.g. ifnames).
+FLOW_GROUP_PARAMS = {
+    'ipv4': {
+        'inbound-interface': {
+            'expr': 'iifname',
+            'size': 16,
+            'quote': True,
+        },
+        'outbound-interface': {
+            'expr': 'oifname',
+            'size': 16,
+            'quote': True,
+        },
+        'ipv4-source-address': {
+            'expr': 'ip saddr',
+            'size': 4,
+        },
+        'ipv4-destination-address': {
+            'expr': 'ip daddr',
+            'size': 4,
+        },
+        'source-port': {
+            'expr': 'th sport',
+            'size': 2,
+        },
+        'destination-port': {
+            'expr': 'th dport',
+            'size': 2,
+        },
+        'protocol': {
+            'expr': 'meta l4proto',
+            'size': 1,
+        },
+        'mark': {
+            'expr': 'meta mark',
+            'size': 4,
+        },
+        'connection-mark': {
+            'expr': 'ct mark',
+            'size': 4,
+        },
+        'dscp': {
+            'expr': 'ip dscp',
+            'size': 1,
+        },
+        'icmp-type': {
+            'expr': 'icmp type',
+            'size': 1,
+        },
+        'icmp-code': {
+            'expr': 'icmp code',
+            'size': 1,
+        },
+    },
+    'ipv6': {
+        'inbound-interface': {
+            'expr': 'iifname',
+            'size': 16,
+            'quote': True,
+        },
+        'outbound-interface': {
+            'expr': 'oifname',
+            'size': 16,
+            'quote': True,
+        },
+        'ipv6-source-address': {
+            'expr': 'ip6 saddr',
+            'size': 16,
+        },
+        'ipv6-destination-address': {
+            'expr': 'ip6 daddr',
+            'size': 16,
+        },
+        'source-port': {
+            'expr': 'th sport',
+            'size': 2,
+        },
+        'destination-port': {
+            'expr': 'th dport',
+            'size': 2,
+        },
+        'protocol': {
+            'expr': 'meta l4proto',
+            'size': 1,
+        },
+        'mark': {
+            'expr': 'meta mark',
+            'size': 4,
+        },
+        'connection-mark': {
+            'expr': 'ct mark',
+            'size': 4,
+        },
+        'dscp': {
+            'expr': 'ip6 dscp',
+            'size': 1,
+        },
+        'icmpv6-type': {
+            'expr': 'icmpv6 type',
+            'size': 1,
+        },
+        'icmpv6-code': {
+            'expr': 'icmpv6 code',
+            'size': 1,
+        },
+    },
+}
+
+def flow_group_parameters(group_conf):
+    """Return the flow-group parameter list from config.
+
+    A multi leaf with a single value may be stored as a bare string rather than
+    a list; normalize so callers always receive a list.
+    """
+    parameters = group_conf.get('parameter', [])
+    if isinstance(parameters, str):
+        return [parameters]
+    return list(parameters) if parameters else []
+
+def _rule_has_path(rule_conf, path):
+    """Return True if ``path`` exists under ``rule_conf`` (via dict_search_args)."""
+    return dict_search_args(rule_conf, *path) is not None
+
+def flow_group_rule_conflicts(rule_conf, parameters):
+    """Find rule options that duplicate a referenced flow-group's parameters.
+
+    A rule must not also configure criteria already matched by the flow-group
+    (e.g. ``source address`` when the group includes ``ipv4-source-address``).
+
+    Args:
+        rule_conf: Firewall rule config dict.
+        parameters: Flow-group parameter names (CLI form with hyphens).
+
+    Returns:
+        List of ``(parameter, rule_option)`` pairs for each conflict found.
+    """
+    address_sides = {
+        'source': [
+            (['source', 'address'], 'source address'),
+            (['source', 'fqdn'], 'source fqdn'),
+            (['source', 'geoip'], 'source geoip'),
+            (['source', 'group', 'address_group'], 'source group address-group'),
+            (['source', 'group', 'network_group'], 'source group network-group'),
+            (['source', 'group', 'domain_group'], 'source group domain-group'),
+            (['source', 'group', 'remote_group'], 'source group remote-group'),
+            (['source', 'group', 'dynamic_address_group'], 'source group dynamic-address-group'),
+        ],
+        'destination': [
+            (['destination', 'address'], 'destination address'),
+            (['destination', 'fqdn'], 'destination fqdn'),
+            (['destination', 'geoip'], 'destination geoip'),
+            (['destination', 'group', 'address_group'], 'destination group address-group'),
+            (['destination', 'group', 'network_group'], 'destination group network-group'),
+            (['destination', 'group', 'domain_group'], 'destination group domain-group'),
+            (['destination', 'group', 'remote_group'], 'destination group remote-group'),
+            (['destination', 'group', 'dynamic_address_group'], 'destination group dynamic-address-group'),
+        ],
+    }
+
+    # Map each flow-group parameter to rule config paths that conflict with it
+    checks = {
+        'inbound-interface': [
+            (['inbound_interface'], 'inbound-interface'),
+        ],
+        'outbound-interface': [
+            (['outbound_interface'], 'outbound-interface'),
+        ],
+        'ipv4-source-address': address_sides['source'],
+        'ipv6-source-address': address_sides['source'],
+        'ipv4-destination-address': address_sides['destination'],
+        'ipv6-destination-address': address_sides['destination'],
+        'source-port': [
+            (['source', 'port'], 'source port'),
+            (['source', 'group', 'port_group'], 'source group port-group'),
+        ],
+        'destination-port': [
+            (['destination', 'port'], 'destination port'),
+            (['destination', 'group', 'port_group'], 'destination group port-group'),
+        ],
+        'protocol': [
+            (['protocol'], 'protocol'),
+        ],
+        'mark': [
+            (['mark'], 'mark'),
+        ],
+        'connection-mark': [
+            (['connection_mark'], 'connection-mark'),
+        ],
+        'dscp': [
+            (['dscp'], 'dscp'),
+            (['dscp_exclude'], 'dscp-exclude'),
+        ],
+        'icmp-type': [
+            (['icmp'], 'icmp'),
+        ],
+        'icmp-code': [
+            (['icmp'], 'icmp'),
+        ],
+        'icmpv6-type': [
+            (['icmpv6'], 'icmpv6'),
+        ],
+        'icmpv6-code': [
+            (['icmpv6'], 'icmpv6'),
+        ],
+    }
+
+    conflicts = []
+    seen = set()
+    for param in parameters:
+        for path, option in checks.get(param, []):
+            if _rule_has_path(rule_conf, path):
+                key = (param, option)
+                if key not in seen:
+                    seen.add(key)
+                    conflicts.append(key)
+    return conflicts
+
+def flow_group_key_size(parameters, family):
+    """Calculate the concatenated nftables key size for a parameter list.
+
+    Args:
+        parameters: Flow-group parameter names in CLI order.
+        family: ``ipv4`` or ``ipv6``.
+
+    Returns:
+        ``(total_bytes, [(param, size_bytes), ...])`` for error reporting.
+    """
+    param_meta = FLOW_GROUP_PARAMS[family]
+    sizes = []
+    total = 0
+    for param in parameters:
+        size = param_meta[param]['size']
+        sizes.append((param, size))
+        total += size
+    return total, sizes
+
+def flow_group_typeof(parameters, family):
+    """Build an nftables ``typeof`` / match expression for the parameter list.
+
+    Example: ``['ipv4-source-address', 'destination-port']`` →
+    ``ip saddr . th dport``.
+    """
+    param_meta = FLOW_GROUP_PARAMS[family]
+    return ' . '.join(param_meta[p]['expr'] for p in parameters)
+
+def flow_group_format_element(match_conf, parameters, family):
+    """Format one match as an nftables concatenated set element.
+
+    Values follow parameter order. ICMP types are rendered as symbolic names
+    when possible; interface names are quoted.
+    """
+    param_meta = FLOW_GROUP_PARAMS[family]
+    parts = []
+    for param in parameters:
+        key = param.replace('-', '_')
+        value = match_conf[key]
+        if param in ('icmp-type', 'icmpv6-type'):
+            # Prefer symbolic names in nftables output
+            type_name = icmp_type_to_name(value, family)
+            if type_name:
+                value = type_name
+        if param_meta[param].get('quote'):
+            value = f'"{value}"'
+        parts.append(str(value))
+    return ' . '.join(parts)
+
+def flow_group_elements(group_conf, family):
+    """Build the comma-separated elements string for a flow-group set.
+
+    Disabled matches are omitted. Returns an empty string when there are no
+    enabled matches.
+    """
+    parameters = flow_group_parameters(group_conf)
+    matches = group_conf.get('match', {})
+    if not parameters or not matches:
+        return ''
+    elements = []
+    for match_conf in matches.values():
+        if 'disable' in match_conf:
+            continue
+        elements.append(flow_group_format_element(match_conf, parameters, family))
+    return ', '.join(elements)
+
 # Functions below used by template generation
 
 def nft_action(vyos_action):
@@ -102,7 +512,7 @@ def nft_action(vyos_action):
         return 'return'
     return vyos_action
 
-def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
+def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name, flow_groups=None):
     output = []
 
     if ip_name == 'ip6':
@@ -111,6 +521,14 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
     else:
         def_suffix = ''
         family = 'bri' if ip_name == 'bri' else 'ipv4'
+
+    if 'flow_group' in rule_conf and flow_groups:
+        # Attach the referenced flow-group config for this rule
+        group_name = rule_conf['flow_group']
+        if group_name[0] == '!':
+            group_name = group_name[1:]
+        if group_name in flow_groups:
+            rule_conf['_flow_group'] = flow_groups[group_name]
 
     if 'state' in rule_conf and rule_conf['state']:
         states = ",".join([s for s in rule_conf['state']])
@@ -150,6 +568,20 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
         if proto == 'tcp_udp':
             proto = '{tcp, udp}'
         output.append(f'meta l4proto {operator} {proto}')
+
+    if '_flow_group' in rule_conf:
+        group_name = rule_conf['flow_group']
+        operator = ''
+        if group_name[0] == '!':
+            operator = '!='
+            group_name = group_name[1:]
+        parameters = flow_group_parameters(rule_conf['_flow_group'])
+        expr = flow_group_typeof(parameters, family)
+        set_name = f'FG{"6" if family == "ipv6" else "4"}_{group_name}'
+        if operator:
+            output.append(f'{expr} {operator} @{set_name}')
+        else:
+            output.append(f'{expr} @{set_name}')
 
     if 'ethernet_type' in rule_conf:
         ether_type_mapping = {

--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -467,7 +467,7 @@ def flow_group_typeof(parameters, family):
     param_meta = FLOW_GROUP_PARAMS[family]
     return ' . '.join(param_meta[p]['expr'] for p in parameters)
 
-# nftables limits user comments to NFT_USERDATA_MAXLEN (128 bytes).
+# nftables limits user comments to NFT_USERDATA_MAXLEN (128 characters).
 # CLI descriptions allow up to 255 characters; truncate before emitting.
 NFT_COMMENT_MAX_LEN = 128
 

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -616,9 +616,9 @@ def nft_action(vyos_action):
     return vyos_action
 
 @register_filter('nft_rule')
-def nft_rule(rule_conf, fw_hook, fw_name, rule_id, ip_name='ip'):
+def nft_rule(rule_conf, fw_hook, fw_name, rule_id, ip_name='ip', flow_groups=None):
     from vyos.firewall import parse_rule
-    return parse_rule(rule_conf, fw_hook, fw_name, rule_id, ip_name)
+    return parse_rule(rule_conf, fw_hook, fw_name, rule_id, ip_name, flow_groups)
 
 @register_filter('nft_default_rule')
 def nft_default_rule(fw_conf, fw_name, family):
@@ -699,7 +699,20 @@ def nft_nested_group(out_list, includes, groups, key):
 
     for name in includes:
         add_includes(name)
+
     return out_list
+
+@register_filter('nft_flow_group_typeof')
+def nft_flow_group_typeof(parameters, family):
+    from vyos.firewall import flow_group_typeof
+    if isinstance(parameters, str):
+        parameters = [parameters]
+    return flow_group_typeof(parameters, family)
+
+@register_filter('nft_flow_group_elements')
+def nft_flow_group_elements(group_conf, family):
+    from vyos.firewall import flow_group_elements
+    return flow_group_elements(group_conf, family)
 
 @register_filter('nft_accept_invalid')
 def nft_accept_invalid(ether_type):

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -714,6 +714,11 @@ def nft_flow_group_elements(group_conf, family):
     from vyos.firewall import flow_group_elements
     return flow_group_elements(group_conf, family)
 
+@register_filter('nft_flow_group_comment')
+def nft_flow_group_comment(text):
+    from vyos.firewall import flow_group_nft_comment
+    return flow_group_nft_comment(text)
+
 @register_filter('nft_accept_invalid')
 def nft_accept_invalid(ether_type):
     ether_type_mapping = {

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -198,8 +198,10 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
     def test_flow_groups(self):
         # IPv4 flow-group: source address + destination port concatenation
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'WEB', 'description', 'web flows'])
         self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'WEB', 'parameter', 'ipv4-source-address'])
         self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'WEB', 'parameter', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'WEB', 'match', 'office', 'description', 'office https'])
         self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'WEB', 'match', 'office', 'ipv4-source-address', '192.0.2.10'])
         self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'WEB', 'match', 'office', 'destination-port', '443'])
         self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'WEB', 'match', 'guest', 'ipv4-source-address', '198.51.100.10'])
@@ -219,10 +221,15 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         self.cli_commit()
 
+        nftables_conf = read_file('/run/nftables.conf')
+        self.assertIn('comment "web flows"', nftables_conf)
+        self.assertIn('192.0.2.10 . 443 comment "office https"', nftables_conf)
+
         nftables_search_v4 = [
             ['set FG4_WEB'],
             ['typeof ip saddr . th dport'],
-            ['192.0.2.10 . 443'],
+            ['comment "web flows"'],
+            ['192.0.2.10 . 443', 'comment "office https"'],
             ['198.51.100.10 . 8443'],
             ['ip saddr . th dport @FG4_WEB', 'accept'],
         ]

--- a/smoketest/scripts/cli/test_firewall.py
+++ b/smoketest/scripts/cli/test_firewall.py
@@ -196,6 +196,134 @@ class TestFirewall(VyOSUnitTestSHIM.TestCase):
 
         self.verify_nftables(nftables_search, 'ip vyos_filter')
 
+    def test_flow_groups(self):
+        # IPv4 flow-group: source address + destination port concatenation
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'WEB', 'parameter', 'ipv4-source-address'])
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'WEB', 'parameter', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'WEB', 'match', 'office', 'ipv4-source-address', '192.0.2.10'])
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'WEB', 'match', 'office', 'destination-port', '443'])
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'WEB', 'match', 'guest', 'ipv4-source-address', '198.51.100.10'])
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'WEB', 'match', 'guest', 'destination-port', '8443'])
+
+        self.cli_set(['firewall', 'ipv4', 'forward', 'filter', 'rule', '10', 'action', 'accept'])
+        self.cli_set(['firewall', 'ipv4', 'forward', 'filter', 'rule', '10', 'flow-group', 'WEB'])
+
+        # IPv6 flow-group
+        self.cli_set(['firewall', 'group', 'ipv6-flow-group', 'WEB6', 'parameter', 'ipv6-source-address'])
+        self.cli_set(['firewall', 'group', 'ipv6-flow-group', 'WEB6', 'parameter', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-flow-group', 'WEB6', 'match', 'office', 'ipv6-source-address', '2001:db8::10'])
+        self.cli_set(['firewall', 'group', 'ipv6-flow-group', 'WEB6', 'match', 'office', 'destination-port', '443'])
+
+        self.cli_set(['firewall', 'ipv6', 'forward', 'filter', 'rule', '10', 'action', 'accept'])
+        self.cli_set(['firewall', 'ipv6', 'forward', 'filter', 'rule', '10', 'flow-group', 'WEB6'])
+
+        self.cli_commit()
+
+        nftables_search_v4 = [
+            ['set FG4_WEB'],
+            ['typeof ip saddr . th dport'],
+            ['192.0.2.10 . 443'],
+            ['198.51.100.10 . 8443'],
+            ['ip saddr . th dport @FG4_WEB', 'accept'],
+        ]
+        self.verify_nftables(nftables_search_v4, 'ip vyos_filter')
+
+        nftables_search_v6 = [
+            ['set FG6_WEB6'],
+            ['typeof ip6 saddr . th dport'],
+            ['2001:db8::10 . 443'],
+            ['ip6 saddr . th dport @FG6_WEB6', 'accept'],
+        ]
+        self.verify_nftables(nftables_search_v6, 'ip6 vyos_filter')
+
+        # DSCP + destination port
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'QOS', 'parameter', 'dscp'])
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'QOS', 'parameter', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'QOS', 'match', 'ef', 'dscp', '46'])
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'QOS', 'match', 'ef', 'destination-port', '5060'])
+        self.cli_set(['firewall', 'ipv4', 'forward', 'filter', 'rule', '15', 'action', 'accept'])
+        self.cli_set(['firewall', 'ipv4', 'forward', 'filter', 'rule', '15', 'flow-group', 'QOS'])
+        self.cli_commit()
+
+        self.assertIn('46 . 5060', read_file('/run/nftables.conf'))
+        nftables_qos = [
+            ['set FG4_QOS'],
+            ['typeof ip dscp . th dport'],
+            ['ip dscp . th dport @FG4_QOS', 'accept'],
+        ]
+        self.verify_nftables(nftables_qos, 'ip vyos_filter')
+
+        # Connection mark + destination port
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'CMARK', 'parameter', 'connection-mark'])
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'CMARK', 'parameter', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'CMARK', 'match', '1', 'connection-mark', '100'])
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'CMARK', 'match', '1', 'destination-port', '22'])
+        self.cli_set(['firewall', 'ipv4', 'forward', 'filter', 'rule', '16', 'action', 'accept'])
+        self.cli_set(['firewall', 'ipv4', 'forward', 'filter', 'rule', '16', 'flow-group', 'CMARK'])
+        self.cli_commit()
+
+        self.assertIn('100 . 22', read_file('/run/nftables.conf'))
+        nftables_cmark = [
+            ['set FG4_CMARK'],
+            ['typeof ct mark . th dport'],
+            ['ct mark . th dport @FG4_CMARK', 'accept'],
+        ]
+        self.verify_nftables(nftables_cmark, 'ip vyos_filter')
+
+        # Incomplete match must fail
+        self.cli_delete(['firewall', 'group', 'ipv4-flow-group', 'WEB', 'match', 'guest', 'destination-port'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'WEB', 'match', 'guest', 'destination-port', '8443'])
+
+        # Key size over 64 bytes must fail
+        self.cli_set(['firewall', 'group', 'ipv6-flow-group', 'TOO_BIG', 'parameter', 'inbound-interface'])
+        self.cli_set(['firewall', 'group', 'ipv6-flow-group', 'TOO_BIG', 'parameter', 'outbound-interface'])
+        self.cli_set(['firewall', 'group', 'ipv6-flow-group', 'TOO_BIG', 'parameter', 'ipv6-source-address'])
+        self.cli_set(['firewall', 'group', 'ipv6-flow-group', 'TOO_BIG', 'parameter', 'ipv6-destination-address'])
+        self.cli_set(['firewall', 'group', 'ipv6-flow-group', 'TOO_BIG', 'parameter', 'destination-port'])
+        self.cli_set(['firewall', 'group', 'ipv6-flow-group', 'TOO_BIG', 'match', '1', 'inbound-interface', 'eth0'])
+        self.cli_set(['firewall', 'group', 'ipv6-flow-group', 'TOO_BIG', 'match', '1', 'outbound-interface', 'eth1'])
+        self.cli_set(['firewall', 'group', 'ipv6-flow-group', 'TOO_BIG', 'match', '1', 'ipv6-source-address', '2001:db8::1'])
+        self.cli_set(['firewall', 'group', 'ipv6-flow-group', 'TOO_BIG', 'match', '1', 'ipv6-destination-address', '2001:db8::2'])
+        self.cli_set(['firewall', 'group', 'ipv6-flow-group', 'TOO_BIG', 'match', '1', 'destination-port', '80'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(['firewall', 'group', 'ipv6-flow-group', 'TOO_BIG'])
+
+        # ICMP type/code mapping: numeric type converted to name; invalid code rejected
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'ICMP', 'parameter', 'icmp-type'])
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'ICMP', 'parameter', 'icmp-code'])
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'ICMP', 'match', 'ping', 'icmp-type', '8'])
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'ICMP', 'match', 'ping', 'icmp-code', '0'])
+        self.cli_set(['firewall', 'ipv4', 'input', 'filter', 'rule', '20', 'action', 'accept'])
+        self.cli_set(['firewall', 'ipv4', 'input', 'filter', 'rule', '20', 'flow-group', 'ICMP'])
+        self.cli_commit()
+
+        # Generated ruleset uses the symbolic ICMP type name
+        self.assertIn('echo-request . 0', read_file('/run/nftables.conf'))
+
+        # Default nft list maps icmp code 0 -> net-unreachable; use -n for numerics
+        nftables_icmp = [
+            ['set FG4_ICMP'],
+            ['typeof icmp type . icmp code'],
+            ['8 . 0'],
+            ['icmp type . icmp code @FG4_ICMP', 'accept'],
+        ]
+        self.verify_nftables(nftables_icmp, 'ip vyos_filter', args='-n')
+
+        # code 3 is invalid for echo-request
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'ICMP', 'match', 'ping', 'icmp-code', '3'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_set(['firewall', 'group', 'ipv4-flow-group', 'ICMP', 'match', 'ping', 'icmp-code', '0'])
+
+        # Rule options must not overlap flow-group parameters
+        self.cli_set(['firewall', 'ipv4', 'forward', 'filter', 'rule', '10', 'source', 'address', '192.0.2.1'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(['firewall', 'ipv4', 'forward', 'filter', 'rule', '10', 'source'])
+
     def test_ipv4_basic_rules(self):
         name = 'smoketest'
         interface = 'eth0'

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -28,6 +28,12 @@ from vyos.configdep import set_dependents, call_dependents
 from vyos.configverify import verify_interface_exists
 from vyos.ethtool import Ethtool
 from vyos.firewall import fqdn_config_parse
+from vyos.firewall import flow_group_key_size
+from vyos.firewall import flow_group_parameters
+from vyos.firewall import flow_group_rule_conflicts
+from vyos.firewall import icmp_codes_for_type
+from vyos.firewall import icmp_type_to_name
+from vyos.firewall import NFT_CONCAT_MAX_KEY_SIZE
 from vyos.geoip import geoip_refresh, geoip_update
 from vyos.template import render
 from vyos.utils.convert import human_to_seconds
@@ -465,6 +471,30 @@ def verify_rule(firewall, family, hook, priority, rule_id, rule_conf):
                 if not group_obj:
                     Warning(f'{rule_num}interface-group "{group_name}" has no members!')
 
+    if 'flow_group' in rule_conf:
+        group_name = rule_conf['flow_group']
+        if group_name[0] == '!':
+            group_name = group_name[1:]
+
+        # Flow-groups are IPv4/IPv6 only (not available on bridge rules)
+        if family not in ['ipv4', 'ipv6']:
+            raise ConfigError('flow-group is only valid for IPv4 and IPv6 firewall rules')
+
+        group_type = f'{family}_flow_group'
+        error_group = group_type.replace('_', '-')
+        group_obj = dict_search_args(firewall, 'group', group_type, group_name)
+
+        # Referenced flow-group must exist
+        if group_obj is None:
+            raise ConfigError(f'Invalid {error_group} "{group_name}" on firewall rule')
+
+        # Rule must not repeat criteria already covered by the flow-group parameters
+        for param, option in flow_group_rule_conflicts(rule_conf, flow_group_parameters(group_obj)):
+            raise ConfigError(
+                f'Cannot use {error_group} "{group_name}" with rule {option}:\n'
+                f'parameter "{param}" is already matched by the flow-group'
+            )
+
 def verify_nested_group(group_name, group, groups, seen):
     if 'include' not in group:
         return
@@ -480,6 +510,99 @@ def verify_nested_group(group_name, group, groups, seen):
 
         if 'include' in groups[g]:
             verify_nested_group(g, groups[g], groups, seen)
+
+def verify_flow_group(group_name, group_conf, family):
+    error_prefix = f'{family}-flow-group "{group_name}"'
+
+    parameters = flow_group_parameters(group_conf)
+    # nftables concatenation requires at least two fields
+    if len(parameters) < 2:
+        raise ConfigError(f'{error_prefix} requires at least two parameters for concatenation')
+    # More than five parameters corrupts values when rendered into the set
+    if len(parameters) > 5:
+        raise ConfigError(f'{error_prefix} supports a maximum of 5 parameters')
+
+    # icmp-code is meaningless without the corresponding icmp-type in the key
+    if 'icmp-code' in parameters and 'icmp-type' not in parameters:
+        raise ConfigError(f'{error_prefix} parameter icmp-code requires icmp-type')
+    if 'icmpv6-code' in parameters and 'icmpv6-type' not in parameters:
+        raise ConfigError(f'{error_prefix} parameter icmpv6-code requires icmpv6-type')
+
+    # nftables rejects concatenated keys larger than NFT_DATA_VALUE_MAXLEN (64 bytes)
+    total, sizes = flow_group_key_size(parameters, family)
+    if total > NFT_CONCAT_MAX_KEY_SIZE:
+        detail = '\n'.join(f'  {name:<28} {size} bytes' for name, size in sizes)
+        raise ConfigError(
+            f'Flow group key size is {total} bytes (maximum {NFT_CONCAT_MAX_KEY_SIZE} bytes).\n'
+            f'\n'
+            f'Parameter sizes:\n'
+            f'{detail}'
+        )
+
+    # Every flow-group needs at least one match element
+    if 'match' not in group_conf or not group_conf['match']:
+        raise ConfigError(f'{error_prefix} requires at least one match')
+
+    for match_name, match_conf in group_conf['match'].items():
+        match_keys = {k for k in match_conf if k not in ('description', 'disable')}
+        expected = {p.replace('-', '_') for p in parameters}
+
+        # Each match must supply a value for every configured parameter
+        missing = expected - match_keys
+        if missing:
+            missing_cli = ', '.join(sorted(k.replace('_', '-') for k in missing))
+            raise ConfigError(
+                f'{error_prefix} match "{match_name}" is missing parameter value(s): {missing_cli}'
+            )
+
+        # Match must not define fields outside the group's parameter list
+        extra = match_keys - expected
+        if extra:
+            extra_cli = ', '.join(sorted(k.replace('_', '-') for k in extra))
+            raise ConfigError(
+                f'{error_prefix} match "{match_name}" has value(s) for unconfigured parameter(s): {extra_cli}'
+            )
+
+        for param in parameters:
+            key = param.replace('-', '_')
+            value = match_conf[key]
+            # "all" / "tcp_udp" are not valid inet_proto set members
+            if param == 'protocol' and value in ['all', 'tcp_udp']:
+                raise ConfigError(
+                    f'{error_prefix} match "{match_name}" protocol cannot be "{value}"'
+                )
+
+        # ICMP type may be numeric or symbolic; resolve to a known name
+        type_key = 'icmp_type' if family == 'ipv4' else 'icmpv6_type'
+        code_key = 'icmp_code' if family == 'ipv4' else 'icmpv6_code'
+        type_cli = type_key.replace('_', '-')
+        code_cli = code_key.replace('_', '-')
+
+        if type_key in match_conf:
+            type_name = icmp_type_to_name(match_conf[type_key], family)
+            if type_name is None:
+                raise ConfigError(
+                    f'{error_prefix} match "{match_name}" has invalid {type_cli} '
+                    f'"{match_conf[type_key]}"'
+                )
+
+            # ICMP code validity depends on the selected type
+            if code_key in match_conf:
+                try:
+                    code = int(match_conf[code_key])
+                except (TypeError, ValueError):
+                    raise ConfigError(
+                        f'{error_prefix} match "{match_name}" {code_cli} must be numeric'
+                    )
+
+                valid_codes = icmp_codes_for_type(type_name, family)
+                if valid_codes is None or code not in valid_codes:
+                    valid_str = ', '.join(str(c) for c in sorted(valid_codes or []))
+                    raise ConfigError(
+                        f'{error_prefix} match "{match_name}" {code_cli} {code} '
+                        f'is not valid for {type_cli} {type_name} '
+                        f'(valid codes: {valid_str})'
+                    )
 
 def verify_hardware_offload(ifname):
     ethtool = Ethtool(ifname)
@@ -553,6 +676,11 @@ def verify(firewall):
                             f'remote-group {group_name} interval must be '
                             'between 60 seconds and 4 weeks'
                         )
+
+        for family, group_type in [('ipv4', 'ipv4_flow_group'), ('ipv6', 'ipv6_flow_group')]:
+            if group_type in firewall['group']:
+                for group_name, group_conf in firewall['group'][group_type].items():
+                    verify_flow_group(group_name, group_conf, family)
 
     offload_chains_v4 = set()
     offload_chains_v6 = set()

--- a/src/conf_mode/firewall.py
+++ b/src/conf_mode/firewall.py
@@ -486,12 +486,12 @@ def verify_rule(firewall, family, hook, priority, rule_id, rule_conf):
 
         # Referenced flow-group must exist
         if group_obj is None:
-            raise ConfigError(f'Invalid {error_group} "{group_name}" on firewall rule')
+            raise ConfigError(f'{rule_num}Invalid {error_group} "{group_name}" on firewall rule')
 
         # Rule must not repeat criteria already covered by the flow-group parameters
         for param, option in flow_group_rule_conflicts(rule_conf, flow_group_parameters(group_obj)):
             raise ConfigError(
-                f'Cannot use {error_group} "{group_name}" with rule {option}:\n'
+                f'{rule_num}Cannot use {error_group} "{group_name}" with rule {option}:\n'
                 f'parameter "{param}" is already matched by the flow-group'
             )
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->

<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary

<!--- Provide a general summary of your changes in the Title above -->

Add support for nftables concatenated sets in firewall groups through new IPv4 and IPv6 flow groups.

Flow groups allow multiple packet fields to be combined into a single nftables set key, making it possible to match specific combinations of values rather than matching each field independently.

Supported flow-group parameters include addresses, ports, protocol, interfaces, DSCP, marks, and ICMP/ICMPv6 type and code fields.

### Parameter options:
```
vyos@vyos# set firewall group ipv4-flow-group test parameter
Possible completions:
   inbound-interface    Inbound interface name
   outbound-interface   Outbound interface name
   ipv4-source-address  IPv4 source address
   ipv4-destination-address
                        IPv4 destination address
   source-port          Transport source port
   destination-port     Transport destination port
   protocol             IP protocol
   mark                 Packet mark
   connection-mark      Connection mark
   dscp                 DSCP value
   icmp-type            ICMP type
   icmp-code            ICMP code
```
## Types of changes

<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Code style update (formatting, renaming)
* [ ] Refactoring (no functional changes)
* [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
* [ ] Other (please describe):

## Related Task(s)

<!-- optional: Link to related other tasks on Phabricator. -->

<!-- * https://vyos.dev/Txxxx -->

https://vyos.dev/T9176

## Related PR(s)

<!-- Link here any PRs in other repositories that are required by this PR -->

None.

## How to test / Smoketest result

<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

### Configure a flow-group:
```text
set firewall group ipv4-flow-group test parameter 'ipv4-source-address'
set firewall group ipv4-flow-group test parameter 'ipv4-destination-address'
set firewall group ipv4-flow-group test parameter 'destination-port'
set firewall group ipv4-flow-group test parameter 'protocol'
set firewall group ipv4-flow-group test match SSH destination-port '22'
set firewall group ipv4-flow-group test match SSH ipv4-destination-address '10.0.101.83'
set firewall group ipv4-flow-group test match SSH ipv4-source-address '192.168.2.21'
set firewall group ipv4-flow-group test match SSH protocol 'tcp'
```
### Apply to a rule:
```text
set firewall ipv4 input filter rule 10 action 'accept'
set firewall ipv4 input filter rule 10 flow-group 'test'
```
### Verify inside of nftables:
```
table ip vyos_filter {
        set FG4_test {
                typeof ip saddr . ip daddr . th dport . meta l4proto
                flags interval
                counter
                elements = { 192.168.2.21 . 10.0.101.83 . 22 . tcp counter packets 154 bytes 10960 }
        }

        chain VYOS_INPUT_filter {
                type filter hook input priority filter; policy accept;
                ip saddr . ip daddr . th dport . meta l4proto @FG4_test counter packets 154 bytes 10960 accept comment "ipv4-INP-filter-10"
                counter packets 3 bytes 228 accept comment "INP-filter default-action accept"
        }
```
### Smoketest results:
```text
test_bridge_firewall (__main__.TestFirewall.test_bridge_firewall) ... ok
test_cyclic_jump_validation (__main__.TestFirewall.test_cyclic_jump_validation) ... ok
test_disable_conntrack_per_chain (__main__.TestFirewall.test_disable_conntrack_per_chain) ... ok
test_flow_groups (__main__.TestFirewall.test_flow_groups) ... ok
test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
test_geoip (__main__.TestFirewall.test_geoip) ... ok
test_gre_match (__main__.TestFirewall.test_gre_match) ... ok
test_groups (__main__.TestFirewall.test_groups) ... ok
test_ipsec_metadata_match (__main__.TestFirewall.test_ipsec_metadata_match) ... ok
test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
test_ipv4_dynamic_groups (__main__.TestFirewall.test_ipv4_dynamic_groups) ... ok
test_ipv4_global_state (__main__.TestFirewall.test_ipv4_global_state) ... ok
test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
test_ipv4_remote_group (__main__.TestFirewall.test_ipv4_remote_group) ... ok
test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... ok
test_ipv4_time_weekdays (__main__.TestFirewall.test_ipv4_time_weekdays) ... ok
test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
test_ipv6_dynamic_groups (__main__.TestFirewall.test_ipv6_dynamic_groups) ... ok
test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
test_ipv6_remote_group (__main__.TestFirewall.test_ipv6_remote_group) ... ok
test_ipv6_time_weekdays (__main__.TestFirewall.test_ipv6_time_weekdays) ... ok
test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
test_remote_group (__main__.TestFirewall.test_remote_group) ... ok
test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
test_timeout_sysctl (__main__.TestFirewall.test_timeout_sysctl) ... ok
test_wildcard_interfaces (__main__.TestFirewall.test_wildcard_interfaces) ... ok
test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... ok
test_zone_with_default_firewall (__main__.TestFirewall.test_zone_with_default_firewall) ... ok
test_zone_with_vrf (__main__.TestFirewall.test_zone_with_vrf) ... ok
test_zone_without_member (__main__.TestFirewall.test_zone_without_member) ... ok

----------------------------------------------------------------------
Ran 35 tests in 95.192s

OK
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->

* [x] I have read the [**[CONTRIBUTING](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md)**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
* [x] I have linked this PR to one or more Phabricator Task(s)
* [x] I have run the components [**[SMOKETESTS](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli)**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
* [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
* [x] My commit headlines contain a valid Task id
* [x] My change requires a change to the documentation
* [ ] I have updated the documentation accordingly