### PR TITLE
xml: T9179: reject VRF names in interface-name constraint

### DIFF
--- a/interface-definitions/include/constraint/interface-name.xml.i
+++ b/interface-definitions/include/constraint/interface-name.xml.i
@@ -1,4 +1,4 @@
 <!-- include start from constraint/interface-name.xml.i -->
 <regex>(bond|br|dum|en|ersp|eth|gnv|ifb|ipoe|lan|l2tp|l2tpeth|macsec|peth|ppp|pppoe|pptp|sstp|sstpc|tun|veth|vpptap|vpptun|vti|vtun|vxlan|wg|wlan|wwan)[0-9]+(.\d+)?|pod-[-_a-zA-Z0-9]{1,11}|lo</regex>
-<validator name="file-path --lookup-path /sys/class/net --directory"/>
+<validator name="interface-exists"/>
 <!-- include end -->

--- a/smoketest/scripts/cli/test_system_flow-accounting.py
+++ b/smoketest/scripts/cli/test_system_flow-accounting.py
@@ -278,12 +278,9 @@ class TestSystemFlowAccounting(VyOSUnitTestSHIM.TestCase):
 
         # A source-interface that names a VRF is not an interface and must be
         # rejected
-        self.cli_set(
-            base_path
-            + ['netflow', 'server', '198.51.100.9', 'source-interface', vrf_name]
-        )
         with self.assertRaises(ConfigSessionError):
-            self.cli_commit()
+            self.cli_set(base_path + ['netflow', 'server', '198.51.100.9',
+                                      'source-interface', vrf_name])
         self.cli_delete(base_path + ['netflow', 'server', '198.51.100.9'])
 
         self.cli_delete(['interfaces', 'dummy', dummy_if])

--- a/src/conf_mode/system_flow-accounting.py
+++ b/src/conf_mode/system_flow-accounting.py
@@ -25,9 +25,7 @@ from vyos.config import config_dict_merge
 from vyos.configverify import verify_vrf
 from vyos.configverify import verify_interface_exists
 from vyos.template import render
-from vyos.utils.dict import dict_search
 from vyos.utils.file import read_file
-from vyos.utils.network import get_interface_config
 from vyos.utils.network import get_interface_vrf
 from vyos.utils.network import interface_exists
 from vyos.utils.network import is_addr_assigned
@@ -121,16 +119,6 @@ def verify(flow_config):
             verify_interface_exists(
                 flow_config, data['source_interface'], warning_only=True
             )
-            # A VRF is not an interface. Cisco and Juniper both source a flow
-            # exporter from a routed interface and never from a VRF, and VRF
-            # export is already selected with "system flow-accounting vrf", so
-            # reject a source-interface that names a VRF device.
-            source_interface_config = get_interface_config(data['source_interface'])
-            if dict_search('linkinfo.info_kind', source_interface_config) == 'vrf':
-                raise ConfigError(
-                    f'Configured "netflow server {server} source-interface '
-                    f'{data["source_interface"]}" is a VRF, not an interface!'
-                )
             # A source-interface used together with a VRF must be a member of
             # that VRF, otherwise the exported flows would silently leave via a
             # different routing table. Due to the VyOS priorities the interface

--- a/src/validators/interface-exists
+++ b/src/validators/interface-exists
@@ -1,0 +1,40 @@
+#!/bin/sh
+#
+# Copyright (C) VyOS Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Passes only if $1 is a net device that exists on the system and is not a
+# VRF. Used as a fallback alongside a naming-pattern regex, so a currently
+# existing device is accepted as a physical/logical interface only if it is
+# not a VRF (VRFs are real net devices but must never be accepted where an
+# interface is expected).
+
+case "$1" in
+    ""|.|..|*/*)
+        echo "Error: $1 does not exist"
+        exit 1
+        ;;
+esac
+
+if [ ! -d "/sys/class/net/$1" ]; then
+    echo "Error: $1 does not exist"
+    exit 1
+fi
+
+if ip vrf show "$1" >/dev/null 2>&1; then
+    echo "Error: $1 is a VRF, not a network interface"
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Tab completion for source-interface and other interface leafNodes already excludes VRF names, but the shared interface-name constraint accepted them anyway: an existing VRF is a real net device, so it passed the file-path existence check even though it failed the interface-name regex.

Replace the file-path validator with a new interface-exists validator that requires the value to both exist under `/sys/class/net` and not be a VRF. The regex-match fallback is unchanged, so dynamic interfaces (e.g. pppoe) referenced before they exist still validate correctly.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9179

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
All smoketests passed

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
