### PR TITLE
firewall: T9210: bugfix in fqdn_resolve() exception handling

### DIFF
--- a/python/vyos/firewall.py
+++ b/python/vyos/firewall.py
@@ -16,7 +16,6 @@ import re
 
 from socket import AF_INET
 from socket import AF_INET6
-from socket import gaierror
 from socket import getaddrinfo
 
 from vyos.template import is_ipv4
@@ -80,7 +79,7 @@ def fqdn_resolve(fqdn, ipv6=False):
     try:
         res = getaddrinfo(fqdn, None, AF_INET6 if ipv6 else AF_INET)
         return set(item[4][0] for item in res)
-    except gaierror:
+    except OSError:
         return None
 
 def find_nftables_rule(table, chain, rule_matches=[]):


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Commit 4d621da33 (`firewall: T9210: fix ruff findings in python/vyos/firewall.py`) narrowed fqdn_resolve() exception handling in from a bare `except:` statement to `except gaierror:`, claiming "no behavior change." That let non-gaierror OSErrors (e.g. transient network errors right after commit) escape uncaught, crashing the unguarded main loop of the vyos-domain-resolver daemon, the process that fills in `D_*` (domain-group) nftables sets.

Change except clause back to `OSError`, as `gaierror` is a subclass.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9210

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-1x/pull/5401

## How to test / Smoketest result

```
DEBUG - Running Testcase (1/1): /usr/libexec/vyos/tests/smoke/cli/test_firewall.py
DEBUG - test_bridge_firewall (__main__.TestFirewall.test_bridge_firewall) ... ok
DEBUG - test_cyclic_jump_validation (__main__.TestFirewall.test_cyclic_jump_validation) ... ok
DEBUG - test_disable_conntrack_per_chain (__main__.TestFirewall.test_disable_conntrack_per_chain) ... ok
DEBUG - test_flow_offload (__main__.TestFirewall.test_flow_offload) ... ok
DEBUG - test_geoip (__main__.TestFirewall.test_geoip) ... ok
DEBUG - test_gre_match (__main__.TestFirewall.test_gre_match) ... ok
DEBUG - test_groups (__main__.TestFirewall.test_groups) ... ok
DEBUG - test_ipsec_metadata_match (__main__.TestFirewall.test_ipsec_metadata_match) ... ok
DEBUG - test_ipv4_advanced (__main__.TestFirewall.test_ipv4_advanced) ... ok
DEBUG - test_ipv4_basic_rules (__main__.TestFirewall.test_ipv4_basic_rules) ... ok
DEBUG - test_ipv4_dynamic_groups (__main__.TestFirewall.test_ipv4_dynamic_groups) ... ok
DEBUG - test_ipv4_global_state (__main__.TestFirewall.test_ipv4_global_state) ... ok
DEBUG - test_ipv4_mask (__main__.TestFirewall.test_ipv4_mask) ... ok
DEBUG - test_ipv4_remote_group (__main__.TestFirewall.test_ipv4_remote_group) ... ok
DEBUG - test_ipv4_state_and_status_rules (__main__.TestFirewall.test_ipv4_state_and_status_rules) ... ok
DEBUG - test_ipv4_synproxy (__main__.TestFirewall.test_ipv4_synproxy) ... ok
DEBUG - test_ipv4_time_weekdays (__main__.TestFirewall.test_ipv4_time_weekdays) ... ok
DEBUG - test_ipv6_advanced (__main__.TestFirewall.test_ipv6_advanced) ... ok
DEBUG - test_ipv6_basic_rules (__main__.TestFirewall.test_ipv6_basic_rules) ... ok
DEBUG - test_ipv6_dynamic_groups (__main__.TestFirewall.test_ipv6_dynamic_groups) ... ok
DEBUG - test_ipv6_mask (__main__.TestFirewall.test_ipv6_mask) ... ok
DEBUG - test_ipv6_remote_group (__main__.TestFirewall.test_ipv6_remote_group) ... ok
DEBUG - test_ipv6_time_weekdays (__main__.TestFirewall.test_ipv6_time_weekdays) ... ok
DEBUG - test_last_used (__main__.TestFirewall.test_last_used) ... ok
DEBUG - test_nested_groups (__main__.TestFirewall.test_nested_groups) ... ok
DEBUG - test_protocol_normalization (__main__.TestFirewall.test_protocol_normalization) ... ok
DEBUG - test_remote_group (__main__.TestFirewall.test_remote_group) ... ok
DEBUG - test_source_validation (__main__.TestFirewall.test_source_validation) ... ok
DEBUG - test_sysfs (__main__.TestFirewall.test_sysfs) ... ok
DEBUG - test_timeout_sysctl (__main__.TestFirewall.test_timeout_sysctl) ... ok
DEBUG - test_wildcard_interfaces (__main__.TestFirewall.test_wildcard_interfaces) ... ok
DEBUG - test_zone_basic (__main__.TestFirewall.test_zone_basic) ... ok
DEBUG - test_zone_flow_offload (__main__.TestFirewall.test_zone_flow_offload) ... ok
DEBUG - test_zone_with_default_firewall (__main__.TestFirewall.test_zone_with_default_firewall) ... ok
DEBUG - test_zone_with_vrf (__main__.TestFirewall.test_zone_with_vrf) ... ok
DEBUG - test_zone_without_member (__main__.TestFirewall.test_zone_without_member) ... ok
DEBUG -
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 36 tests in 117.904s
DEBUG -
DEBUG - OK
DEBUG - SUCCESS! All 1 tests passed.
DEBUG - vyos@vyos:~$ echo EXITCODE:$?
DEBUG - echo EXITCODE:$?
DEBUG - EXITCODE:0
 INFO - Smoketest finished successfully!
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
