### PR TITLE
smoketest: T9218: wait for commit lock before cli_set/cli_delete too

### DIFF
--- a/smoketest/scripts/cli/base_vyostest_shim.py
+++ b/smoketest/scripts/cli/base_vyostest_shim.py
@@ -25,11 +25,10 @@ from typing import Type
 from vyos import ConfigError
 from vyos.configsession import ConfigSession
 from vyos.configsession import ConfigSessionError
-from vyos.defaults import commit_lock
 from vyos.frrender import mgmt_daemon
+from vyos.utils.commit import commit_in_progress2
 from vyos.utils.process import cmdl
 from vyos.utils.process import process_named_running
-from vyos.utils.process import run
 
 save_config = '/tmp/vyos-smoketest-save'
 
@@ -92,29 +91,37 @@ class VyOSUnitTestSHIM:
             # check process health and continuity
             self.assertEqual(self.mgmt_daemon_pid, process_named_running(mgmt_daemon))
 
+        @staticmethod
+        def _wait_for_commit_lock():
+            # A concurrent commit (e.g. a previous commit asynchronous cleanup
+            # still finishing) keeps the commit lock held for a moment after
+            # control already returned to the caller.
+            while commit_in_progress2():
+                sleep(0.250)
+
         def cli_set(self, path, value=None):
             if self.debug:
                 str = f'set {" ".join(path)} {value}' if value else f'set {" ".join(path)}'
                 print(str)
+            self._wait_for_commit_lock()
             self._session.set(path, value)
 
         def cli_delete(self, config):
             if self.debug:
                 print('del ' + ' '.join(config))
+            self._wait_for_commit_lock()
             self._session.delete(config)
 
         def cli_discard(self):
             if self.debug:
                 print('DISCARD')
+            self._wait_for_commit_lock()
             self._session.discard()
 
         def cli_commit(self):
             if self.debug:
                 print('commit')
-            # During a commit there is a process opening commit_lock, and run()
-            # returns 0
-            while run(f'sudo lsof -nP {commit_lock}') == 0:
-                sleep(0.250)
+            self._wait_for_commit_lock()
             # Return the output of commit
             # Necessary for testing Warning cases
             return self._session.commit()


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

`cli_commit()` already busy-waits for the `CStore` `commit_lock` to clear before committing, since a concurrent process can still hold it open for a moment.

`cli_set()`/`cli_delete()` had no such guard, so a set/delete issued right after a commit could race against that lingering lock and fail with a generic "Set failed"/"Delete failed" `ConfigSessionError`.

This is what caused the intermittent `test_bgp_27_route_reflector_client` failures, whose set/commit/discard loop hammers the session tightly enough to hit the race. Share the wait via a single helper used by all three.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9218

## How to test / Smoketest result
Embedded smoketests run fir this PR

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
