### PR TITLE
login: T9212: split radius source-address per address family

### DIFF
--- a/data/templates/login/pam_radius_auth.conf.j2
+++ b/data/templates/login/pam_radius_auth.conf.j2
@@ -2,26 +2,15 @@
 # RADIUS configuration file
 
 {% if radius is vyos_defined %}
-{#     RADIUS IPv6 source address must be specified in [] notation #}
-{%     set source_address = namespace()  %}
-{%     if radius.source_address is vyos_defined %}
-{%         for address in radius.source_address %}
-{%             if address | is_ipv4 %}
-{%                 set source_address.ipv4 = address %}
-{%             elif address | is_ipv6 %}
-{%                 set source_address.ipv6 = address %}
-{%             endif %}
-{%         endfor %}
-{%     endif %}
 {%     if radius.server is vyos_defined %}
 # server[:port]        shared_secret             timeout    source_ip
 {# .items() returns a tuple of two elements: key and value. 1 relates to the 2nd element i.e. the value and .priority relates to the key from the internal dict #}
 {%         for server, options in radius.server.items() | sort(attribute='1.priority') if not 'disable' in options %}
 {#         RADIUS IPv6 servers must be specified in [] notation #}
 {%             if server | is_ipv4 %}
-{{ server }}:{{ options.port }} {{ "%-25s" | format(options.key) }} {{ "%-10s" | format(options.timeout) }} {{ source_address.ipv4 if source_address.ipv4 is vyos_defined }}
+{{ server }}:{{ options.port }} {{ "%-25s" | format(options.key) }} {{ "%-10s" | format(options.timeout) }} {{ radius.source_address if radius.source_address is vyos_defined }}
 {%             else %}
-{{ server | bracketize_ipv6 }}:{{ options.port }} {{ "%-25s" | format(options.key) }} {{ "%-10s" | format(options.timeout) }} {{ source_address.ipv6 if source_address.ipv6 is vyos_defined }}
+{{ server | bracketize_ipv6 }}:{{ options.port }} {{ "%-25s" | format(options.key) }} {{ "%-10s" | format(options.timeout) }} {{ radius.source_address6 if radius.source_address6 is vyos_defined }}
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/interface-definitions/include/radius-server-ipv4-ipv6.xml.i
+++ b/interface-definitions/include/radius-server-ipv4-ipv6.xml.i
@@ -25,7 +25,8 @@
         #include <include/radius-server-auth-port.xml.i>
       </children>
     </tagNode>
-    #include <include/source-address-ipv4-ipv6-multi.xml.i>
+    #include <include/source-address-ipv4.xml.i>
+    #include <include/source-address6.xml.i>
     <leafNode name="security-mode">
       <properties>
         <help>Security mode for RADIUS authentication</help>

--- a/interface-definitions/include/source-address6.xml.i
+++ b/interface-definitions/include/source-address6.xml.i
@@ -1,0 +1,17 @@
+<!-- include start from source-address6.xml.i -->
+<leafNode name="source-address6">
+  <properties>
+    <help>IPv6 address used to initiate connection</help>
+    <completionHelp>
+      <script>${vyos_completion_dir}/list_local_ips.sh --ipv6</script>
+    </completionHelp>
+    <valueHelp>
+      <format>ipv6</format>
+      <description>IPv6 source address</description>
+    </valueHelp>
+    <constraint>
+      <validator name="ipv6-address"/>
+    </constraint>
+  </properties>
+</leafNode>
+<!-- include end -->

--- a/interface-definitions/include/version/system-version.xml.i
+++ b/interface-definitions/include/version/system-version.xml.i
@@ -1,3 +1,3 @@
 <!-- include start from include/version/system-version.xml.i -->
-<syntaxVersion component='system' version='33'></syntaxVersion>
+<syntaxVersion component='system' version='34'></syntaxVersion>
 <!-- include end -->

--- a/smoketest/scripts/cli/test_system_login.py
+++ b/smoketest/scripts/cli/test_system_login.py
@@ -367,13 +367,16 @@ class TestSystemLogin(VyOSUnitTestSHIM.TestCase):
 
         # Define RADIUS traffic source address
         self.cli_set(['interfaces', 'dummy', dummy_if, 'address', f'{radius_source}/{radius_source_mask}'])
-        self.cli_set(base_path + ['radius', 'source-address', radius_source])
-        self.cli_set(base_path + ['radius', 'source-address', inc_ip(radius_source, 1)])
 
-        # check validate() - Only one IPv4 source-address supported
-        with self.assertRaises(ConfigSessionError):
-            self.cli_commit()
-        self.cli_delete(base_path + ['radius', 'source-address', inc_ip(radius_source, 1)])
+        # IPv4 and IPv6 source addresses live on separate scalar nodes, so
+        # setting one a second time replaces the previous value instead of
+        # appending to it
+        source_node = 'source-address'
+        if is_ipv6(radius_source):
+            source_node = 'source-address6'
+
+        self.cli_set(base_path + ['radius', source_node, inc_ip(radius_source, 1)])
+        self.cli_set(base_path + ['radius', source_node, radius_source])
 
         self.cli_commit()
 
@@ -386,6 +389,10 @@ class TestSystemLogin(VyOSUnitTestSHIM.TestCase):
                 radius_server = rf'\[{radius_server}\]'
             tmp = re.findall(rf'\n?{radius_server}:{default_port}\s+{radius_key}\s+{default_timeout}\s+{radius_source}', pam_radius_auth_conf)
             self.assertTrue(tmp)
+
+        # The source-address set first was replaced, not appended to - it must
+        # not have made it into the generated configuration
+        self.assertNotIn(inc_ip(radius_source, 1), pam_radius_auth_conf)
 
         # required, static options
         self.assertIn('priv-lvl 15', pam_radius_auth_conf)

--- a/src/conf_mode/system_login.py
+++ b/src/conf_mode/system_login.py
@@ -32,7 +32,6 @@ from vyos.configdep import call_dependents
 from vyos.configverify import verify_vrf
 from vyos.defaults import SSH_DSA_DEPRECATION_WARNING
 from vyos.template import render
-from vyos.template import is_ipv4
 from vyos.utils.auth import DEFAULT_PASSWORD
 from vyos.utils.auth import EPasswdStrength
 from vyos.utils.auth import evaluate_strength
@@ -214,21 +213,12 @@ def verify(login):
 
         verify_vrf(login['radius'])
 
-        if addresses := dict_search('radius.source_address', login):
-            ipv4_count = 0
-            ipv6_count = 0
-            radius_vrf = dict_search('radius.vrf', login)
-            for address in addresses:
-                if is_ipv4(address): ipv4_count += 1
-                else:                ipv6_count += 1
-
-                if not is_addr_assigned(address, vrf=radius_vrf):
-                    Warning(f'Specified RADIUS source-address "{address}" is not assigned!')
-
-            if ipv4_count > 1:
-                raise ConfigError('Only one IPv4 source-address can be set!')
-            if ipv6_count > 1:
-                raise ConfigError('Only one IPv6 source-address can be set!')
+        radius_vrf = dict_search('radius.vrf', login)
+        for node in ['source_address', 'source_address6']:
+            address = dict_search(f'radius.{node}', login)
+            if address and not is_addr_assigned(address, vrf=radius_vrf):
+                tmp = node.replace('_', '-')
+                Warning(f'Specified RADIUS {tmp} "{address}" is not assigned!')
 
     if 'tacacs' in login:
         tacacs_servers_count: int = 0

--- a/src/migration-scripts/system/33-to-34
+++ b/src/migration-scripts/system/33-to-34
@@ -1,0 +1,49 @@
+# Copyright (C) VyOS Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+# T9212: "system login radius source-address" was a multi node which only ever
+# accepted a single address per address family. Move the IPv6 address to its
+# own "source-address6" node so that both are scalar and a subsequent "set"
+# replaces the value instead of appending to it.
+
+from vyos.configtree import ConfigTree
+from vyos.template import is_ipv4
+from vyos.template import is_ipv6
+
+base = ['system', 'login', 'radius', 'source-address']
+base_ipv6 = ['system', 'login', 'radius', 'source-address6']
+
+def migrate(config: ConfigTree) -> None:
+    if not config.exists(base):
+        return
+
+    addresses = config.return_values(base)
+    ipv4 = [address for address in addresses if is_ipv4(address)]
+    ipv6 = [address for address in addresses if is_ipv6(address)]
+
+    # A lone IPv4 address already has the shape the now scalar node expects
+    if len(addresses) == len(ipv4) == 1:
+        return
+
+    config.delete(base)
+
+    # verify() only ever accepted one address per address family, so for any
+    # configuration committed through the CLI these lists hold at most one
+    # entry each. A hand-edited config.boot could carry more - keep the last
+    # one, matching the "last one wins" behaviour of the previous template.
+    if ipv4:
+        config.set(base, value=ipv4[-1], replace=True)
+    if ipv6:
+        config.set(base_ipv6, value=ipv6[-1], replace=True)


### PR DESCRIPTION
## Change summary

`set system login radius source-address <ip>` was a `<multi/>` node, so a second `set` **appended** rather than **replaced**. The CLI accepted any number of addresses and staged them all, then `commit` rejected the result with `Only one IPv4 source-address can be set!`. The adjacent `system login tacacs source-address` is a scalar node and behaves as users expect, which makes the inconsistency more surprising still.

The `<multi/>` was **not** an oversight. `b9feaf0d6` (T3192) added it specifically so one IPv4 *and* one IPv6 source address can coexist, and `pam_radius_auth.conf.j2` pairs each server with the source address of its own address family. Simply dropping `<multi/>` would regress dual-stack deployments, so this PR gives each address family its own scalar node instead:

```
set system login radius source-address  <ipv4>
set system login radius source-address6 <ipv6>
```

Both now replace on `set`. The per-family counters in `verify()` are gone, and the template consumes the two values directly rather than collapsing a list into a `namespace()`.

The `6` suffix follows existing house style (`route6`, `local-route6`, `prefix-list6`, `ospf6`, `nat66`). A new include was needed because `include/source-address-ipv6.xml.i` declares its leaf node as `name="source-address"` — its only consumers sit in paths that are already IPv6-only — so it would collide as a sibling of `source-address-ipv4.xml.i`.

### Behaviour change for automation

`source-address` is now IPv4-only. Saved configurations migrate automatically, but any Ansible/API automation that puts an IPv6 address in `source-address` must move it to `source-address6`. Flagged on T9212 as *config syntax change (migratable)*.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): CLI syntax change with a migration script (`system` 33 → 34)

## Related Task(s)

* https://vyos.dev/T9212

Context, not fixed here:

* https://vyos.dev/T3192 — added the `<multi/>` for dual-stack; this PR preserves that capability
* https://vyos.dev/T3234 — `multi_to_list` failing on this exact node
* https://vyos.dev/T1582 — same defect class in OpenVPN `local-address`, closed as invalid

## Related PR(s)

None. A `vyos-documentation` update is required and not yet raised — see the checklist below.

## How to test / Smoketest result

> [!IMPORTANT]
> **I have not been able to run the smoketests** — no VyOS build/test host was available. `test_system_login.py` requires a live system (it starts a FreeRADIUS container and reads `/etc/pam_radius_auth.conf`). The suite needs a run before merge.

What *was* verified off-box:

**1. XML builds, validates, and adds exactly one node.** Ran `transclude-template` → `override-default` → `override-help` → `check-properties-collision`, then validated against `schema/interface_definition.rng`, comparing against an unmodified `origin/rolling` worktree:

```
=== BASELINE ===                        === THIS BRANCH ===
RelaxNG: PASS                           RelaxNG: PASS
check-properties-collision: exit 0      check-properties-collision: exit 0

system login radius children:
  security-mode, server, server,          security-mode, server, server,
  source-address, vrf                     source-address, source-address6, vrf

source-address  (radius) multi=True     source-address  (radius) multi=False
                                        source-address6 (radius) multi=False
source-address  (tacacs) multi=False    source-address  (tacacs) multi=False
```

(The duplicated `server` is the pre-existing T3234 element redundancy, present in baseline too.)

**2. The generated `pam_radius_auth.conf` is byte-identical.** Rendered the old and new templates with equivalent data across a matrix:

```
IDENTICAL   v4 servers, v4 source
IDENTICAL   v6 servers, v6 source
IDENTICAL   dual servers, dual source
IDENTICAL   dual servers, v4 source only
IDENTICAL   dual servers, v6 source only
IDENTICAL   dual servers, no source
IDENTICAL   no servers, dual source
IDENTICAL   with vrf
IDENTICAL   disabled server

FAILURES: 0
```

**3. Migration logic.** `vyos.configtree` needs libvyosconfig, so the migration was executed against a stub tree with equivalent semantics:

```
PASS  no radius source-address at all
PASS  single IPv4 (the common case)      <- performs zero operations
PASS  single IPv6 only
PASS  dual stack pair
PASS  dual stack, IPv6 listed first
PASS  hand-edited: two IPv4 (last wins)
PASS  hand-edited: two IPv6 (last wins)
PASS  hand-edited: two of each
PASS  empty node

FAILURES: 0
```

Every configuration that could previously pass `verify()` migrates without loss. More than one address of a family is only reachable via a hand-edited `config.boot`; there the last value wins, matching the old template's existing silent behaviour.

**4. Lint**, matching CI (changed lines only, against `origin/rolling`):

```
darker -r origin/rolling --check --diff .     -> exit 0
graylint -L "ruff check" --revision origin/rolling .  -> exit 0
```

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable — **not run, see above**
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools — **author review pending**
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly — **docs PR not yet raised**
