### PR TITLE
wan-load-balance: T9145: add health script interface env

### DIFF
--- a/smoketest/scripts/cli/test_load-balancing_wan.py
+++ b/smoketest/scripts/cli/test_load-balancing_wan.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import tempfile
 import unittest
 import time
 
@@ -390,6 +391,89 @@ echo "$ifname - $state" > {hook_output_path}
 
         with open(hook_output_path, 'r') as f:
             self.assertIn('eth0 - FAILED', f.read())
+
+    def test_user_defined_health_check_script_env(self):
+        isp_interfaces = {
+            'eth0': ('203.0.113.2/30', '203.0.113.1'),
+            'eth1': ('192.0.2.2/30', '192.0.2.1'),
+        }
+        lan_iface = 'eth2'
+        temp_dir = tempfile.TemporaryDirectory(prefix='wlb_health_check_')
+        self.addCleanup(temp_dir.cleanup)
+        script_path = os.path.join(temp_dir.name, 'health_check.sh')
+        output_path = os.path.join(temp_dir.name, 'health_check_output')
+
+        health_check_script = f"""
+#!/bin/sh
+
+printf 'WLB_INTERFACE_NAME=%s WLB_SCRIPT_IFACE=%s\\n' \\
+    "$WLB_INTERFACE_NAME" "$WLB_SCRIPT_IFACE" >> {output_path}
+
+[ "$WLB_INTERFACE_NAME" = "$WLB_SCRIPT_IFACE" ]
+"""
+
+        write_file(script_path, health_check_script)
+        chmod_755(script_path)
+
+        for isp_iface, (address, nexthop) in isp_interfaces.items():
+            self.cli_set(['interfaces', 'ethernet', isp_iface, 'address', address])
+            self.cli_set(
+                base_path + ['wan', 'interface-health', isp_iface, 'failure-count', '1']
+            )
+            self.cli_set(
+                base_path + ['wan', 'interface-health', isp_iface, 'nexthop', nexthop]
+            )
+            self.cli_set(
+                base_path + ['wan', 'interface-health', isp_iface, 'success-count', '1']
+            )
+            self.cli_set(
+                base_path
+                + [
+                    'wan',
+                    'interface-health',
+                    isp_iface,
+                    'test',
+                    '10',
+                    'test-script',
+                    script_path,
+                ]
+            )
+            self.cli_set(
+                base_path
+                + [
+                    'wan',
+                    'interface-health',
+                    isp_iface,
+                    'test',
+                    '10',
+                    'type',
+                    'user-defined',
+                ]
+            )
+
+        self.cli_set(
+            ['interfaces', 'ethernet', lan_iface, 'address', '198.51.100.2/30']
+        )
+        self.cli_set(base_path + ['wan', 'rule', '10', 'inbound-interface', lan_iface])
+
+        for isp_iface in isp_interfaces:
+            self.cli_set(base_path + ['wan', 'rule', '10', 'interface', isp_iface])
+
+        self.cli_commit()
+
+        def check_script_output():
+            if not os.path.exists(output_path):
+                return False
+
+            with open(output_path, 'r') as f:
+                output = f.read()
+
+            return all(
+                f'WLB_INTERFACE_NAME={isp_iface} WLB_SCRIPT_IFACE={isp_iface}' in output
+                for isp_iface in isp_interfaces
+            )
+
+        wait_for(check_script_output)
 
     def test_firewall_groups(self):
         isp1_iface = 'eth0'

--- a/src/helpers/vyos-load-balancer.py
+++ b/src/helpers/vyos-load-balancer.py
@@ -72,7 +72,14 @@ def health_check(ifname, conf, state, test_defaults):
                 return False
         elif check_type == 'user-defined':
             script = test_conf['test_script']
-            rc = run(script)
+            env = os.environ.copy()
+            env.update(
+                {
+                    'WLB_INTERFACE_NAME': ifname,
+                    'WLB_SCRIPT_IFACE': ifname,
+                }
+            )
+            rc = run(script, env=env)
             if rc != 0:
                 return False
 


### PR DESCRIPTION
## Change summary

User-defined WAN load-balancing health checks now receive the interface being tested through both `WLB_INTERFACE_NAME` and the legacy `WLB_SCRIPT_IFACE` variable.

The smoketest coverage checks that a user-defined health-check script sees both variables for the interface under test.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T9145

## Related PR(s)

N/A

## How to test / Smoketest result

Local checks:

```
python3 -m py_compile src/helpers/vyos-load-balancer.py smoketest/scripts/cli/test_load-balancing_wan.py
git diff --check
```

I also checked the `health_check()` user-defined path locally to verify that both environment variables are passed to the script.

Full VyOS CLI smoketest was not run on this workstation because it requires a VyOS test image and changes networking state.

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
