### PR TITLE
pki: T9225: Support ED25519 and ED448 signatures on public keys in PKI

### DIFF
--- a/python/vyos/pki.py
+++ b/python/vyos/pki.py
@@ -26,6 +26,8 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import dh
 from cryptography.hazmat.primitives.asymmetric import dsa
 from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.hazmat.primitives.asymmetric import ed448
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric import rsa
 
@@ -390,6 +392,14 @@ def verify_certificate(cert, ca_cert):
                 cert.signature,
                 cert.tbs_certificate_bytes,
                 signature_algorithm=ec.ECDSA(cert.signature_hash_algorithm))
+        elif isinstance(ca_public_key, ed25519.Ed25519PublicKey):
+            ca_public_key.verify(
+                cert.signature,
+                cert.tbs_certificate_bytes)
+        elif isinstance(ca_public_key, ed448.Ed448PublicKey):
+            ca_public_key.verify(
+                cert.signature,
+                cert.tbs_certificate_bytes)
         else:
             return False # We cannot verify it
         return True
@@ -419,6 +429,14 @@ def verify_crl(crl, ca_cert):
                 crl.signature,
                 crl.tbs_certlist_bytes,
                 signature_algorithm=ec.ECDSA(crl.signature_hash_algorithm))
+        elif isinstance(ca_public_key, ed25519.Ed25519PublicKey):
+            ca_public_key.verify(
+                crl.signature,
+                crl.tbs_certlist_bytes)
+        elif isinstance(ca_public_key, ed448.Ed448PublicKey):
+            ca_public_key.verify(
+                crl.signature,
+                crl.tbs_certlist_bytes)
         else:
             return False # We cannot verify it
         return True


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
Letsencrypt started signing their CA certificates (current Root YE and intermediates YE1 and YE1) with ED25519 and ED448, neither of which are supported in VyOS PKI, so importing those new LE CA's into the VyOS PKI is impossible, which makes impossible using LE-issued certificates on the HAPROXY loadbalancer.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
https://vyos.dev/T9225

## Related PR(s)
none

## How to test / Smoketest result
1. Download the Letsencrypt Root YE certificate from: https://letsencrypt.org/certs/gen-y/root-ye-by-x2.pem
2. Add it into the VyOS keystore like so, according to VyOS documentation: https://docs.vyos.io/en/rolling/configuration/pki/index.html#cfgcmd-set-pki-ca-name-certificate
```
$ set pki ca le_root_ye certificate "<certificate_content>"
```
3. Make sure the certificate is added to the certificate store:
```
$ sh pki ca
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
