### PR TITLE
pki: T9135: derive ACME certificate chains from disk

### DIFF
--- a/op-mode-definitions/pki.xml.in
+++ b/op-mode-definitions/pki.xml.in
@@ -521,6 +521,12 @@
                   </leafNode>
                 </children>
               </node>
+              <leafNode name="text">
+                <properties>
+                  <help>Show x509 CA certificate in human-readable text format</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/pki.py show_certificate_authority --name "$4" --text</command>
+              </leafNode>
             </children>
           </tagNode>
           <tagNode name="certificate">
@@ -550,6 +556,12 @@
                   </leafNode>
                 </children>
               </node>
+              <leafNode name="text">
+                <properties>
+                  <help>Show x509 certificate in human-readable text format</help>
+                </properties>
+                <command>${vyos_op_scripts_dir}/pki.py show_certificate --name "$4" --text</command>
+              </leafNode>
               <tagNode name="fingerprint">
                 <properties>
                   <help>Show x509 certificate fingerprint</help>

--- a/op-mode-definitions/pki.xml.in
+++ b/op-mode-definitions/pki.xml.in
@@ -364,6 +364,7 @@
               <help>Import CA certificate into PKI</help>
               <completionHelp>
                 <list>&lt;name&gt;</list>
+                <path>pki ca</path>
               </completionHelp>
             </properties>
             <children>
@@ -386,6 +387,7 @@
               <help>Import certificate into PKI</help>
               <completionHelp>
                 <list>&lt;name&gt;</list>
+                <path>pki certificate</path>
               </completionHelp>
             </properties>
             <children>

--- a/op-mode-definitions/pki.xml.in
+++ b/op-mode-definitions/pki.xml.in
@@ -369,7 +369,7 @@
             <children>
               <tagNode name="file">
                 <properties>
-                  <help>Path to CA certificate file</help>
+                  <help>Path or URL to CA certificate file</help>
                 </properties>
                 <command>${vyos_op_scripts_dir}/pki.py import_pki --pki-type ca --name "$4" --filename "$6"</command>
               </tagNode>

--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -360,7 +360,6 @@ class Config(object):
             if pki_dict:
                 if 'certificate' in pki_dict:
                     from vyos.defaults import directories
-                    from vyos.pki import AUTOCHAIN_PREFIX
                     from vyos.pki import acme_chain_ca_entry
                     from vyos.pki import acme_chain_redundant
                     vyos_certbot_dir = directories['certbot']
@@ -385,10 +384,9 @@ class Config(object):
                         leaf_cert = cert_conf.get('certificate')
                         if leaf_cert and 'acme' in cert_conf and not acme_chain_redundant(
                                 leaf_cert, real_ca_certs):
-                            chain_entry = acme_chain_ca_entry(vyos_certbot_dir, certificate)
-                            if chain_entry:
-                                ca_dict = pki_dict.setdefault('ca', {})
-                                autochain_name = f'{AUTOCHAIN_PREFIX}{certificate}'
+                            ca_dict = pki_dict.setdefault('ca', {})
+                            for autochain_name, chain_entry in acme_chain_ca_entry(
+                                    vyos_certbot_dir, certificate).items():
                                 # A real, manually-configured CLI CA object
                                 # with this name wins over the synthetic one
                                 if autochain_name not in ca_dict:

--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -359,9 +359,39 @@ class Config(object):
                                             get_first_key=True)
             if pki_dict:
                 if 'certificate' in pki_dict:
+                    from vyos.defaults import directories
+                    from vyos.pki import AUTOCHAIN_PREFIX
+                    from vyos.pki import acme_chain_ca_entry
+                    from vyos.pki import acme_chain_redundant
+                    vyos_certbot_dir = directories['certbot']
+                    # Snapshot of explicitly/manually configured CAs, taken
+                    # before any synthetic entries are added below
+                    real_ca_certs = dict(pki_dict.get('ca', {}))
+
                     for certificate in pki_dict['certificate']:
                         pki_dict['certificate'][certificate] = config_dict_mangle_acme(
                             certificate, pki_dict['certificate'][certificate])
+
+                        # If this is an ACME certificate, also make its
+                        # intermediate CA chain (read live from certbot's
+                        # own chain.pem, never persisted to the CLI)
+                        # available under pki.ca, the same way consumers
+                        # already look up any manually-configured CA, so
+                        # find_chain() can build the full chain for them -
+                        # unless an explicit, manually-configured CA
+                        # already completes the chain, making this
+                        # redundant.
+                        cert_conf = pki_dict['certificate'][certificate]
+                        if 'acme' in cert_conf and not acme_chain_redundant(
+                                cert_conf['certificate'], real_ca_certs):
+                            chain_entry = acme_chain_ca_entry(vyos_certbot_dir, certificate)
+                            if chain_entry:
+                                ca_dict = pki_dict.setdefault('ca', {})
+                                autochain_name = f'{AUTOCHAIN_PREFIX}{certificate}'
+                                # A real, manually-configured CLI CA object
+                                # with this name wins over the synthetic one
+                                if autochain_name not in ca_dict:
+                                    ca_dict[autochain_name] = chain_entry
 
                 conf_dict['pki'] = pki_dict
 

--- a/python/vyos/config.py
+++ b/python/vyos/config.py
@@ -382,8 +382,9 @@ class Config(object):
                         # already completes the chain, making this
                         # redundant.
                         cert_conf = pki_dict['certificate'][certificate]
-                        if 'acme' in cert_conf and not acme_chain_redundant(
-                                cert_conf['certificate'], real_ca_certs):
+                        leaf_cert = cert_conf.get('certificate')
+                        if leaf_cert and 'acme' in cert_conf and not acme_chain_redundant(
+                                leaf_cert, real_ca_certs):
                             chain_entry = acme_chain_ca_entry(vyos_certbot_dir, certificate)
                             if chain_entry:
                                 ca_dict = pki_dict.setdefault('ca', {})

--- a/python/vyos/pki.py
+++ b/python/vyos/pki.py
@@ -482,25 +482,42 @@ def find_chain(cert, ca_certs):
 # without it ever being a real, settable, or deletable CLI object.
 AUTOCHAIN_PREFIX = 'AUTOCHAIN_'
 
-def acme_chain_ca_entry(vyos_certbot_dir: str, cert_name: str) -> dict | None:
-    """Build a synthetic 'pki ca <name>'-shaped dict entry
-    (`{'certificate': <base64>}`) for an ACME certificate's intermediate
-    CA chain, read live from certbot's own chain.pem.
+def acme_chain_ca_entry(vyos_certbot_dir: str, cert_name: str) -> dict:
+    """Build synthetic 'pki ca <name>'-shaped dict entries
+    (`{<name>: {'certificate': <base64>}, ...}`) for every certificate in
+    an ACME certificate's chain, read live from certbot's own chain.pem.
 
-    Returns None if chain.pem is not (yet) present - e.g. the certificate
-    has not been issued yet, or a prior request failed - so callers can
-    skip this certificate's chain gracefully instead of crashing.
+    certbot commonly writes more than just the immediate intermediate to
+    chain.pem (e.g. the intermediate's own issuing root too), and every
+    one of them is needed for find_chain() to walk the full chain - a
+    single 'pki ca' object only ever holds one certificate, so each one
+    gets its own synthetic entry here.
+
+    Returns an empty dict if chain.pem is not (yet) present - e.g. the
+    certificate has not been issued yet, or a prior request failed - so
+    callers can skip this certificate's chain gracefully instead of
+    crashing.
     """
+    import re
     from vyos.utils.file import read_file
     tmp = read_file(f'{vyos_certbot_dir}/live/{cert_name}/chain.pem',
                      defaultonfailure=None)
     if tmp is None:
-        return None
-    tmp = load_certificate(tmp, wrap_tags=False)
-    if not tmp:
-        return None
-    chain_base64 = "".join(encode_certificate(tmp).strip().split("\n")[1:-1])
-    return {'certificate': chain_base64}
+        return {}
+
+    entries = {}
+    for block in re.findall(
+            r'-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----',
+            tmp, re.DOTALL):
+        cert = load_certificate(block, wrap_tags=False)
+        if not cert:
+            continue
+        index = len(entries) + 1
+        name = f'{AUTOCHAIN_PREFIX}{cert_name}' if index == 1 else \
+               f'{AUTOCHAIN_PREFIX}{cert_name}_{index}'
+        chain_base64 = "".join(encode_certificate(cert).strip().split("\n")[1:-1])
+        entries[name] = {'certificate': chain_base64}
+    return entries
 
 def acme_chain_redundant(leaf_cert_base64: str, ca_certs: dict) -> bool:
     """Return True if one of the already-configured CAs in ca_certs (a

--- a/python/vyos/pki.py
+++ b/python/vyos/pki.py
@@ -470,6 +470,55 @@ def find_chain(cert, ca_certs):
 
     return chain
 
+# ACME certificates are managed entirely by certbot under
+# {vyos_certbot_dir}/live/<cert_name>/ - the intermediate CA certbot
+# obtained alongside the leaf cert (chain.pem) is derived data, not
+# configuration, so it is never written to the CLI. AUTOCHAIN_<cert_name>
+# is only ever used as an in-memory dict key (see
+# Config.get_config_dict()'s with_pki handling and
+# src/op_mode/pki.py's get_config_ca_certificate()) so consumers that
+# build a full certificate chain via find_chain() - and "show pki ca" -
+# see the same data they would if it had been manually configured,
+# without it ever being a real, settable, or deletable CLI object.
+AUTOCHAIN_PREFIX = 'AUTOCHAIN_'
+
+def acme_chain_ca_entry(vyos_certbot_dir: str, cert_name: str) -> dict | None:
+    """Build a synthetic 'pki ca <name>'-shaped dict entry
+    (`{'certificate': <base64>}`) for an ACME certificate's intermediate
+    CA chain, read live from certbot's own chain.pem.
+
+    Returns None if chain.pem is not (yet) present - e.g. the certificate
+    has not been issued yet, or a prior request failed - so callers can
+    skip this certificate's chain gracefully instead of crashing.
+    """
+    from vyos.utils.file import read_file
+    tmp = read_file(f'{vyos_certbot_dir}/live/{cert_name}/chain.pem',
+                     defaultonfailure=None)
+    if tmp is None:
+        return None
+    tmp = load_certificate(tmp, wrap_tags=False)
+    if not tmp:
+        return None
+    chain_base64 = "".join(encode_certificate(tmp).strip().split("\n")[1:-1])
+    return {'certificate': chain_base64}
+
+def acme_chain_redundant(leaf_cert_base64: str, ca_certs: dict) -> bool:
+    """Return True if one of the already-configured CAs in ca_certs (a
+    'pki ca'-shaped dict, e.g. Config's pki_dict['ca']) directly signs the
+    given leaf certificate - meaning an explicit, manually-configured CA
+    already completes the chain, so synthesizing/showing an
+    AUTOCHAIN_<cert_name> entry (see acme_chain_ca_entry()) is redundant.
+    """
+    leaf_cert = load_certificate(leaf_cert_base64)
+    if not leaf_cert:
+        return False
+    loaded_ca_certs = [
+        load_certificate(ca['certificate'])
+        for ca in ca_certs.values() if 'certificate' in ca
+    ]
+    loaded_ca_certs = [cert for cert in loaded_ca_certs if cert]
+    return find_parent(leaf_cert, loaded_ca_certs) is not None
+
 def sort_ca_chain(ca_names, pki_node):
     def ca_cmp(ca_name1, ca_name2, pki_node):
         cert1 = load_certificate(pki_node[ca_name1]['certificate'])

--- a/python/vyos/utils/file.py
+++ b/python/vyos/utils/file.py
@@ -31,10 +31,13 @@ def file_is_persistent(path):
     absolute = os.path.abspath(os.path.dirname(path))
     return re.match(location,absolute)
 
-def read_file(fname, defaultonfailure=None, sudo=False):
+_unset = object()
+
+def read_file(fname, defaultonfailure=_unset, sudo=False):
     """
     read the content of a file, stripping any end characters (space, newlines)
-    should defaultonfailure be not None, it is returned on failure to read
+    should defaultonfailure be given (including None), it is returned on
+    failure to read instead of raising
     """
     try:
         # Some files can only be read by root - emulate sudo cat call
@@ -47,7 +50,7 @@ def read_file(fname, defaultonfailure=None, sudo=False):
                 data = f.read()
         return data.strip()
     except Exception as e:
-        if defaultonfailure is not None:
+        if defaultonfailure is not _unset:
             return defaultonfailure
         raise e
 

--- a/smoketest/scripts/cli/test_pki.py
+++ b/smoketest/scripts/cli/test_pki.py
@@ -158,6 +158,7 @@ class TestPKI(VyOSUnitTestSHIM.TestCase):
         # ensure we can also run this test on a live system - so lets clean
         # out the current configuration :)
         cls.cli_delete(cls, base_path)
+        cls.cli_delete(cls, ['load-balancing', 'haproxy'])
         cls.cli_delete(cls, ['service', 'https'])
 
     def tearDown(self):

--- a/src/conf_mode/pki.py
+++ b/src/conf_mode/pki.py
@@ -19,7 +19,6 @@ import os
 from sys import argv
 from sys import exit
 
-from vyos.base import Message
 from vyos.config import Config
 from vyos.config import config_dict_merge
 from vyos.configdep import set_dependents
@@ -31,6 +30,7 @@ from vyos.defaults import directories
 from vyos.defaults import internal_ports
 from vyos.defaults import systemd_services
 from vyos.pki import encode_certificate
+from vyos.pki import find_chain
 from vyos.pki import is_ca_certificate
 from vyos.pki import load_certificate
 from vyos.pki import load_public_key
@@ -40,7 +40,6 @@ from vyos.pki import load_private_key
 from vyos.pki import load_crl
 from vyos.pki import load_dh_parameters
 from vyos.utils.boot import boot_configuration_complete
-from vyos.utils.configfs import add_cli_node
 from vyos.utils.dict import dict_search
 from vyos.utils.dict import dict_search_args
 from vyos.utils.dict import dict_search_recursive
@@ -120,12 +119,85 @@ sync_translate = {
     'key': 'openssh',
 }
 
+def dispatch_dependents_for_reference(pki_system, search, key, item_name, conf, D):
+    """If item_name is referenced under key somewhere below search['path']
+    in the full system config, register that service (search['path'][1])
+    as a dependent to be regenerated/reloaded via call_dependents().
+    """
+    search_dict = dict_search_args(pki_system, *search['path'])
+    if not search_dict:
+        return
+    for found_name, found_path in dict_search_recursive(search_dict, key):
+        if isinstance(found_name, list) and item_name not in found_name:
+            continue
+        if isinstance(found_name, str) and found_name != item_name:
+            continue
+
+        # prefer orig_path over path when unmangling is needed
+        path = search.get('orig_path', search.get('path'))
+        if path[0] == 'interfaces':
+            ifname = found_path[0]
+            if not D.node_changed_presence(path + [ifname]):
+                set_dependents(path[1], conf, ifname)
+        else:
+            if not D.node_changed_presence(path):
+                set_dependents(path[1], conf)
+
 def certbot_delete(certificate):
     if not boot_configuration_complete():
         return
     if os.path.exists(f'{vyos_certbot_dir}/renewal/{certificate}.conf'):
         cmdl(['certbot', 'delete', '--non-interactive', '--config-dir',
               vyos_certbot_dir, '--cert-name', certificate])
+
+def certbot_backup_path(name: str) -> str:
+    return f'{vyos_certbot_dir}/.vyos-backup/{name}'
+
+def certbot_backup(name: str) -> None:
+    """Move a certificate's live/archive/renewal-config files aside rather
+    than deleting them outright, so certbot_restore()/certbot_discard_backup()
+    can put them back (or drop them) once the caller knows whether the
+    replacement certbot_request() actually succeeded.
+
+    Without this, certbot_delete() followed by a failed certbot_request()
+    (a rate limit, a transient ACME/network issue) leaves the certificate
+    missing entirely, with no way back short of a fresh, successful ACME
+    issuance.
+    """
+    import shutil
+    backup = certbot_backup_path(name)
+    if os.path.exists(backup):
+        shutil.rmtree(backup)
+    os.makedirs(backup)
+    for sub in ('live', 'archive'):
+        src = f'{vyos_certbot_dir}/{sub}/{name}'
+        if os.path.exists(src):
+            shutil.move(src, f'{backup}/{sub}')
+    renewal_conf = f'{vyos_certbot_dir}/renewal/{name}.conf'
+    if os.path.exists(renewal_conf):
+        shutil.move(renewal_conf, f'{backup}/renewal.conf')
+
+def certbot_restore(name: str) -> None:
+    """Restore a backup made by certbot_backup(), if one exists."""
+    import shutil
+    backup = certbot_backup_path(name)
+    if not os.path.isdir(backup):
+        return
+    for sub in ('live', 'archive'):
+        src = f'{backup}/{sub}'
+        if os.path.exists(src):
+            dst = f'{vyos_certbot_dir}/{sub}/{name}'
+            if os.path.exists(dst):
+                shutil.rmtree(dst)
+            shutil.move(src, dst)
+    renewal_src = f'{backup}/renewal.conf'
+    if os.path.exists(renewal_src):
+        shutil.move(renewal_src, f'{vyos_certbot_dir}/renewal/{name}.conf')
+    shutil.rmtree(backup, ignore_errors=True)
+
+def certbot_discard_backup(name: str) -> None:
+    import shutil
+    shutil.rmtree(certbot_backup_path(name), ignore_errors=True)
 
 def certbot_request(name: str, config: dict, dry_run: bool=True) -> None:
     # We do not call certbot when booting the system - there is no need to do so and
@@ -165,8 +237,54 @@ def certbot_request(name: str, config: dict, dry_run: bool=True) -> None:
     cmdl(tmp, raising=ConfigError, message=f'Certbot request failed for "{name}"!')
     return None
 
+def certbot_renewal_due(name: str) -> bool:
+    """Approximate check for whether this certbot-managed certificate is
+    within its renewal window, without invoking certbot itself - so the
+    caller can skip certbot renew (and its unconditional --pre-hook)
+    entirely when nothing needs renewing.
+
+    VyOS never overrides certbot's own --renew-before-expiry (30 days),
+    so that default is used directly here rather than parsing it back out
+    of the renewal config, which certbot itself only ever writes as a
+    commented-out placeholder in the absence of an override.
+
+    Fails open (returns True) if the local certificate can't be read, so
+    this can never itself block a renewal that should actually happen -
+    worst case, the same check just runs again next time.
+    """
+    from datetime import datetime
+    from datetime import timedelta
+
+    tmp = read_file(f'{vyos_certbot_dir}/live/{name}/cert.pem', defaultonfailure=None)
+    if tmp is None:
+        return True
+    try:
+        expiry = load_certificate(tmp, wrap_tags=False).not_valid_after
+    except Exception:
+        return True
+
+    renew_before_expiry_days = 30
+    return datetime.utcnow() >= expiry - timedelta(days=renew_before_expiry_days)
+
+def any_certbot_renewal_due(certificates: dict) -> bool:
+    """True if any ACME-managed certificate in this pki['certificate']
+    dict is within its renewal window - see certbot_renewal_due(). False
+    (not due) if there are no ACME-managed certificates at all. Shared by
+    get_config() (deciding whether to mark ACME certs as "changed" at
+    all) and certbot_renew() (deciding whether to actually invoke
+    certbot), so both agree on whether this certbot_renew pass is a real
+    one - see the comment above get_config()'s use of this for why that
+    matters.
+    """
+    acme_certs = [name for name, cert_conf in certificates.items() if 'acme' in cert_conf]
+    return any(certbot_renewal_due(name) for name in acme_certs)
+
 def certbot_renew(config: dict, force: bool=False) -> None:
     """ Renew all certificates managed via certbot """
+    if not force and not any_certbot_renewal_due(config.get('certificate', {})):
+        print('No certificates due for renewal - skipping certbot renew.')
+        return None
+
     tmp = ['certbot', 'renew', '--no-random-sleep-on-renew',
            '--config-dir', vyos_certbot_dir]
 
@@ -196,6 +314,25 @@ def certbot_renew(config: dict, force: bool=False) -> None:
             print(f'Restarting "{service}" with non-renewed certificate...')
             cmdl(['systemctl', 'restart', service])
     return None
+
+def leaf_cert_base64(name: str, cert_conf: dict):
+    """Return a certificate's own base64-encoded content for chain
+    resolution purposes: the CLI-configured value for a regular
+    certificate, or - since ACME certificates never carry one on the CLI -
+    read live from certbot's own cert.pem. Returns None if neither is
+    available (e.g. an ACME certificate not yet issued).
+    """
+    if 'certificate' in cert_conf:
+        return cert_conf['certificate']
+    if 'acme' not in cert_conf:
+        return None
+    tmp = read_file(f'{vyos_certbot_dir}/live/{name}/cert.pem', defaultonfailure=None)
+    if tmp is None:
+        return None
+    tmp = load_certificate(tmp, wrap_tags=False)
+    if not tmp:
+        return None
+    return "".join(encode_certificate(tmp).strip().split("\n")[1:-1])
 
 def get_config(config=None):
     if config:
@@ -242,20 +379,27 @@ def get_config(config=None):
 
     # Certbot triggered an external renew of the certificates.
     # Mark all ACME based certificates as "changed" to trigger
-    # update of dependent services
+    # update of dependent services - but only if certbot_renew() below is
+    # actually going to invoke certbot: this would otherwise run
+    # unconditionally on every timer-triggered pass, making apply()'s
+    # call_dependents() regenerate and reload every dependent service
+    # (HAProxy, HTTPS, ...) twice a day even when nothing was due for
+    # renewal.
     if 'certificate' in pki and 'certbot_renew' in pki:
-        renew = []
-        for name, cert_config in pki['certificate'].items():
-            if 'acme' in cert_config:
-                renew.append(name)
-        if renew:
-            # Get the current list of changed certificates
-            tmp = pki.get('changed', {}).get('certificate', [])
-            # and extend it with the list of ACME based certificates
-            tmp += renew
-            # remove any duplicates if necessary
-            tmp = set(tmp)
-            dict_set_nested('changed.certificate', tmp, pki)
+        force = 'force' in pki['certbot_renew']
+        if force or any_certbot_renewal_due(pki['certificate']):
+            renew = []
+            for name, cert_config in pki['certificate'].items():
+                if 'acme' in cert_config:
+                    renew.append(name)
+            if renew:
+                # Get the current list of changed certificates
+                tmp = pki.get('changed', {}).get('certificate', [])
+                # and extend it with the list of ACME based certificates
+                tmp += renew
+                # remove any duplicates if necessary
+                tmp = set(tmp)
+                dict_set_nested('changed.certificate', tmp, pki)
 
     # We need to get the entire system configuration to verify that we are not
     # deleting a certificate that is still referenced somewhere!
@@ -278,31 +422,57 @@ def get_config(config=None):
                     node_present = dict_search_args(pki, changed_key, item_name)
 
                 if node_present:
-                    search_dict = dict_search_args(pki['system'], *search['path'])
-                    if not search_dict:
-                        continue
-                    for found_name, found_path in dict_search_recursive(search_dict, key):
-                        if isinstance(found_name, list) and item_name not in found_name:
-                            continue
+                    dispatch_dependents_for_reference(pki['system'], search, key, item_name, conf, D)
 
-                        if isinstance(found_name, str) and found_name != item_name:
-                            continue
+    # find_chain() based consumers (HAProxy, HTTPS, stunnel, sstpc,
+    # openconnect, IPsec, eapol, ...) build their full certificate chain
+    # dynamically from the entire pki['ca'] pool, not from an explicit,
+    # per-service CA reference - so adding, changing, or removing a CA can
+    # change a certificate's resolved chain even though that CA is never
+    # referenced by name anywhere, which the named-reference matching
+    # above would miss. Only trigger a certificate's dependents when its
+    # actually-resolved chain differs before vs after, so an
+    # unrelated/unused CA edit does not needlessly reload every
+    # certificate-consuming service.
+    #
+    # This deliberately dispatches dependents directly instead of adding
+    # these certificates to changed.certificate: that list is also used
+    # by verify()/generate() to decide whether to re-request an ACME
+    # certificate from the CA, and a CA-only edit must never cause an
+    # unrelated, unnecessary ACME re-issuance of a certificate whose own
+    # content did not change.
+    if dict_search_args(pki, 'changed', 'ca') and 'certificate' in pki:
+        old_ca = conf.get_config_dict(['pki', 'ca'], effective=True,
+                                       key_mangling=('-', '_'),
+                                       no_tag_node_value_mangle=True,
+                                       get_first_key=True) or {}
+        new_ca = pki.get('ca', {})
 
-                        # prefer orig_path over path when unmangling is needed
-                        path = search.get('orig_path', search.get('path'))
-                        # Only enable this for debug purposes - otherwise we will always
-                        # print this message for ACME certificates during renew tests -
-                        # even if they are not due for renew!
-                        # path_str = ' '.join(path + found_path)
-                        # print(f'Updating configuration: "{path_str} {item_name}"')
+        def _ca_pool(ca_dict):
+            return [cert for cert in (
+                load_certificate(ca['certificate'])
+                for ca in ca_dict.values() if 'certificate' in ca
+            ) if cert]
 
-                        if path[0] == 'interfaces':
-                            ifname = found_path[0]
-                            if not D.node_changed_presence(path + [ifname]):
-                                set_dependents(path[1], conf, ifname)
-                        else:
-                            if not D.node_changed_presence(path):
-                                set_dependents(path[1], conf)
+        old_pool = _ca_pool(old_ca)
+        new_pool = _ca_pool(new_ca)
+
+        for name, cert_conf in pki['certificate'].items():
+            leaf_base64 = leaf_cert_base64(name, cert_conf)
+            if not leaf_base64:
+                continue
+            leaf = load_certificate(leaf_base64)
+            if not leaf:
+                continue
+            old_chain = [encode_certificate(c) for c in find_chain(leaf, old_pool)]
+            new_chain = [encode_certificate(c) for c in find_chain(leaf, new_pool)]
+            if old_chain == new_chain:
+                continue
+
+            for search in sync_search:
+                if 'certificate' not in search['keys']:
+                    continue
+                dispatch_dependents_for_reference(pki['system'], search, 'certificate', name, conf, D)
 
     # Check PKI certificates if they are auto-generated by ACME. If they are,
     # traverse the current configuration and determine the service where the
@@ -570,54 +740,53 @@ def generate(pki):
                 # system, generate it
                 if name not in certbot_list_on_disk:
                     certbot_request(name, cert_conf['acme'], dry_run=False)
-                    # Now that the certificate was properly generated we have
-                    # the PEM files on disk. We need to add the certificate to
-                    # certbot_list_on_disk to automatically import the CA chain
                     certbot_list_on_disk.append(name)
                 # We already had an ACME managed certificate on the system, but
                 # something changed in the configuration
                 elif changed_certificates != None and name in changed_certificates:
-                    # Delete old ACME certificate first
+                    have_backup = False
+                    # Back up (rather than outright delete) the old ACME
+                    # certificate first, so it can be restored if the
+                    # replacement request below fails for any reason - a
+                    # rate limit, a transient ACME/network issue, or
+                    # anything else. Without this, a failed request here
+                    # left the certificate missing entirely until the next
+                    # successful issuance.
                     if name in certbot_list_on_disk:
+                        certbot_backup(name)
+                        have_backup = True
                         certbot_delete(name)
                     # Request new certificate via certbot
-                    certbot_request(name, cert_conf['acme'], dry_run=False)
+                    try:
+                        certbot_request(name, cert_conf['acme'], dry_run=False)
+                    except ConfigError:
+                        if have_backup:
+                            certbot_restore(name)
+                        raise
+                    if have_backup:
+                        # A request made while boot_configuration_complete()
+                        # is False silently no-ops (see certbot_request()) -
+                        # verify the certificate is actually back on disk
+                        # before discarding the backup, rather than trusting
+                        # the absence of an exception alone.
+                        if os.path.exists(f'{vyos_certbot_dir}/live/{name}/cert.pem'):
+                            certbot_discard_backup(name)
+                        else:
+                            certbot_restore(name)
 
     # Cleanup certbot configuration and certificates if no longer in use by CLI
     # Get foldernames under vyos_certbot_dir which each represent a certbot cert
+    #
+    # Note: the intermediate CA certbot obtains alongside each of these
+    # certificates (chain.pem) is intentionally never imported into the
+    # CLI here - it is derived data, not configuration, and is instead
+    # read live from disk by whatever needs it (find_chain() consumers,
+    # "show pki ca") - see vyos.pki.acme_chain_ca_entry().
     if os.path.exists(f'{vyos_certbot_dir}/live'):
         for cert in certbot_list_on_disk:
             # ACME certificate is no longer in use by CLI remove it
             if cert not in certbot_list:
                 certbot_delete(cert)
-                continue
-            # ACME not enabled for individual certificate - bail out early
-            if 'acme' not in pki['certificate'][cert]:
-                continue
-
-            # Read in ACME certificate chain information
-            tmp = read_file(f'{vyos_certbot_dir}/live/{cert}/chain.pem')
-            tmp = load_certificate(tmp, wrap_tags=False)
-            cert_chain_base64 = "".join(encode_certificate(tmp).strip().split("\n")[1:-1])
-
-            # Check if CA chain certificate is already present on CLI to avoid adding
-            # a duplicate. This only checks for manual added CA certificates and not
-            # auto added ones with the AUTOCHAIN_ prefix
-            autochain_prefix = 'AUTOCHAIN_'
-            ca_cert_present = False
-            if 'ca' in pki:
-                for ca_base64, cli_path in dict_search_recursive(pki['ca'], 'certificate'):
-                    # Ignore automatic added CA certificates
-                    if any(item.startswith(autochain_prefix) for item in cli_path):
-                        continue
-                    if cert_chain_base64 == ca_base64:
-                        ca_cert_present = True
-
-            if not ca_cert_present:
-                tmp = dict_search_args(pki, 'ca', f'{autochain_prefix}{cert}', 'certificate')
-                if not bool(tmp) or tmp != cert_chain_base64:
-                    Message(f'Add/replace automatically imported CA certificate for "{cert}" ...')
-                    add_cli_node(['pki', 'ca', f'{autochain_prefix}{cert}', 'certificate'], value=cert_chain_base64)
 
     return None
 

--- a/src/conf_mode/pki.py
+++ b/src/conf_mode/pki.py
@@ -143,6 +143,41 @@ def dispatch_dependents_for_reference(pki_system, search, key, item_name, conf, 
             if not D.node_changed_presence(path):
                 set_dependents(path[1], conf)
 
+certbot_log_file = '/var/log/letsencrypt/letsencrypt.log'
+
+def certbot_log_offset() -> int:
+    """Current size of certbot's own debug log, to be passed to
+    certbot_error_reason() after a failed invocation so it only looks at
+    what this specific invocation appended - certbot's log is shared
+    across all certificates and accumulates across every past run.
+    """
+    return os.path.getsize(certbot_log_file) if os.path.exists(certbot_log_file) else 0
+
+def certbot_error_reason(offset: int) -> str | None:
+    """Pull the actual ACME protocol error (e.g. rate limiting, failed
+    domain validation) out of certbot's own debug log.
+
+    certbot's non-interactive stdout/stderr reporting can itself crash
+    on an unrelated certbot/josepy bug while trying to report an ACME
+    error (AttributeError: can't set attribute, seen live), which masks
+    the real reason entirely from cmdl()'s captured output. The real
+    reason is still always written to the debug log first, so read it
+    directly instead of relying on certbot's own top-level reporting.
+    """
+    try:
+        with open(certbot_log_file) as f:
+            f.seek(offset)
+            log_tail = f.read()
+    except OSError:
+        return None
+
+    reason = None
+    prefix = 'acme.messages.Error:'
+    for line in log_tail.splitlines():
+        if line.startswith(prefix):
+            reason = line[len(prefix):].strip()
+    return reason
+
 def certbot_delete(certificate):
     if not boot_configuration_complete():
         return
@@ -234,7 +269,14 @@ def certbot_request(name: str, config: dict, dry_run: bool=True) -> None:
     if dry_run:
         tmp += ['--dry-run']
 
-    cmdl(tmp, raising=ConfigError, message=f'Certbot request failed for "{name}"!')
+    offset = certbot_log_offset()
+    try:
+        cmdl(tmp, raising=ConfigError, message=f'Certbot request failed for "{name}"!')
+    except ConfigError as e:
+        reason = certbot_error_reason(offset)
+        if reason:
+            raise ConfigError(f'Certbot request failed for "{name}": {reason}') from e
+        raise
     return None
 
 def certbot_renewal_due(name: str) -> bool:
@@ -306,10 +348,12 @@ def certbot_renew(config: dict, force: bool=False) -> None:
     if force:
         tmp += ['--force-renewal']
 
+    offset = certbot_log_offset()
     try:
         print(cmdl(tmp, raising=ConfigError, message=f'Certbot renew failed!'))
     except ConfigError as e:
-        print(e)
+        reason = certbot_error_reason(offset)
+        print(f'Certbot renew failed: {reason}' if reason else e)
         for service in stop_services:
             print(f'Restarting "{service}" with non-renewed certificate...')
             cmdl(['systemctl', 'restart', service])

--- a/src/conf_mode/pki.py
+++ b/src/conf_mode/pki.py
@@ -803,7 +803,7 @@ def generate(pki):
                     # Request new certificate via certbot
                     try:
                         certbot_request(name, cert_conf['acme'], dry_run=False)
-                    except ConfigError:
+                    except Exception:
                         if have_backup:
                             certbot_restore(name)
                         raise

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -984,10 +984,17 @@ def import_ca_certificate(
         # get_key(), which this mirrors.
         url = urllib.parse.urlparse(path)
         if url.scheme in ('', 'file'):
-            if not os.path.exists(path):
-                print(f'File not found: {path}')
+            if url.scheme == 'file':
+                if url.netloc:
+                    print(f'Unsupported file URL host: {url.netloc}')
+                    return
+                local_path = urllib.parse.unquote(url.path)
+            else:
+                local_path = path
+            if not os.path.exists(local_path):
+                print(f'File not found: {local_path}')
                 return
-            with open(path) as f:
+            with open(local_path) as f:
                 cert_data = f.read()
         else:
             cert_data = vyos.remote.get_remote_config(path)

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -151,7 +151,6 @@ def get_config_ca_certificate(name=None):
     # object, but consumers (find_chain(), "show pki ca") should see it
     # the same way they'd see a manually-configured CA.
     from vyos.defaults import directories
-    from vyos.pki import AUTOCHAIN_PREFIX
     from vyos.pki import acme_chain_ca_entry
     from vyos.pki import acme_chain_redundant
     vyos_certbot_dir = directories['certbot']
@@ -167,9 +166,8 @@ def get_config_ca_certificate(name=None):
             continue
         if acme_chain_redundant(leaf_cert, real_ca_certs):
             continue
-        chain_entry = acme_chain_ca_entry(vyos_certbot_dir, cert_name)
-        if chain_entry:
-            autochain_name = f'{AUTOCHAIN_PREFIX}{cert_name}'
+        for autochain_name, chain_entry in acme_chain_ca_entry(
+                vyos_certbot_dir, cert_name).items():
             # A real, manually-configured CLI CA object with this name
             # wins over the synthetic one
             if autochain_name not in ca_certs:

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -78,7 +78,12 @@ def _verify(target):
             name = kwargs.get('name')
             unconf_message = f'PKI {target} "{name}" does not exist!'
             if name:
-                if not conf.exists(['pki', target, name]):
+                exists = conf.exists(['pki', target, name])
+                if not exists and target == 'ca':
+                    from vyos.pki import AUTOCHAIN_PREFIX
+                    if name.startswith(AUTOCHAIN_PREFIX):
+                        exists = name in (get_config_ca_certificate() or {})
+                if not exists:
                     raise vyos.opmode.UnconfiguredSubsystem(unconf_message)
             return func(*args, **kwargs)
 
@@ -121,19 +126,53 @@ def get_default_values():
 def get_config_ca_certificate(name=None):
     # Fetch ca certificates from config
     base = ['pki', 'ca']
-    if not conf.exists(base):
-        return False
 
     if name:
-        base = base + [name]
-        if not conf.exists(base + ['private', 'key']) or not conf.exists(
-            base + ['certificate']
+        # A specific, real CLI-configured CA is being requested (e.g. for
+        # sign/generate operations) - ACME-derived synthetic entries are
+        # never addressable this way, since they are not real CLI objects.
+        if not conf.exists(base + [name, 'private', 'key']) or not conf.exists(
+            base + [name, 'certificate']
         ):
             return False
+        return conf.get_config_dict(
+            base + [name], key_mangling=('-', '_'), get_first_key=True,
+            no_tag_node_value_mangle=True
+        )
 
-    return conf.get_config_dict(
-        base, key_mangling=('-', '_'), get_first_key=True, no_tag_node_value_mangle=True
-    )
+    ca_certs = {}
+    if conf.exists(base):
+        ca_certs = conf.get_config_dict(
+            base, key_mangling=('-', '_'), get_first_key=True, no_tag_node_value_mangle=True
+        )
+
+    # Also surface each ACME certificate's intermediate CA chain, read
+    # live from certbot's own chain.pem - never a real, settable CLI
+    # object, but consumers (find_chain(), "show pki ca") should see it
+    # the same way they'd see a manually-configured CA.
+    from vyos.defaults import directories
+    from vyos.pki import AUTOCHAIN_PREFIX
+    from vyos.pki import acme_chain_ca_entry
+    from vyos.pki import acme_chain_redundant
+    vyos_certbot_dir = directories['certbot']
+    # Snapshot of explicitly/manually configured CAs, taken before any
+    # synthetic entries are added below
+    real_ca_certs = dict(ca_certs)
+
+    for cert_name, cert_conf in (get_config_certificate() or {}).items():
+        if 'acme' not in cert_conf:
+            continue
+        if acme_chain_redundant(cert_conf['certificate'], real_ca_certs):
+            continue
+        chain_entry = acme_chain_ca_entry(vyos_certbot_dir, cert_name)
+        if chain_entry:
+            autochain_name = f'{AUTOCHAIN_PREFIX}{cert_name}'
+            # A real, manually-configured CLI CA object with this name
+            # wins over the synthetic one
+            if autochain_name not in ca_certs:
+                ca_certs[autochain_name] = chain_entry
+
+    return ca_certs or False
 
 
 def get_config_certificate(name=None):

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -109,6 +109,12 @@ def _encode_certificate_chain(cert, ca_certs):
     return ''.join(encode_certificate(c) for c in find_chain(cert, loaded_ca_certs))
 
 
+def _print_certificate_text(cert):
+    """Print a certificate in OpenSSL's human-readable "-text" format."""
+    print(cmdl(['openssl', 'x509', '-noout', '-text'],
+               input=encode_certificate(cert)))
+
+
 def get_default_values():
     # Fetch default x509 values
     base = ['pki', 'x509', 'default']
@@ -1270,6 +1276,7 @@ def show_certificate_authority(
     raw: bool,
     name: typing.Optional[str] = None,
     pem: typing.Optional[bool] = False,
+    text: typing.Optional[bool] = False,
     full_chain: typing.Optional[bool] = False,
 ):
     headers = [
@@ -1300,6 +1307,9 @@ def show_certificate_authority(
                     print(_encode_certificate_chain(cert, certs))
                 else:
                     print(encode_certificate(cert))
+                return
+            if name and text:
+                _print_certificate_text(cert)
                 return
 
             parent_ca_name = get_certificate_ca(cert, certs)
@@ -1335,6 +1345,7 @@ def show_certificate(
     name: typing.Optional[str] = None,
     private: typing.Optional[bool] = False,
     pem: typing.Optional[bool] = False,
+    text: typing.Optional[bool] = False,
     full_chain: typing.Optional[bool] = False,
     fingerprint: typing.Optional[ArgsFingerprint] = None,
 ):
@@ -1370,6 +1381,9 @@ def show_certificate(
                     print(_encode_certificate_chain(cert, ca_certs))
                 else:
                     print(encode_certificate(cert))
+                return
+            elif name and text and not (private or fingerprint):
+                _print_certificate_text(cert)
                 return
             elif name and fingerprint and not private:
                 print(get_certificate_fingerprint(cert, fingerprint))

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -20,11 +20,13 @@ import re
 import sys
 import tabulate
 import typing
+import urllib.parse
 
 from cryptography import x509
 from cryptography.x509.oid import ExtendedKeyUsageOID
 
 import vyos.opmode
+import vyos.remote
 
 from vyos.base import Warning
 from vyos.config import Config
@@ -937,15 +939,20 @@ def import_ca_certificate(
     name, path=None, key_path=None, no_prompt=False, passphrase=None
 ):
     if path:
-        if not os.path.exists(path):
-            print(f'File not found: {path}')
-            return
+        # path may be a local file path or a remote URL (http, https, ftp,
+        # sftp, scp, tftp, ...) - same convention as generate public-key's
+        # get_key(), which this mirrors.
+        url = urllib.parse.urlparse(path)
+        if url.scheme in ('', 'file'):
+            if not os.path.exists(path):
+                print(f'File not found: {path}')
+                return
+            with open(path) as f:
+                cert_data = f.read()
+        else:
+            cert_data = vyos.remote.get_remote_config(path)
 
-        cert = None
-
-        with open(path) as f:
-            cert_data = f.read()
-            cert = load_certificate(cert_data, wrap_tags=False)
+        cert = load_certificate(cert_data, wrap_tags=False)
 
         if not cert:
             print(f'Invalid certificate: {path}')

--- a/src/op_mode/pki.py
+++ b/src/op_mode/pki.py
@@ -162,7 +162,10 @@ def get_config_ca_certificate(name=None):
     for cert_name, cert_conf in (get_config_certificate() or {}).items():
         if 'acme' not in cert_conf:
             continue
-        if acme_chain_redundant(cert_conf['certificate'], real_ca_certs):
+        leaf_cert = cert_conf.get('certificate')
+        if not leaf_cert:
+            continue
+        if acme_chain_redundant(leaf_cert, real_ca_certs):
             continue
         chain_entry = acme_chain_ca_entry(vyos_certbot_dir, cert_name)
         if chain_entry:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Certificates issued via ACME (Let's Encrypt) need certbot's intermediate CA to build a full chain for consumers like HAProxy, HTTPS, IPsec, stunnel, and EAPOL. This intermediate was previously imported into the running configuration as a synthetic `pki ca AUTOCHAIN_<cert>` object purely so those consumers could find it - leaking certbot's internal state into the CLI as a real, user-visible, deletable object that never needed to exist there.

This PR removes that object entirely. The intermediate is read live from disk, in memory only, wherever a full chain is resolved or displayed (`show pki ca`) - never as a settable or deletable configuration object. An already-configured CA that completes the chain on its own takes precedence, and nothing synthetic is added or shown in that case.

Adding, changing, or removing any CA now reloads only the services whose resolved chain is actually affected by that specific change, instead of either missing the update or reloading everything unconditionally - and without side effects on certificates whose own content didn't change (an ACME certificate is never re-requested just because an unrelated CA changed).

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9135

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-1x/pull/5359

## How to test / Smoketest result
... waiting on builds ...

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
