### PR TITLE
dns: T8045: expose PowerDNS dont-query list as recursion-exclude-address

### DIFF
--- a/data/templates/dns-forwarding/recursor.conf.j2
+++ b/data/templates/dns-forwarding/recursor.conf.j2
@@ -49,6 +49,11 @@ dnssec={{ dnssec }}
 dns64-prefix={{ dns64_prefix }}
 {% endif %}
 
+{% if recursion_exclude_address is vyos_defined %}
+# dont-query
+dont-query+={{ recursion_exclude_address | join(',') }}
+{% endif %}
+
 {% if exclude_throttle_address is vyos_defined %}
 # dont-throttle-netmasks
 dont-throttle-netmasks={{ exclude_throttle_address | join(',') }}
@@ -79,4 +84,3 @@ ecs-ipv4-bits={{ options.ecs_ipv4_bits }}
 {% if options.edns_subnet_allow_list is vyos_defined %}
 edns-subnet-allow-list={{ options.edns_subnet_allow_list | join(',') }}
 {% endif %}
-

--- a/interface-definitions/service_dns_forwarding.xml.in
+++ b/interface-definitions/service_dns_forwarding.xml.in
@@ -758,6 +758,54 @@
                   <valueless/>
                 </properties>
               </leafNode>
+              <leafNode name="recursion-exclude-address">
+                <properties>
+                  <help>Authoritative server addresses to exclude from recursive queries, use '!' to define an exception</help>
+                  <valueHelp>
+                    <format>ipv4</format>
+                    <description>IPv4 address to exclude from recursive queries</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ipv4net</format>
+                    <description>IPv4 prefix to exclude from recursive queries</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ipv6</format>
+                    <description>IPv6 address to exclude from recursive queries</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>ipv6net</format>
+                    <description>IPv6 prefix to exclude from recursive queries</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>!ipv4</format>
+                    <description>IPv4 address exception to the recursive query exclusion list</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>!ipv4net</format>
+                    <description>IPv4 prefix exception to the recursive query exclusion list</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>!ipv6</format>
+                    <description>IPv6 address exception to the recursive query exclusion list</description>
+                  </valueHelp>
+                  <valueHelp>
+                    <format>!ipv6net</format>
+                    <description>IPv6 prefix exception to the recursive query exclusion list</description>
+                  </valueHelp>
+                  <constraint>
+                    <validator name="ipv4-address"/>
+                    <validator name="ipv4-prefix"/>
+                    <validator name="ipv6-address"/>
+                    <validator name="ipv6-prefix"/>
+                    <validator name="ipv4-address-exclude"/>
+                    <validator name="ipv4-prefix-exclude"/>
+                    <validator name="ipv6-address-exclude"/>
+                    <validator name="ipv6-prefix-exclude"/>
+                  </constraint>
+                  <multi/>
+                </properties>
+              </leafNode>
               <leafNode name="exclude-throttle-address">
                 <properties>
                   <help>IP address or subnet</help>

--- a/smoketest/scripts/cli/test_service_dns_forwarding.py
+++ b/smoketest/scripts/cli/test_service_dns_forwarding.py
@@ -248,6 +248,44 @@ class TestServicePowerDNS(VyOSUnitTestSHIM.TestCase):
         tmp = get_config_value('dns64-prefix')
         self.assertEqual(tmp, dns_prefix)
 
+    def test_recursion_exclude_address(self):
+        recursion_exclude_address = [
+            '198.18.0.0/15',
+            '!127.0.0.0/8',
+            '2001:db8:ffff::1',
+            '!2001:db8::/32',
+        ]
+        for network in recursion_exclude_address:
+            self.cli_set(base_path + ['recursion-exclude-address', network])
+
+        self.cli_commit()
+
+        self.assertEqual(
+            get_config_value(r'dont-query\+'), ','.join(recursion_exclude_address)
+        )
+
+        # Removing all configured values must remove the incremental setting,
+        # allowing PowerDNS to use its native defaults again.
+        self.cli_delete(base_path + ['recursion-exclude-address'])
+        self.cli_commit()
+        config = read_file(CONFIG_FILE)
+        self.assertNotIn('\ndont-query=', config)
+        self.assertNotIn('\ndont-query+=', config)
+
+    def test_recursion_exclude_address_conflicting_entry_order(self):
+        self.cli_set(base_path + ['recursion-exclude-address', '1.0.0.0/8'])
+        self.cli_set(base_path + ['recursion-exclude-address', '!1.0.0.0/8'])
+        self.cli_commit()
+        self.assertEqual(get_config_value(r'dont-query\+'), '1.0.0.0/8,!1.0.0.0/8')
+
+        self.cli_delete(base_path + ['recursion-exclude-address'])
+        self.cli_commit()
+
+        self.cli_set(base_path + ['recursion-exclude-address', '!1.0.0.0/8'])
+        self.cli_set(base_path + ['recursion-exclude-address', '1.0.0.0/8'])
+        self.cli_commit()
+        self.assertEqual(get_config_value(r'dont-query\+'), '!1.0.0.0/8,1.0.0.0/8')
+
     def test_exclude_throttle_adress(self):
         exclude_throttle_adress_examples = [
             '192.168.128.255',


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary

PowerDNS Recursor has a [config key](https://doc.powerdns.com/recursor/settings.html#dont-query) dont-query to include addresses that should not be queried by pdns-recursor. Its default value is set to 127.0.0.0/8, 10.0.0.0/8, 100.64.0.0/10, 169.254.0.0/16, 192.168.0.0/16, 172.16.0.0/12, ::1/128, fc00::/7, fe80::/10, 0.0.0.0/8, 192.0.0.0/24, 192.0.2.0/24, 198.51.100.0/24, 203.0.113.0/24, 240.0.0.0/4, ::/96, ::ffff:0:0/96, 100::/64, 2001:db8::/32.

Sometimes we may actual use addresses in these ranges as authoritative DNS servers (e.g. split-horizon private DNS server, dn42, ...). This PR allows `dont-query` list to be configured from the VyOS side.

The `+=` append syntax is used for appending. To remove from the defaults, users can use negation. e.g., use 

```
set service dns forwarding recursion-exclude-address !172.16.0.0/12
```

to allow querying servers in that range.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

https://vyos.dev/T8045

## Related PR(s)

N/A

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_service_dns_forwarding.py
test_basic_forwarding (__main__.TestServicePowerDNS.test_basic_forwarding) ... ok
test_dns64 (__main__.TestServicePowerDNS.test_dns64) ... ok
test_dnssec (__main__.TestServicePowerDNS.test_dnssec) ... ok
test_domain_forwarding (__main__.TestServicePowerDNS.test_domain_forwarding) ... ok
test_dont_query (__main__.TestServicePowerDNS.test_dont_query) ... ok
test_dont_query_conflicting_entry_order (__main__.TestServicePowerDNS.test_dont_query_conflicting_entry_order) ... ok
test_ecs_add_for (__main__.TestServicePowerDNS.test_ecs_add_for) ... ok
test_ecs_ipv4_bits (__main__.TestServicePowerDNS.test_ecs_ipv4_bits) ... ok
test_edns_subnet_allow_list (__main__.TestServicePowerDNS.test_edns_subnet_allow_list) ... ok
test_exclude_throttle_adress (__main__.TestServicePowerDNS.test_exclude_throttle_adress) ... ok
test_external_nameserver (__main__.TestServicePowerDNS.test_external_nameserver) ... ok
test_listening_port (__main__.TestServicePowerDNS.test_listening_port) ... ok
test_multiple_ns_records (__main__.TestServicePowerDNS.test_multiple_ns_records) ... ok
test_no_rfc1918_forwarding (__main__.TestServicePowerDNS.test_no_rfc1918_forwarding) ... ok
test_nothing_below_nxdomain (__main__.TestServicePowerDNS.test_nothing_below_nxdomain) ... ok
test_recursor_cache_options (__main__.TestServicePowerDNS.test_recursor_cache_options) ... ok
test_serve_stale_extension (__main__.TestServicePowerDNS.test_serve_stale_extension) ... ok
test_zone_cache_axfr (__main__.TestServicePowerDNS.test_zone_cache_axfr) ... ok
test_zone_cache_options (__main__.TestServicePowerDNS.test_zone_cache_options) ... ok
test_zone_cache_url (__main__.TestServicePowerDNS.test_zone_cache_url) ... ok
test_zone_cache_wrong_source (__main__.TestServicePowerDNS.test_zone_cache_wrong_source) ... ok

----------------------------------------------------------------------
Ran 21 tests in 93.366s

OK
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly (https://github.com/vyos/vyos-documentation/pull/2211)
