### PR TITLE
utils: T9185: fix ask_yes_no() busy-looping forever on non-tty stdin

### DIFF
--- a/python/vyos/utils/io.py
+++ b/python/vyos/utils/io.py
@@ -56,7 +56,10 @@ def ask_input(question, default='', numeric_only=False, valid_responses=[],
 
 def ask_yes_no(question, default=False) -> bool:
     """Ask a yes/no question via input() and return their answer."""
-    from sys import stdout
+    from sys import stdin, stdout
+
+    if not stdin.isatty():
+        return default
     default_msg = "[Y/n]" if default else "[y/N]"
     while True:
         try:

--- a/python/vyos/utils/io.py
+++ b/python/vyos/utils/io.py
@@ -55,7 +55,11 @@ def ask_input(question, default='', numeric_only=False, valid_responses=[],
     return response
 
 def ask_yes_no(question, default=False) -> bool:
-    """Ask a yes/no question via input() and return their answer."""
+    """Ask a yes/no question via input() and return their answer.
+
+    If stdin is not a TTY (e.g. non-interactive scripts), returns
+    default without prompting.
+    """
     from sys import stdin, stdout
 
     if not stdin.isatty():

--- a/python/vyos/utils/io.py
+++ b/python/vyos/utils/io.py
@@ -57,13 +57,23 @@ def ask_input(question, default='', numeric_only=False, valid_responses=[],
 def ask_yes_no(question, default=False) -> bool:
     """Ask a yes/no question via input() and return their answer.
 
-    If stdin is not a TTY (e.g. non-interactive scripts), returns
-    default without prompting.
+    Raises EOFError immediately if stdin is not a TTY (e.g. non-interactive
+    scripts), instead of ever calling input(). A silent default here has
+    caused real incidents (T9185): a caller that forgets to guard an
+    interactive-only prompt gets no error and no visible hang, just a
+    process quietly pegging a core. Callers that are meant to run
+    non-interactively must check for that explicitly (see the no_prompt
+    parameter used across config_mgmt.py/backend.py) rather than rely on
+    this function to fall back to a default.
     """
     from sys import stdin, stdout
 
     if not stdin.isatty():
-        return default
+        raise EOFError(
+            f'Cannot prompt "{question}" ([Y/n] default={default}): '
+            'stdin is not a TTY. Pass an explicit non-interactive option '
+            '(e.g. no_prompt/-y) instead of relying on ask_yes_no().'
+        )
     default_msg = "[Y/n]" if default else "[y/N]"
     while True:
         try:

--- a/src/tests/test_utils_io.py
+++ b/src/tests/test_utils_io.py
@@ -1,0 +1,46 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from unittest.mock import patch
+
+from vyos.utils.io import ask_yes_no
+
+
+class TestVyOSUtilsIO(unittest.TestCase):
+    def test_ask_yes_no_non_interactive_returns_default_without_reading_stdin(self):
+        # T9185: on a non-TTY stdin (e.g. a non-interactive vbash session),
+        # input() raises EOFError immediately and forever; ask_yes_no() must
+        # return the default straight away instead of ever looping on input().
+        with patch('sys.stdin') as mock_stdin:
+            mock_stdin.isatty.return_value = False
+            with patch('builtins.input') as mock_input:
+                self.assertTrue(ask_yes_no('Proceed?', default=True))
+                self.assertFalse(ask_yes_no('Proceed?', default=False))
+                mock_input.assert_not_called()
+
+    def test_ask_yes_no_interactive_reads_input(self):
+        with patch('sys.stdin') as mock_stdin:
+            mock_stdin.isatty.return_value = True
+            with patch('builtins.input', return_value='y'):
+                self.assertTrue(ask_yes_no('Proceed?', default=False))
+            with patch('builtins.input', return_value='n'):
+                self.assertFalse(ask_yes_no('Proceed?', default=True))
+            with patch('builtins.input', return_value=''):
+                self.assertTrue(ask_yes_no('Proceed?', default=True))
+                self.assertFalse(ask_yes_no('Proceed?', default=False))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/tests/test_utils_io.py
+++ b/src/tests/test_utils_io.py
@@ -19,15 +19,20 @@ from vyos.utils.io import ask_yes_no
 
 
 class TestVyOSUtilsIO(unittest.TestCase):
-    def test_ask_yes_no_non_interactive_returns_default_without_reading_stdin(self):
+    def test_ask_yes_no_non_interactive_raises_without_reading_stdin(self):
         # T9185: on a non-TTY stdin (e.g. a non-interactive vbash session),
-        # input() raises EOFError immediately and forever; ask_yes_no() must
-        # return the default straight away instead of ever looping on input().
+        # input() raises EOFError immediately and forever; looping on it
+        # spins a core at 100% CPU. Returning a silent default instead is
+        # also wrong (jestabro/dmbaturin, PR #5390): a caller that forgot
+        # to guard this with an explicit non-interactive option would get
+        # no error and no visible hang, just a quietly-succeeding prompt.
+        # ask_yes_no() must raise immediately instead of ever calling
+        # input() or returning a default.
         with patch('sys.stdin') as mock_stdin:
             mock_stdin.isatty.return_value = False
             with patch('builtins.input') as mock_input:
-                self.assertTrue(ask_yes_no('Proceed?', default=True))
-                self.assertFalse(ask_yes_no('Proceed?', default=False))
+                self.assertRaises(EOFError, ask_yes_no, 'Proceed?', default=True)
+                self.assertRaises(EOFError, ask_yes_no, 'Proceed?', default=False)
                 mock_input.assert_not_called()
 
     def test_ask_yes_no_interactive_reads_input(self):


### PR DESCRIPTION
 ## Change summary
  
  `ask_yes_no()` busy-loops at ~100% CPU forever when stdin isn't a TTY,
  since `input()` raises `EOFError` immediately and repeatedly in that case
  and the handler looped straight back to `input()` with no backoff or exit
  condition. `commit-confirm` (and ~40 other call sites sharing this
  function) hang indefinitely when invoked non-interactively, e.g.
  `vbash -c "... commit-confirm 10; exit"`.
  
  Fix: check `stdin.isatty()` up front and return `default` immediately when
  it's not a TTY — behaviorally identical to a user pressing Enter (accepting
  the default) in an interactive session, so nothing changes for normal use.
  
  ## Types of changes 
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Code style update (formatting, renaming)
  - [ ] Refactoring (no functional changes)
  - [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
  - [ ] Other (please describe):
  
  ## Related Task(s)
  * https://vyos.dev/T9185
  
  ## Related PR(s)
  
  ## How to test / Smoketest result
  
  Added `src/tests/test_utils_io.py`, verified locally:
  - against the unpatched code, the non-interactive test genuinely hangs
    (killed via timeout — reproduces the reported busy-loop)
  - against the patch, both tests pass immediately without ever calling
    `input()` when stdin isn't a TTY
  
  $ python3 -m pytest src/tests/test_utils_io.py -v
  test_ask_yes_no_interactive_reads_input PASSED
  test_ask_yes_no_non_interactive_returns_default_without_reading_stdin PASSED
  
  ## Checklist:
  - [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
  - [x] I have linked this PR to one or more Phabricator Task(s)
  - [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
  - [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools 
  - [x] My commit headlines contain a valid Task id
  - [ ] My change requires a change to the documentation
  - [x] I have updated the documentation accordingly