### PR TITLE
container: T9184: add chown capability

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -31,7 +31,7 @@
             <properties>
               <help>Grant individual Linux capability to container instance</help>
               <completionHelp>
-                <list>net-admin net-bind-service net-raw mknod setpcap sys-admin sys-module sys-nice sys-time</list>
+                <list>net-admin net-bind-service net-raw chown mknod setpcap sys-admin sys-module sys-nice sys-time</list>
               </completionHelp>
               <valueHelp>
                 <format>net-admin</format>
@@ -44,6 +44,10 @@
               <valueHelp>
                 <format>net-raw</format>
                 <description>Permission to create raw network sockets</description>
+              </valueHelp>
+              <valueHelp>
+                <format>chown</format>
+                <description>Permission to set file UIDs and GIDs</description>
               </valueHelp>
               <valueHelp>
                 <format>mknod</format>
@@ -70,7 +74,7 @@
                 <description>Permission to set system clock</description>
               </valueHelp>
               <constraint>
-                <regex>(net-admin|net-bind-service|net-raw|mknod|setpcap|sys-admin|sys-module|sys-nice|sys-time)</regex>
+                <regex>(net-admin|net-bind-service|net-raw|chown|mknod|setpcap|sys-admin|sys-module|sys-nice|sys-time)</regex>
               </constraint>
               <multi/>
             </properties>


### PR DESCRIPTION
## Change summary
Add chown to list of possible container capabilities (needed by Pi-hole for example).

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T9184

## Related PR(s)


## How to test / Smoketest result


## Checklist:
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [X] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [X] My commit headlines contain a valid Task id
- [X] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
