### PR TITLE
firewall: T9210: fix ruff findings in python/vyos/firewall.py

### DIFF
--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -16,6 +16,7 @@ import re
 
 from socket import AF_INET
 from socket import AF_INET6
+from socket import gaierror
 from socket import getaddrinfo
 
 from vyos.template import is_ipv4
@@ -79,7 +80,7 @@ def fqdn_resolve(fqdn, ipv6=False):
     try:
         res = getaddrinfo(fqdn, None, AF_INET6 if ipv6 else AF_INET)
         return set(item[4][0] for item in res)
-    except:
+    except gaierror:
         return None
 
 def find_nftables_rule(table, chain, rule_matches=[]):
@@ -219,7 +220,7 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
                 geoip_prefix = 'CC' if country_code else 'ASN'
                 operator = ''
                 hook_name = ''
-                if dict_search_args(side_conf, 'geoip', 'inverse_match') != None:
+                if dict_search_args(side_conf, 'geoip', 'inverse_match') is not None:
                     operator = '!='
                 if hook == 'FWD':
                     hook_name = 'forward'
@@ -230,7 +231,7 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
                 if hook == 'PRE':
                     hook_name = 'prerouting'
                 if hook == 'NAM':
-                    hook_name = f'name'
+                    hook_name = 'name'
                 # for policy
                 if hook == 'route' or hook == 'route6':
                     hook_name = hook
@@ -409,7 +410,7 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
         output.append(f'ip{def_suffix} length != {{{negated_lengths_str}}}')
 
     if 'packet_type' in rule_conf:
-        output.append(f'pkttype ' + rule_conf['packet_type'])
+        output.append('pkttype ' + rule_conf['packet_type'])
 
     if 'dscp' in rule_conf:
         dscp_str = ','.join(rule_conf['dscp'])
@@ -550,7 +551,7 @@ def parse_rule(rule_conf, hook, fw_name, rule_id, ip_name):
                     output.append(f'snaplen {log_snaplen}')
 
     if 'last_used' in rule_conf:
-        output.append(f'last')
+        output.append('last')
 
     output.append('counter')
 


### PR DESCRIPTION
## Summary
- Split out of #5372 (T9157) at sarthurdev's request: that PR bundled unrelated ruff findings in `python/vyos/firewall.py` with the fib-type-match feature because it happened to touch this file.
- Purely mechanical, no behavior change:
  - `fqdn_resolve()`: bare `except:` → `except gaierror:` (E722)
  - `!= None` → `is not None` in the geoip inverse-match check (E711)
  - 3x extraneous `f` prefix on string literals without placeholders (F541): `hook_name = f'name'`, `output.append(f'pkttype ' + ...)`, `output.append(f'last')`

Task: https://vyos.dev/T9210

## Test plan
- [x] `ruff check python/vyos/firewall.py` passes clean
- [x] `python3 -m py_compile python/vyos/firewall.py`