### PR TITLE
tunnel: T9193: honor remote and source-interface in GRE key uniqueness check

### DIFF
--- a/smoketest/scripts/cli/test_interfaces_tunnel.py
+++ b/smoketest/scripts/cli/test_interfaces_tunnel.py
@@ -544,6 +544,16 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
         self.assertEqual('0.0.0.50', conf['linkinfo']['info_data']['ikey'])
         self.assertEqual('0.0.0.50', conf['linkinfo']['info_data']['okey'])
 
+        # Dropping back to a zero key must be rejected just the same. Only the
+        # tunnel which changed is verified again here, so this is the case a
+        # check trusting its own zero key - but not the neighbours - lets
+        # through: both tunnels commit, and every later commit touching the
+        # keyless one is refused from then on
+        self.cli_set(self._base_path + ['tun20', 'parameters', 'ip', 'key', '0'])
+
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
     def test_tunnel_invalid_source_interface(self):
         encapsulation = 'gre'
         remote = '192.0.2.1'

--- a/smoketest/scripts/cli/test_interfaces_tunnel.py
+++ b/smoketest/scripts/cli/test_interfaces_tunnel.py
@@ -468,6 +468,36 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
         self.cli_set(self._base_path + ['tun20', 'parameters', 'ip', 'key', '31'])
         self.cli_commit()
 
+    def test_multiple_gre_tunnel_keyless_and_keyed(self):
+        # A keyless tunnel is distinct from a keyed one even when both share
+        # the same local and remote address - the Kernel only matches a tunnel
+        # carrying no key against another tunnel carrying no key
+        ip_key = '40'
+
+        for tunnel in ['tun10', 'tun20']:
+            self.cli_set(self._base_path + [tunnel, 'encapsulation', 'gre'])
+            self.cli_set(self._base_path + [tunnel, 'source-address', self.local_v4])
+        self.cli_set(self._base_path + ['tun20', 'remote', '0.0.0.0'])
+        self.cli_set(self._base_path + ['tun20', 'parameters', 'ip', 'key', ip_key])
+
+        self.cli_commit()
+
+        # Re-verifying the keyless tunnel must keep succeeding - if it does not,
+        # the next commit touching it fails and it is lost on the next boot
+        self.cli_set(self._base_path + ['tun10', 'description', 'foo'])
+        self.cli_commit()
+
+        conf = get_interface_config('tun10')
+        self.assertEqual('gre', conf['linkinfo']['info_kind'])
+        self.assertEqual(self.local_v4, conf['linkinfo']['info_data']['local'])
+        self.assertNotIn('ikey', conf['linkinfo']['info_data'])
+
+        conf = get_interface_config('tun20')
+        self.assertEqual('gre', conf['linkinfo']['info_kind'])
+        self.assertEqual(self.local_v4, conf['linkinfo']['info_data']['local'])
+        self.assertEqual(f'0.0.0.{ip_key}', conf['linkinfo']['info_data']['ikey'])
+        self.assertEqual(f'0.0.0.{ip_key}', conf['linkinfo']['info_data']['okey'])
+
     def test_tunnel_invalid_source_interface(self):
         encapsulation = 'gre'
         remote = '192.0.2.1'

--- a/smoketest/scripts/cli/test_interfaces_tunnel.py
+++ b/smoketest/scripts/cli/test_interfaces_tunnel.py
@@ -430,7 +430,7 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
         ip_key = '20'
         tunnels = {
             'tun10': source_if,
-            'tun20': source_if_alt,
+            'tun20': source_if2,
         }
 
         for tunnel, interface in tunnels.items():

--- a/smoketest/scripts/cli/test_interfaces_tunnel.py
+++ b/smoketest/scripts/cli/test_interfaces_tunnel.py
@@ -501,7 +501,8 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
     def test_multiple_gre_tunnel_keyless_different_source_interface(self):
         # Tunnels bound to different source-interfaces stay distinct for the
         # Kernel even when they share one local and remote address - "dev" is
-        # compared as parms.link - so no GRE key is needed to tell them apart
+        # compared as the tunnel link index - so no GRE key is needed to tell
+        # them apart
         remote = '1.2.3.4'
         tunnels = {
             'tun10': source_if,

--- a/smoketest/scripts/cli/test_interfaces_tunnel.py
+++ b/smoketest/scripts/cli/test_interfaces_tunnel.py
@@ -525,6 +525,24 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
             self.assertEqual(remote, conf['linkinfo']['info_data']['remote'])
             self.assertNotIn('ikey', conf['linkinfo']['info_data'])
 
+    def test_multiple_gre_tunnel_zero_key(self):
+        # A zero GRE key cannot be told apart from an unset key on receive, thus
+        # it does not make a tunnel unique - a non-zero key does
+        for tunnel in ['tun10', 'tun20']:
+            self.cli_set(self._base_path + [tunnel, 'encapsulation', 'gre'])
+            self.cli_set(self._base_path + [tunnel, 'source-interface', source_if])
+        self.cli_set(self._base_path + ['tun20', 'parameters', 'ip', 'key', '0'])
+
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_set(self._base_path + ['tun20', 'parameters', 'ip', 'key', '50'])
+        self.cli_commit()
+
+        conf = get_interface_config('tun20')
+        self.assertEqual('0.0.0.50', conf['linkinfo']['info_data']['ikey'])
+        self.assertEqual('0.0.0.50', conf['linkinfo']['info_data']['okey'])
+
     def test_tunnel_invalid_source_interface(self):
         encapsulation = 'gre'
         remote = '192.0.2.1'

--- a/smoketest/scripts/cli/test_interfaces_tunnel.py
+++ b/smoketest/scripts/cli/test_interfaces_tunnel.py
@@ -26,6 +26,7 @@ from vyos.template import inc_ip
 remote_ip4 = '192.0.2.100'
 remote_ip6 = '2001:db8::ffff'
 source_if = 'dum2222'
+source_if2 = 'dum2223'
 mtu = 1476
 
 class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
@@ -45,10 +46,12 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
         # create some test interfaces
         cls.cli_set(cls, ['interfaces', 'dummy', source_if, 'address', cls.local_v4 + '/32'])
         cls.cli_set(cls, ['interfaces', 'dummy', source_if, 'address', cls.local_v6 + '/128'])
+        cls.cli_set(cls, ['interfaces', 'dummy', source_if2])
 
     @classmethod
     def tearDownClass(cls):
         cls.cli_delete(cls, ['interfaces', 'dummy', source_if])
+        cls.cli_delete(cls, ['interfaces', 'dummy', source_if2])
         super().tearDownClass()
 
     def test_ipv4_encapsulations(self):
@@ -393,6 +396,77 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
             self.assertEqual(tunnel_config['source_interface'], conf['link'])
             self.assertEqual(tunnel_config['encapsulation'],    conf['linkinfo']['info_kind'])
             self.assertEqual(tunnel_config['remote'],           conf['linkinfo']['info_data']['remote'])
+
+    def test_multiple_gre_tunnel_same_key_different_remote(self):
+        # The Kernel identifies a tunnel by local address, remote address,
+        # source-interface and key - a differing remote address is enough to
+        # make both tunnels unique, even if they share one GRE key
+        ip_key = '10'
+        tunnels = {
+            'tun10': '1.2.3.4',
+            'tun20': '1.2.3.5',
+        }
+
+        for tunnel, remote in tunnels.items():
+            self.cli_set(self._base_path + [tunnel, 'encapsulation', 'gre'])
+            self.cli_set(self._base_path + [tunnel, 'source-address', self.local_v4])
+            self.cli_set(self._base_path + [tunnel, 'remote', remote])
+            self.cli_set(self._base_path + [tunnel, 'parameters', 'ip', 'key', ip_key])
+
+        self.cli_commit()
+
+        for tunnel, remote in tunnels.items():
+            conf = get_interface_config(tunnel)
+
+            self.assertEqual('gre', conf['linkinfo']['info_kind'])
+            self.assertEqual(self.local_v4, conf['linkinfo']['info_data']['local'])
+            self.assertEqual(remote, conf['linkinfo']['info_data']['remote'])
+            self.assertEqual(f'0.0.0.{ip_key}', conf['linkinfo']['info_data']['ikey'])
+            self.assertEqual(f'0.0.0.{ip_key}', conf['linkinfo']['info_data']['okey'])
+
+    def test_multiple_gre_tunnel_same_key_different_source_interface(self):
+        # Tunnels bound to different source-interfaces are distinct for the
+        # Kernel, thus they are free to share one GRE key
+        ip_key = '20'
+        tunnels = {
+            'tun10': source_if,
+            'tun20': source_if_alt,
+        }
+
+        for tunnel, interface in tunnels.items():
+            self.cli_set(self._base_path + [tunnel, 'encapsulation', 'gre'])
+            self.cli_set(self._base_path + [tunnel, 'source-interface', interface])
+            self.cli_set(self._base_path + [tunnel, 'parameters', 'ip', 'key', ip_key])
+
+        self.cli_commit()
+
+        for tunnel, interface in tunnels.items():
+            conf = get_interface_config(tunnel)
+
+            self.assertEqual(interface, conf['link'])
+            self.assertEqual('gre', conf['linkinfo']['info_kind'])
+            self.assertEqual(f'0.0.0.{ip_key}', conf['linkinfo']['info_data']['ikey'])
+            self.assertEqual(f'0.0.0.{ip_key}', conf['linkinfo']['info_data']['okey'])
+
+    def test_multiple_gre_tunnel_any_remote(self):
+        # The Kernel stores an unset remote address as the any address, thus
+        # "remote 0.0.0.0" and an unset remote must be treated alike - creating
+        # both would fail with "add tunnel "gre0" failed: File exists"
+        ip_key = '30'
+
+        for tunnel in ['tun10', 'tun20']:
+            self.cli_set(self._base_path + [tunnel, 'encapsulation', 'gre'])
+            self.cli_set(self._base_path + [tunnel, 'source-address', self.local_v4])
+            self.cli_set(self._base_path + [tunnel, 'parameters', 'ip', 'key', ip_key])
+        self.cli_set(self._base_path + ['tun10', 'remote', '0.0.0.0'])
+
+        # Both tunnels resolve to the same Kernel tunnel - this must be rejected
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        # A differing key makes them unique again
+        self.cli_set(self._base_path + ['tun20', 'parameters', 'ip', 'key', '31'])
+        self.cli_commit()
 
     def test_tunnel_invalid_source_interface(self):
         encapsulation = 'gre'

--- a/smoketest/scripts/cli/test_interfaces_tunnel.py
+++ b/smoketest/scripts/cli/test_interfaces_tunnel.py
@@ -324,7 +324,22 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
         # GRE key must be supplied with a 0.0.0.0 source address
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
+
+        # A zero key is no key at all for such a tunnel - with an any
+        # source-address and no remote it catches every packet, exactly as a
+        # keyless tunnel would
+        self.cli_set(self._base_path + [interface, 'parameters', 'ip', 'key', '0'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
         self.cli_set(self._base_path + [interface, 'parameters', 'ip', 'key', key])
+
+        self.cli_commit()
+
+        # A remote address identifies the tunnel on its own, so a zero key is
+        # no longer a problem
+        self.cli_set(self._base_path + [interface, 'parameters', 'ip', 'key', '0'])
+        self.cli_set(self._base_path + [interface, 'remote', remote_ip4])
 
         self.cli_commit()
 

--- a/smoketest/scripts/cli/test_interfaces_tunnel.py
+++ b/smoketest/scripts/cli/test_interfaces_tunnel.py
@@ -527,8 +527,9 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
             self.assertNotIn('ikey', conf['linkinfo']['info_data'])
 
     def test_multiple_gre_tunnel_zero_key(self):
-        # A zero GRE key cannot be told apart from an unset key on receive, thus
-        # it does not make a tunnel unique - a non-zero key does
+        # Carrying neither a source-address nor a remote, these tunnels are only
+        # told apart by their key - and a zero key does not do that, it cannot be
+        # told from an unset one on receive. A non-zero key can
         for tunnel in ['tun10', 'tun20']:
             self.cli_set(self._base_path + [tunnel, 'encapsulation', 'gre'])
             self.cli_set(self._base_path + [tunnel, 'source-interface', source_if])
@@ -553,6 +554,55 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
 
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
+
+    def test_multiple_gre_tunnel_zero_key_with_endpoints(self):
+        # A zero key does tell a tunnel apart from a keyless one as soon as a
+        # local or a remote address is set - the Kernel then matches through
+        # ip_tunnel_key_match(), which tests the flag saying that a key is set
+        # before it compares the value
+        for tunnel in ['tun10', 'tun20']:
+            self.cli_set(self._base_path + [tunnel, 'encapsulation', 'gre'])
+            self.cli_set(self._base_path + [tunnel, 'source-address', self.local_v4])
+        self.cli_set(self._base_path + ['tun20', 'parameters', 'ip', 'key', '0'])
+
+        # The same holds when it is the remote address which identifies them
+        for tunnel in ['tun30', 'tun40']:
+            self.cli_set(self._base_path + [tunnel, 'encapsulation', 'gre'])
+            self.cli_set(self._base_path + [tunnel, 'source-interface', source_if])
+            self.cli_set(self._base_path + [tunnel, 'remote', remote_ip4])
+        self.cli_set(self._base_path + ['tun40', 'parameters', 'ip', 'key', '0'])
+
+        self.cli_commit()
+
+        # Re-verifying the keyless tunnels must keep succeeding - if it does
+        # not, the next commit touching them fails and they are lost on the
+        # next boot
+        for tunnel in ['tun10', 'tun30']:
+            self.cli_set(self._base_path + [tunnel, 'description', 'foo'])
+
+        self.cli_commit()
+
+        for tunnel in ['tun10', 'tun20']:
+            conf = get_interface_config(tunnel)
+
+            self.assertEqual('gre', conf['linkinfo']['info_kind'])
+            self.assertEqual(self.local_v4, conf['linkinfo']['info_data']['local'])
+
+        for tunnel in ['tun30', 'tun40']:
+            conf = get_interface_config(tunnel)
+
+            self.assertEqual(source_if, conf['link'])
+            self.assertEqual('gre', conf['linkinfo']['info_kind'])
+            self.assertEqual(remote_ip4, conf['linkinfo']['info_data']['remote'])
+
+        # The keyless tunnels must have stayed keyless. That the commit went
+        # through at all is what proves the zero key reached the Kernel with its
+        # flag set - dropped, it would have left two keyless tunnels sharing one
+        # endpoint and the second of them could not have been created
+        for tunnel in ['tun10', 'tun30']:
+            conf = get_interface_config(tunnel)
+
+            self.assertNotIn('ikey', conf['linkinfo']['info_data'])
 
     def test_tunnel_invalid_source_interface(self):
         encapsulation = 'gre'

--- a/smoketest/scripts/cli/test_interfaces_tunnel.py
+++ b/smoketest/scripts/cli/test_interfaces_tunnel.py
@@ -498,6 +498,33 @@ class TunnelInterfaceTest(BasicInterfaceTest.TestCase):
         self.assertEqual(f'0.0.0.{ip_key}', conf['linkinfo']['info_data']['ikey'])
         self.assertEqual(f'0.0.0.{ip_key}', conf['linkinfo']['info_data']['okey'])
 
+    def test_multiple_gre_tunnel_keyless_different_source_interface(self):
+        # Tunnels bound to different source-interfaces stay distinct for the
+        # Kernel even when they share one local and remote address - "dev" is
+        # compared as parms.link - so no GRE key is needed to tell them apart
+        remote = '1.2.3.4'
+        tunnels = {
+            'tun10': source_if,
+            'tun20': source_if2,
+        }
+
+        for tunnel, interface in tunnels.items():
+            self.cli_set(self._base_path + [tunnel, 'encapsulation', 'gre'])
+            self.cli_set(self._base_path + [tunnel, 'source-address', self.local_v4])
+            self.cli_set(self._base_path + [tunnel, 'source-interface', interface])
+            self.cli_set(self._base_path + [tunnel, 'remote', remote])
+
+        self.cli_commit()
+
+        for tunnel, interface in tunnels.items():
+            conf = get_interface_config(tunnel)
+
+            self.assertEqual(interface, conf['link'])
+            self.assertEqual('gre', conf['linkinfo']['info_kind'])
+            self.assertEqual(self.local_v4, conf['linkinfo']['info_data']['local'])
+            self.assertEqual(remote, conf['linkinfo']['info_data']['remote'])
+            self.assertNotIn('ikey', conf['linkinfo']['info_data'])
+
     def test_tunnel_invalid_source_interface(self):
         encapsulation = 'gre'
         remote = '192.0.2.1'

--- a/src/conf_mode/interfaces_tunnel.py
+++ b/src/conf_mode/interfaces_tunnel.py
@@ -189,8 +189,11 @@ def verify(tunnel):
                 # A keyless tunnel never collides with a keyed one, as the Kernel
                 # only matches a tunnel carrying no key against another tunnel
                 # carrying no key, see ip_tunnel_key_match() in
-                # include/net/ip_tunnels.h
-                if their_key is not None:
+                # include/net/ip_tunnels.h. A zero key does not count as a key
+                # here - ip_tunnel_lookup() ends in a flag-blind compare and
+                # ip6gre_tunnel_locate() compares the key with no flag gate at
+                # all, so "key 0" and no key stay ambiguous on receive.
+                if their_key is not None and their_key != '0':
                     continue
 
                 # If no IP GRE key is defined we cannot have more than one GRE tunnel

--- a/src/conf_mode/interfaces_tunnel.py
+++ b/src/conf_mode/interfaces_tunnel.py
@@ -186,14 +186,14 @@ def verify(tunnel):
                         f'for tunnel "{o_tunnel}"!'
                     )
             else:
-                # If no IP GRE key is defined we cannot have more then one GRE tunnel
+                # If no IP GRE key is defined we cannot have more than one GRE tunnel
                 # bound to any one interface/IP address and the same remote. This will
                 # result in a OS  PermissionError: add tunnel "gre0" failed: File exists
                 if our_address is not None and their_address == our_address:
                     # If set to the same values, this is always a fail
                     raise ConfigError(
                         'Missing required "ip key" parameter when '
-                        'running more then one GRE based tunnel on the '
+                        'running more than one GRE based tunnel on the '
                         'same source-address'
                     )
 
@@ -203,7 +203,7 @@ def verify(tunnel):
                     # source-ifs set and matching with unset source-ips is a fail
                     raise ConfigError(
                         'Missing required "ip key" parameter when '
-                        'running more then one GRE based tunnel on the '
+                        'running more than one GRE based tunnel on the '
                         'same source-interface'
                     )
 

--- a/src/conf_mode/interfaces_tunnel.py
+++ b/src/conf_mode/interfaces_tunnel.py
@@ -145,13 +145,25 @@ def verify(tunnel):
             if 'direction' not in tunnel['parameters']['erspan']:
                 raise ConfigError('ERSPAN version 2 requires direction to be set!')
 
-    # If tunnel source is any and gre key is not set
+    # If tunnel source is any and the gre key does not identify the tunnel
     interface = tunnel['ifname']
-    if tunnel['encapsulation'] in ['gre'] and \
-       dict_search('source_address', tunnel) == '0.0.0.0' and \
-       dict_search('parameters.ip.key', tunnel) == None:
-        raise ConfigError(f'"parameters ip key" must be set for {interface} when '\
-                           'encapsulation is GRE!')
+    if (
+        tunnel['encapsulation'] in ['gre']
+        and dict_search('source_address', tunnel) == '0.0.0.0'
+    ):
+        # The source-address being the any address, a tunnel without a remote
+        # carries no endpoint at all - a zero key does not tell such a tunnel
+        # apart from a keyless one either, see get_tunnel_key()
+        no_endpoints = get_tunnel_endpoint(dict_search('remote', tunnel)) is None
+        key = dict_search('parameters.ip.key', tunnel)
+        if get_tunnel_key(key, no_endpoints) is None:
+            # Only a tunnel which has no remote either is asked for a
+            # non-zero key, a zero one does identify the rest
+            tmp = 'set to a non-zero value' if no_endpoints else 'set'
+            raise ConfigError(
+                f'"parameters ip key" must be {tmp} for {interface} when '
+                'encapsulation is GRE!'
+            )
 
     gre_encapsulations = ['gre', 'gretap']
     if tunnel['encapsulation'] in gre_encapsulations and 'other_tunnels' in tunnel:

--- a/src/conf_mode/interfaces_tunnel.py
+++ b/src/conf_mode/interfaces_tunnel.py
@@ -223,9 +223,14 @@ def verify(tunnel):
                     # Note that lack of a None check here is deliberate.
                     # source-if and source-ip matching while unset (all None) is a fail
                     # source-ifs set and matching with unset source-ips is a fail
-                    tmp = 'source-interface'
-                    if our_address is not None:
-                        tmp = 'source-address'
+
+                    # Name what the two tunnels really have in common. An "any"
+                    # source-address normalises to None and cannot pick the noun,
+                    # and a tunnel carrying no source-interface always has a
+                    # source-address, see verify_tunnel()
+                    tmp = 'source-address'
+                    if our_source_if is not None:
+                        tmp = 'source-interface'
                     if zero_key:
                         raise ConfigError(
                             'A zero "ip key" parameter cannot be told apart from '

--- a/src/conf_mode/interfaces_tunnel.py
+++ b/src/conf_mode/interfaces_tunnel.py
@@ -48,6 +48,18 @@ def get_tunnel_endpoint(address):
         return None
     return address
 
+
+def get_tunnel_key(key):
+    """
+    A zero GRE key cannot be told apart from a key which is not set at all when a
+    packet is received, thus it does not make a tunnel unique - ip_tunnel_lookup()
+    ends in a flag-blind compare and ip6gre_tunnel_locate() compares the key with
+    no flag gate at all
+    """
+    if key == '0':
+        return None
+    return key
+
 def get_config(config=None):
     """
     Retrieve CLI config as dictionary. Dictionary can never be empty, as at least
@@ -163,6 +175,14 @@ def verify(tunnel):
             their_source_if = dict_search('source_interface', o_tunnel_conf)
             their_remote = get_tunnel_endpoint(dict_search('remote', o_tunnel_conf))
 
+            # Both sides must classify a zero key the same way, else the very same
+            # pair of tunnels is accepted or rejected depending on which of the two
+            # is being verified. Remember whether one was configured, the error
+            # message differs from the one for a tunnel carrying no key at all.
+            zero_key = '0' in [our_key, their_key]
+            our_key = get_tunnel_key(our_key)
+            their_key = get_tunnel_key(their_key)
+
             # The Kernel identifies a tunnel by the tuple of local address, remote
             # address, source-interface and - if configured - the GRE key, see
             # ip_tunnel_find() in net/ipv4/ip_tunnel.c. A differing remote address
@@ -189,11 +209,8 @@ def verify(tunnel):
                 # A keyless tunnel never collides with a keyed one, as the Kernel
                 # only matches a tunnel carrying no key against another tunnel
                 # carrying no key, see ip_tunnel_key_match() in
-                # include/net/ip_tunnels.h. A zero key does not count as a key
-                # here - ip_tunnel_lookup() ends in a flag-blind compare and
-                # ip6gre_tunnel_locate() compares the key with no flag gate at
-                # all, so "key 0" and no key stay ambiguous on receive.
-                if their_key is not None and their_key != '0':
+                # include/net/ip_tunnels.h
+                if their_key is not None:
                     continue
 
                 # If no IP GRE key is defined we cannot have more than one GRE tunnel
@@ -209,6 +226,12 @@ def verify(tunnel):
                     tmp = 'source-interface'
                     if our_address is not None:
                         tmp = 'source-address'
+                    if zero_key:
+                        raise ConfigError(
+                            'A zero "ip key" parameter cannot be told apart from '
+                            'an unset one - use a non-zero key to run more than '
+                            f'one GRE based tunnel on the same {tmp} as "{o_tunnel}"'
+                        )
                     raise ConfigError(
                         'Missing required "ip key" parameter when running more '
                         f'than one GRE based tunnel on the same {tmp}'

--- a/src/conf_mode/interfaces_tunnel.py
+++ b/src/conf_mode/interfaces_tunnel.py
@@ -186,6 +186,13 @@ def verify(tunnel):
                         f'for tunnel "{o_tunnel}"!'
                     )
             else:
+                # A keyless tunnel never collides with a keyed one, as the Kernel
+                # only matches a tunnel carrying no key against another tunnel
+                # carrying no key, see ip_tunnel_key_match() in
+                # include/net/ip_tunnels.h
+                if their_key is not None:
+                    continue
+
                 # If no IP GRE key is defined we cannot have more than one GRE tunnel
                 # bound to any one interface/IP address and the same remote. This will
                 # result in a OS  PermissionError: add tunnel "gre0" failed: File exists

--- a/src/conf_mode/interfaces_tunnel.py
+++ b/src/conf_mode/interfaces_tunnel.py
@@ -196,22 +196,18 @@ def verify(tunnel):
                 # If no IP GRE key is defined we cannot have more than one GRE tunnel
                 # bound to any one interface/IP address and the same remote. This will
                 # result in a OS  PermissionError: add tunnel "gre0" failed: File exists
-                if our_address is not None and their_address == our_address:
-                    # If set to the same values, this is always a fail
-                    raise ConfigError(
-                        'Missing required "ip key" parameter when '
-                        'running more than one GRE based tunnel on the '
-                        'same source-address'
-                    )
-
-                if their_source_if == our_source_if and their_address == our_address:
-                    # Note that lack of None check on these is deliberate.
+                if their_address == our_address and their_source_if == our_source_if:
+                    # A differing source-interface alone already keeps both apart,
+                    # it is passed as "dev" and compared by the Kernel as parms.link.
+                    # Note that lack of a None check here is deliberate.
                     # source-if and source-ip matching while unset (all None) is a fail
                     # source-ifs set and matching with unset source-ips is a fail
+                    tmp = 'source-interface'
+                    if our_address is not None:
+                        tmp = 'source-address'
                     raise ConfigError(
-                        'Missing required "ip key" parameter when '
-                        'running more than one GRE based tunnel on the '
-                        'same source-interface'
+                        'Missing required "ip key" parameter when running more '
+                        f'than one GRE based tunnel on the same {tmp}'
                     )
 
     # Keys are not allowed with ipip and sit tunnels

--- a/src/conf_mode/interfaces_tunnel.py
+++ b/src/conf_mode/interfaces_tunnel.py
@@ -49,14 +49,15 @@ def get_tunnel_endpoint(address):
     return address
 
 
-def get_tunnel_key(key):
+def get_tunnel_key(key, no_endpoints):
     """
-    A zero GRE key cannot be told apart from a key which is not set at all when a
-    packet is received, thus it does not make a tunnel unique - ip_tunnel_lookup()
-    ends in a flag-blind compare and ip6gre_tunnel_locate() compares the key with
-    no flag gate at all
+    A zero GRE key only fails to make a tunnel unique when neither a local nor a
+    remote address is set - ip_tunnel_lookup() then ends in a loop which compares
+    the key without testing the flag saying that a key is set at all. A tunnel
+    which carries an address is matched before that, by ip_tunnel_key_match(),
+    where a zero key and an unset key differ
     """
-    if key == '0':
+    if no_endpoints and key == '0':
         return None
     return key
 
@@ -175,13 +176,18 @@ def verify(tunnel):
             their_source_if = dict_search('source_interface', o_tunnel_conf)
             their_remote = get_tunnel_endpoint(dict_search('remote', o_tunnel_conf))
 
-            # Both sides must classify a zero key the same way, else the very same
-            # pair of tunnels is accepted or rejected depending on which of the two
-            # is being verified. Remember whether one was configured, the error
+            # A zero key only fails to make a tunnel unique when neither of the
+            # two carries a local or a remote address, see get_tunnel_key(). Both
+            # sides must classify it the same way, else the very same pair of
+            # tunnels is accepted or rejected depending on which of the two is
+            # being verified. Remember whether one was configured, the error
             # message differs from the one for a tunnel carrying no key at all.
+            no_endpoints = not any(
+                [our_address, our_remote, their_address, their_remote]
+            )
             zero_key = '0' in [our_key, their_key]
-            our_key = get_tunnel_key(our_key)
-            their_key = get_tunnel_key(their_key)
+            our_key = get_tunnel_key(our_key, no_endpoints)
+            their_key = get_tunnel_key(their_key, no_endpoints)
 
             # The Kernel identifies a tunnel by the tuple of local address, remote
             # address, source-interface and - if configured - the GRE key, see

--- a/src/conf_mode/interfaces_tunnel.py
+++ b/src/conf_mode/interfaces_tunnel.py
@@ -38,6 +38,16 @@ from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
 
+
+def get_tunnel_endpoint(address):
+    """
+    The Kernel stores an unconfigured tunnel endpoint as the any address, thus
+    "0.0.0.0" and "::" must compare equal to an endpoint which is not set at all
+    """
+    if address in ['0.0.0.0', '::']:
+        return None
+    return address
+
 def get_config(config=None):
     """
     Retrieve CLI config as dictionary. Dictionary can never be empty, as at least
@@ -142,36 +152,57 @@ def verify(tunnel):
                 not in gre_encapsulations:
                 continue
 
-            our_address = dict_search('source_address', tunnel)
+            our_address = get_tunnel_endpoint(dict_search('source_address', tunnel))
             our_key = dict_search('parameters.ip.key', tunnel)
-            their_address = dict_search('source_address', o_tunnel_conf)
+            our_source_if = dict_search('source_interface', tunnel)
+            our_remote = get_tunnel_endpoint(dict_search('remote', tunnel))
+            their_address = get_tunnel_endpoint(
+                dict_search('source_address', o_tunnel_conf)
+            )
             their_key = dict_search('parameters.ip.key', o_tunnel_conf)
-            if our_key != None:
-                if their_address == our_address and their_key == our_key:
-                    raise ConfigError(f'Key "{our_key}" for source-address "{our_address}" ' \
-                                      f'is already used for tunnel "{o_tunnel}"!')
+            their_source_if = dict_search('source_interface', o_tunnel_conf)
+            their_remote = get_tunnel_endpoint(dict_search('remote', o_tunnel_conf))
+
+            # The Kernel identifies a tunnel by the tuple of local address, remote
+            # address, source-interface and - if configured - the GRE key, see
+            # ip_tunnel_find() in net/ipv4/ip_tunnel.c. A differing remote address
+            # alone already makes both tunnels unique, whether a key is used or not.
+            if our_remote != their_remote:
+                continue
+
+            if our_key is not None:
+                # Prevent the same key for 2 tunnels sharing both endpoints. T2920
+                if (
+                    their_address == our_address
+                    and their_source_if == our_source_if
+                    and their_key == our_key
+                ):
+                    tmp = our_address if our_address else our_source_if
+                    raise ConfigError(
+                        f'Key "{our_key}" for source "{tmp}" is already used '
+                        f'for tunnel "{o_tunnel}"!'
+                    )
             else:
-                our_source_if = dict_search('source_interface', tunnel)
-                their_source_if = dict_search('source_interface', o_tunnel_conf)
-                our_remote = dict_search('remote', tunnel)
-                their_remote = dict_search('remote', o_tunnel_conf)
                 # If no IP GRE key is defined we cannot have more then one GRE tunnel
                 # bound to any one interface/IP address and the same remote. This will
                 # result in a OS  PermissionError: add tunnel "gre0" failed: File exists
-                if our_remote == their_remote:
-                    if our_address is not None and their_address == our_address: 
-                        # If set to the same values, this is always a fail 
-                        raise ConfigError(f'Missing required "ip key" parameter when '\
-                                           'running more then one GRE based tunnel on the '\
-                                           'same source-address')
+                if our_address is not None and their_address == our_address:
+                    # If set to the same values, this is always a fail
+                    raise ConfigError(
+                        'Missing required "ip key" parameter when '
+                        'running more then one GRE based tunnel on the '
+                        'same source-address'
+                    )
 
-                    if their_source_if == our_source_if and their_address == our_address:
-                        # Note that lack of None check on these is deliberate. 
-                        # source-if and source-ip matching while unset (all None) is a fail
-                        # source-ifs set and matching with unset source-ips is a fail
-                        raise ConfigError(f'Missing required "ip key" parameter when '\
-                                           'running more then one GRE based tunnel on the '\
-                                           'same source-interface')
+                if their_source_if == our_source_if and their_address == our_address:
+                    # Note that lack of None check on these is deliberate.
+                    # source-if and source-ip matching while unset (all None) is a fail
+                    # source-ifs set and matching with unset source-ips is a fail
+                    raise ConfigError(
+                        'Missing required "ip key" parameter when '
+                        'running more then one GRE based tunnel on the '
+                        'same source-interface'
+                    )
 
     # Keys are not allowed with ipip and sit tunnels
     if tunnel['encapsulation'] in ['ipip', 'sit']:

--- a/src/conf_mode/interfaces_tunnel.py
+++ b/src/conf_mode/interfaces_tunnel.py
@@ -177,7 +177,10 @@ def verify(tunnel):
                     and their_source_if == our_source_if
                     and their_key == our_key
                 ):
-                    tmp = our_address if our_address else our_source_if
+                    # Report the source as configured and not as normalised,
+                    # else an "any" source-address would render as "None".
+                    # One of both is always present, see verify_tunnel()
+                    tmp = dict_search('source_address', tunnel) or our_source_if
                     raise ConfigError(
                         f'Key "{our_key}" for source "{tmp}" is already used '
                         f'for tunnel "{o_tunnel}"!'

--- a/src/conf_mode/interfaces_tunnel.py
+++ b/src/conf_mode/interfaces_tunnel.py
@@ -201,7 +201,8 @@ def verify(tunnel):
                 # result in a OS  PermissionError: add tunnel "gre0" failed: File exists
                 if their_address == our_address and their_source_if == our_source_if:
                     # A differing source-interface alone already keeps both apart,
-                    # it is passed as "dev" and compared by the Kernel as parms.link.
+                    # it is passed as "dev" and compared by the Kernel as the
+                    # tunnel link index, see ip_tunnel_find().
                     # Note that lack of a None check here is deliberate.
                     # source-if and source-ip matching while unset (all None) is a fail
                     # source-ifs set and matching with unset source-ips is a fail


### PR DESCRIPTION
### Change Summary

The pairwise GRE tunnel collision check in `src/conf_mode/interfaces_tunnel.py` was more
restrictive **with** a GRE key configured than without one. The keyed branch only compared
`source-address` and `key` — `remote` and `source_interface` were not even in scope there,
as they are looked up inside the `else:` branch. It is unchanged since T2920 (2020); T4267
added the `remote` comparison to the keyless branch only.

Consequently these were rejected, although the Kernel keeps both pairs apart:

```
set interfaces tunnel tun10 encapsulation 'gre'
set interfaces tunnel tun10 source-address '192.0.2.1'
set interfaces tunnel tun10 remote '203.0.113.1'
set interfaces tunnel tun10 parameters ip key '10'
set interfaces tunnel tun20 encapsulation 'gre'
set interfaces tunnel tun20 source-address '192.0.2.1'
set interfaces tunnel tun20 remote '203.0.113.2'
set interfaces tunnel tun20 parameters ip key '10'
```
> Key "10" for source-address "192.0.2.1" is already used for tunnel "tun10"!

```
set interfaces tunnel tun10 encapsulation 'gre'
set interfaces tunnel tun10 source-interface 'eth0'
set interfaces tunnel tun10 parameters ip key '10'
set interfaces tunnel tun20 encapsulation 'gre'
set interfaces tunnel tun20 source-interface 'eth1'
set interfaces tunnel tun20 parameters ip key '10'
```

`ip_tunnel_find()` in `net/ipv4/ip_tunnel.c` treats a tunnel as a duplicate only when
local address, remote address, `parms.link` (the source-interface), `dev->type` and the
key all match. On receive, `ip_tunnel_lookup()` compares local **and** remote before it
looks at the key and uses `parms.link` as a tie-break, so both pairs also demultiplex
unambiguously — this is not merely "the Kernel lets you create it".

This models the check on that tuple. It also normalizes `0.0.0.0`/`::` to an unset
endpoint, because the Kernel stores an unconfigured endpoint as the any address: previously
`remote 0.0.0.0` and an unset `remote` compared as distinct, letting a colliding pair pass
`verify()` and then fail on commit with `add tunnel "gre0" failed: File exists`.

Deliberately **still** rejected, as the Kernel cannot demultiplex either pair:

- two tunnels sharing local and remote without a key, whichever `source-interface` is used —
  they are byte-identical on the wire outbound;
- two mGRE tunnels sharing a key on one `source-interface` (DMVPN).

Not addressed here, worth separate tasks: `gre` and `gretap` are still compared with each
other although the Kernel keeps them in separate tunnel tables, and `ip6gre`/`ip6gretap`
receive no uniqueness validation at all.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

On the breaking-change box: the relaxations are purely additive — configurations that were
rejected now commit, and nothing that worked stops working. The `0.0.0.0` normalization is
the one case that goes the other way, newly rejecting at commit time two GRE tunnels that
share a source address and key where one sets `remote 0.0.0.0` and the other omits `remote`.
That configuration already failed to apply with `add tunnel "gre0" failed: File exists`, so
no *working* configuration changes behaviour — the failure just moves from apply time to
commit time, where it can be reported properly. No migration script is required and there
are no CLI syntax changes.

### Related Task(s)

* https://vyos.dev/T9193

### Component(s) name

tunnel

### Proposed changes

`verify()` now resolves `source-address`, `source-interface`, `remote` and `key` for both
tunnels, skips the peer outright when the remote addresses differ, and applies the same
endpoint comparison to the keyed and keyless branches. A small `get_tunnel_endpoint()`
helper maps `0.0.0.0`/`::` onto `None` so the any address and an unset node compare equal.

### How to test

Verified against the Kernel rather than by inspection alone — Linux 6.12 / iproute2 6.15,
in a network namespace:

```
ip tunnel add gre1 mode gre local 192.0.2.1 remote 192.0.2.10 key 10   # OK
ip tunnel add gre2 mode gre local 192.0.2.1 remote 192.0.2.11 key 10   # OK
ip tunnel add gre3 mode gre dev dum0 key 20                            # OK
ip tunnel add gre4 mode gre dev dum1 key 20                            # OK

ip tunnel add gre5 mode gre local 192.0.2.1 remote 0.0.0.0 key 30      # OK
ip tunnel add gre6 mode gre local 192.0.2.1 key 30                     # File exists
```

The full matrix run covers 22 create/collide cases; the resulting accept/reject sets match
this patch exactly, including every case left deliberately stricter than the Kernel.

Three smoketests added to `smoketest/scripts/cli/test_interfaces_tunnel.py`:

* `test_multiple_gre_tunnel_same_key_different_remote`
* `test_multiple_gre_tunnel_same_key_different_source_interface`
* `test_multiple_gre_tunnel_any_remote` (the `0.0.0.0` collision, expects a rejection)

The existing `test_multiple_gre_tunnel_same_remote` and
`test_multiple_gre_tunnel_different_remote` are unaffected.

To be explicit about what I could **not** run: the smoketests need a live VyOS image, which
I do not have to hand, so they have not been executed locally — I am relying on CI for those.
What was executed locally is the Kernel matrix above, plus `darker` and `ruff` (via
`graylint`, diff-scoped against `rolling`), both clean.

### Checklist

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components smoketest after applying my changes
- [x] My commit headline contains a valid Task id
