### PR TITLE
http-api: T9223: add VRF option to traceroute REST API endpoint

### DIFF
--- a/python/vyos/configsession.py
+++ b/python/vyos/configsession.py
@@ -494,6 +494,9 @@ class ConfigSession(object):
         out = self.__run_command(cmd)
         return out
 
-    def traceroute(self, host):
-        out = self.__run_command(TRACEROUTE + [host])
+    def traceroute(self, host, vrf: str | None = None):
+        cmd = TRACEROUTE + [host]
+        if vrf is not None:
+            cmd += ['--vrf', vrf]
+        out = self.__run_command(cmd)
         return out

--- a/src/services/api/rest/models.py
+++ b/src/services/api/rest/models.py
@@ -332,6 +332,7 @@ class PingModel(ApiModel):
 class TracerouteModel(ApiModel):
     op: StrictStr
     host: StrictStr
+    vrf: StrictStr | None = None
 
     class Config:
         schema_extra = {
@@ -339,6 +340,7 @@ class TracerouteModel(ApiModel):
                 'key': 'id_key',
                 'op': 'traceroute',
                 'host': 'host',
+                'vrf': 'vrf',
             }
         }
 

--- a/src/services/api/rest/routers.py
+++ b/src/services/api/rest/routers.py
@@ -992,10 +992,11 @@ def traceroute_op(data: TracerouteModel):
 
     op = data.op
     host = data.host
+    vrf = data.vrf
 
     try:
         if op == 'traceroute':
-            res = session.traceroute(host)
+            res = session.traceroute(host, vrf)
         else:
             return error(400, f"'{op}' is not a valid operation")
     except ConfigSessionError as e:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary

Add an optional VRF argument to the existing REST API `/traceroute` endpoint.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
https://vyos.dev/T9223

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

Enable the HTTP API service and configure a VRF. Then perform a traceroute via curl:

1. First verify existing `/traceroue` works without (validate no breaking change)
```
curl -k --location --request POST 'https://vyos/traceroute' \
--form data='{"op": "traceroute", "host": "1.1.1.1"}' \
--form key='MY-HTTPS-API-PLAINTEXT-KEY'
```

2. Next verify VRF option works:
```
curl -k --location --request POST 'https://vyos/traceroute' \
--form data='{"op": "traceroute", "host": "1.1.1.1", "vrf": "test"}' \
--form key='MY-HTTPS-API-PLAINTEXT-KEY'
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
