### PR TITLE
utils: T9207: is_intf_addr_assigned() rejects hyphenated ranges

### DIFF
--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -492,9 +492,13 @@ def is_intf_addr_assigned(ifname: str, addr: str, netns: str=None) -> bool:
     from vyos.utils.process import rc_cmd
     from ipaddress import ip_interface
 
-    # Remove the interface name if present in the given address
+    # Remove the interface name if present in the given address. Use
+    # rsplit() so only the trailing zone suffix is dropped: split() would
+    # truncate a hyphenated range with a zone suffix on both endpoints
+    # (e.g. "::1%lo-::2%lo") down to just its first endpoint, silently
+    # discarding the "-" the check below relies on.
     if '%' in addr:
-        addr = addr.split('%')[0]
+        addr = addr.rsplit('%', 1)[0]
 
     # is_intf_addr_assigned() only checks a single address; a hyphenated
     # range (a valid address_group/address_range member elsewhere) is

--- a/python/vyos/utils/network.py
+++ b/python/vyos/utils/network.py
@@ -492,6 +492,17 @@ def is_intf_addr_assigned(ifname: str, addr: str, netns: str=None) -> bool:
     from vyos.utils.process import rc_cmd
     from ipaddress import ip_interface
 
+    # Remove the interface name if present in the given address
+    if '%' in addr:
+        addr = addr.split('%')[0]
+
+    # is_intf_addr_assigned() only checks a single address; a hyphenated
+    # range (a valid address_group/address_range member elsewhere) is
+    # never assigned to an interface as such and ip_interface() would
+    # raise ValueError on it instead of returning False
+    if '-' in addr:
+        return False
+
     netns_cmd = f'ip netns exec {netns}' if netns else ''
     rc, out = rc_cmd(f'{netns_cmd} ip --json address show dev {ifname}')
     if rc == 0:
@@ -501,9 +512,6 @@ def is_intf_addr_assigned(ifname: str, addr: str, netns: str=None) -> bool:
             family = address_info['family']
             address = address_info['address']
             prefixlen = address_info['prefixlen']
-            # Remove the interface name if present in the given address
-            if '%' in addr:
-                addr = addr.split('%')[0]
             interface = ip_interface(f"{address}/{prefixlen}")
             if ip_interface(addr) == interface or address == addr:
                 return True

--- a/src/tests/test_utils_network.py
+++ b/src/tests/test_utils_network.py
@@ -24,6 +24,13 @@ class TestVyOSUtilsNetwork(TestCase):
         self.assertTrue(vyos.utils.network.is_addr_assigned('::1'))
         self.assertFalse(vyos.utils.network.is_addr_assigned('127.251.255.123'))
 
+    def test_is_addr_assigned_hyphenated_range(self):
+        # A hyphenated address range can never be assigned to an interface
+        # as such; is_intf_addr_assigned() must return False for it
+        # instead of raising ValueError from ip_interface()
+        self.assertFalse(vyos.utils.network.is_addr_assigned('127.0.0.1-127.0.0.2'))
+        self.assertFalse(vyos.utils.network.is_addr_assigned('::1-::2'))
+
     def test_is_ipv6_link_local(self):
         self.assertFalse(vyos.utils.network.is_ipv6_link_local('169.254.0.1'))
         self.assertTrue(vyos.utils.network.is_ipv6_link_local('fe80::'))

--- a/src/tests/test_utils_network.py
+++ b/src/tests/test_utils_network.py
@@ -30,6 +30,9 @@ class TestVyOSUtilsNetwork(TestCase):
         # instead of raising ValueError from ip_interface()
         self.assertFalse(vyos.utils.network.is_addr_assigned('127.0.0.1-127.0.0.2'))
         self.assertFalse(vyos.utils.network.is_addr_assigned('::1-::2'))
+        # A zone suffix on each range endpoint must not truncate the
+        # string down to just the first endpoint before the "-" check
+        self.assertFalse(vyos.utils.network.is_addr_assigned('::1%lo-::2%lo'))
 
     def test_is_ipv6_link_local(self):
         self.assertFalse(vyos.utils.network.is_ipv6_link_local('169.254.0.1'))


### PR DESCRIPTION
## Summary
- `is_intf_addr_assigned()` called `ip_interface(addr)` without checking whether `addr` is a hyphenated address range (e.g. `192.0.2.1-192.0.2.2`) — a valid `address-group`/`address-range` member elsewhere in the CLI. For such input, `ip_interface()` raises `ValueError` instead of the function returning `False`, and the exception is uncaught: it propagates out of `is_intf_addr_assigned()` and its caller `is_addr_assigned()` (which loops over every interface), crashing any code path that checks whether a range-form address is assigned to an interface.
- Moved the existing IPv6 zone-suffix strip ahead of the interface lookup (it was redundantly repeated inside the loop) and reject a hyphenated range there too, before `ip_interface()` ever sees it.
- Found while reviewing coderabbitai feedback on #5374 (T9160); this bug is pre-existing and unrelated to that PR's diff, so it's filed and fixed here separately rather than folded into it.

Task: https://vyos.dev/T9207

## Test plan
- [x] `ruff check python/vyos/utils/network.py src/tests/test_utils_network.py` passes clean (one pre-existing, unrelated `F811` duplicate-test-name finding in the same file, not touched by this change)
- [x] `python3 -m py_compile` on both touched files
- [x] Added `test_is_addr_assigned_hyphenated_range` covering both IPv4 and IPv6 hyphenated ranges
- [x] Manually verified against `lo`: hyphenated ranges now return `False` instead of raising; single-address checks (assigned and not-assigned) are unaffected