### PR TITLE
dns: T9175: make PowerDNS security status poll opt-in

### DIFF
--- a/data/templates/dns-forwarding/recursor.conf.j2
+++ b/data/templates/dns-forwarding/recursor.conf.j2
@@ -84,3 +84,9 @@ ecs-ipv4-bits={{ options.ecs_ipv4_bits }}
 {% if options.edns_subnet_allow_list is vyos_defined %}
 edns-subnet-allow-list={{ options.edns_subnet_allow_list | join(',') }}
 {% endif %}
+
+# security-poll-suffix: unset (the VyOS default) disables the periodic
+# security status poll, since VyOS ships a patched/backported package that
+# is never updated in place and the poll result is thus meaningless (T9175)
+security-poll-suffix={{ options.security_poll_suffix if options.security_poll_suffix is vyos_defined else '' }}
+

--- a/data/templates/dns-forwarding/recursor.conf.j2
+++ b/data/templates/dns-forwarding/recursor.conf.j2
@@ -88,5 +88,5 @@ edns-subnet-allow-list={{ options.edns_subnet_allow_list | join(',') }}
 # security-poll-suffix: unset (the VyOS default) disables the periodic
 # security status poll, since VyOS ships a patched/backported package that
 # is never updated in place and the poll result is thus meaningless (T9175)
-security-poll-suffix={{ options.security_poll_suffix if options.security_poll_suffix is vyos_defined else '' }}
+security-poll-suffix={{ options.security_status_poll_domain if options.security_status_poll_domain is vyos_defined else '' }}
 

--- a/interface-definitions/service_dns_forwarding.xml.in
+++ b/interface-definitions/service_dns_forwarding.xml.in
@@ -889,16 +889,16 @@
                       <multi/>
                     </properties>
                   </leafNode>
-                  <leafNode name="security-poll-suffix">
+                  <leafNode name="security-status-poll-domain">
                     <properties>
-                      <help>Domain suffix for the periodic PowerDNS security status poll (default: disabled)</help>
+                      <help>Domain name for the periodic PowerDNS security status poll, which checks the running version for known vulnerabilities (default: disabled)</help>
                       <valueHelp>
                         <format>secpoll.powerdns.com</format>
                         <description>Use PowerDNS' own security status poll domain</description>
                       </valueHelp>
                       <valueHelp>
                         <format>txt</format>
-                        <description>Custom domain suffix to poll instead</description>
+                        <description>Custom domain to poll instead</description>
                       </valueHelp>
                       <constraint>
                         <validator name="fqdn"/>

--- a/interface-definitions/service_dns_forwarding.xml.in
+++ b/interface-definitions/service_dns_forwarding.xml.in
@@ -889,6 +889,22 @@
                       <multi/>
                     </properties>
                   </leafNode>
+                  <leafNode name="security-poll-suffix">
+                    <properties>
+                      <help>Domain suffix for the periodic PowerDNS security status poll (default: disabled)</help>
+                      <valueHelp>
+                        <format>secpoll.powerdns.com</format>
+                        <description>Use PowerDNS' own security status poll domain</description>
+                      </valueHelp>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Custom domain suffix to poll instead</description>
+                      </valueHelp>
+                      <constraint>
+                        <validator name="fqdn"/>
+                      </constraint>
+                    </properties>
+                  </leafNode>
                 </children>
               </node>
               <tagNode name="zone-cache">

--- a/smoketest/scripts/cli/test_service_dns_forwarding.py
+++ b/smoketest/scripts/cli/test_service_dns_forwarding.py
@@ -354,19 +354,19 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         tmp = get_config_value('edns-subnet-allow-list')
         self.assertEqual(tmp, ','.join(options))
 
-    def test_security_poll_suffix(self):
+    def test_security_status_poll_domain(self):
         # commit changes - the periodic security status poll must be
-        # disabled (empty suffix) by default, see T9175
+        # disabled (empty) by default, see T9175
         self.cli_commit()
         tmp = get_config_value('security-poll-suffix')
         self.assertEqual(tmp, '')
 
-        # explicitly configuring a suffix must enable and use it
-        suffix = 'secpoll.powerdns.com'
-        self.cli_set(base_path + ['options', 'security-poll-suffix', suffix])
+        # explicitly configuring a domain must enable and use it
+        domain = 'secpoll.powerdns.com'
+        self.cli_set(base_path + ['options', 'security-status-poll-domain', domain])
         self.cli_commit()
         tmp = get_config_value('security-poll-suffix')
-        self.assertEqual(tmp, suffix)
+        self.assertEqual(tmp, domain)
 
     def test_multiple_ns_records(self):
         test_zone = 'example.com'

--- a/smoketest/scripts/cli/test_service_dns_forwarding.py
+++ b/smoketest/scripts/cli/test_service_dns_forwarding.py
@@ -354,6 +354,20 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         tmp = get_config_value('edns-subnet-allow-list')
         self.assertEqual(tmp, ','.join(options))
 
+    def test_security_poll_suffix(self):
+        # commit changes - the periodic security status poll must be
+        # disabled (empty suffix) by default, see T9175
+        self.cli_commit()
+        tmp = get_config_value('security-poll-suffix')
+        self.assertEqual(tmp, '')
+
+        # explicitly configuring a suffix must enable and use it
+        suffix = 'secpoll.powerdns.com'
+        self.cli_set(base_path + ['options', 'security-poll-suffix', suffix])
+        self.cli_commit()
+        tmp = get_config_value('security-poll-suffix')
+        self.assertEqual(tmp, suffix)
+
     def test_multiple_ns_records(self):
         test_zone = 'example.com'
         self.cli_set(base_path + ['authoritative-domain', test_zone, 'records', 'ns', 'test', 'target', f'ns1.{test_zone}'])


### PR DESCRIPTION
## Change summary
  
  The PowerDNS recursor periodically polls `secpoll.powerdns.com` to check for
  known security issues in the running version. VyOS ships a patched/backported
  `pdns-recursor` package that is never updated in-place, so the poll result is
  meaningless and only produces log noise (e.g. `Not validating response for
  security status update, this is a non-release version`).
  
  This adds a new, disabled-by-default option:

  set service dns forwarding options security-status-poll-domain <domain-suffix>

  Leaving it unset disables the poll entirely (new VyOS default). Users who
  still want the check can opt back in, either against PowerDNS' own 
  `secpoll.powerdns.com` or a custom domain suffix operated by their own
  organization.
  
  ## Types of changes
  
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Code style update (formatting, renaming)
  - [ ] Refactoring (no functional changes)
  - [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
  - [ ] Other (please describe):
  
  ## Related Task(s)
  * https://vyos.dev/T9175
  
  ## Related PR(s)
  * vyos/vyos-documentation#2193 (documents the new `security-status-poll-domain` option)
  
  ## How to test / Smoketest result
  
  Added `test_security_status_poll_domain` to
  `smoketest/scripts/cli/test_service_dns_forwarding.py`, covering:
  - default (unset) renders an empty `security-poll-suffix=` line (the
    underlying PowerDNS recursor.conf directive name, unchanged), i.e. the
    poll is disabled
  - explicitly setting the option renders the configured suffix

  $ /usr/libexec/vyos/tests/smoke/cli/test_service_dns_forwarding.py
  test_security_status_poll_domain (main.TestServicePowerDNS.test_security_status_poll_domain) ... ok
  
  Template and XML changes were verified for well-formedness locally
  (Jinja2 parse, XML parse); the smoketest itself has not yet been run against
  a live VyOS image/QEMU harness — please run CI/smoketest on this PR before
  merge.
  
  ## Checklist:
  - [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
  - [x] I have linked this PR to one or more Phabricator Task(s)
  - [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
  - [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
  - [x] My commit headlines contain a valid Task id
  - [x] My change requires a change to the documentation
  - [x] I have updated the documentation accordingly

