### PR TITLE
T3871: don't reserve a pending node's name with no established baseline

### DIFF
--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -385,6 +385,14 @@ warn_missing_interface_hardware ()
         [ -n "${intf}" ] || continue
         log_failure_msg "interface '${intf}' still has no hw-id configured after this boot's naming pass - bind it manually, e.g. 'set interfaces ethernet ${intf} hw-id <mac>', or remove the node if it is no longer needed"
     done
+
+    # these nodes DID get hardware, but which NIC went to which name was
+    # inferred from PCI slot order rather than being the only possibility
+    jq -r '.reclaimed_by_topology // [] | .[]' "${status_file}" 2>/dev/null | \
+        while read -r intf; do
+        [ -n "${intf}" ] || continue
+        log_warning_msg "interface '${intf}' had no hw-id and was matched to hardware by PCI slot order - verify it is the port you expect before relying on its configuration"
+    done
 }
 
 cleanup_post_commit_hooks () {

--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -393,6 +393,18 @@ warn_missing_interface_hardware ()
         [ -n "${intf}" ] || continue
         log_warning_msg "interface '${intf}' had no hw-id and was matched to hardware by PCI slot order - verify it is the port you expect before relying on its configuration"
     done
+
+    # and here even the choice of WHICH ports were in the running came from
+    # the names they happened to carry this boot. Those names only narrowed
+    # the field: PCI slot order still decided which port got which name, so
+    # report the mac actually bound rather than implying the name matched.
+    jq -r '(.reclaimed_by_name // []) as $names | (.reclaimed // {})
+           | to_entries[] | select(.value as $v | $names | index($v))
+           | "\(.value) \(.key)"' "${status_file}" 2>/dev/null | \
+        while read -r intf hwid; do
+        [ -n "${intf}" ] || continue
+        log_warning_msg "interface '${intf}' had no hw-id and was matched to ${hwid} by PCI slot order, among the ports whose current names matched the configuration - verify it is the port you expect before relying on its configuration"
+    done
 }
 
 cleanup_post_commit_hooks () {

--- a/src/system/vyos-net-name-resolve.py
+++ b/src/system/vyos-net-name-resolve.py
@@ -154,27 +154,6 @@ def get_pending_hwid_nodes() -> dict:
     return pending
 
 
-def has_established_baseline(configured: dict, intf_type: str) -> bool:
-    """Whether config.boot already binds at least one real hw-id of this
-    type (ethernet/wireless). Used to decide whether a pending (hw-id-less)
-    node of that type needs its name reserved: that reservation exists
-    solely to protect an established mapping from a wrong guess (see
-    match_pending_nodes()), so it only makes sense once such a mapping
-    actually exists. On a box that has never bound a hw-id of this type at
-    all, there is nothing yet to protect.
-
-    Still needed alongside match_pending_nodes()' exact-cover pairing,
-    which covers a different shape: a cover consumes the whole type group,
-    so the reservation is moot whenever pairing succeeds, but a virgin box
-    whose only pending node is the default 'eth0' a cloud-init/first-boot
-    script wrote into config.boot, with several NICs present, is not a
-    cover - pairing refuses, and without this carve-out 'eth0' would stay
-    reserved and empty while the real NICs bootstrapped at eth1..ethN.
-    """
-    prefix = 'wlan' if intf_type == 'wireless' else 'eth'
-    return any(name.startswith(prefix) for name in configured.values())
-
-
 def get_permanent_mac(ifname: str, sys_class_net: str = '/sys/class/net') -> str:
     """Best-effort permanent hardware address of an interface.
 
@@ -621,15 +600,8 @@ def compute_bootstrap_plan(configured: dict, current: dict, existing_plan: dict,
     a candidate main() could not unambiguously match to one via
     match_pending_nodes() must never squat there instead, since that name
     still carries the node's other settings (address, description, ...).
-    This reservation only applies to a type (ethernet/wireless) that
-    already has at least one real hw-id binding of its own - see
-    has_established_baseline() - since it exists purely to protect an
-    established mapping from a wrong guess, and a type with no bindings
-    at all has no established mapping to protect: a hw-id-less node of
-    that type (e.g. one a cloud-init/first-boot script wrote straight
-    into config.boot before this script ever ran, on a box that has
-    never had hw-id at all) is then just another open slot, exactly like
-    a plain numeric gap, and competes for it the same way.
+    This pass may never fill a pending name - only match_pending_nodes()
+    may, and only under a rule that reports what it did.
     reclaimed is {mac: node_name} for the candidates main() already
     matched to a pending node - their macs are excluded from this pass so
     it never reassigns them elsewhere, and their target names counted as
@@ -665,14 +637,11 @@ def compute_bootstrap_plan(configured: dict, current: dict, existing_plan: dict,
     # as taken here either.
     reserved_pending = set()
     if pending:
-        for intf_type, names in pending.items():
-            if names and has_established_baseline(configured, intf_type):
-                reserved_pending |= names
-    # a reclaim target is authoritative the same way a rightful mover's
-    # is, but its plan entry's source IS a candidate, so rightful_movers
-    # deliberately filters it out above - union it back in here rather
-    # than leaning on reserved_pending, which a type with no established
-    # baseline skips.
+        for names in pending.values():
+            reserved_pending |= names
+    # a reclaim target is authoritative the same way a rightful mover's is,
+    # but its plan entry's source IS a candidate, so rightful_movers filters
+    # it out above - union it back in here
     taken = (set(current) - candidate_names - set(rightful_movers)) \
         | set(rightful_movers.values()) | reserved_pending \
         | set(reclaimed.values())
@@ -765,7 +734,6 @@ def sync_rescan_hints(current_state: dict, configured: dict,
 def write_status(configured: dict, found: dict, missing: set, plan: dict,
                   pending: dict = None, reclaimed: dict = None,
                   candidates: list = None,
-                  resolved_pending: set = frozenset(),
                   reclaimed_by_topology: set = frozenset(),
                   reclaimed_by_name: set = frozenset()) -> None:
     """candidates is the full unmatched_candidates() list evaluated this
@@ -775,12 +743,6 @@ def write_status(configured: dict, found: dict, missing: set, plan: dict,
     'unconfigured_candidates' names every physical interface that was in
     the running for one, without needing a separate `ip -br link show` or
     `show configuration commands` to reconstruct the same picture by hand.
-
-    resolved_pending is every pending name real hardware ended up under
-    this boot via an ordinary bootstrap assignment - for a type with no
-    established baseline, see has_established_baseline() - rather than an
-    explicit match_pending_nodes() reclaim (already covered by
-    `reclaimed` below); only a name in neither is genuinely unresolved.
 
     reclaimed_by_topology is the subset of `reclaimed` that came from an
     exact cover of more than one pending node, i.e. was paired by PCI slot
@@ -798,13 +760,12 @@ def write_status(configured: dict, found: dict, missing: set, plan: dict,
     reclaimed = reclaimed or {}
     candidates = candidates or []
     all_pending = pending.get('ethernet', set()) | pending.get('wireless', set())
-    resolved = set(reclaimed.values()) | set(resolved_pending)
     status = {
         'configured': configured,
         'found': sorted(found.values()),
         'missing': {mac: configured[mac] for mac in sorted(missing)},
         'renamed': plan,
-        'pending_unresolved': sorted(all_pending - resolved),
+        'pending_unresolved': sorted(all_pending - set(reclaimed.values())),
         'reclaimed': reclaimed,
         'reclaimed_by_topology': sorted(reclaimed_by_topology),
         'reclaimed_by_name': sorted(reclaimed_by_name),
@@ -896,14 +857,7 @@ def main():
     applied = safe_bulk_rename(plan)
 
     final_current = discover_physical_interfaces()
-    # a pending node whose type had no established baseline (see
-    # has_established_baseline()) was never reserved above, so it may
-    # simply have been claimed by ordinary bootstrap naming instead of a
-    # match_pending_nodes() reclaim - real hardware sits under its name
-    # either way, so it is resolved, not still-pending, even though
-    # `reclaimed` (handled separately below) only tracks the former.
-    resolved_pending = all_pending & set(final_current)
-    for name in sorted(all_pending - set(reclaimed.values()) - resolved_pending):
+    for name in sorted(all_pending - set(reclaimed.values())):
         logger.warning(
             f"pending node '{name}' still has no hw-id after this boot's "
             'naming pass'
@@ -916,7 +870,6 @@ def main():
     sync_rescan_hints(final_current, configured, set(applied.keys()))
     write_status(configured, current, missing, applied,
                  pending=pending, reclaimed=reclaimed, candidates=candidates,
-                 resolved_pending=resolved_pending,
                  reclaimed_by_topology=reclaim_rules['topology'],
                  reclaimed_by_name=reclaim_rules['name'])
 

--- a/src/system/vyos-net-name-resolve.py
+++ b/src/system/vyos-net-name-resolve.py
@@ -154,6 +154,27 @@ def get_pending_hwid_nodes() -> dict:
     return pending
 
 
+def has_established_baseline(configured: dict, intf_type: str) -> bool:
+    """Whether config.boot already binds at least one real hw-id of this
+    type (ethernet/wireless). Used to decide whether a pending (hw-id-less)
+    node of that type needs its name reserved: that reservation exists
+    solely to protect an established mapping from a wrong guess (see
+    match_pending_nodes()), so it only makes sense once such a mapping
+    actually exists. On a box that has never bound a hw-id of this type at
+    all, there is nothing yet to protect.
+
+    Still needed alongside match_pending_nodes()' exact-cover pairing,
+    which covers a different shape: a cover consumes the whole type group,
+    so the reservation is moot whenever pairing succeeds, but a virgin box
+    whose only pending node is the default 'eth0' a cloud-init/first-boot
+    script wrote into config.boot, with several NICs present, is not a
+    cover - pairing refuses, and without this carve-out 'eth0' would stay
+    reserved and empty while the real NICs bootstrapped at eth1..ethN.
+    """
+    prefix = 'wlan' if intf_type == 'wireless' else 'eth'
+    return any(name.startswith(prefix) for name in configured.values())
+
+
 def get_permanent_mac(ifname: str, sys_class_net: str = '/sys/class/net') -> str:
     """Best-effort permanent hardware address of an interface.
 
@@ -246,36 +267,90 @@ def is_wireless_interface(name: str, sys_class_net: str = '/sys/class/net') -> b
     return (Path(sys_class_net) / name / 'phy80211').exists()
 
 
-PCI_BDF_RE = re.compile(r'^[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9a-f]$')
+PCI_BDF_RE = re.compile(r'^([0-9a-f]{4}):([0-9a-f]{2}):([0-9a-f]{2})\.([0-9a-f])$')
 
 # No real hop-count can reach this - reserves it as a sort-last sentinel
-# for interfaces whose bus topology can't be determined (USB NICs, or a
-# device symlink that doesn't exist/resolve).
+# for interfaces whose bus topology can't be determined (a device symlink
+# that doesn't exist/resolve, or a bus with no PCI ancestor at all).
 PCIE_DISTANCE_UNKNOWN = 999
 
+# Every field at its maximum, so it sorts after any real address. It must
+# not be the empty tuple: that would sort FIRST.
+PCIE_ADDRESS_UNKNOWN = ((0xffff, 0xff, 0xff, 0xf),)
 
-def pcie_distance(name: str, sys_class_net: str = '/sys/class/net') -> int:
-    """Approximate PCIe bus distance from the root complex - counts PCI
-    domain:bus:device.function segments (e.g. 0000:00:1f.6) in the fully
-    resolved sysfs path of the interface's 'device' symlink. Non-PCI hops
-    (virtioN, usbN, the net/<ifname> tail, ...) simply don't match and are
-    skipped, so virtio's device->virtioN->real-PCI-parent indirection
-    needs no special-casing. Multi-function siblings at the same slot
-    contribute exactly one matching segment each, so they are not
-    double-counted relative to their shared depth.
 
-    Returns PCIE_DISTANCE_UNKNOWN (sorts after every real hop-count) if
-    the 'device' symlink is missing/unresolvable, or the resolved path
-    has no PCI BDF segment at all (e.g. a USB NIC).
+def _device_bdfs(name: str, sys_class_net: str = '/sys/class/net') -> list:
+    """Ordered (domain, bus, device, function) tuples for every PCI segment
+    in the fully resolved sysfs path of the interface's 'device' symlink,
+    root complex first. Non-PCI hops (virtioN, usbN, the net/<ifname>
+    tail, ...) simply don't match and are skipped, so virtio's
+    device->virtioN->real-PCI-parent indirection needs no special-casing.
+    Multi-function siblings at the same slot contribute exactly one
+    segment each, so they are not double-counted relative to their shared
+    depth - they differ only in the function field of that last segment.
+
+    Returns an empty list if the symlink is missing/unresolvable or the
+    resolved path has no PCI BDF segment at all. Resolving once here means
+    pcie_distance() and pcie_address() can never disagree about the same
+    interface.
     """
     device_link = Path(sys_class_net) / name / 'device'
     try:
         resolved = device_link.resolve(strict=True)
     except (OSError, RuntimeError):
-        return PCIE_DISTANCE_UNKNOWN
+        return []
 
-    hops = sum(1 for part in resolved.parts if PCI_BDF_RE.match(part))
-    return hops if hops > 0 else PCIE_DISTANCE_UNKNOWN
+    bdfs = []
+    for part in resolved.parts:
+        m = PCI_BDF_RE.match(part)
+        if m:
+            bdfs.append(tuple(int(g, 16) for g in m.groups()))
+    return bdfs
+
+
+def pcie_distance(name: str, sys_class_net: str = '/sys/class/net') -> int:
+    """Approximate PCIe bus distance from the root complex - the number of
+    PCI domain:bus:device.function segments (e.g. 0000:00:1f.6) on the
+    interface's resolved sysfs path, see _device_bdfs().
+
+    Returns PCIE_DISTANCE_UNKNOWN (sorts after every real hop-count) when
+    that path has no PCI segment at all. Note this is rarer than it looks:
+    a USB NIC still resolves through its xHCI controller
+    (.../0000:00:14.0/usb1/1-1/1-1:1.0/net/eth0) and so reports a real
+    hop-count like any onboard device.
+    """
+    return len(_device_bdfs(name, sys_class_net)) or PCIE_DISTANCE_UNKNOWN
+
+
+def pcie_address(name: str, sys_class_net: str = '/sys/class/net') -> tuple:
+    """The interface's full PCI path as an ordered tuple of BDF tuples,
+    see _device_bdfs(). Unlike pcie_distance() this is a bus ADDRESS, not
+    a hop count, so it distinguishes two devices sitting at the same depth
+    - the common case in a VM, where every NIC hangs off the same bus and
+    the hypervisor allocates slots in the order the NICs were attached.
+
+    Returns PCIE_ADDRESS_UNKNOWN (sorts last) when the path has no PCI
+    segment at all.
+    """
+    return tuple(_device_bdfs(name, sys_class_net)) or PCIE_ADDRESS_UNKNOWN
+
+
+def canonical_sort_key(mac: str, name: str) -> tuple:
+    """The one canonical hardware order this script names by, used both for
+    ordinary bootstrap naming (compute_bootstrap_plan()) and for pairing
+    hardware with pending nodes (match_pending_nodes()) - they must agree,
+    or a name assigned by one would contradict the other.
+
+    PCIe distance leads deliberately: an onboard/directly CPU-attached NIC
+    should not sort after add-in cards merely because of its bus address.
+    Within one distance the full PCI address decides, so same-depth NICs
+    follow real slot order (and a dual-port card's function 0 precedes its
+    function 1) instead of raw MAC magnitude, which bears no relation to
+    how the ports are wired. MAC remains only as a last-resort tie-break
+    for devices with no distinguishing PCI address at all - it is the only
+    guaranteed-unique component, so the order stays total.
+    """
+    return (pcie_distance(name), pcie_address(name), mac)
 
 
 def find_available(names: set, prefix: str) -> str:
@@ -378,30 +453,62 @@ def unmatched_candidates(configured: dict, current: dict, existing_plan: dict) -
             if mac not in configured]
 
 
+def node_name_order(name: str) -> tuple:
+    """Sort key putting interface node names in numeric, not lexical,
+    order - 'eth2' before 'eth10'. A name with no trailing digits has no
+    position in that sequence and sorts last, by name.
+    """
+    m = re.search(r'(\d+)$', name)
+    return (0, int(m.group(1)), name) if m else (1, 0, name)
+
+
 def match_pending_nodes(pending: dict, candidates: list) -> dict:
     """Match this boot's unconfigured candidates to pending (hw-id-less)
-    config nodes, one type (ethernet/wireless) at a time. Conservative by
-    design: only matches when there is EXACTLY ONE pending node and
-    EXACTLY ONE candidate of that type this boot - any other cardinality
-    is left alone rather than guessed.
+    config nodes, one type (ethernet/wireless) at a time. Matches only on
+    an EXACT COVER - as many pending nodes of that type as unconfigured
+    candidates of that type this boot - pairing them in order: nodes by
+    their numeric index (see node_name_order()), hardware by the same
+    canonical order everything else here names by (see
+    canonical_sort_key()). Any other cardinality is left alone rather
+    than guessed.
 
     A pending node still carries its OTHER settings (address,
-    description, ...) - a wrong guess would silently apply one physical
-    port's configuration to a DIFFERENT port. Confirmed in the field: on
-    a real, already-provisioned box (whose hw-id came from historical
-    probe-order rescan, not from any PCIe/MAC sort), a second, completely
-    unrelated candidate freed in the same boot - e.g. a different
-    interface's config being fully deleted - is enough for a naive
-    ascending-sort fill to swap the two, binding a configured node's
-    address to the wrong wire. There is no way to tell, from MAC and
-    PCIe position alone, which candidate is genuinely the pending node's
-    own hardware once its hw-id is gone; leaving the node unresolved and
-    reported is safer than guessing. A candidate that isn't reclaimed
-    here is not otherwise held back - it still proceeds to ordinary
-    bootstrap naming (see compute_bootstrap_plan()) and gets its own
-    fresh, settings-free name instead.
+    description, ...), so a wrong pairing silently applies one physical
+    port's configuration to a DIFFERENT port - which is why anything but
+    an exact cover refuses. Confirmed in the field: on a real,
+    already-provisioned box (whose hw-id came from historical probe-order
+    rescan, not from any PCIe/MAC sort), a second, completely unrelated
+    candidate freed in the same boot - e.g. a different interface's
+    config being fully deleted - is enough for a naive ascending-sort
+    fill to swap the two, binding a configured node's address to the
+    wrong wire. With more candidates than nodes there is genuinely no way
+    to tell which one is the node's own hardware, and leaving it
+    unresolved and reported is safer than guessing.
 
-    Returns {mac: node_name} for every unambiguous match this boot.
+    An exact cover is different in kind, not just in degree: every node is
+    going to receive real hardware whatever happens, so the only open
+    question is the permutation - and PCI slot order is the best answer
+    available, while refusing strands 100% of the nodes on interfaces
+    that do not exist, permanently, across reboots (see the multi-NIC
+    cloud-init case in has_established_baseline()). Note this is not a
+    new class of behaviour: an unreserved pending name (no established
+    baseline) is already filled by ordinary bootstrap naming's implicit
+    ascending fill. Pairing here makes that guess explicit, logged, and
+    topology-ordered rather than gap-ordered.
+
+    It is NOT infallible, and a cover of more than one node is logged as
+    a warning for exactly that reason: a leftover scratch interface from
+    a failed rename, or a pending node whose own hardware is dead, can
+    make a false cover, and on a legacy box whose names came from
+    historical probe order the slot order carries no information about
+    which node is which.
+
+    A candidate that isn't reclaimed here is not otherwise held back - it
+    still proceeds to ordinary bootstrap naming (see
+    compute_bootstrap_plan()) and gets its own fresh, settings-free name
+    instead.
+
+    Returns {mac: node_name} for every match this boot.
     """
     grouped = {'ethernet': [], 'wireless': []}
     for mac, name in candidates:
@@ -413,17 +520,36 @@ def match_pending_nodes(pending: dict, candidates: list) -> dict:
         if not nodes:
             continue
         cands = grouped.get(intf_type, [])
-        if len(nodes) == 1 and len(cands) == 1:
-            (mac, _name) = cands[0]
-            (target,) = nodes
-            matched[mac] = target
-        else:
+        if len(nodes) != len(cands):
             cand_desc = ', '.join(f"'{name}' ({mac})" for mac, name in cands) or 'none'
             logger.warning(
                 f'{len(nodes)} pending {intf_type} node(s) '
-                f"({', '.join(sorted(nodes))}) and {len(cands)} unconfigured "
-                f'{intf_type} candidate(s) this boot ({cand_desc}) - not '
-                'unambiguous, leaving pending rather than guessing'
+                f"({', '.join(sorted(nodes, key=node_name_order))}) and "
+                f'{len(cands)} unconfigured {intf_type} candidate(s) this '
+                f'boot ({cand_desc}) - not an exact cover, leaving pending '
+                'rather than guessing'
+            )
+            continue
+
+        targets = sorted(nodes, key=node_name_order)
+        hardware = sorted(cands, key=lambda c: canonical_sort_key(*c))
+        for target, (mac, name) in zip(targets, hardware):
+            matched[mac] = target
+
+        if len(targets) > 1:
+            # a single node and a single candidate leave no permutation to
+            # get wrong - anything larger was ordered by PCI slot, which is
+            # a well-founded guess but still a guess, so say so loudly
+            # enough that an admin can verify the wiring
+            pairs = ', '.join(
+                f"{target} <- {mac} (pci {pcie_address(name)}, now '{name}')"
+                for target, (mac, name) in zip(targets, hardware)
+            )
+            logger.warning(
+                f'{len(targets)} pending {intf_type} node(s) exactly cover '
+                f"this boot's unconfigured {intf_type} hardware - pairing "
+                f'them in PCI slot order: {pairs} - verify this matches how '
+                'the ports are actually wired'
             )
 
     return matched
@@ -431,15 +557,12 @@ def match_pending_nodes(pending: dict, candidates: list) -> dict:
 
 def compute_bootstrap_plan(configured: dict, current: dict, existing_plan: dict,
                             pending: dict = None,
-                            reclaimed_macs: frozenset = frozenset()) -> dict:
+                            reclaimed: dict = None) -> dict:
     """Build {from_name: to_name} for physical interfaces that have no
     configured hw-id at all, assigning them a canonical name within their
-    type group (ethernet/wireless) ordered by PCIe distance from the root
-    complex first and MAC address as a tie-break, instead of leaving them
-    at whatever name the racy udev-time fast path produced. Ordering by
-    topology rather than raw MAC magnitude means an onboard/directly
-    CPU-attached NIC isn't sorted after add-in cards just because its MAC
-    happens to be numerically higher. This is what makes a box's very
+    type group (ethernet/wireless) in canonical hardware order (see
+    canonical_sort_key()), instead of leaving them at whatever name the
+    racy udev-time fast path produced. This is what makes a box's very
     first boot - before any hw-id exists - just as deterministic as every
     boot after hw-id is written (PCIe wiring and MAC are both static
     hardware properties), since the name assigned here gets frozen into
@@ -461,8 +584,19 @@ def compute_bootstrap_plan(configured: dict, current: dict, existing_plan: dict,
     a candidate main() could not unambiguously match to one via
     match_pending_nodes() must never squat there instead, since that name
     still carries the node's other settings (address, description, ...).
-    reclaimed_macs are candidates main() already matched to a pending
-    node - excluded here so this function never reassigns them elsewhere.
+    This reservation only applies to a type (ethernet/wireless) that
+    already has at least one real hw-id binding of its own - see
+    has_established_baseline() - since it exists purely to protect an
+    established mapping from a wrong guess, and a type with no bindings
+    at all has no established mapping to protect: a hw-id-less node of
+    that type (e.g. one a cloud-init/first-boot script wrote straight
+    into config.boot before this script ever ran, on a box that has
+    never had hw-id at all) is then just another open slot, exactly like
+    a plain numeric gap, and competes for it the same way.
+    reclaimed is {mac: node_name} for the candidates main() already
+    matched to a pending node - their macs are excluded from this pass so
+    it never reassigns them elsewhere, and their target names counted as
+    taken so it can never hand the same name to a second interface.
 
     A numeric slot is only ever off-limits here because something still
     occupies or reserves it - a real hw-id target or a pending node. A gap
@@ -474,9 +608,10 @@ def compute_bootstrap_plan(configured: dict, current: dict, existing_plan: dict,
     deleting the whole node is the admin's explicit way of saying so.
     """
     plan = {}
+    reclaimed = reclaimed or {}
     candidates = unmatched_candidates(configured, current, existing_plan)
     candidates = [(mac, name) for mac, name in candidates
-                  if mac not in reclaimed_macs]
+                  if mac not in reclaimed]
     if not candidates:
         return plan
 
@@ -493,11 +628,19 @@ def compute_bootstrap_plan(configured: dict, current: dict, existing_plan: dict,
     # as taken here either.
     reserved_pending = set()
     if pending:
-        reserved_pending = pending.get('ethernet', set()) | pending.get('wireless', set())
+        for intf_type, names in pending.items():
+            if names and has_established_baseline(configured, intf_type):
+                reserved_pending |= names
+    # a reclaim target is authoritative the same way a rightful mover's
+    # is, but its plan entry's source IS a candidate, so rightful_movers
+    # deliberately filters it out above - union it back in here rather
+    # than leaning on reserved_pending, which a type with no established
+    # baseline skips.
     taken = (set(current) - candidate_names - set(rightful_movers)) \
-        | set(rightful_movers.values()) | reserved_pending
+        | set(rightful_movers.values()) | reserved_pending \
+        | set(reclaimed.values())
 
-    for mac, name in sorted(candidates, key=lambda c: (pcie_distance(c[1]), c[0])):
+    for mac, name in sorted(candidates, key=lambda c: canonical_sort_key(*c)):
         prefix = 'wlan' if is_wireless_interface(name) else 'eth'
         new_name = find_next_available(taken, prefix)
         taken.add(new_name)
@@ -584,7 +727,9 @@ def sync_rescan_hints(current_state: dict, configured: dict,
 
 def write_status(configured: dict, found: dict, missing: set, plan: dict,
                   pending: dict = None, reclaimed: dict = None,
-                  candidates: list = None) -> None:
+                  candidates: list = None,
+                  resolved_pending: set = frozenset(),
+                  reclaimed_by_topology: set = frozenset()) -> None:
     """candidates is the full unmatched_candidates() list evaluated this
     boot (before reclaim/bootstrap assignment) - surfaced here so a
     pending node left unresolved for lack of hardware is self-diagnosable
@@ -592,18 +737,32 @@ def write_status(configured: dict, found: dict, missing: set, plan: dict,
     'unconfigured_candidates' names every physical interface that was in
     the running for one, without needing a separate `ip -br link show` or
     `show configuration commands` to reconstruct the same picture by hand.
+
+    resolved_pending is every pending name real hardware ended up under
+    this boot via an ordinary bootstrap assignment - for a type with no
+    established baseline, see has_established_baseline() - rather than an
+    explicit match_pending_nodes() reclaim (already covered by
+    `reclaimed` below); only a name in neither is genuinely unresolved.
+
+    reclaimed_by_topology is the subset of `reclaimed` that came from an
+    exact cover of more than one pending node, i.e. was paired by PCI slot
+    order rather than being the single unambiguous possibility - surfaced
+    separately so an admin can see which bindings were inferred and worth
+    verifying against how the ports are actually wired.
     """
     pending = pending or {}
     reclaimed = reclaimed or {}
     candidates = candidates or []
     all_pending = pending.get('ethernet', set()) | pending.get('wireless', set())
+    resolved = set(reclaimed.values()) | set(resolved_pending)
     status = {
         'configured': configured,
         'found': sorted(found.values()),
         'missing': {mac: configured[mac] for mac in sorted(missing)},
         'renamed': plan,
-        'pending_unresolved': sorted(all_pending - set(reclaimed.values())),
+        'pending_unresolved': sorted(all_pending - resolved),
         'reclaimed': reclaimed,
+        'reclaimed_by_topology': sorted(reclaimed_by_topology),
         'unconfigured_candidates': {name: mac for mac, name in candidates},
     }
     try:
@@ -632,6 +791,7 @@ def main():
     all_pending = pending.get('ethernet', set()) | pending.get('wireless', set())
 
     reclaimed = {}
+    reclaimed_by_topology = set()
     candidates = []
     if all_pending or any(mac not in configured for mac in current.values()):
         # The `all_pending` half of this condition matters even when
@@ -654,13 +814,23 @@ def main():
             plan = compute_rename_plan(configured, current, pending)
 
         # let a NIC that just lost its hw-id (the documented "delete
-        # hw-id to force regeneration" remediation) reclaim the exact
-        # node its other settings (address, description, ...) still live
-        # under, rather than bootstrap-naming it to a new bare node and
-        # orphaning that config - only when unambiguous, see
-        # match_pending_nodes()
+        # hw-id to force regeneration" remediation), or one a
+        # cloud-init/first-boot script named in config.boot before this
+        # script ever ran, reclaim the exact node its other settings
+        # (address, description, ...) still live under, rather than
+        # bootstrap-naming it to a new bare node and orphaning that
+        # config - only on an exact cover, see match_pending_nodes()
         candidates = unmatched_candidates(configured, current, plan)
         reclaimed = match_pending_nodes(pending, candidates)
+        # a type group of more than one node can only have matched as an
+        # exact cover paired by PCI slot order - a well-founded guess, but
+        # still a guess, so keep it distinguishable from the single
+        # unambiguous 1:1 case all the way out to the status file
+        reclaimed_by_topology = {
+            name for intf_type, nodes in pending.items()
+            if len(nodes) > 1 and nodes <= set(reclaimed.values())
+            for name in nodes
+        }
         candidate_by_mac = dict(candidates)
         for mac, target in reclaimed.items():
             name = candidate_by_mac[mac]
@@ -674,29 +844,39 @@ def main():
         # bootstrap-name whatever is left, deterministically by PCIe
         # distance and MAC, instead of leaving it at its racy cosmetic
         # udev-time name - this is what vyos-interface-rescan.py will
-        # freeze into config.boot. Pending node names stay reserved here
-        # (see compute_bootstrap_plan()) so an ambiguous leftover
-        # candidate can never squat on one and inherit its settings.
+        # freeze into config.boot. A pending node name left unmatched
+        # above stays reserved here (see compute_bootstrap_plan()) so an
+        # ambiguous leftover candidate can never squat on one and inherit
+        # its settings.
         plan.update(compute_bootstrap_plan(
             configured, current, plan, pending=pending,
-            reclaimed_macs=set(reclaimed)))
+            reclaimed=reclaimed))
 
-    for name in sorted(all_pending - set(reclaimed.values())):
+    applied = safe_bulk_rename(plan)
+
+    final_current = discover_physical_interfaces()
+    # a pending node whose type had no established baseline (see
+    # has_established_baseline()) was never reserved above, so it may
+    # simply have been claimed by ordinary bootstrap naming instead of a
+    # match_pending_nodes() reclaim - real hardware sits under its name
+    # either way, so it is resolved, not still-pending, even though
+    # `reclaimed` (handled separately below) only tracks the former.
+    resolved_pending = all_pending & set(final_current)
+    for name in sorted(all_pending - set(reclaimed.values()) - resolved_pending):
         logger.warning(
             f"pending node '{name}' still has no hw-id after this boot's "
             'naming pass'
         )
 
-    applied = safe_bulk_rename(plan)
-
-    final_current = discover_physical_interfaces()
     # configured is passed unmutated (not merged with `reclaimed`): the
     # reclaimed mac still has no real hw-id in config.boot yet, so it must
     # still get a rescan hint under its (now reclaimed) name, letting
     # vyos-interface-rescan.py write the hw-id into the existing node.
     sync_rescan_hints(final_current, configured, set(applied.keys()))
     write_status(configured, current, missing, applied,
-                 pending=pending, reclaimed=reclaimed, candidates=candidates)
+                 pending=pending, reclaimed=reclaimed, candidates=candidates,
+                 resolved_pending=resolved_pending,
+                 reclaimed_by_topology=reclaimed_by_topology)
 
 
 if __name__ == '__main__':

--- a/src/system/vyos-net-name-resolve.py
+++ b/src/system/vyos-net-name-resolve.py
@@ -28,6 +28,13 @@
 # second chance since each uevent is only evaluated once. This script
 # sidesteps that by re-reading live state after hardware has had time to
 # settle, and by verifying/repairing the outcome rather than guessing once.
+#
+# The pass runs in three stages: move interfaces to their configured hw-id
+# names (compute_rename_plan), let hw-id-less config nodes reclaim their
+# own hardware (match_pending_nodes), then name whatever is left
+# (compute_bootstrap_plan). Each rule here was added for a specific field
+# report; the reasoning lives in the test that pins it, in
+# src/tests/test_net_name_resolve.py, where it cannot drift unnoticed.
 
 import json
 import logging
@@ -127,15 +134,13 @@ def get_configfile_interfaces() -> dict:
 
 
 def get_pending_hwid_nodes() -> dict:
-    """Interface nodes that exist under interfaces/{ethernet,wireless} in
-    config.boot but have no 'hw-id' leaf - e.g. the documented "NIC
-    replaced" remediation (`delete interfaces ethernet eth1 hw-id`)
-    intentionally leaves the node (and its other settings, like address)
-    in place, expecting the SAME node to receive a fresh hw-id. These
-    names have no known MAC yet - that is the point - so they cannot be
-    folded into get_configfile_interfaces()'s MAC-keyed dict; they are
-    surfaced here, grouped by type, so main() can try to match them to
-    this boot's unconfigured hardware (see match_pending_nodes()).
+    """{'ethernet': names, 'wireless': names} for config.boot nodes with
+    no 'hw-id' leaf - the "NIC replaced" remediation deletes only the
+    hw-id, keeping the node and its address for the same port to reclaim.
+
+    They have no known MAC by definition, so they cannot go in
+    get_configfile_interfaces()' MAC-keyed dict; match_pending_nodes()
+    tries to pair them with hardware instead.
     """
     pending = {'ethernet': set(), 'wireless': set()}
 
@@ -154,13 +159,21 @@ def get_pending_hwid_nodes() -> dict:
     return pending
 
 
+def pending_names(pending: dict) -> set:
+    """Every pending node name, both types together."""
+    if not pending:
+        return set()
+    return pending.get('ethernet', set()) | pending.get('wireless', set())
+
+
 def get_permanent_mac(ifname: str, sys_class_net: str = '/sys/class/net') -> str:
     """Best-effort permanent hardware address of an interface.
 
-    Falls back to the interface's current address if the driver does not
-    support reporting a permanent address separately (ethtool -P).
+    Falls back to the interface's current address when the driver cannot
+    report a permanent one (ethtool -P).
 
-    sys_class_net is overridable for testing against a fake sysfs tree.
+    sys_class_net redirects the sysfs fallback only; the ethtool branch
+    always queries the real host.
     """
     code, out = rc_cmd(f'ethtool -P {ifname}')
     if code == 0:
@@ -175,15 +188,12 @@ def get_permanent_mac(ifname: str, sys_class_net: str = '/sys/class/net') -> str
 
 
 def discover_physical_interfaces(sys_class_net: str = '/sys/class/net') -> dict:
-    """Return {kernel_name: mac} for every interface backed by a real bus
-    device - excludes lo, bridges, bonds, VLANs, veth, tunnels, etc.
+    """{kernel_name: mac} for interfaces backed by a real bus device -
+    excludes lo, bridges, bonds, VLANs, veth, tunnels and the like.
 
-    Also excludes interfaces enslaved to another netdev (master symlink
-    present), which covers Azure VF datapath interfaces bound under their
-    synthetic parent. Those are acceleration children, not independent
-    primary interfaces, and must not be candidates for hw-id naming.
-
-    sys_class_net is overridable for testing against a fake sysfs tree.
+    Also excludes anything enslaved to another netdev (master symlink),
+    which covers Azure VF datapath interfaces: acceleration children of
+    their synthetic parent, never hw-id naming candidates.  T8329
     """
     interfaces = {}
     net_dir = Path(sys_class_net)
@@ -224,9 +234,9 @@ def wait_for_hardware(configured_macs: set, timeout: float = HARDWARE_WAIT_TIMEO
 def wait_for_settle(initial: dict, timeout: float = HARDWARE_SETTLE_TIMEOUT,
                      poll: float = HARDWARE_WAIT_POLL,
                      stable_polls: int = HARDWARE_SETTLE_STABLE_POLLS) -> dict:
-    """Poll until discover_physical_interfaces() returns the same snapshot
-    stable_polls times in a row, or until timeout. Used before bootstrap-
-    naming hardware that has no configured hw-id to wait for by MAC.
+    """Poll until discover_physical_interfaces() repeats stable_polls
+    times, or timeout. Stands in for "hardware stopped appearing" when
+    there is no specific MAC to wait for.
     """
     deadline = time.monotonic() + timeout
     current = initial
@@ -240,8 +250,8 @@ def wait_for_settle(initial: dict, timeout: float = HARDWARE_SETTLE_TIMEOUT,
 
 
 def is_wireless_interface(name: str, sys_class_net: str = '/sys/class/net') -> bool:
-    """Race-free wireless check: existence of the phy80211 symlink, not the
-    interface's current (possibly still cosmetic/pre-bootstrap) name.
+    """Wireless check by phy80211 symlink, never by name - the name may
+    still be a provisional one at this point.
     """
     return (Path(sys_class_net) / name / 'phy80211').exists()
 
@@ -260,18 +270,14 @@ PCIE_ADDRESS_UNKNOWN = ((0xffff, 0xff, 0xff, 0xf),)
 
 def _device_bdfs(name: str, sys_class_net: str = '/sys/class/net') -> list:
     """Ordered (domain, bus, device, function) tuples for every PCI segment
-    in the fully resolved sysfs path of the interface's 'device' symlink,
-    root complex first. Non-PCI hops (virtioN, usbN, the net/<ifname>
-    tail, ...) simply don't match and are skipped, so virtio's
-    device->virtioN->real-PCI-parent indirection needs no special-casing.
-    Multi-function siblings at the same slot contribute exactly one
-    segment each, so they are not double-counted relative to their shared
-    depth - they differ only in the function field of that last segment.
+    on the interface's resolved 'device' symlink, root complex first.
+    Non-PCI hops (virtioN, usbN, ...) don't match and are skipped, so
+    virtio's device->virtioN->PCI-parent indirection needs no special
+    case; multi-function siblings differ only in the last function field.
 
     Returns an empty list if the symlink is missing/unresolvable or the
-    resolved path has no PCI BDF segment at all. Resolving once here means
-    pcie_distance() and pcie_address() can never disagree about the same
-    interface.
+    resolved path has no PCI BDF segment at all. pcie_distance() and
+    pcie_address() both derive from this, so they cannot disagree.
     """
     device_link = Path(sys_class_net) / name / 'device'
     try:
@@ -288,84 +294,54 @@ def _device_bdfs(name: str, sys_class_net: str = '/sys/class/net') -> list:
 
 
 def pcie_distance(name: str, sys_class_net: str = '/sys/class/net') -> int:
-    """Approximate PCIe bus distance from the root complex - the number of
-    PCI domain:bus:device.function segments (e.g. 0000:00:1f.6) on the
-    interface's resolved sysfs path, see _device_bdfs().
+    """Number of PCI segments on the interface's resolved sysfs path, i.e.
+    hop depth from the root complex. See _device_bdfs().
 
-    Returns PCIE_DISTANCE_UNKNOWN (sorts after every real hop-count) when
-    that path has no PCI segment at all. Note this is rarer than it looks:
-    a USB NIC still resolves through its xHCI controller
-    (.../0000:00:14.0/usb1/1-1/1-1:1.0/net/eth0) and so reports a real
-    hop-count like any onboard device.
+    PCIE_DISTANCE_UNKNOWN (sorts last) when the path has no PCI segment at
+    all - rarer than it looks, since a USB NIC still resolves through its
+    xHCI controller and reports an ordinary depth.
     """
     return len(_device_bdfs(name, sys_class_net)) or PCIE_DISTANCE_UNKNOWN
 
 
 def pcie_address(name: str, sys_class_net: str = '/sys/class/net') -> tuple:
-    """The interface's full PCI path as an ordered tuple of BDF tuples,
-    see _device_bdfs(). Unlike pcie_distance() this is a bus ADDRESS, not
-    a hop count, so it distinguishes two devices sitting at the same depth
-    - the common case in a VM, where every NIC hangs off the same bus and
-    the hypervisor allocates slots in the order the NICs were attached.
+    """The interface's PCI path as a tuple of BDF tuples, see
+    _device_bdfs(). A bus ADDRESS rather than a depth, so it separates two
+    devices at the same depth - the usual case in a VM, where the
+    hypervisor allocates a slot per NIC in attach order.
 
-    Returns PCIE_ADDRESS_UNKNOWN (sorts last) when the path has no PCI
-    segment at all.
+    PCIE_ADDRESS_UNKNOWN (sorts last) when there is no PCI segment.
     """
     return tuple(_device_bdfs(name, sys_class_net)) or PCIE_ADDRESS_UNKNOWN
 
 
 def canonical_sort_key(mac: str, name: str) -> tuple:
-    """The one canonical hardware order this script names by, used both for
-    ordinary bootstrap naming (compute_bootstrap_plan()) and for pairing
-    hardware with pending nodes (match_pending_nodes()) - they must agree,
-    or a name assigned by one would contradict the other.
+    """The single hardware order this script names by. Both
+    compute_bootstrap_plan() and match_pending_nodes() use it; if they
+    disagreed, one would contradict the other's names.
 
-    PCIe distance leads deliberately: an onboard/directly CPU-attached NIC
-    should not sort after add-in cards merely because of its bus address.
-    Within one distance the full PCI address decides, so same-depth NICs
-    follow real slot order (and a dual-port card's function 0 precedes its
-    function 1) instead of raw MAC magnitude, which bears no relation to
-    how the ports are wired. MAC remains only as a last-resort tie-break
-    for devices with no distinguishing PCI address at all - it is the only
-    guaranteed-unique component, so the order stays total.
+    Distance leads so an onboard NIC does not sort after add-in cards.
+    Within a distance the PCI address decides, giving real slot order
+    rather than MAC magnitude, which says nothing about wiring. MAC is the
+    last-resort tie-break and the only guaranteed-unique part, so the
+    order is total.  T3871
     """
     return (pcie_distance(name), pcie_address(name), mac)
 
 
-def find_available(names: set, prefix: str) -> str:
-    """Find the lowest free index for a given interface name prefix"""
-    index_list = []
-    for name in names:
-        if not name.startswith(prefix):
-            continue
-        suffix = name[len(prefix):]
-        if suffix.isdigit():
-            index_list.append(int(suffix))
+def find_available(names: set, prefix: str, floor: int = None) -> str:
+    """Lowest free '<prefix><n>' not in `names`, scanning up from `floor`.
 
-    if not index_list:
-        return f'{prefix}0'
-
-    index_list.sort()
-    # find 'holes' in list, if any
-    missing = sorted(set(range(index_list[0], index_list[-1])) - set(index_list))
-    if missing:
-        return f'{prefix}{missing[0]}'
-
-    return f'{prefix}{index_list[-1] + 1}'
-
-
-def find_next_available(names: set, prefix: str, floor: int = 0) -> str:
-    """Find the lowest free index for a prefix, scanning up from floor.
-
-    Unlike find_available(), this always starts the scan at floor (0 by
-    default) rather than at the lowest index already present in `names` -
-    used for bootstrap naming, where a gap must be backfillable even when
-    it sits below every other index currently in `names` (e.g. `names`
-    contains only 'eth5' and 'eth9', but 'eth0'..'eth4' and 'eth6'..'eth8'
-    are genuinely free). A slot only stays unavailable here because it is
-    explicitly present in `names` - the caller decides what belongs there
-    (configured hw-id targets, pending nodes, ...), not this function.
+    floor=None starts at the lowest index already present, so an existing
+    block of names is only ever extended or hole-filled. Bootstrap naming
+    passes floor=0 instead, because a slot below every present index is
+    still genuinely free and must be reusable.
     """
+    if floor is None:
+        indexes = [int(name[len(prefix):]) for name in names
+                   if name.startswith(prefix) and name[len(prefix):].isdigit()]
+        floor = min(indexes, default=0)
+
     n = floor
     while f'{prefix}{n}' in names:
         n += 1
@@ -373,9 +349,8 @@ def find_next_available(names: set, prefix: str, floor: int = 0) -> str:
 
 
 def compute_rename_plan(configured: dict, current: dict, pending: dict = None) -> dict:
-    """Build {from_name: to_name} for every interface that needs to move to
-    its CLI hw-id name. Also relocates any interface that currently squats
-    on a name owned by a different hw-id, so the rightful owner can take it.
+    """{from_name: to_name} moving every interface to its configured hw-id
+    name, evicting whatever squats on one so the owner can take it.
     """
     plan = {}
     current_by_mac = {mac: name for name, mac in current.items()}
@@ -387,18 +362,11 @@ def compute_rename_plan(configured: dict, current: dict, pending: dict = None) -
             plan[source] = target
 
     unchanged = set(current) - set(plan)
-    # every configured target is reserved, even one whose hw-id hasn't
-    # shown up yet this boot (missing/faulty/slow driver) - a squatter must
-    # never be relocated onto a name that hardware still owns, or it would
-    # just need relocating again the moment that hardware actually appears.
-    # A pending (hw-id-less but still-configured) node name is reserved the
-    # same way: it may be about to be reclaimed by the exact NIC that just
-    # vacated it (see match_pending_nodes()), and even when it isn't, its
-    # other settings (address, description, ...) are still live in
-    # config.boot and must not be handed to an unrelated squatter.
-    reserved = set(configured.values())
-    if pending:
-        reserved |= pending.get('ethernet', set()) | pending.get('wireless', set())
+    # every configured target is reserved even if its hardware is absent
+    # this boot, or a squatter moved there would need moving again the
+    # moment it appears. Pending names likewise: their address and
+    # description are live and must not go to an unrelated squatter.
+    reserved = set(configured.values()) | pending_names(pending)
 
     for name, mac in current.items():
         if name in plan:
@@ -414,28 +382,21 @@ def compute_rename_plan(configured: dict, current: dict, pending: dict = None) -
     return plan
 
 
-def unmatched_candidates(configured: dict, current: dict, existing_plan: dict) -> list:
-    """Physical interfaces this boot with no configured hw-id - the pool
-    both ordinary bootstrap naming and pending-node reclaim matching draw
-    from. This deliberately INCLUDES squatters compute_rename_plan() is
-    already evicting from a configured target name: excluding them here
-    let their mac skip match_pending_nodes() entirely, so an unconfigured
-    NIC that happened to be squatting on someone else's hw-id slot could
-    silently get a permanent, possibly-ambiguous hw-id via ordinary
-    bootstrap naming instead of being reclaimed or held back like any
-    other unconfigured candidate. Their eviction destination from
-    existing_plan still stands as the fallback - match_pending_nodes()
-    (via main()'s reclaim loop) or compute_bootstrap_plan() only override
-    it, they never leave a squatter un-evicted.
+def unmatched_candidates(configured: dict, current: dict) -> list:
+    """[(mac, name)] for physical interfaces with no configured hw-id -
+    the pool both bootstrap naming and pending-node matching draw from.
+
+    Deliberately includes squatters already being evicted from a
+    configured name: hiding them here would let one collect a permanent
+    hw-id without ever facing the ambiguity checks.  T3871
     """
     return [(mac, name) for name, mac in current.items()
             if mac not in configured]
 
 
 def node_name_order(name: str) -> tuple:
-    """Sort key putting interface node names in numeric, not lexical,
-    order - 'eth2' before 'eth10'. A name with no trailing digits has no
-    position in that sequence and sorts last, by name.
+    """Numeric, not lexical, name order - 'eth2' before 'eth10'. A name
+    with no trailing digits has no position and sorts last.
     """
     m = re.search(r'(\d+)$', name)
     return (0, int(m.group(1)), name) if m else (1, 0, name)
@@ -443,68 +404,28 @@ def node_name_order(name: str) -> tuple:
 
 def match_pending_nodes(pending: dict, candidates: list,
                          rules: dict = None) -> dict:
-    """Match this boot's unconfigured candidates to pending (hw-id-less)
-    config nodes, one type (ethernet/wireless) at a time.
+    """Pair this boot's unconfigured candidates with pending (hw-id-less)
+    config nodes, one type at a time. The first rule that applies wins;
+    if neither does, nothing of that type is matched:
 
-    Two rules are tried per type, in this order, and nothing is matched if
-    neither applies:
+      1. exact cover - as many candidates of this type as pending nodes
+      2. name cover  - exactly as many candidates carrying a pending node
+                       name as there are pending nodes
 
-    1. EXACT COVER - as many pending nodes of that type as unconfigured
-       candidates of that type this boot.
-    2. NAME-FILTERED COVER - the candidates whose CURRENT name is one of
-       the pending node names, when there are exactly as many of those as
-       there are pending nodes.
+    Both pair the same way: nodes by index, hardware by
+    canonical_sort_key(). Rule 1 must stay first - a current name only
+    SELECTS candidates, it never decides which node one gets, because
+    src/udev/vyos_net_name hands out provisional names in probe order
+    without reading config.boot.
 
-    Either way the pairing itself is the same: nodes by their numeric
-    index (see node_name_order()), hardware by the canonical order
-    everything else here names by (see canonical_sort_key()).
+    Both rules are cardinality-strict: a wrong pairing moves one port's
+    address and description onto another port, so ambiguity is logged and
+    left pending rather than guessed. Anything that had a permutation to
+    get wrong is warned about.
 
-    The order of those two rules matters and must not be swapped. Rule 2
-    uses the current names only to decide WHICH candidates belong to the
-    pending group - never which node each one gets. A pending node named
-    'eth1' by cloud-init means "the second NIC as the hypervisor attached
-    it", i.e. PCI slot order; it does not mean "whatever this boot's probe
-    race happened to call eth1", because src/udev/vyos_net_name assigns
-    those provisional names in probe order without ever reading
-    config.boot. Letting a candidate claim the node bearing its own name
-    would therefore reintroduce a reported field failure where two NICs
-    arriving under each other's provisional names were left crossed, with
-    both data links silently dead.
-
-    Rule 2 exists because rule 1 is defeated by a single spare NIC.
-    Reported from the field: a cloud-init guest configured for three NICs
-    but built with four left both data nodes unmatched, so their names
-    stayed reserved, the real hardware parked on fresh names beyond them,
-    and the box never recovered - on every later boot the parked ports
-    held a hw-id, so there were no unconfigured candidates left to match.
-    Filtering by name reaches exactly the candidates that config was
-    written against and ignores the spare.
-
-    A pending node still carries its OTHER settings (address,
-    description, ...), so a wrong pairing applies one physical port's
-    configuration to a DIFFERENT port. That is why neither rule ever
-    guesses past its own cardinality: with more name-matching candidates
-    than nodes there is genuinely no way to tell which is which, and
-    leaving the node unresolved and reported is safer.
-
-    Neither rule is infallible, so anything that had a permutation to get
-    wrong is logged as a warning: a leftover scratch interface from a
-    failed rename, or a pending node whose own hardware is dead, can make
-    a false cover, and on a legacy box whose names came from historical
-    probe order the slot order carries no information about which node is
-    which. A rule-2 match is warned at any cardinality, since provisional
-    names can line up by pure coincidence.
-
-    A candidate that isn't reclaimed here is not otherwise held back - it
-    still proceeds to ordinary bootstrap naming (see
-    compute_bootstrap_plan()) and gets its own fresh, settings-free name
-    instead.
-
-    rules, when given, is filled in with {'topology': set(), 'name':
-    set()} naming the nodes each rule resolved, so main() can report a
-    guess distinctly from a certainty without re-deriving which rule ran.
-
-    Returns {mac: node_name} for every match this boot.
+    Fills rules['topology'|'name'] with the nodes each rule resolved.
+    Returns {mac: node_name}. See TestMatchPendingNodes for the field
+    reports behind each rule.  T3871
     """
     grouped = {'ethernet': [], 'wireless': []}
     for mac, name in candidates:
@@ -574,81 +495,44 @@ def match_pending_nodes(pending: dict, candidates: list,
 def compute_bootstrap_plan(configured: dict, current: dict, existing_plan: dict,
                             pending: dict = None,
                             reclaimed: dict = None) -> dict:
-    """Build {from_name: to_name} for physical interfaces that have no
-    configured hw-id at all, assigning them a canonical name within their
-    type group (ethernet/wireless) in canonical hardware order (see
-    canonical_sort_key()), instead of leaving them at whatever name the
-    racy udev-time fast path produced. This is what makes a box's very
-    first boot - before any hw-id exists - just as deterministic as every
-    boot after hw-id is written (PCIe wiring and MAC are both static
-    hardware properties), since the name assigned here gets frozen into
-    config.boot by vyos-interface-rescan.py the same way a real hw-id
-    match would.
+    """{from_name: to_name} for hardware with no configured hw-id, named
+    in canonical_sort_key() order per type - so a first boot is as
+    deterministic as an hw-id boot, since vyos-interface-rescan.py freezes
+    these names into config.boot exactly as it would a real hw-id match.
 
-    existing_plan is the hw-id based plan already computed by
-    compute_rename_plan(): its RIGHTFUL-OWNER targets (an interface moving
-    to its own configured hw-id name) are reserved so a bootstrap name can
-    never collide with a configured one. A squatter compute_rename_plan()
-    is evicting from a configured target IS still bootstrap candidacy here
-    (see unmatched_candidates()) - its OWN eviction destination is only a
-    provisional fallback that this function is about to recompute for it
-    from scratch, so that value must not also count as "taken" (it would
-    needlessly block a lower slot this function might otherwise give it,
-    or another candidate, once real).
+    A name is off-limits only while something holds it: a configured hw-id
+    target, a pending node name, or a reclaim target. A plain numeric gap
+    left by deleting a whole node has no holder and is backfilled.
 
-    pending node names are reserved the same way a real hw-id target is -
-    a candidate main() could not unambiguously match to one via
-    match_pending_nodes() must never squat there instead, since that name
-    still carries the node's other settings (address, description, ...).
     This pass may never fill a pending name - only match_pending_nodes()
     may, and only under a rule that reports what it did.
-    reclaimed is {mac: node_name} for the candidates main() already
-    matched to a pending node - their macs are excluded from this pass so
-    it never reassigns them elsewhere, and their target names counted as
-    taken so it can never hand the same name to a second interface.
 
-    A numeric slot is only ever off-limits here because something still
-    occupies or reserves it - a real hw-id target or a pending node. A gap
-    left by fully deleting an interface's config (hw-id and node both
-    gone, nothing in `pending` either) carries no such reservation and is
-    freely backfilled, exactly as bootstrap naming would treat it on a
-    system that never had any config for it at all - there is no
-    remaining signal in config.boot to tell those two cases apart, and
-    deleting the whole node is the admin's explicit way of saying so.
+    Squatters that existing_plan is evicting ARE candidates here, but
+    their provisional eviction target is deliberately not reserved; only
+    a rightful owner's target is.  T3871
     """
     plan = {}
     reclaimed = reclaimed or {}
-    candidates = unmatched_candidates(configured, current, existing_plan)
+    candidates = unmatched_candidates(configured, current)
     candidates = [(mac, name) for mac, name in candidates
                   if mac not in reclaimed]
     if not candidates:
         return plan
 
     candidate_names = {name for _, name in candidates}
-    # a plan entry whose source IS one of this function's own candidates
-    # is a squatter's provisional eviction fallback, about to be
-    # recomputed below - only a rightful-owner move's target is a real,
-    # authoritative reservation
+    # a plan entry sourced from one of our own candidates is a squatter's
+    # provisional eviction, recomputed below - not a real reservation
     rightful_movers = {src: target for src, target in existing_plan.items()
                         if src not in candidate_names}
-    # a rightful mover's CURRENT (source) name looks occupied right now,
-    # but safe_bulk_rename()'s two-phase scratch-name staging vacates it
-    # before any target name is actually claimed - so it must not count
-    # as taken here either.
-    reserved_pending = set()
-    if pending:
-        for names in pending.values():
-            reserved_pending |= names
-    # a reclaim target is authoritative the same way a rightful mover's is,
-    # but its plan entry's source IS a candidate, so rightful_movers filters
-    # it out above - union it back in here
+    # a rightful mover's source name is vacated by safe_bulk_rename()'s
+    # scratch phase before any target is claimed, so it is not taken
     taken = (set(current) - candidate_names - set(rightful_movers)) \
-        | set(rightful_movers.values()) | reserved_pending \
+        | set(rightful_movers.values()) | pending_names(pending) \
         | set(reclaimed.values())
 
     for mac, name in sorted(candidates, key=lambda c: canonical_sort_key(*c)):
         prefix = 'wlan' if is_wireless_interface(name) else 'eth'
-        new_name = find_next_available(taken, prefix)
+        new_name = find_available(taken, prefix, floor=0)
         taken.add(new_name)
         if new_name != name:
             plan[name] = new_name
@@ -674,12 +558,9 @@ def rename_interface(old: str, new: str) -> bool:
 
 
 def safe_bulk_rename(plan: dict) -> dict:
-    """Two-phase rename: stage every interface via a unique scratch name
-    (derived from its ifindex, which is always unique) before assigning
-    final names. This makes the whole batch collision-proof regardless of
-    permutations/cycles between current and target names - a straight
-    from->to rename can fail if the target name is still held by another
-    interface earlier/later in the same plan.
+    """Two-phase rename via per-ifindex scratch names, so any permutation
+    or cycle in the plan applies safely - a direct from->to rename fails
+    when the target is still held by another interface in the same batch.
     """
     if not plan:
         return {}
@@ -706,9 +587,9 @@ def safe_bulk_rename(plan: dict) -> dict:
 
 def sync_rescan_hints(current_state: dict, configured: dict,
                        stale_names: set = frozenset()) -> None:
-    """Leave a hint under vyos_udev_dir for every interface that has no
-    hw-id configured yet, so vyos-interface-rescan.py can auto-populate
-    config.boot. Remove stale/no-longer-hw-id-needed hints.
+    """Leave {name: mac} hints under vyos_udev_dir for interfaces with no
+    hw-id yet, so vyos-interface-rescan.py can populate config.boot; drop
+    hints that are stale or no longer needed.
     """
     try:
         Path(vyos_udev_dir).mkdir(parents=True, exist_ok=True)
@@ -733,33 +614,23 @@ def sync_rescan_hints(current_state: dict, configured: dict,
 
 def write_status(configured: dict, found: dict, missing: set, plan: dict,
                   pending: dict = None, reclaimed: dict = None,
-                  candidates: list = None,
-                  reclaimed_by_topology: set = frozenset(),
-                  reclaimed_by_name: set = frozenset()) -> None:
-    """candidates is the full unmatched_candidates() list evaluated this
-    boot (before reclaim/bootstrap assignment) - surfaced here so a
-    pending node left unresolved for lack of hardware is self-diagnosable
-    from this one file: 'pending_unresolved' names what needed a match,
-    'unconfigured_candidates' names every physical interface that was in
-    the running for one, without needing a separate `ip -br link show` or
-    `show configuration commands` to reconstruct the same picture by hand.
+                  candidates: list = None, rules: dict = None) -> None:
+    """Write /run/vyos-net-name-resolve.json.
 
-    reclaimed_by_topology is the subset of `reclaimed` that came from an
-    exact cover of more than one pending node, i.e. was paired by PCI slot
-    order rather than being the single unambiguous possibility - surfaced
-    separately so an admin can see which bindings were inferred and worth
-    verifying against how the ports are actually wired.
+    candidates is the full unmatched_candidates() list from this boot, so
+    a node left unresolved for lack of hardware is diagnosable from this
+    one file: 'pending_unresolved' says what needed a match,
+    'unconfigured_candidates' says what was in the running for one.
 
-    reclaimed_by_name is the subset whose hardware was SELECTED by
-    carrying the pending node names this boot (match_pending_nodes()'s
-    second rule) rather than by being all that was left. Provisional names
-    can line up by coincidence, so this is reported at any cardinality,
-    including a single node.
+    rules splits `reclaimed` by how each match was reached, so a guess
+    stays visible as one - see match_pending_nodes(). src/init/vyos-router
+    turns these keys into boot-time warnings.
     """
     pending = pending or {}
     reclaimed = reclaimed or {}
     candidates = candidates or []
-    all_pending = pending.get('ethernet', set()) | pending.get('wireless', set())
+    rules = rules or {}
+    all_pending = pending_names(pending)
     status = {
         'configured': configured,
         'found': sorted(found.values()),
@@ -767,8 +638,8 @@ def write_status(configured: dict, found: dict, missing: set, plan: dict,
         'renamed': plan,
         'pending_unresolved': sorted(all_pending - set(reclaimed.values())),
         'reclaimed': reclaimed,
-        'reclaimed_by_topology': sorted(reclaimed_by_topology),
-        'reclaimed_by_name': sorted(reclaimed_by_name),
+        'reclaimed_by_topology': sorted(rules.get('topology', ())),
+        'reclaimed_by_name': sorted(rules.get('name', ())),
         'unconfigured_candidates': {name: mac for mac, name in candidates},
     }
     try:
@@ -794,43 +665,25 @@ def main():
         logger.info('no hw-id configured yet')
         current, missing, plan = discover_physical_interfaces(), set(), {}
 
-    all_pending = pending.get('ethernet', set()) | pending.get('wireless', set())
+    all_pending = pending_names(pending)
 
     reclaimed = {}
-    reclaim_rules = {'topology': set(), 'name': set()}
+    reclaim_rules = {}
     candidates = []
     if all_pending or any(mac not in configured for mac in current.values()):
-        # The `all_pending` half of this condition matters even when
-        # `current` (from wait_for_hardware() above, bounded only on
-        # already-CONFIGURED macs) shows nothing unconfigured yet: on a
-        # system with several different NIC vendors/drivers, the exact
-        # hardware a pending node needs can simply not have finished
-        # probing at this snapshot. Without this, wait_for_settle() below
-        # would never even run, giving that slower hardware zero extra
-        # time to appear before this boot gives up on the pending node.
+        # a pending node forces the settle wait even when nothing looks
+        # unconfigured yet - its hardware may still be probing
         current = wait_for_settle(current)
         if configured:
-            # a configured hw-id whose driver was too slow to show up
-            # within wait_for_hardware()'s timeout can still appear during
-            # the extra time wait_for_settle() just spent waiting for
-            # unconfigured hardware to stabilize - recompute against the
-            # settled snapshot so it still gets renamed (and drops out of
-            # `missing`) this boot instead of being silently skipped.
+            # slow hw-id hardware may have turned up during that wait
             missing = set(configured) - set(current.values())
             plan = compute_rename_plan(configured, current, pending)
 
-        # let a NIC that just lost its hw-id (the documented "delete
-        # hw-id to force regeneration" remediation), or one a
-        # cloud-init/first-boot script named in config.boot before this
-        # script ever ran, reclaim the exact node its other settings
-        # (address, description, ...) still live under, rather than
-        # bootstrap-naming it to a new bare node and orphaning that
-        # config - only on an exact cover, see match_pending_nodes()
-        candidates = unmatched_candidates(configured, current, plan)
-        # match_pending_nodes() classifies each match as it makes it: a
-        # guess (paired by PCI slot order, or with hardware selected by
-        # name) stays distinguishable from the single unambiguous case all
-        # the way out to the status file and the boot console
+        # let hardware reclaim the pending node whose address and
+        # description it should keep, rather than bootstrap-naming it to a
+        # bare node and orphaning that config. `rules` records which
+        # matches were guesses, all the way out to the boot console.
+        candidates = unmatched_candidates(configured, current)
         reclaimed = match_pending_nodes(pending, candidates,
                                          rules=reclaim_rules)
         candidate_by_mac = dict(candidates)
@@ -843,13 +696,8 @@ def main():
                 'this boot'
             )
 
-        # bootstrap-name whatever is left, deterministically by PCIe
-        # distance and MAC, instead of leaving it at its racy cosmetic
-        # udev-time name - this is what vyos-interface-rescan.py will
-        # freeze into config.boot. A pending node name left unmatched
-        # above stays reserved here (see compute_bootstrap_plan()) so an
-        # ambiguous leftover candidate can never squat on one and inherit
-        # its settings.
+        # name whatever is left in canonical order rather than leaving it
+        # on a racy udev-time name; unmatched pending names stay reserved
         plan.update(compute_bootstrap_plan(
             configured, current, plan, pending=pending,
             reclaimed=reclaimed))
@@ -863,15 +711,13 @@ def main():
             'naming pass'
         )
 
-    # configured is passed unmutated (not merged with `reclaimed`): the
-    # reclaimed mac still has no real hw-id in config.boot yet, so it must
-    # still get a rescan hint under its (now reclaimed) name, letting
-    # vyos-interface-rescan.py write the hw-id into the existing node.
+    # `configured` is deliberately not merged with `reclaimed`: that mac
+    # has no hw-id in config.boot yet and still needs a hint under its new
+    # name for vyos-interface-rescan.py to write one into the existing node
     sync_rescan_hints(final_current, configured, set(applied.keys()))
     write_status(configured, current, missing, applied,
                  pending=pending, reclaimed=reclaimed, candidates=candidates,
-                 reclaimed_by_topology=reclaim_rules['topology'],
-                 reclaimed_by_name=reclaim_rules['name'])
+                 rules=reclaim_rules)
 
 
 if __name__ == '__main__':

--- a/src/system/vyos-net-name-resolve.py
+++ b/src/system/vyos-net-name-resolve.py
@@ -462,51 +462,68 @@ def node_name_order(name: str) -> tuple:
     return (0, int(m.group(1)), name) if m else (1, 0, name)
 
 
-def match_pending_nodes(pending: dict, candidates: list) -> dict:
+def match_pending_nodes(pending: dict, candidates: list,
+                         rules: dict = None) -> dict:
     """Match this boot's unconfigured candidates to pending (hw-id-less)
-    config nodes, one type (ethernet/wireless) at a time. Matches only on
-    an EXACT COVER - as many pending nodes of that type as unconfigured
-    candidates of that type this boot - pairing them in order: nodes by
-    their numeric index (see node_name_order()), hardware by the same
-    canonical order everything else here names by (see
-    canonical_sort_key()). Any other cardinality is left alone rather
-    than guessed.
+    config nodes, one type (ethernet/wireless) at a time.
+
+    Two rules are tried per type, in this order, and nothing is matched if
+    neither applies:
+
+    1. EXACT COVER - as many pending nodes of that type as unconfigured
+       candidates of that type this boot.
+    2. NAME-FILTERED COVER - the candidates whose CURRENT name is one of
+       the pending node names, when there are exactly as many of those as
+       there are pending nodes.
+
+    Either way the pairing itself is the same: nodes by their numeric
+    index (see node_name_order()), hardware by the canonical order
+    everything else here names by (see canonical_sort_key()).
+
+    The order of those two rules matters and must not be swapped. Rule 2
+    uses the current names only to decide WHICH candidates belong to the
+    pending group - never which node each one gets. A pending node named
+    'eth1' by cloud-init means "the second NIC as the hypervisor attached
+    it", i.e. PCI slot order; it does not mean "whatever this boot's probe
+    race happened to call eth1", because src/udev/vyos_net_name assigns
+    those provisional names in probe order without ever reading
+    config.boot. Letting a candidate claim the node bearing its own name
+    would therefore reintroduce a reported field failure where two NICs
+    arriving under each other's provisional names were left crossed, with
+    both data links silently dead.
+
+    Rule 2 exists because rule 1 is defeated by a single spare NIC.
+    Reported from the field: a cloud-init guest configured for three NICs
+    but built with four left both data nodes unmatched, so their names
+    stayed reserved, the real hardware parked on fresh names beyond them,
+    and the box never recovered - on every later boot the parked ports
+    held a hw-id, so there were no unconfigured candidates left to match.
+    Filtering by name reaches exactly the candidates that config was
+    written against and ignores the spare.
 
     A pending node still carries its OTHER settings (address,
-    description, ...), so a wrong pairing silently applies one physical
-    port's configuration to a DIFFERENT port - which is why anything but
-    an exact cover refuses. Confirmed in the field: on a real,
-    already-provisioned box (whose hw-id came from historical probe-order
-    rescan, not from any PCIe/MAC sort), a second, completely unrelated
-    candidate freed in the same boot - e.g. a different interface's
-    config being fully deleted - is enough for a naive ascending-sort
-    fill to swap the two, binding a configured node's address to the
-    wrong wire. With more candidates than nodes there is genuinely no way
-    to tell which one is the node's own hardware, and leaving it
-    unresolved and reported is safer than guessing.
+    description, ...), so a wrong pairing applies one physical port's
+    configuration to a DIFFERENT port. That is why neither rule ever
+    guesses past its own cardinality: with more name-matching candidates
+    than nodes there is genuinely no way to tell which is which, and
+    leaving the node unresolved and reported is safer.
 
-    An exact cover is different in kind, not just in degree: every node is
-    going to receive real hardware whatever happens, so the only open
-    question is the permutation - and PCI slot order is the best answer
-    available, while refusing strands 100% of the nodes on interfaces
-    that do not exist, permanently, across reboots (see the multi-NIC
-    cloud-init case in has_established_baseline()). Note this is not a
-    new class of behaviour: an unreserved pending name (no established
-    baseline) is already filled by ordinary bootstrap naming's implicit
-    ascending fill. Pairing here makes that guess explicit, logged, and
-    topology-ordered rather than gap-ordered.
-
-    It is NOT infallible, and a cover of more than one node is logged as
-    a warning for exactly that reason: a leftover scratch interface from
-    a failed rename, or a pending node whose own hardware is dead, can
-    make a false cover, and on a legacy box whose names came from
-    historical probe order the slot order carries no information about
-    which node is which.
+    Neither rule is infallible, so anything that had a permutation to get
+    wrong is logged as a warning: a leftover scratch interface from a
+    failed rename, or a pending node whose own hardware is dead, can make
+    a false cover, and on a legacy box whose names came from historical
+    probe order the slot order carries no information about which node is
+    which. A rule-2 match is warned at any cardinality, since provisional
+    names can line up by pure coincidence.
 
     A candidate that isn't reclaimed here is not otherwise held back - it
     still proceeds to ordinary bootstrap naming (see
     compute_bootstrap_plan()) and gets its own fresh, settings-free name
     instead.
+
+    rules, when given, is filled in with {'topology': set(), 'name':
+    set()} naming the nodes each rule resolved, so main() can report a
+    guess distinctly from a certainty without re-deriving which rule ran.
 
     Returns {mac: node_name} for every match this boot.
     """
@@ -515,42 +532,62 @@ def match_pending_nodes(pending: dict, candidates: list) -> dict:
         group = 'wireless' if is_wireless_interface(name) else 'ethernet'
         grouped[group].append((mac, name))
 
-    matched = {}
-    for intf_type, nodes in pending.items():
-        if not nodes:
-            continue
-        cands = grouped.get(intf_type, [])
-        if len(nodes) != len(cands):
-            cand_desc = ', '.join(f"'{name}' ({mac})" for mac, name in cands) or 'none'
-            logger.warning(
-                f'{len(nodes)} pending {intf_type} node(s) '
-                f"({', '.join(sorted(nodes, key=node_name_order))}) and "
-                f'{len(cands)} unconfigured {intf_type} candidate(s) this '
-                f'boot ({cand_desc}) - not an exact cover, leaving pending '
-                'rather than guessing'
-            )
-            continue
+    if rules is not None:
+        rules.setdefault('topology', set())
+        rules.setdefault('name', set())
 
+    matched = {}
+
+    def pair(intf_type, nodes, hardware, rule):
         targets = sorted(nodes, key=node_name_order)
-        hardware = sorted(cands, key=lambda c: canonical_sort_key(*c))
-        for target, (mac, name) in zip(targets, hardware):
+        hardware = sorted(hardware, key=lambda c: canonical_sort_key(*c))
+        for target, (mac, _name) in zip(targets, hardware):
             matched[mac] = target
 
-        if len(targets) > 1:
-            # a single node and a single candidate leave no permutation to
-            # get wrong - anything larger was ordered by PCI slot, which is
-            # a well-founded guess but still a guess, so say so loudly
-            # enough that an admin can verify the wiring
+        # one node and one candidate selected by name leave no permutation
+        # to get wrong, but the selection itself was still a guess - only
+        # a lone exact cover is free of both, and only it goes unreported
+        if rule == 'name' or len(targets) > 1:
+            if rules is not None:
+                rules[rule] |= set(targets)
             pairs = ', '.join(
                 f"{target} <- {mac} (pci {pcie_address(name)}, now '{name}')"
                 for target, (mac, name) in zip(targets, hardware)
             )
+            how = ('carry the pending node names this boot'
+                   if rule == 'name' else
+                   f"exactly cover this boot's unconfigured {intf_type} "
+                   'hardware')
             logger.warning(
-                f'{len(targets)} pending {intf_type} node(s) exactly cover '
-                f"this boot's unconfigured {intf_type} hardware - pairing "
-                f'them in PCI slot order: {pairs} - verify this matches how '
-                'the ports are actually wired'
+                f'{len(targets)} pending {intf_type} node(s) - the '
+                f'candidates that {how} were paired with them in PCI slot '
+                f'order: {pairs} - verify this matches how the ports are '
+                'actually wired'
             )
+
+    for intf_type, nodes in pending.items():
+        if not nodes:
+            continue
+        cands = grouped.get(intf_type, [])
+
+        if cands and len(nodes) == len(cands):
+            pair(intf_type, nodes, cands, 'topology')
+            continue
+
+        by_name = [(mac, name) for mac, name in cands if name in nodes]
+        if by_name and len(by_name) == len(nodes):
+            pair(intf_type, nodes, by_name, 'name')
+            continue
+
+        cand_desc = ', '.join(f"'{name}' ({mac})" for mac, name in cands) or 'none'
+        logger.warning(
+            f'{len(nodes)} pending {intf_type} node(s) '
+            f"({', '.join(sorted(nodes, key=node_name_order))}) and "
+            f'{len(cands)} unconfigured {intf_type} candidate(s) this '
+            f'boot ({cand_desc}), of which {len(by_name)} carry a pending '
+            'node name - neither an exact cover nor a name cover, leaving '
+            'pending rather than guessing'
+        )
 
     return matched
 
@@ -729,7 +766,8 @@ def write_status(configured: dict, found: dict, missing: set, plan: dict,
                   pending: dict = None, reclaimed: dict = None,
                   candidates: list = None,
                   resolved_pending: set = frozenset(),
-                  reclaimed_by_topology: set = frozenset()) -> None:
+                  reclaimed_by_topology: set = frozenset(),
+                  reclaimed_by_name: set = frozenset()) -> None:
     """candidates is the full unmatched_candidates() list evaluated this
     boot (before reclaim/bootstrap assignment) - surfaced here so a
     pending node left unresolved for lack of hardware is self-diagnosable
@@ -749,6 +787,12 @@ def write_status(configured: dict, found: dict, missing: set, plan: dict,
     order rather than being the single unambiguous possibility - surfaced
     separately so an admin can see which bindings were inferred and worth
     verifying against how the ports are actually wired.
+
+    reclaimed_by_name is the subset whose hardware was SELECTED by
+    carrying the pending node names this boot (match_pending_nodes()'s
+    second rule) rather than by being all that was left. Provisional names
+    can line up by coincidence, so this is reported at any cardinality,
+    including a single node.
     """
     pending = pending or {}
     reclaimed = reclaimed or {}
@@ -763,6 +807,7 @@ def write_status(configured: dict, found: dict, missing: set, plan: dict,
         'pending_unresolved': sorted(all_pending - resolved),
         'reclaimed': reclaimed,
         'reclaimed_by_topology': sorted(reclaimed_by_topology),
+        'reclaimed_by_name': sorted(reclaimed_by_name),
         'unconfigured_candidates': {name: mac for mac, name in candidates},
     }
     try:
@@ -791,7 +836,7 @@ def main():
     all_pending = pending.get('ethernet', set()) | pending.get('wireless', set())
 
     reclaimed = {}
-    reclaimed_by_topology = set()
+    reclaim_rules = {'topology': set(), 'name': set()}
     candidates = []
     if all_pending or any(mac not in configured for mac in current.values()):
         # The `all_pending` half of this condition matters even when
@@ -821,16 +866,12 @@ def main():
         # bootstrap-naming it to a new bare node and orphaning that
         # config - only on an exact cover, see match_pending_nodes()
         candidates = unmatched_candidates(configured, current, plan)
-        reclaimed = match_pending_nodes(pending, candidates)
-        # a type group of more than one node can only have matched as an
-        # exact cover paired by PCI slot order - a well-founded guess, but
-        # still a guess, so keep it distinguishable from the single
-        # unambiguous 1:1 case all the way out to the status file
-        reclaimed_by_topology = {
-            name for intf_type, nodes in pending.items()
-            if len(nodes) > 1 and nodes <= set(reclaimed.values())
-            for name in nodes
-        }
+        # match_pending_nodes() classifies each match as it makes it: a
+        # guess (paired by PCI slot order, or with hardware selected by
+        # name) stays distinguishable from the single unambiguous case all
+        # the way out to the status file and the boot console
+        reclaimed = match_pending_nodes(pending, candidates,
+                                         rules=reclaim_rules)
         candidate_by_mac = dict(candidates)
         for mac, target in reclaimed.items():
             name = candidate_by_mac[mac]
@@ -876,7 +917,8 @@ def main():
     write_status(configured, current, missing, applied,
                  pending=pending, reclaimed=reclaimed, candidates=candidates,
                  resolved_pending=resolved_pending,
-                 reclaimed_by_topology=reclaimed_by_topology)
+                 reclaimed_by_topology=reclaim_rules['topology'],
+                 reclaimed_by_name=reclaim_rules['name'])
 
 
 if __name__ == '__main__':

--- a/src/tests/test_net_name_resolve.py
+++ b/src/tests/test_net_name_resolve.py
@@ -173,13 +173,13 @@ class TestUnmatchedCandidates(unittest.TestCase):
         configured = {'m0': 'eth1'}
         current = {'eth1': 'squatter-mac', 'eth9': 'm0'}
         existing_plan = {'eth1': 'eth3', 'eth9': 'eth1'}
-        candidates = resolver.unmatched_candidates(configured, current, existing_plan)
+        candidates = resolver.unmatched_candidates(configured, current)
         self.assertEqual(candidates, [('squatter-mac', 'eth1')])
 
     def test_rightful_owner_still_excluded(self):
         configured = {'m0': 'eth0'}
         current = {'eth0': 'm0'}
-        candidates = resolver.unmatched_candidates(configured, current, {})
+        candidates = resolver.unmatched_candidates(configured, current)
         self.assertEqual(candidates, [])
 
 
@@ -1088,11 +1088,13 @@ class TestComputeBootstrapPlanGapFill(unittest.TestCase):
         self.assertNotIn('eth0', plan.values())
 
     def test_unmatchable_pending_name_is_held_open_not_backfilled(self):
-        # nothing of this type has a hw-id, the pending name is carried by
-        # no candidate, and the cardinality is not a cover - so
-        # match_pending_nodes() declines. The name stays empty and is
-        # reported unresolved rather than handed to the lowest-sorting
-        # NIC, which is the case this behaviour change turns around.
+        # the divergent shape: nothing of this type has a hw-id, the
+        # pending name is carried by no candidate, and the cardinality is
+        # not a cover - so match_pending_nodes() declines. The name stays
+        # empty and is reported unresolved rather than being handed to the
+        # lowest-sorting NIC. Bootstrap naming may never fill a pending
+        # name: that silent path is what rearranged a box whose hw-ids
+        # were all deleted at once (T3871, PR #5417).
         configured = {}
         pending = {'ethernet': {'eth0'}, 'wireless': set()}
         current = {'eth5': 'n5', 'eth6': 'n6', 'eth7': 'n7'}

--- a/src/tests/test_net_name_resolve.py
+++ b/src/tests/test_net_name_resolve.py
@@ -185,15 +185,21 @@ class TestUnmatchedCandidates(unittest.TestCase):
 
 class TestMatchPendingNodes(unittest.TestCase):
     """A pending node's hw-id is unknown by construction - there's no MAC
-    to check a candidate against - so matching must only ever happen in
-    the unambiguous exactly-one-pending/exactly-one-candidate case per
-    type. Confirmed in the field: a naive deterministic fill (sorting
-    pending nodes and candidates together like numeric gaps) silently
-    bound a configured node's address to a different physical NIC than
-    its own, because an already-provisioned box's existing names have no
-    relationship to PCIe/MAC sort order. Guessing in any other
-    cardinality risks the same mistake; leaving the node unresolved and
-    reported is safer.
+    to check a candidate against - so matching only ever happens on an
+    exact cover: as many pending nodes of a type as unconfigured
+    candidates of that type. Confirmed in the field: a naive
+    deterministic fill (sorting pending nodes and candidates together
+    like numeric gaps) silently bound a configured node's address to a
+    different physical NIC than its own, because an already-provisioned
+    box's existing names have no relationship to PCIe/MAC sort order.
+    With MORE candidates than nodes there is no way to tell which one is
+    the node's own hardware, so nothing is matched.
+
+    An exact cover is a different situation: every node receives real
+    hardware whatever happens, so only the permutation is open, and
+    refusing strands 100% of the nodes on interfaces that do not exist
+    (the multi-NIC cloud-init report). Those are paired in canonical
+    hardware order, which is why pcie_address is pinned below.
     """
 
     def setUp(self):
@@ -201,6 +207,19 @@ class TestMatchPendingNodes(unittest.TestCase):
                                      return_value=False)
         self.is_wireless = patcher.start()
         self.addCleanup(patcher.stop)
+
+        # see TestComputeBootstrapPlan.setUp() - keep the canonical order
+        # off the build host's real sysfs, so these exercise MAC rank
+        distance_patcher = mock.patch.object(resolver, 'pcie_distance',
+                                              return_value=0)
+        self.pcie_distance = distance_patcher.start()
+        self.addCleanup(distance_patcher.stop)
+
+        address_patcher = mock.patch.object(
+            resolver, 'pcie_address',
+            return_value=resolver.PCIE_ADDRESS_UNKNOWN)
+        self.pcie_address = address_patcher.start()
+        self.addCleanup(address_patcher.stop)
 
     def test_unambiguous_single_pending_single_candidate_matches(self):
         pending = {'ethernet': {'eth1'}, 'wireless': set()}
@@ -215,6 +234,69 @@ class TestMatchPendingNodes(unittest.TestCase):
         candidates = [('m1', 'eth9')]
         matched = resolver.match_pending_nodes(pending, candidates)
         self.assertEqual(matched, {})
+
+    def test_exact_cover_pairs_in_canonical_hardware_order(self):
+        # the multi-NIC cloud-init shape: two address-bearing nodes with
+        # no hw-id and exactly two unconfigured NICs. Refusing here would
+        # strand BOTH addresses on interfaces that never come to exist,
+        # so they are paired - lowest node index to first-sorted hardware.
+        pending = {'ethernet': {'eth1', 'eth2'}, 'wireless': set()}
+        candidates = [('bb', 'eth8'), ('aa', 'eth9')]
+        matched = resolver.match_pending_nodes(pending, candidates)
+        self.assertEqual(matched, {'aa': 'eth1', 'bb': 'eth2'})
+
+    def test_exact_cover_pairs_by_pci_slot_not_mac_magnitude(self):
+        # the reported silent-swap shape: hardware order must come from
+        # the PCI address, not from raw MAC rank - here the numerically
+        # LOWER mac sits in the HIGHER slot and must get the higher name.
+        self.pcie_address.side_effect = lambda name: {
+            'eth8': ((0, 0, 5, 0),),
+            'eth9': ((0, 0, 6, 0),),
+        }[name]
+        pending = {'ethernet': {'eth1', 'eth2'}, 'wireless': set()}
+        candidates = [('52:54:00:00:00:22', 'eth9'),
+                      ('52:54:00:ff:00:21', 'eth8')]
+        matched = resolver.match_pending_nodes(pending, candidates)
+        self.assertEqual(matched, {'52:54:00:ff:00:21': 'eth1',
+                                    '52:54:00:00:00:22': 'eth2'})
+
+    def test_exact_cover_orders_node_names_numerically(self):
+        # 'eth10' must pair after 'eth2', not before it as a plain
+        # lexical sort of the names would have it.
+        pending = {'ethernet': {'eth2', 'eth10'}, 'wireless': set()}
+        candidates = [('aa', 'eth8'), ('bb', 'eth9')]
+        matched = resolver.match_pending_nodes(pending, candidates)
+        self.assertEqual(matched, {'aa': 'eth2', 'bb': 'eth10'})
+
+    def test_three_pending_three_candidates_cover(self):
+        pending = {'ethernet': {'eth0', 'eth1', 'eth2'}, 'wireless': set()}
+        candidates = [('cc', 'eth7'), ('aa', 'eth9'), ('bb', 'eth8')]
+        matched = resolver.match_pending_nodes(pending, candidates)
+        self.assertEqual(matched, {'aa': 'eth0', 'bb': 'eth1', 'cc': 'eth2'})
+
+    def test_three_pending_two_candidates_no_match(self):
+        pending = {'ethernet': {'eth0', 'eth1', 'eth2'}, 'wireless': set()}
+        candidates = [('aa', 'eth9'), ('bb', 'eth8')]
+        matched = resolver.match_pending_nodes(pending, candidates)
+        self.assertEqual(matched, {})
+
+    def test_two_pending_three_candidates_no_match(self):
+        # one candidate too many - the field-reported "unrelated interface
+        # freed in the same boot" hazard, at a larger cardinality.
+        pending = {'ethernet': {'eth0', 'eth1'}, 'wireless': set()}
+        candidates = [('aa', 'eth9'), ('bb', 'eth8'), ('cc', 'eth7')]
+        matched = resolver.match_pending_nodes(pending, candidates)
+        self.assertEqual(matched, {})
+
+    def test_covers_are_judged_per_type_not_across_types(self):
+        # ethernet covers 2:2 while wireless is 1:2 - the ethernet nodes
+        # are still paired, and the wireless one is still left pending.
+        self.is_wireless.side_effect = lambda name: name.startswith('radio')
+        pending = {'ethernet': {'eth1', 'eth2'}, 'wireless': {'wlan0'}}
+        candidates = [('aa', 'eth9'), ('bb', 'eth8'),
+                      ('cc', 'radio0'), ('dd', 'radio1')]
+        matched = resolver.match_pending_nodes(pending, candidates)
+        self.assertEqual(matched, {'aa': 'eth1', 'bb': 'eth2'})
 
     def test_one_pending_two_candidates_no_match(self):
         # the field-reported shape: an unrelated second candidate (e.g.
@@ -480,10 +562,151 @@ class TestPcieDistance(unittest.TestCase):
                           resolver.PCIE_DISTANCE_UNKNOWN)
 
     def test_no_pci_segment_at_all_returns_sentinel(self):
-        # simulated USB NIC: resolved path has no PCI BDF component
+        # resolved path has no PCI BDF component at all
         self._make_iface_pointing_at('eth5', 'usb1', '1-1', '1-1:1.0')
         self.assertEqual(resolver.pcie_distance('eth5', self.tmp),
                           resolver.PCIE_DISTANCE_UNKNOWN)
+
+    def test_usb_nic_behind_its_controller_is_not_a_sentinel(self):
+        # a real USB NIC resolves THROUGH the xHCI controller, so it has a
+        # perfectly ordinary hop-count - the sentinel above is rarer than
+        # it looks, which is why the address tie-break matters here too.
+        self._make_iface_pointing_at(
+            'eth6', 'pci0000:00', '0000:00:14.0', 'usb1', '1-1', '1-1:1.0')
+        self.assertEqual(resolver.pcie_distance('eth6', self.tmp), 1)
+
+
+class TestPcieAddress(unittest.TestCase):
+    """Hop depth alone ties for every NIC on the same bus - the normal
+    case in a VM, where the hypervisor allocates one slot per attached
+    NIC off the same root bus. The field report was exactly that: two
+    virtio NICs at equal depth, ordered by raw MAC magnitude, which
+    reversed the hypervisor's slot order and put each configured address
+    on the wrong physical wire. The full bus address is what breaks that
+    tie correctly.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self.devices_root = os.path.join(self.tmp, 'devices')
+        os.makedirs(self.devices_root)
+
+    def _make_iface_pointing_at(self, name, *path_segments):
+        target = os.path.join(self.devices_root, *path_segments)
+        os.makedirs(target, exist_ok=True)
+        iface_path = os.path.join(self.tmp, name)
+        os.mkdir(iface_path)
+        os.symlink(target, os.path.join(iface_path, 'device'))
+
+    def test_shallow_device_is_its_own_bdf(self):
+        self._make_iface_pointing_at('eth0', 'pci0000:00', '0000:00:1f.6')
+        self.assertEqual(resolver.pcie_address('eth0', self.tmp),
+                          ((0, 0, 0x1f, 6),))
+
+    def test_deep_device_keeps_the_whole_path_root_first(self):
+        self._make_iface_pointing_at(
+            'eth1', 'pci0000:00', '0000:00:1c.0',
+            '0000:01:00.0', '0000:02:04.0')
+        self.assertEqual(resolver.pcie_address('eth1', self.tmp),
+                          ((0, 0, 0x1c, 0), (0, 1, 0, 0), (0, 2, 4, 0)))
+
+    def test_virtio_indirection_skipped_like_pcie_distance(self):
+        self._make_iface_pointing_at(
+            'eth2', 'pci0000:00', '0000:00:12.0', 'virtio2', 'net')
+        self.assertEqual(resolver.pcie_address('eth2', self.tmp),
+                          ((0, 0, 0x12, 0),))
+
+    def test_same_slot_orders_by_pci_slot_number(self):
+        # the reported shape: two NICs on the same bus, different slots
+        self._make_iface_pointing_at('ethA', 'pci0000:00', '0000:00:05.0')
+        self._make_iface_pointing_at('ethB', 'pci0000:00', '0000:00:06.0')
+        self.assertLess(resolver.pcie_address('ethA', self.tmp),
+                         resolver.pcie_address('ethB', self.tmp))
+
+    def test_multifunction_siblings_order_by_function(self):
+        # a dual-port card: port 0 must come before port 1, and hop count
+        # cannot tell them apart at all
+        self._make_iface_pointing_at(
+            'ethC', 'pci0000:00', '0000:00:1c.0', '0000:03:00.0')
+        self._make_iface_pointing_at(
+            'ethD', 'pci0000:00', '0000:00:1c.0', '0000:03:00.1')
+        self.assertEqual(resolver.pcie_distance('ethC', self.tmp),
+                          resolver.pcie_distance('ethD', self.tmp))
+        self.assertLess(resolver.pcie_address('ethC', self.tmp),
+                         resolver.pcie_address('ethD', self.tmp))
+
+    def test_missing_device_symlink_returns_sentinel(self):
+        os.mkdir(os.path.join(self.tmp, 'eth3'))
+        self.assertEqual(resolver.pcie_address('eth3', self.tmp),
+                          resolver.PCIE_ADDRESS_UNKNOWN)
+
+    def test_broken_device_symlink_returns_sentinel(self):
+        iface_path = os.path.join(self.tmp, 'eth4')
+        os.mkdir(iface_path)
+        os.symlink(os.path.join(self.devices_root, 'does-not-exist'),
+                    os.path.join(iface_path, 'device'))
+        self.assertEqual(resolver.pcie_address('eth4', self.tmp),
+                          resolver.PCIE_ADDRESS_UNKNOWN)
+
+    def test_sentinel_sorts_after_every_real_address(self):
+        # it must not be the empty tuple, which would sort FIRST
+        self._make_iface_pointing_at('eth5', 'pci0000:00', '0000:00:1f.6')
+        self.assertLess(resolver.pcie_address('eth5', self.tmp),
+                         resolver.PCIE_ADDRESS_UNKNOWN)
+
+
+class TestCanonicalSortKey(unittest.TestCase):
+    """One canonical hardware order, shared by ordinary bootstrap naming
+    and by pending-node pairing - if they disagreed, a name assigned by
+    one would contradict the other.
+    """
+
+    def test_distance_still_leads_over_address(self):
+        # an onboard NIC deep in the bus address space must still beat an
+        # add-in card behind a bridge, whatever their addresses look like
+        with mock.patch.object(resolver, 'pcie_distance',
+                                side_effect=lambda n: {'a': 1, 'b': 2}[n]), \
+             mock.patch.object(resolver, 'pcie_address',
+                                side_effect=lambda n: {'a': ((0, 0, 0x1f, 6),),
+                                                        'b': ((0, 0, 1, 0),)}[n]):
+            self.assertLess(resolver.canonical_sort_key('zz', 'a'),
+                             resolver.canonical_sort_key('aa', 'b'))
+
+    def test_address_beats_mac_magnitude_at_equal_distance(self):
+        with mock.patch.object(resolver, 'pcie_distance', return_value=1), \
+             mock.patch.object(resolver, 'pcie_address',
+                                side_effect=lambda n: {'a': ((0, 0, 5, 0),),
+                                                        'b': ((0, 0, 6, 0),)}[n]):
+            # 'a' has the numerically HIGHER mac but the lower slot
+            self.assertLess(resolver.canonical_sort_key('ff:ff', 'a'),
+                             resolver.canonical_sort_key('00:00', 'b'))
+
+    def test_mac_is_the_last_resort_tie_break(self):
+        with mock.patch.object(resolver, 'pcie_distance', return_value=1), \
+             mock.patch.object(resolver, 'pcie_address',
+                                return_value=resolver.PCIE_ADDRESS_UNKNOWN):
+            self.assertLess(resolver.canonical_sort_key('aa', 'x'),
+                             resolver.canonical_sort_key('bb', 'y'))
+
+
+class TestNodeNameOrder(unittest.TestCase):
+    """Pending node names are paired with hardware in index order, which
+    has to be numeric - a plain sort puts 'eth10' before 'eth2'.
+    """
+
+    def test_numeric_not_lexical(self):
+        self.assertEqual(sorted(['eth10', 'eth2', 'eth1'],
+                                 key=resolver.node_name_order),
+                          ['eth1', 'eth2', 'eth10'])
+
+    def test_name_without_index_sorts_last(self):
+        self.assertEqual(sorted(['eth1', 'lan'],
+                                 key=resolver.node_name_order),
+                          ['eth1', 'lan'])
+        self.assertEqual(sorted(['lan', 'eth9'],
+                                 key=resolver.node_name_order),
+                          ['eth9', 'lan'])
 
 
 class TestComputeBootstrapPlan(unittest.TestCase):
@@ -506,6 +729,39 @@ class TestComputeBootstrapPlan(unittest.TestCase):
                                               return_value=0)
         self.pcie_distance = distance_patcher.start()
         self.addCleanup(distance_patcher.stop)
+
+        # the fake names below ('eth0', 'eth1', ...) exist for real on some
+        # build hosts - without this, pcie_address() would resolve the
+        # host's own sysfs for those and the sentinel for the rest, making
+        # the canonical order host-dependent. Pinned to the sentinel so
+        # these tests keep exercising pure MAC-rank ordering.
+        address_patcher = mock.patch.object(
+            resolver, 'pcie_address',
+            return_value=resolver.PCIE_ADDRESS_UNKNOWN)
+        self.pcie_address = address_patcher.start()
+        self.addCleanup(address_patcher.stop)
+
+    def test_equal_distance_orders_by_pci_slot_not_mac_magnitude(self):
+        # the reported silent-swap shape, at the bootstrap-naming layer:
+        # both NICs sit at the same depth, so MAC rank used to decide -
+        # the lower slot must win regardless of MAC magnitude.
+        self.pcie_address.side_effect = lambda name: {
+            'ethA': ((0, 0, 5, 0),),
+            'ethB': ((0, 0, 6, 0),),
+        }[name]
+        current = {'ethB': '52:54:00:00:00:22', 'ethA': '52:54:00:ff:00:21'}
+        plan = resolver.compute_bootstrap_plan({}, current, {})
+        self.assertEqual(plan, {'ethA': 'eth0', 'ethB': 'eth1'})
+
+    def test_distance_still_beats_pci_address(self):
+        self.pcie_distance.side_effect = lambda name: {'ethA': 2, 'ethB': 1}[name]
+        self.pcie_address.side_effect = lambda name: {
+            'ethA': ((0, 0, 5, 0),),
+            'ethB': ((0, 0, 6, 0),),
+        }[name]
+        current = {'ethA': 'aa', 'ethB': 'bb'}
+        plan = resolver.compute_bootstrap_plan({}, current, {})
+        self.assertEqual(plan, {'ethB': 'eth0', 'ethA': 'eth1'})
 
     def test_sorted_by_mac_independent_of_current_names(self):
         # names are in the OPPOSITE order of their MACs
@@ -635,6 +891,17 @@ class TestComputeBootstrapPlanGapFill(unittest.TestCase):
         self.pcie_distance = distance_patcher.start()
         self.addCleanup(distance_patcher.stop)
 
+        # the fake names below ('eth0', 'eth1', ...) exist for real on some
+        # build hosts - without this, pcie_address() would resolve the
+        # host's own sysfs for those and the sentinel for the rest, making
+        # the canonical order host-dependent. Pinned to the sentinel so
+        # these tests keep exercising pure MAC-rank ordering.
+        address_patcher = mock.patch.object(
+            resolver, 'pcie_address',
+            return_value=resolver.PCIE_ADDRESS_UNKNOWN)
+        self.pcie_address = address_patcher.start()
+        self.addCleanup(address_patcher.stop)
+
     def test_open_name_filled_like_an_ordinary_gap(self):
         # 'eth1' has nothing configured for it and no pending reservation
         # - it is simply the lowest open name.
@@ -701,18 +968,46 @@ class TestComputeBootstrapPlanGapFill(unittest.TestCase):
         self.assertEqual(plan.get('eth0'), 'eth6')
 
     def test_pending_name_reserved_against_unrelated_bootstrap_candidate(self):
-        # 'eth1' is pending (no hw-id) - two unrelated new NICs discovered
-        # this boot must not land on it just because sequential numbering
-        # would otherwise reach it as the second assignment.
-        configured = {}
+        # 'eth1' is pending (no hw-id) on a box that already has an
+        # established ethernet baseline (eth0's own hw-id) - two unrelated
+        # new NICs discovered this boot must not land on it just because
+        # sequential numbering would otherwise reach it as the second
+        # assignment.
+        configured = {'m0': 'eth0'}
         pending = {'ethernet': {'eth1'}, 'wireless': set()}
+        current = {'eth0': 'm0', 'eth9': 'aa', 'eth8': 'bb'}
+        plan = resolver.compute_bootstrap_plan(configured, current, {},
+                                                pending=pending)
+        self.assertEqual(plan.get('eth9'), 'eth2')
+        self.assertEqual(plan.get('eth8'), 'eth3')
+        self.assertNotEqual(plan.get('eth9'), 'eth1')
+        self.assertNotEqual(plan.get('eth8'), 'eth1')
+
+    def test_pending_name_not_reserved_with_no_established_baseline(self):
+        # 'eth0' is pending (e.g. a cloud-init/first-boot script wrote it
+        # into config.boot before this script ever ran) on a box that has
+        # NEVER bound a real ethernet hw-id - there is no established
+        # mapping to protect, so it is just another open slot and
+        # competes for it like any other unconfigured candidate, exactly
+        # as it would if `pending` had not been passed at all.
+        configured = {}
+        pending = {'ethernet': {'eth0'}, 'wireless': set()}
         current = {'eth9': 'aa', 'eth8': 'bb'}
         plan = resolver.compute_bootstrap_plan(configured, current, {},
                                                 pending=pending)
         self.assertEqual(plan.get('eth9'), 'eth0')
-        self.assertEqual(plan.get('eth8'), 'eth2')
-        self.assertNotEqual(plan.get('eth9'), 'eth1')
-        self.assertNotEqual(plan.get('eth8'), 'eth1')
+        self.assertEqual(plan.get('eth8'), 'eth1')
+
+    def test_pending_name_reserved_if_baseline_exists_for_other_type(self):
+        # an established WIRELESS baseline must not protect a pending
+        # ETHERNET node - the two type groups are judged independently.
+        configured = {'w0': 'wlan0'}
+        pending = {'ethernet': {'eth0'}, 'wireless': set()}
+        current = {'eth9': 'aa', 'eth8': 'bb'}
+        plan = resolver.compute_bootstrap_plan(configured, current, {},
+                                                pending=pending)
+        self.assertEqual(plan.get('eth9'), 'eth0')
+        self.assertEqual(plan.get('eth8'), 'eth1')
 
     def test_reclaimed_candidate_excluded_from_ordinary_bootstrap(self):
         # main() already matched this candidate to a pending node via
@@ -722,7 +1017,7 @@ class TestComputeBootstrapPlanGapFill(unittest.TestCase):
         configured = {}
         current = {'eth9': 'm1', 'eth8': 'm2'}
         plan = resolver.compute_bootstrap_plan(configured, current, {},
-                                                reclaimed_macs={'m1'})
+                                                reclaimed={'m1': 'eth1'})
         self.assertNotIn('eth9', plan)
         self.assertIn('eth8', plan)
 
@@ -993,6 +1288,9 @@ class TestMainFirstBootBootstrap(unittest.TestCase):
              mock.patch.object(resolver, 'is_wireless_interface',
                                 return_value=False), \
              mock.patch.object(resolver, 'pcie_distance', return_value=0), \
+             mock.patch.object(
+                 resolver, 'pcie_address',
+                 return_value=resolver.PCIE_ADDRESS_UNKNOWN), \
              mock.patch.object(resolver, 'run', side_effect=fake_run), \
              mock.patch('time.sleep'):
             resolver.main()
@@ -1096,6 +1394,9 @@ class TestMainFirstBootBootstrap(unittest.TestCase):
              mock.patch.object(resolver, 'is_wireless_interface',
                                 return_value=False), \
              mock.patch.object(resolver, 'pcie_distance', return_value=0), \
+             mock.patch.object(
+                 resolver, 'pcie_address',
+                 return_value=resolver.PCIE_ADDRESS_UNKNOWN), \
              mock.patch.object(resolver, 'run', side_effect=fake_run), \
              mock.patch('time.sleep'):
             resolver.main()
@@ -1149,6 +1450,9 @@ class TestMainFirstBootBootstrap(unittest.TestCase):
              mock.patch.object(resolver, 'is_wireless_interface',
                                 return_value=False), \
              mock.patch.object(resolver, 'pcie_distance', return_value=0), \
+             mock.patch.object(
+                 resolver, 'pcie_address',
+                 return_value=resolver.PCIE_ADDRESS_UNKNOWN), \
              mock.patch.object(resolver, 'run', side_effect=fake_run), \
              mock.patch('time.sleep'):
             resolver.main()
@@ -1197,6 +1501,9 @@ class TestMainFirstBootBootstrap(unittest.TestCase):
              mock.patch.object(resolver, 'is_wireless_interface',
                                 return_value=False), \
              mock.patch.object(resolver, 'pcie_distance', return_value=0), \
+             mock.patch.object(
+                 resolver, 'pcie_address',
+                 return_value=resolver.PCIE_ADDRESS_UNKNOWN), \
              mock.patch.object(resolver, 'run', side_effect=fake_run), \
              mock.patch('time.sleep'):
             resolver.main()
@@ -1246,6 +1553,9 @@ class TestMainFirstBootBootstrap(unittest.TestCase):
              mock.patch.object(resolver, 'is_wireless_interface',
                                 return_value=False), \
              mock.patch.object(resolver, 'pcie_distance', return_value=0), \
+             mock.patch.object(
+                 resolver, 'pcie_address',
+                 return_value=resolver.PCIE_ADDRESS_UNKNOWN), \
              mock.patch.object(resolver, 'run', side_effect=fake_run), \
              mock.patch('time.sleep'):
             resolver.main()
@@ -1263,19 +1573,17 @@ class TestMainFirstBootBootstrap(unittest.TestCase):
         self.assertEqual(status['pending_unresolved'], ['eth2'])
         self.assertEqual(status['reclaimed'], {})
 
-    def test_simultaneous_ambiguity_holds_back_every_candidate(self):
+    def test_simultaneous_pending_nodes_are_covered_by_their_hardware(self):
         # two NICs' hw-id were deleted before the same reboot (eth0 and
         # eth2, nodes left in place), and both came back racily named.
-        # Each candidate's MAC happens to obviously "belong" to one
-        # specific pending node (racyA's mac ends in :00, matching what
-        # eth0 used to be; racyB's mac ends in :02, matching eth2) - but
-        # there is no way to actually verify that pairing, so with 2
-        # pending nodes and 2 candidates present at once, neither may be
-        # auto-matched: guessing the "obvious" pairing risks silently
-        # binding a configured node's settings to the wrong physical NIC
-        # if the guess is ever wrong. Both stay pending and reported;
-        # both candidates still get a real, settings-free hw-id via
-        # ordinary bootstrap naming.
+        # This is an exact cover - 2 pending nodes, 2 unconfigured
+        # candidates - so both nodes are filled, paired in canonical
+        # hardware order. Holding them back instead (the earlier policy)
+        # left eth0/eth2's addresses configured on interfaces that never
+        # came to exist, permanently, while the hardware bootstrapped at
+        # eth8/eth9; every node gets real hardware either way here, so
+        # only the permutation is open and PCI slot order decides it.
+        # The pairing is logged as a warning for exactly that reason.
         configured = {
             'm1': 'eth1', 'm3': 'eth3', 'm4': 'eth4',
             'm5': 'eth5', 'm6': 'eth6', 'm7': 'eth7',
@@ -1308,24 +1616,164 @@ class TestMainFirstBootBootstrap(unittest.TestCase):
              mock.patch.object(resolver, 'is_wireless_interface',
                                 return_value=False), \
              mock.patch.object(resolver, 'pcie_distance', return_value=0), \
+             mock.patch.object(
+                 resolver, 'pcie_address',
+                 return_value=resolver.PCIE_ADDRESS_UNKNOWN), \
              mock.patch.object(resolver, 'run', side_effect=fake_run), \
              mock.patch('time.sleep'):
             resolver.main()
 
-        # neither pending node is guessed at - both candidates land on
-        # fresh, settings-free bootstrap names instead (no ordinary gaps
-        # exist here, so both go beyond the highest configured index)
-        self.assertNotIn('eth0', state)
-        self.assertNotIn('eth2', state)
-        self.assertEqual(state.get('eth8'), 'aa:bb:cc:dd:ee:00')
-        self.assertEqual(state.get('eth9'), 'aa:bb:cc:dd:ee:02')
+        # both pending nodes now have real hardware under them, and
+        # nothing was bootstrapped past the highest configured index
+        self.assertEqual(state.get('eth0'), 'aa:bb:cc:dd:ee:00')
+        self.assertEqual(state.get('eth2'), 'aa:bb:cc:dd:ee:02')
+        self.assertNotIn('eth8', state)
+        self.assertNotIn('eth9', state)
 
+        # hints under the reclaimed names, so vyos-interface-rescan.py
+        # writes the fresh hw-id into the EXISTING node and its address
+        # and description survive
         hints = set(os.listdir(self.udev_dir))
-        self.assertEqual(hints, {'eth8', 'eth9'})
+        self.assertEqual(hints, {'eth0', 'eth2'})
 
         status = json.loads(resolver.status_file.read_text())
-        self.assertEqual(status['pending_unresolved'], ['eth0', 'eth2'])
-        self.assertEqual(status['reclaimed'], {})
+        self.assertEqual(status['pending_unresolved'], [])
+        self.assertEqual(status['reclaimed'], {'aa:bb:cc:dd:ee:00': 'eth0',
+                                                'aa:bb:cc:dd:ee:02': 'eth2'})
+        # inferred from slot order rather than being the single
+        # possibility - surfaced separately so an admin can verify it
+        self.assertEqual(status['reclaimed_by_topology'], ['eth0', 'eth2'])
+
+    def test_cloud_init_multi_nic_addresses_are_not_stranded(self):
+        """Field report, kvm/libvirt qcow2 + NoCloud user-data on a three
+        NIC guest: cloud-init synthesized an hw-id for eth0 only, while
+        `vyos_config_commands` also set addresses on eth1 and eth2. That
+        left 2 pending nodes and 2 unconfigured NICs, which used to be
+        refused as ambiguous while eth1/eth2 stayed RESERVED (eth0's
+        hw-id makes has_established_baseline() true) - so the real NICs
+        were renamed to eth3/eth4 and both configured addresses sat on
+        interfaces that did not exist, across reboots.
+        """
+        configured = {'52:54:00:00:00:10': 'eth0'}
+        pending = {'ethernet': {'eth1', 'eth2'}, 'wireless': set()}
+        state = {
+            'eth0': '52:54:00:00:00:10',
+            'eth1': '52:54:00:ff:00:21',  # libvirt slot 0000:00:05.0
+            'eth2': '52:54:00:00:00:22',  # libvirt slot 0000:00:06.0
+        }
+        slots = {
+            'eth0': ((0, 0, 4, 0),),
+            'eth1': ((0, 0, 5, 0),),
+            'eth2': ((0, 0, 6, 0),),
+        }
+
+        def fake_discover(*_a, **_kw):
+            return dict(state)
+
+        def fake_run(command, *_a, **_kw):
+            parts = command.split()
+            if 'name' in parts:
+                old = parts[parts.index('dev') + 1]
+                new = parts[parts.index('name') + 1]
+                if old in state:
+                    state[new] = state.pop(old)
+                    slots[new] = slots.pop(old, resolver.PCIE_ADDRESS_UNKNOWN)
+            return 0
+
+        with mock.patch.object(resolver, 'get_configfile_interfaces',
+                                return_value=configured), \
+             mock.patch.object(resolver, 'get_pending_hwid_nodes',
+                                return_value=pending), \
+             mock.patch.object(resolver, 'discover_physical_interfaces',
+                                side_effect=fake_discover), \
+             mock.patch.object(resolver, 'is_wireless_interface',
+                                return_value=False), \
+             mock.patch.object(resolver, 'pcie_distance', return_value=1), \
+             mock.patch.object(
+                 resolver, 'pcie_address',
+                 side_effect=lambda name: slots.get(
+                     name, resolver.PCIE_ADDRESS_UNKNOWN)), \
+             mock.patch.object(resolver, 'run', side_effect=fake_run), \
+             mock.patch('time.sleep'):
+            resolver.main()
+
+        # nothing moved, and in particular nothing landed on eth3/eth4
+        self.assertEqual(state, {
+            'eth0': '52:54:00:00:00:10',
+            'eth1': '52:54:00:ff:00:21',
+            'eth2': '52:54:00:00:00:22',
+        })
+
+        # hints under eth1/eth2 so vyos-interface-rescan.py writes the
+        # hw-id into those EXISTING nodes and their addresses survive.
+        # eth0 already has an hw-id, so it needs no hint.
+        self.assertEqual(set(os.listdir(self.udev_dir)), {'eth1', 'eth2'})
+
+        status = json.loads(resolver.status_file.read_text())
+        self.assertEqual(status['pending_unresolved'], [])
+        self.assertEqual(status['renamed'], {})
+        self.assertEqual(status['reclaimed'], {'52:54:00:ff:00:21': 'eth1',
+                                                '52:54:00:00:00:22': 'eth2'})
+
+    def test_cloud_init_multi_nic_names_follow_pci_slot_order(self):
+        """Second field report, same shape: the addresses matched their
+        logical names, but the resolver swapped WHICH physical NIC each
+        name identified. Both NICs sit at the same PCIe depth, so the old
+        (distance, mac) key fell through to raw MAC magnitude - and
+        52:54:00:00:00:22 (slot 6) sorts below 52:54:00:ff:00:21 (slot 5),
+        reversing the hypervisor's attach order. Both data links then had
+        100% packet loss, silently, and the swap froze into config.boot.
+        Here the NICs arrive under the OPPOSITE names to make the point.
+        """
+        configured = {}
+        pending = {'ethernet': {'eth1', 'eth2'}, 'wireless': set()}
+        state = {
+            'eth1': '52:54:00:00:00:22',  # slot 6, arrived first this boot
+            'eth2': '52:54:00:ff:00:21',  # slot 5
+        }
+        slots = {
+            'eth1': ((0, 0, 6, 0),),
+            'eth2': ((0, 0, 5, 0),),
+        }
+
+        def fake_discover(*_a, **_kw):
+            return dict(state)
+
+        def fake_run(command, *_a, **_kw):
+            parts = command.split()
+            if 'name' in parts:
+                old = parts[parts.index('dev') + 1]
+                new = parts[parts.index('name') + 1]
+                if old in state:
+                    state[new] = state.pop(old)
+                    slots[new] = slots.pop(old, resolver.PCIE_ADDRESS_UNKNOWN)
+            return 0
+
+        with mock.patch.object(resolver, 'get_configfile_interfaces',
+                                return_value=configured), \
+             mock.patch.object(resolver, 'get_pending_hwid_nodes',
+                                return_value=pending), \
+             mock.patch.object(resolver, 'discover_physical_interfaces',
+                                side_effect=fake_discover), \
+             mock.patch.object(resolver, 'is_wireless_interface',
+                                return_value=False), \
+             mock.patch.object(resolver, 'pcie_distance', return_value=1), \
+             mock.patch.object(
+                 resolver, 'pcie_address',
+                 side_effect=lambda name: slots.get(
+                     name, resolver.PCIE_ADDRESS_UNKNOWN)), \
+             mock.patch.object(resolver, 'run', side_effect=fake_run), \
+             mock.patch('time.sleep'):
+            resolver.main()
+
+        # the lower PCI slot takes the lower name, whatever the MACs say
+        self.assertEqual(state['eth1'], '52:54:00:ff:00:21')
+        self.assertEqual(state['eth2'], '52:54:00:00:00:22')
+
+        status = json.loads(resolver.status_file.read_text())
+        self.assertEqual(status['pending_unresolved'], [])
+        self.assertEqual(status['reclaimed'], {'52:54:00:ff:00:21': 'eth1',
+                                                '52:54:00:00:00:22': 'eth2'})
 
     def test_squatting_pending_candidate_still_reclaims_correctly(self):
         # field report: deleting eth7's hw-id (node left in place) produced
@@ -1372,6 +1820,9 @@ class TestMainFirstBootBootstrap(unittest.TestCase):
              mock.patch.object(resolver, 'is_wireless_interface',
                                 return_value=False), \
              mock.patch.object(resolver, 'pcie_distance', return_value=0), \
+             mock.patch.object(
+                 resolver, 'pcie_address',
+                 return_value=resolver.PCIE_ADDRESS_UNKNOWN), \
              mock.patch.object(resolver, 'run', side_effect=fake_run), \
              mock.patch('time.sleep'):
             resolver.main()
@@ -1431,6 +1882,9 @@ class TestMainFirstBootBootstrap(unittest.TestCase):
              mock.patch.object(resolver, 'is_wireless_interface',
                                 return_value=False), \
              mock.patch.object(resolver, 'pcie_distance', return_value=0), \
+             mock.patch.object(
+                 resolver, 'pcie_address',
+                 return_value=resolver.PCIE_ADDRESS_UNKNOWN), \
              mock.patch.object(resolver, 'run', side_effect=fake_run), \
              mock.patch('time.sleep'):
             resolver.main()
@@ -1496,6 +1950,9 @@ class TestMainFirstBootBootstrap(unittest.TestCase):
              mock.patch.object(resolver, 'is_wireless_interface',
                                 return_value=False), \
              mock.patch.object(resolver, 'pcie_distance', return_value=0), \
+             mock.patch.object(
+                 resolver, 'pcie_address',
+                 return_value=resolver.PCIE_ADDRESS_UNKNOWN), \
              mock.patch.object(resolver, 'run', side_effect=fake_run), \
              mock.patch('time.sleep'):
             resolver.main()

--- a/src/tests/test_net_name_resolve.py
+++ b/src/tests/test_net_name_resolve.py
@@ -1071,31 +1071,35 @@ class TestComputeBootstrapPlanGapFill(unittest.TestCase):
         self.assertNotEqual(plan.get('eth9'), 'eth1')
         self.assertNotEqual(plan.get('eth8'), 'eth1')
 
-    def test_pending_name_not_reserved_with_no_established_baseline(self):
-        # 'eth0' is pending (e.g. a cloud-init/first-boot script wrote it
-        # into config.boot before this script ever ran) on a box that has
-        # NEVER bound a real ethernet hw-id - there is no established
-        # mapping to protect, so it is just another open slot and
-        # competes for it like any other unconfigured candidate, exactly
-        # as it would if `pending` had not been passed at all.
+    def test_pending_name_reserved_even_with_no_hwid_configured(self):
+        # a pending name is off-limits here whatever else config.boot
+        # holds. This pass is not allowed to fill one at all: only
+        # match_pending_nodes() may, and only under a rule that reports
+        # what it did. Leaving a gap here for it to fall into is how the
+        # naming of a box whose hw-ids were all deleted at once was
+        # silently rearranged (T3871, PR #5417).
         configured = {}
         pending = {'ethernet': {'eth0'}, 'wireless': set()}
         current = {'eth9': 'aa', 'eth8': 'bb'}
         plan = resolver.compute_bootstrap_plan(configured, current, {},
                                                 pending=pending)
-        self.assertEqual(plan.get('eth9'), 'eth0')
-        self.assertEqual(plan.get('eth8'), 'eth1')
+        self.assertEqual(plan.get('eth9'), 'eth1')
+        self.assertEqual(plan.get('eth8'), 'eth2')
+        self.assertNotIn('eth0', plan.values())
 
-    def test_pending_name_reserved_if_baseline_exists_for_other_type(self):
-        # an established WIRELESS baseline must not protect a pending
-        # ETHERNET node - the two type groups are judged independently.
-        configured = {'w0': 'wlan0'}
+    def test_unmatchable_pending_name_is_held_open_not_backfilled(self):
+        # nothing of this type has a hw-id, the pending name is carried by
+        # no candidate, and the cardinality is not a cover - so
+        # match_pending_nodes() declines. The name stays empty and is
+        # reported unresolved rather than handed to the lowest-sorting
+        # NIC, which is the case this behaviour change turns around.
+        configured = {}
         pending = {'ethernet': {'eth0'}, 'wireless': set()}
-        current = {'eth9': 'aa', 'eth8': 'bb'}
+        current = {'eth5': 'n5', 'eth6': 'n6', 'eth7': 'n7'}
         plan = resolver.compute_bootstrap_plan(configured, current, {},
                                                 pending=pending)
-        self.assertEqual(plan.get('eth9'), 'eth0')
-        self.assertEqual(plan.get('eth8'), 'eth1')
+        self.assertEqual(plan, {'eth5': 'eth1', 'eth6': 'eth2',
+                                 'eth7': 'eth3'})
 
     def test_reclaimed_candidate_excluded_from_ordinary_bootstrap(self):
         # main() already matched this candidate to a pending node via

--- a/src/tests/test_net_name_resolve.py
+++ b/src/tests/test_net_name_resolve.py
@@ -288,6 +288,94 @@ class TestMatchPendingNodes(unittest.TestCase):
         matched = resolver.match_pending_nodes(pending, candidates)
         self.assertEqual(matched, {})
 
+    def test_name_cover_reaches_what_an_exact_cover_cannot(self):
+        # reported from the field: a cloud-init guest configured for three
+        # NICs but built with FOUR. 2 pending nodes vs 3 candidates is not
+        # an exact cover, so refusing left both data nodes stranded on
+        # interfaces that never came to exist - and the box never
+        # recovered, because on every later boot the parked ports held a
+        # hw-id and there were no candidates left. The two candidates
+        # carrying the pending names are exactly the ones that config was
+        # written against; the spare is ignored.
+        self.pcie_address.side_effect = lambda name: {
+            'eth1': ((0, 0, 2, 0),),
+            'eth2': ((0, 0, 3, 0),),
+            'eth3': ((0, 0, 4, 0),),
+        }[name]
+        pending = {'ethernet': {'eth1', 'eth2'}, 'wireless': set()}
+        candidates = [('m1', 'eth1'), ('m2', 'eth2'), ('spare', 'eth3')]
+        matched = resolver.match_pending_nodes(pending, candidates)
+        self.assertEqual(matched, {'m1': 'eth1', 'm2': 'eth2'})
+
+    def test_exact_cover_takes_precedence_over_the_name_cover(self):
+        # THE ordering constraint. Both rules apply here and they
+        # disagree: the NICs arrived under each other's provisional names.
+        # A pending 'eth1' means "the second NIC as the hypervisor
+        # attached it" - PCI slot order - not "whatever the probe race
+        # called eth1", so the exact cover must win and swap them. Letting
+        # the name decide would leave both data links crossed, which is a
+        # separately reported field failure (see
+        # test_cloud_init_multi_nic_names_follow_pci_slot_order).
+        self.pcie_address.side_effect = lambda name: {
+            'eth1': ((0, 0, 6, 0),),   # carries the name, but higher slot
+            'eth2': ((0, 0, 5, 0),),
+        }[name]
+        pending = {'ethernet': {'eth1', 'eth2'}, 'wireless': set()}
+        candidates = [('high', 'eth1'), ('low', 'eth2')]
+        matched = resolver.match_pending_nodes(pending, candidates)
+        self.assertEqual(matched, {'low': 'eth1', 'high': 'eth2'})
+
+    def test_partial_name_match_is_not_a_cover(self):
+        # only one of the two pending names is carried by a candidate -
+        # there is nothing to pair the other node with, so neither is
+        # guessed at.
+        pending = {'ethernet': {'eth1', 'eth2'}, 'wireless': set()}
+        candidates = [('m1', 'eth1'), ('m3', 'eth3'), ('m4', 'eth4')]
+        matched = resolver.match_pending_nodes(pending, candidates)
+        self.assertEqual(matched, {})
+
+    def test_more_name_matches_than_nodes_is_not_a_cover(self):
+        # a stale node left behind can make a candidate carry a pending
+        # name it has no claim to - more name matches than nodes means
+        # there is still no way to tell which is which.
+        pending = {'ethernet': {'eth1'}, 'wireless': set()}
+        candidates = [('m1', 'eth1'), ('m2', 'eth1x'), ('m3', 'eth1')]
+        matched = resolver.match_pending_nodes(pending, candidates)
+        self.assertEqual(matched, {})
+
+    def test_name_cover_judged_per_type(self):
+        # ethernet resolves by name cover; wireless has no name match at
+        # all and stays pending, independently.
+        self.is_wireless.side_effect = lambda name: name.startswith('radio')
+        pending = {'ethernet': {'eth1', 'eth2'}, 'wireless': {'wlan0'}}
+        candidates = [('m1', 'eth1'), ('m2', 'eth2'), ('spare', 'eth3'),
+                      ('r1', 'radio0'), ('r2', 'radio1')]
+        matched = resolver.match_pending_nodes(pending, candidates)
+        self.assertEqual(matched, {'m1': 'eth1', 'm2': 'eth2'})
+
+    def test_rules_classify_guesses_but_not_a_lone_exact_cover(self):
+        # a single node and a single candidate leave nothing to get wrong,
+        # so it is reported as a certainty (absent from both buckets); a
+        # name-selected match is a guess at ANY cardinality, because
+        # provisional names can line up by coincidence.
+        rules = {}
+        resolver.match_pending_nodes(
+            {'ethernet': {'eth1'}, 'wireless': set()}, [('m1', 'eth9')],
+            rules=rules)
+        self.assertEqual(rules, {'topology': set(), 'name': set()})
+
+        rules = {}
+        resolver.match_pending_nodes(
+            {'ethernet': {'eth1'}, 'wireless': set()},
+            [('m1', 'eth1'), ('m2', 'eth8')], rules=rules)
+        self.assertEqual(rules, {'topology': set(), 'name': {'eth1'}})
+
+        rules = {}
+        resolver.match_pending_nodes(
+            {'ethernet': {'eth1', 'eth2'}, 'wireless': set()},
+            [('m1', 'eth8'), ('m2', 'eth9')], rules=rules)
+        self.assertEqual(rules, {'topology': {'eth1', 'eth2'}, 'name': set()})
+
     def test_covers_are_judged_per_type_not_across_types(self):
         # ethernet covers 2:2 while wireless is 1:2 - the ethernet nodes
         # are still paired, and the wireless one is still left pending.
@@ -1714,6 +1802,87 @@ class TestMainFirstBootBootstrap(unittest.TestCase):
         self.assertEqual(status['renamed'], {})
         self.assertEqual(status['reclaimed'], {'52:54:00:ff:00:21': 'eth1',
                                                 '52:54:00:00:00:22': 'eth2'})
+
+    def test_cloud_init_spare_nic_does_not_strand_the_configured_nodes(self):
+        """Field report: same cloud-init shape as above, but the VM has one
+        NIC MORE than the config sets up. That made 2 pending nodes vs 3
+        candidates - not an exact cover - so both nodes were refused while
+        their names stayed reserved, and all three NICs parked on fresh
+        names past them (eth3/eth4/eth5) and had a hw-id written there.
+        Both data segments were dead, and it could never recover: on every
+        later boot the parked ports held a hw-id, so the count read "2
+        pending, 0 unconfigured candidates" forever. With exactly three
+        NICs the identical config worked - the spare was the whole
+        difference.
+        """
+        configured = {'00:00:5e:00:54:31': 'eth0'}
+        pending = {'ethernet': {'eth1', 'eth2'}, 'wireless': set()}
+        state = {
+            'eth0': '00:00:5e:00:54:31',
+            'eth1': '00:00:5e:00:54:39',
+            'eth2': '00:00:5e:00:54:32',
+            'eth3': '00:00:5e:00:54:3c',  # the spare, nothing configured
+        }
+        slots = {
+            'eth0': ((0, 0, 1, 0),),
+            'eth1': ((0, 0, 2, 0),),
+            'eth2': ((0, 0, 3, 0),),
+            'eth3': ((0, 0, 4, 0),),
+        }
+
+        def fake_discover(*_a, **_kw):
+            return dict(state)
+
+        def fake_run(command, *_a, **_kw):
+            parts = command.split()
+            if 'name' in parts:
+                old = parts[parts.index('dev') + 1]
+                new = parts[parts.index('name') + 1]
+                if old in state:
+                    state[new] = state.pop(old)
+                    slots[new] = slots.pop(old, resolver.PCIE_ADDRESS_UNKNOWN)
+            return 0
+
+        with mock.patch.object(resolver, 'get_configfile_interfaces',
+                                return_value=configured), \
+             mock.patch.object(resolver, 'get_pending_hwid_nodes',
+                                return_value=pending), \
+             mock.patch.object(resolver, 'discover_physical_interfaces',
+                                side_effect=fake_discover), \
+             mock.patch.object(resolver, 'is_wireless_interface',
+                                return_value=False), \
+             mock.patch.object(resolver, 'pcie_distance', return_value=1), \
+             mock.patch.object(
+                 resolver, 'pcie_address',
+                 side_effect=lambda name: slots.get(
+                     name, resolver.PCIE_ADDRESS_UNKNOWN)), \
+             mock.patch.object(resolver, 'run', side_effect=fake_run), \
+             mock.patch('time.sleep'):
+            resolver.main()
+
+        # the configured nodes keep their own hardware and the spare takes
+        # the next free name - nothing is pushed out to eth4/eth5
+        self.assertEqual(state, {
+            'eth0': '00:00:5e:00:54:31',
+            'eth1': '00:00:5e:00:54:39',
+            'eth2': '00:00:5e:00:54:32',
+            'eth3': '00:00:5e:00:54:3c',
+        })
+
+        # hints under eth1/eth2 so vyos-interface-rescan.py writes the
+        # hw-id into those EXISTING nodes and their addresses survive; the
+        # spare gets one too, for its own fresh node
+        self.assertEqual(set(os.listdir(self.udev_dir)),
+                          {'eth1', 'eth2', 'eth3'})
+
+        status = json.loads(resolver.status_file.read_text())
+        self.assertEqual(status['pending_unresolved'], [])
+        self.assertEqual(status['renamed'], {})
+        self.assertEqual(status['reclaimed'], {'00:00:5e:00:54:39': 'eth1',
+                                                '00:00:5e:00:54:32': 'eth2'})
+        # the hardware was selected by the names it carried this boot, so
+        # the admin is told to verify it rather than left to find out
+        self.assertEqual(status['reclaimed_by_name'], ['eth1', 'eth2'])
 
     def test_cloud_init_multi_nic_names_follow_pci_slot_order(self):
         """Second field report, same shape: the addresses matched their


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The pending-node reservation added to guard against a wrong guess on an already-provisioned box also applied on a box that has never bound any `hw-id` at all for that interface type. A multi-NIC cloud-init first boot hits this: the default network config creates a hw-id-less "eth0" node before naming ever runs, and with N unconfigured candidates the match is ambiguous by design - so eth0's name stayed permanently reserved and unassigned, and every physical NIC bootstrapped one slot too high (eth1..ethN instead of eth0..ethN-1).

Add `has_established_baseline()` and only reserve a pending node's name, per interface type, once config.boot already binds at least one real `hw-id` of that type - there is nothing to protect otherwise, so the node competes for its slot like any other unconfigured candidate. Also stop misreporting a name resolved this way as still-pending in the boot warning and status file.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T3871

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-1x/pull/5350
* https://github.com/vyos/vyos-1x/pull/5405

## How to test / Smoketest result

* `make testifname` passed
* `make test-ci-qcow2` with PROXMOX flavor passes

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
