### PR TITLE
T8482: reject commits referencing an incomplete policy object

### DIFF
--- a/smoketest/scripts/cli/test_protocols_bgp.py
+++ b/smoketest/scripts/cli/test_protocols_bgp.py
@@ -2045,5 +2045,41 @@ class TestProtocolsBGP(VyOSUnitTestSHIM.TestCase):
         frrconfig = self.getFRRconfig(f'router bgp {ASN}', stop_section='^exit')
         self.assertIn(f' address-family link-state', frrconfig)
 
+    def test_bgp_105_reject_bgp_referencing_incomplete_prefix_list(self):
+        # T8482: a peer-group referencing a prefix-list that itself fails
+        # verify() (missing "action") must not let the BGP commit succeed,
+        # and FRR must never receive the otherwise valid BGP configuration
+        # while the referenced policy object remains incomplete.
+        broken_prefix_list = 'pfx-foo-broken'
+        peer_group = 'foo'
+        peer = '192.0.2.100'
+
+        self.cli_set(['policy', 'prefix-list', broken_prefix_list, 'rule', '10', 'prefix', '10.0.0.0/24'])
+
+        self.cli_set(base_path + ['neighbor', peer, 'peer-group', peer_group])
+        self.cli_set(base_path + ['peer-group', peer_group, 'remote-as', '200'])
+        self.cli_set(base_path + ['peer-group', peer_group, 'address-family', 'ipv4-unicast',
+                                   'prefix-list', 'export', broken_prefix_list])
+
+        # Commit must fail - the referenced prefix-list is incomplete
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        # FRR must not see any BGP configuration - nor the still-invalid
+        # prefix-list itself - while the commit is broken
+        frrconfig = self.getFRRconfig()
+        self.assertNotIn('router bgp', frrconfig)
+        self.assertNotIn(f'ip prefix-list {broken_prefix_list}', frrconfig)
+
+        # Completing the prefix-list allows the very same BGP config to commit
+        self.cli_set(['policy', 'prefix-list', broken_prefix_list, 'rule', '10', 'action', 'permit'])
+        self.cli_commit()
+
+        frrconfig = self.getFRRconfig(f'router bgp {ASN}', stop_section='^exit')
+        self.assertIn(f'router bgp {ASN}', frrconfig)
+        self.assertIn(f' neighbor {peer_group} prefix-list {broken_prefix_list} out', frrconfig)
+
+        self.cli_delete(['policy', 'prefix-list', broken_prefix_list])
+
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/src/services/vyos-configd
+++ b/src/services/vyos-configd
@@ -182,6 +182,7 @@ def initialization(config_manager: ConfigManager, socket):
 
     scripts_called = []
     setattr(config, 'scripts_called', scripts_called)
+    setattr(config, 'commit_failed', False)
 
     config_manager.set_config(config)
 
@@ -235,7 +236,14 @@ def process_node_data(config_manager: ConfigManager, data) -> tuple[Response, st
 
     logger.info(f'[{script_name}] {out}')
 
+    if result not in (Response.SUCCESS, Response.PASS):
+        setattr(config, 'commit_failed', True)
+
     return result, out
+
+
+def should_render_frr(res: Response, config) -> bool:
+    return res == Response.SUCCESS and not getattr(config, 'commit_failed', False)
 
 
 def call_frr_render(frr, config):
@@ -346,7 +354,7 @@ if __name__ == '__main__':
                 scripts_called = getattr(config, 'scripts_called', [])
                 logger.debug(f'scripts_called: {scripts_called}')
 
-                if res == Response.SUCCESS:
+                if should_render_frr(res, config):
                     r, o = call_frr_render(frr, config)
                     res = r
                     out = out + o


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

A `verify()` failure in one conf_mode script (e.g. `policy prefix-list`) did not stop `vyos-configd`/`vyos-commitd` from still pushing the shared FRR configuration to `vtysh` once the last script in the same commit batch happened to succeed on its own, since the render step only checked that last script's own result. Track whether any earlier script in the batch failed and gate the shared FRR render on it in both commit daemons.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8482

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
