### PR TITLE
T8598: CLI support to configure a secret which will be used along with calling-station-id, to generate Peer Interface Identifier (IID) - (BP # 2188)

### DIFF
--- a/data/templates/accel-ppp/ppp-options.j2
+++ b/data/templates/accel-ppp/ppp-options.j2
@@ -30,6 +30,9 @@ ipv6-peer-intf-id=ipv4
 ipv6-peer-intf-id={{ ppp_options.ipv6_peer_interface_id }}
 {%         endif %}
 {%     endif %}
+{%     if ppp_options.ipv6_peer_interface_id_secret is vyos_defined %}
+ipv6-peer-intf-id-secret={{ ppp_options.ipv6_peer_interface_id_secret }}
+{%     endif %}
 ipv6-accept-peer-intf-id={{ "1" if ppp_options.ipv6_accept_peer_interface_id is vyos_defined else "0" }}
 {% endif %}
 {# MTU #}

--- a/interface-definitions/include/accel-ppp/ppp-options-ipv6-interface-id.xml.i
+++ b/interface-definitions/include/accel-ppp/ppp-options-ipv6-interface-id.xml.i
@@ -45,6 +45,19 @@
     </constraint>
   </properties>
 </leafNode>
+<leafNode name="ipv6-peer-interface-id-secret">
+  <properties>
+    <help>Secret key for generating calling-sid based IPv6 peer interface identifier (IID)</help>
+    <valueHelp>
+      <format>txt</format>
+      <description>Secret key string used with ipv6-peer-interface-id calling-sid</description>
+    </valueHelp>
+    <constraint>
+        <regex>[!-~]{16,128}</regex>
+    </constraint>
+      <constraintErrorMessage>Secret must be 16 to 128 printable non-whitespace ASCII characters</constraintErrorMessage>
+  </properties>
+</leafNode>
 <leafNode name="ipv6-accept-peer-interface-id">
   <properties>
     <help>Accept peer interface identifier</help>

--- a/interface-definitions/include/version/l2tp-version.xml.i
+++ b/interface-definitions/include/version/l2tp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/l2tp-version.xml.i -->
-<syntaxVersion component='l2tp' version='9'></syntaxVersion>
+<syntaxVersion component='l2tp' version='10'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/include/version/pppoe-server-version.xml.i
+++ b/interface-definitions/include/version/pppoe-server-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/pppoe-server-version.xml.i -->
-<syntaxVersion component='pppoe-server' version='12'></syntaxVersion>
+<syntaxVersion component='pppoe-server' version='13'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/include/version/pptp-version.xml.i
+++ b/interface-definitions/include/version/pptp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/pptp-version.xml.i -->
-<syntaxVersion component='pptp' version='5'></syntaxVersion>
+<syntaxVersion component='pptp' version='6'></syntaxVersion>
 <!-- include end -->

--- a/interface-definitions/include/version/sstp-version.xml.i
+++ b/interface-definitions/include/version/sstp-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/sstp-version.xml.i -->
-<syntaxVersion component='sstp' version='6'></syntaxVersion>
+<syntaxVersion component='sstp' version='7'></syntaxVersion>
 <!-- include end -->

--- a/src/conf_mode/service_pppoe-server.py
+++ b/src/conf_mode/service_pppoe-server.py
@@ -41,6 +41,17 @@ airbag.enable()
 
 pppoe_conf = r'/run/accel-pppd/pppoe.conf'
 pppoe_chap_secrets = r'/run/accel-pppd/pppoe.chap-secrets'
+iid_secret_min_len = 16
+iid_secret_max_len = 128
+
+
+def _is_safe_ascii_secret(value):
+    # Restrict to ASCII printable non-whitespace characters.
+    return value.isascii() and all(ch.isprintable() and not ch.isspace() for ch in value)
+
+
+def _is_valid_iid_secret(value):
+    return iid_secret_min_len <= len(value) <= iid_secret_max_len and _is_safe_ascii_secret(value)
 
 
 def base_ifname(ifname):
@@ -127,6 +138,11 @@ def get_config(config=None):
         is_node_changed(conf, base + ['authentication', 'radius']),
         is_node_changed(conf, base + ['authentication', 'mode']),
         is_node_changed(conf, base + ['authentication', 'protocols']),
+
+        # IPv6 peer IID mode/secret affect negotiated session state.
+        # Restart is required to force existing sessions to re-negotiate.
+        is_node_changed(conf, base + ['ppp-options', 'ipv6-peer-interface-id']),
+        is_node_changed(conf, base + ['ppp-options', 'ipv6-peer-interface-id-secret']),
         any(
             base_ifname(iface) in all_changed_vpp_ifaces
             for iface in pppoe.get('interface', {})
@@ -174,6 +190,17 @@ def verify(pppoe):
     verify_accel_ppp_name_servers(pppoe)
     verify_accel_ppp_wins_servers(pppoe)
     verify_pado_delay(pppoe)
+
+    peer_id_mode = dict_search('ppp_options.ipv6_peer_interface_id', pppoe)
+    peer_id_secret = dict_search('ppp_options.ipv6_peer_interface_id_secret', pppoe)
+    if peer_id_mode == 'calling-sid':
+        if not peer_id_secret:
+            raise ConfigError('ppp-options ipv6-peer-interface-id calling-sid requires ipv6-peer-interface-id-secret')
+        if not _is_valid_iid_secret(peer_id_secret):
+            raise ConfigError(
+                f'ppp-options ipv6-peer-interface-id-secret must be {iid_secret_min_len} to '
+                f'{iid_secret_max_len} printable non-whitespace ASCII characters'
+            )
 
     if 'interface' not in pppoe:
         raise ConfigError('At least one listen interface must be defined!')

--- a/src/conf_mode/service_pppoe-server.py
+++ b/src/conf_mode/service_pppoe-server.py
@@ -47,11 +47,15 @@ iid_secret_max_len = 128
 
 def _is_safe_ascii_secret(value):
     # Restrict to ASCII printable non-whitespace characters.
-    return value.isascii() and all(ch.isprintable() and not ch.isspace() for ch in value)
+    return value.isascii() and all(
+        ch.isprintable() and not ch.isspace() for ch in value
+    )
 
 
 def _is_valid_iid_secret(value):
-    return iid_secret_min_len <= len(value) <= iid_secret_max_len and _is_safe_ascii_secret(value)
+    return iid_secret_min_len <= len(
+        value
+    ) <= iid_secret_max_len and _is_safe_ascii_secret(value)
 
 
 def base_ifname(ifname):
@@ -60,14 +64,16 @@ def base_ifname(ifname):
 
 
 def convert_pado_delay(pado_delay):
-    new_pado_delay = {'delays_without_sessions': [],
-                      'delays_with_sessions': []}
+    new_pado_delay = {'delays_without_sessions': [], 'delays_with_sessions': []}
     for delay, sessions in pado_delay.items():
         if not sessions:
             new_pado_delay['delays_without_sessions'].append(delay)
         else:
-            new_pado_delay['delays_with_sessions'].append((delay, int(sessions['sessions'])))
+            new_pado_delay['delays_with_sessions'].append(
+                (delay, int(sessions['sessions']))
+            )
     return new_pado_delay
+
 
 def get_config(config=None):
     if config:
@@ -112,7 +118,9 @@ def get_config(config=None):
 
     if dict_search('client_ip_pool', pppoe):
         # Multiple named pools require ordered values T5099
-        pppoe['ordered_named_pools'] = get_pools_in_order(dict_search('client_ip_pool', pppoe))
+        pppoe['ordered_named_pools'] = get_pools_in_order(
+            dict_search('client_ip_pool', pppoe)
+        )
 
     if dict_search('pado_delay', pppoe):
         pado_delay = dict_search('pado_delay', pppoe)
@@ -138,7 +146,6 @@ def get_config(config=None):
         is_node_changed(conf, base + ['authentication', 'radius']),
         is_node_changed(conf, base + ['authentication', 'mode']),
         is_node_changed(conf, base + ['authentication', 'protocols']),
-
         # IPv6 peer IID mode/secret affect negotiated session state.
         # Restart is required to force existing sessions to re-negotiate.
         is_node_changed(conf, base + ['ppp-options', 'ipv6-peer-interface-id']),
@@ -152,6 +159,7 @@ def get_config(config=None):
         pppoe.update({'restart_required': {}})
     pppoe['server_type'] = 'pppoe'
     return pppoe
+
 
 def verify_pado_delay(pppoe):
     if 'pado_delay' in pppoe:
@@ -172,7 +180,9 @@ def verify_pado_delay(pppoe):
         if 'disable' in [delay[0] for delay in pado_delay['delays_with_sessions']]:
             # need to sort delays by sessions to verify if there is no delay
             # for sessions after disabling
-            sorted_pado_delay = sorted(pado_delay['delays_with_sessions'], key=lambda k_v: k_v[1])
+            sorted_pado_delay = sorted(
+                pado_delay['delays_with_sessions'], key=lambda k_v: k_v[1]
+            )
             last_delay = sorted_pado_delay[-1]
 
             if last_delay[0] != 'disable':
@@ -180,6 +190,7 @@ def verify_pado_delay(pppoe):
                     f'Cannot add pado-delay after disabled sessions, but '
                     f'"pado-delay {last_delay[0]} sessions {last_delay[1]}" was set'
                 )
+
 
 def verify(pppoe):
     if 'remove' in pppoe:
@@ -195,7 +206,9 @@ def verify(pppoe):
     peer_id_secret = dict_search('ppp_options.ipv6_peer_interface_id_secret', pppoe)
     if peer_id_mode == 'calling-sid':
         if not peer_id_secret:
-            raise ConfigError('ppp-options ipv6-peer-interface-id calling-sid requires ipv6-peer-interface-id-secret')
+            raise ConfigError(
+                'ppp-options ipv6-peer-interface-id calling-sid requires ipv6-peer-interface-id-secret'
+            )
         if not _is_valid_iid_secret(peer_id_secret):
             raise ConfigError(
                 f'ppp-options ipv6-peer-interface-id-secret must be {iid_secret_min_len} to '
@@ -235,8 +248,12 @@ def generate(pppoe):
     render(pppoe_conf, 'accel-ppp/pppoe.config.j2', pppoe)
 
     if dict_search('authentication.mode', pppoe) == 'local':
-        render(pppoe_chap_secrets, 'accel-ppp/chap-secrets.config_dict.j2',
-               pppoe, permission=0o640)
+        render(
+            pppoe_chap_secrets,
+            'accel-ppp/chap-secrets.config_dict.j2',
+            pppoe,
+            permission=0o640,
+        )
     return None
 
 

--- a/src/conf_mode/vpn_l2tp.py
+++ b/src/conf_mode/vpn_l2tp.py
@@ -37,6 +37,17 @@ airbag.enable()
 
 l2tp_conf = '/run/accel-pppd/l2tp.conf'
 l2tp_chap_secrets = '/run/accel-pppd/l2tp.chap-secrets'
+iid_secret_min_len = 16
+iid_secret_max_len = 128
+
+
+def _is_safe_ascii_secret(value):
+    # Restrict to ASCII printable non-whitespace characters.
+    return value.isascii() and all(ch.isprintable() and not ch.isspace() for ch in value)
+
+
+def _is_valid_iid_secret(value):
+    return iid_secret_min_len <= len(value) <= iid_secret_max_len and _is_safe_ascii_secret(value)
 
 def get_config(config=None):
     if config:
@@ -68,6 +79,17 @@ def verify(l2tp):
     verify_accel_ppp_ip_pool(l2tp)
     verify_accel_ppp_name_servers(l2tp)
     verify_accel_ppp_wins_servers(l2tp)
+
+    peer_id_mode = dict_search('ppp_options.ipv6_peer_interface_id', l2tp)
+    peer_id_secret = dict_search('ppp_options.ipv6_peer_interface_id_secret', l2tp)
+    if peer_id_mode == 'calling-sid':
+        if not peer_id_secret:
+            raise ConfigError('ppp-options ipv6-peer-interface-id calling-sid requires ipv6-peer-interface-id-secret')
+        if not _is_valid_iid_secret(peer_id_secret):
+            raise ConfigError(
+                f'ppp-options ipv6-peer-interface-id-secret must be {iid_secret_min_len} to '
+                f'{iid_secret_max_len} printable non-whitespace ASCII characters'
+            )
 
     return None
 

--- a/src/conf_mode/vpn_pptp.py
+++ b/src/conf_mode/vpn_pptp.py
@@ -35,6 +35,17 @@ airbag.enable()
 
 pptp_conf = '/run/accel-pppd/pptp.conf'
 pptp_chap_secrets = '/run/accel-pppd/pptp.chap-secrets'
+iid_secret_min_len = 16
+iid_secret_max_len = 128
+
+
+def _is_safe_ascii_secret(value):
+    # Restrict to ASCII printable non-whitespace characters.
+    return value.isascii() and all(ch.isprintable() and not ch.isspace() for ch in value)
+
+
+def _is_valid_iid_secret(value):
+    return iid_secret_min_len <= len(value) <= iid_secret_max_len and _is_safe_ascii_secret(value)
 
 
 def get_config(config=None):
@@ -66,6 +77,17 @@ def verify(pptp):
     verify_accel_ppp_ip_pool(pptp)
     verify_accel_ppp_name_servers(pptp)
     verify_accel_ppp_wins_servers(pptp)
+
+    peer_id_mode = dict_search('ppp_options.ipv6_peer_interface_id', pptp)
+    peer_id_secret = dict_search('ppp_options.ipv6_peer_interface_id_secret', pptp)
+    if peer_id_mode == 'calling-sid':
+        if not peer_id_secret:
+            raise ConfigError('ppp-options ipv6-peer-interface-id calling-sid requires ipv6-peer-interface-id-secret')
+        if not _is_valid_iid_secret(peer_id_secret):
+            raise ConfigError(
+                f'ppp-options ipv6-peer-interface-id-secret must be {iid_secret_min_len} to '
+                f'{iid_secret_max_len} printable non-whitespace ASCII characters'
+            )
 
 
 def generate(pptp):

--- a/src/conf_mode/vpn_sstp.py
+++ b/src/conf_mode/vpn_sstp.py
@@ -46,6 +46,17 @@ sstp_chap_secrets = '/run/accel-pppd/sstp.chap-secrets'
 cert_file_path = os.path.join(cfg_dir, 'sstp-cert.pem')
 cert_key_path = os.path.join(cfg_dir, 'sstp-cert.key')
 ca_cert_file_path = os.path.join(cfg_dir, 'sstp-ca.pem')
+iid_secret_min_len = 16
+iid_secret_max_len = 128
+
+
+def _is_safe_ascii_secret(value):
+    # Restrict to ASCII printable non-whitespace characters.
+    return value.isascii() and all(ch.isprintable() and not ch.isspace() for ch in value)
+
+
+def _is_valid_iid_secret(value):
+    return iid_secret_min_len <= len(value) <= iid_secret_max_len and _is_safe_ascii_secret(value)
 
 
 def get_config(config=None):
@@ -81,6 +92,17 @@ def verify(sstp):
     verify_accel_ppp_ip_pool(sstp)
     verify_accel_ppp_name_servers(sstp)
     verify_accel_ppp_wins_servers(sstp)
+
+    peer_id_mode = dict_search('ppp_options.ipv6_peer_interface_id', sstp)
+    peer_id_secret = dict_search('ppp_options.ipv6_peer_interface_id_secret', sstp)
+    if peer_id_mode == 'calling-sid':
+        if not peer_id_secret:
+            raise ConfigError('ppp-options ipv6-peer-interface-id calling-sid requires ipv6-peer-interface-id-secret')
+        if not _is_valid_iid_secret(peer_id_secret):
+            raise ConfigError(
+                f'ppp-options ipv6-peer-interface-id-secret must be {iid_secret_min_len} to '
+                f'{iid_secret_max_len} printable non-whitespace ASCII characters'
+            )
 
     if 'ssl' not in sstp:
         raise ConfigError('SSL missing on SSTP config!')

--- a/src/migration-scripts/l2tp/9-to-10
+++ b/src/migration-scripts/l2tp/9-to-10
@@ -1,0 +1,41 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# Backfill IPv6 peer IID secret for legacy calling-sid configuration.
+
+from secrets import token_hex
+
+from vyos.configtree import ConfigTree
+
+base = ['vpn', 'l2tp', 'remote-access']
+peer_id_path = base + ['ppp-options', 'ipv6-peer-interface-id']
+peer_id_secret_path = base + ['ppp-options', 'ipv6-peer-interface-id-secret']
+
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(base):
+        return
+
+    if not config.exists(peer_id_path):
+        return
+
+    if config.return_value(peer_id_path) != 'calling-sid':
+        return
+
+    if config.exists(peer_id_secret_path):
+        return
+
+    config.set(peer_id_secret_path, value=token_hex(32))
+

--- a/src/migration-scripts/pppoe-server/12-to-13
+++ b/src/migration-scripts/pppoe-server/12-to-13
@@ -1,0 +1,41 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# Backfill IPv6 peer IID secret for legacy calling-sid configuration.
+
+from secrets import token_hex
+
+from vyos.configtree import ConfigTree
+
+base = ['service', 'pppoe-server']
+peer_id_path = base + ['ppp-options', 'ipv6-peer-interface-id']
+peer_id_secret_path = base + ['ppp-options', 'ipv6-peer-interface-id-secret']
+
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(base):
+        return
+
+    if not config.exists(peer_id_path):
+        return
+
+    if config.return_value(peer_id_path) != 'calling-sid':
+        return
+
+    if config.exists(peer_id_secret_path):
+        return
+
+    config.set(peer_id_secret_path, value=token_hex(32))
+

--- a/src/migration-scripts/pptp/5-to-6
+++ b/src/migration-scripts/pptp/5-to-6
@@ -1,0 +1,41 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# Backfill IPv6 peer IID secret for legacy calling-sid configuration.
+
+from secrets import token_hex
+
+from vyos.configtree import ConfigTree
+
+base = ['vpn', 'pptp', 'remote-access']
+peer_id_path = base + ['ppp-options', 'ipv6-peer-interface-id']
+peer_id_secret_path = base + ['ppp-options', 'ipv6-peer-interface-id-secret']
+
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(base):
+        return
+
+    if not config.exists(peer_id_path):
+        return
+
+    if config.return_value(peer_id_path) != 'calling-sid':
+        return
+
+    if config.exists(peer_id_secret_path):
+        return
+
+    config.set(peer_id_secret_path, value=token_hex(32))
+

--- a/src/migration-scripts/sstp/6-to-7
+++ b/src/migration-scripts/sstp/6-to-7
@@ -1,0 +1,41 @@
+# Copyright VyOS maintainers and contributors <maintainers@vyos.io>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# Backfill IPv6 peer IID secret for legacy calling-sid configuration.
+
+from secrets import token_hex
+
+from vyos.configtree import ConfigTree
+
+base = ['vpn', 'sstp']
+peer_id_path = base + ['ppp-options', 'ipv6-peer-interface-id']
+peer_id_secret_path = base + ['ppp-options', 'ipv6-peer-interface-id-secret']
+
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(base):
+        return
+
+    if not config.exists(peer_id_path):
+        return
+
+    if config.return_value(peer_id_path) != 'calling-sid':
+        return
+
+    if config.exists(peer_id_secret_path):
+        return
+
+    config.set(peer_id_secret_path, value=token_hex(32))
+


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
(Backport from private circinus # 2188 to public rolling)
- CLI support to configure a secret which will be used along with calling-station-id, to generate Peer Interface Identifier (IID).
- Also includes the corresponding migration support for calling-sid peer-IID secret. As part of the fix, secret needs to be mandatorily configured when calling-sid is configured.

- Secret must be 16 to 128 printable non-whitespace ASCII characters.

- The secret-key can be any user string or can be generated using the existing op-mode command (1 byte = 2 characters. so for generating 64 characters use byte-size = 32):

       `run generate psk random size <byte-size>`
- Below actions will drop existing sessions and trigger the re-negotiation/re-creation of session with the new config.

1. Deleting peer IID calling-sid config
2. Changing the calling-sid secret

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T8598

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
