### PR TITLE
T9231: Add reference_tree utils to return paths satisfying condition

### DIFF
--- a/libvyosconfig/Makefile
+++ b/libvyosconfig/Makefile
@@ -42,7 +42,7 @@ all: sharedlib
 PHONY: depends
 depends:
 	sudo sh -c 'eval $$(opam env --root=/opt/opam --set-root) ;\
-		opam pin add vyos1x-config https://github.com/vyos/vyos1x-config.git#07636e49b3a04fdc76ac42bd65df88736c3945f1 -y ; \
+		opam pin add vyos1x-config https://github.com/vyos/vyos1x-config.git#f7b4459ba3c6551f8d054456b0d5013a4b0e3ee1 -y ; \
 		opam pin add vyconf https://github.com/vyos/vyconf.git#ca209bc03badb1c344907e52803fbcd612f920a4 -y'
 
 sharedlib: depends $(BUILDDIR)/libvyosconfig$(EXTDLL)

--- a/libvyosconfig/lib/bindings.ml
+++ b/libvyosconfig/lib/bindings.ml
@@ -8,6 +8,7 @@ open Commitd_client
 module VT = Vytree
 module CT = Config_tree
 module RT = Reference_tree
+module Util_rt = Util_reference_tree
 module TA = Tree_alg
 module CDict = Config_dict
 module D = Diff
@@ -566,6 +567,45 @@ let config_dict c_ptr_c c_ptr_r c_ptr_m path get_node with_defaults =
     let with_node = not get_node in
     CDict.config_dict ~with_defaults:with_defaults ~with_first_node:with_node rt ct mask path
 
+let get_owner c_ptr path =
+    let rt = Root.get c_ptr in
+    let path = split_on_whitespace path in
+    match Util_rt.get_path_owner rt path with
+    | Some o -> o
+    | None -> ""
+
+let get_multi_nodes c_ptr tag_value_placeholder =
+    let rt = Root.get c_ptr in
+    Util_rt.get_multi_nodes_yojson ~tag_value_placeholder:tag_value_placeholder rt
+
+let get_tag_nodes c_ptr tag_value_placeholder =
+    let rt = Root.get c_ptr in
+    Util_rt.get_tag_nodes_yojson ~tag_value_placeholder:tag_value_placeholder rt
+
+let get_nodes_of_kind c_ptr kind tag_value_placeholder =
+    let rt = Root.get c_ptr in
+    Util_rt.get_nodes_of_kind_yojson ~tag_value_placeholder:tag_value_placeholder rt kind
+
+let get_rdeps_of_kind c_ptr kind tag_value_placeholder =
+    let rt = Root.get c_ptr in
+    Util_rt.get_rdeps_of_kind_yojson ~tag_value_placeholder:tag_value_placeholder rt kind
+
+let get_rdeps_of_kind_data c_ptr kind tag_value_placeholder =
+    let rt = Root.get c_ptr in
+    Util_rt.get_rdeps_of_kind_data_yojson ~tag_value_placeholder:tag_value_placeholder rt kind
+
+let subtree_values_of_path c_ptr_rt c_ptr_ct path =
+    let rt = Root.get c_ptr_rt in
+    let ct = Root.get c_ptr_ct in
+    let path = split_on_whitespace path in
+    try
+        error_message := "";
+        (Derived.subtree_values_of_path_yojson[@alert "-exn"]) rt ct path
+    with
+        Derived.Malformed_path s ->
+            let msg = Printf.sprintf "Malformed path: \'%s\'" s in
+            error_message := msg; "#1@"
+
 module Stubs(I : Cstubs_inverted.INTERNAL) =
 struct
 
@@ -615,4 +655,11 @@ struct
   let () = I.internal "subtree_from_partial" ((ptr void) @-> (ptr void) @-> (ptr void) @-> string @-> returning (ptr void)) subtree_from_partial
   let () = I.internal "validate_tree_filter" ((ptr void) @-> string @-> string @-> returning (ptr void)) validate_tree_filter
   let () = I.internal "config_dict" ((ptr void) @-> (ptr void) @-> (ptr void) @-> string @-> bool @-> bool @-> returning string) config_dict
+  let () = I.internal "get_owner" ((ptr void) @-> string @-> returning string) get_owner
+  let () = I.internal "get_multi_nodes" ((ptr void) @-> string @-> returning string) get_multi_nodes
+  let () = I.internal "get_tag_nodes" ((ptr void) @-> string @-> returning string) get_tag_nodes
+  let () = I.internal "get_nodes_of_kind" ((ptr void) @-> string @-> string @-> returning string) get_nodes_of_kind
+  let () = I.internal "get_rdeps_of_kind" ((ptr void) @-> string @-> string @-> returning string) get_rdeps_of_kind
+  let () = I.internal "get_rdeps_of_kind_data" ((ptr void) @-> string @-> string @-> returning string) get_rdeps_of_kind_data
+  let () = I.internal "subtree_values_of_path" ((ptr void) @-> (ptr void) @-> string @-> returning string) subtree_values_of_path
 end

--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -78,6 +78,7 @@ _PROTOTYPES = {
     'mask_inclusive': ([c_void_p, c_void_p], c_void_p),
     'mask_exclusive': ([c_void_p, c_void_p], c_void_p),
     'subtree_from_partial': ([c_void_p, c_void_p, c_void_p, c_char_p], c_void_p),
+    'subtree_values_of_path': ([c_void_p, c_void_p, c_char_p], c_char_p),
     'reference_tree_to_json': ([c_char_p, c_char_p, c_char_p], None),
     'merge_reference_tree_cache': ([c_char_p, c_char_p, c_char_p], None),
     'interface_definitions_to_cache': ([c_char_p, c_char_p], None),
@@ -89,6 +90,12 @@ _PROTOTYPES = {
     'read_internal_string_reference_tree': ([c_char_p], c_void_p),
     'write_internal_reference_tree': ([c_void_p, c_char_p], None),
     'to_json_reference_tree': ([c_void_p], c_char_p),
+    'get_owner': ([c_void_p, c_char_p], c_char_p),
+    'get_multi_nodes': ([c_void_p, c_char_p], c_char_p),
+    'get_tag_nodes': ([c_void_p, c_char_p], c_char_p),
+    'get_nodes_of_kind': ([c_void_p, c_char_p, c_char_p], c_char_p),
+    'get_rdeps_of_kind': ([c_void_p, c_char_p, c_char_p], c_char_p),
+    'get_rdeps_of_kind_data': ([c_void_p, c_char_p, c_char_p], c_char_p),
 }
 
 
@@ -101,6 +108,8 @@ class _Lib:
     every entry point, and the previous per-instance binding code only failed
     on symbols that were actually used.
     """
+
+    # pylint: disable=too-few-public-methods
 
     def __init__(self, libpath):
         self.__dict__['_lib'] = cdll.LoadLibrary(libpath)
@@ -331,7 +340,9 @@ class ConfigTree:
                     self.__config, path_str, str(value).encode()
                 )
             else:
-                res = self.__lib.set_add_value(self.__config, path_str, str(value).encode())
+                res = self.__lib.set_add_value(
+                    self.__config, path_str, str(value).encode()
+                )
 
         if res != 0:
             msg = self.__lib.get_error().decode()
@@ -694,6 +705,35 @@ def subtree_from_partial(
     return tree
 
 
+def subtree_values_of_path(
+    config_tree: ConfigTree,
+    path: list[str],
+    reference_tree: 'ReferenceTree',
+    libpath=LIBPATH,
+) -> list[tuple[list[str], list[str]]]:
+    # pylint: disable=raise-missing-from
+    check_path(path)
+    path_str = ' '.join(map(str, path)).encode()
+
+    try:
+        lib = get_lib(libpath)
+
+        res = lib.subtree_values_of_path(
+            reference_tree.get_tree(),
+            config_tree.get_tree(),
+            path_str,
+        )
+        res = res.decode()
+    except Exception as e:
+        raise ConfigTreeError(e)
+    if res == '#1@':
+        msg = lib.get_error().decode()
+        raise ConfigTreeError(msg)
+
+    lst = json.loads(res)
+    return list(map(tuple, lst))
+
+
 def reference_tree_to_json(from_dir, to_file, internal_cache='', libpath=LIBPATH):
     # pylint: disable=raise-missing-from
     try:
@@ -738,7 +778,9 @@ def reference_tree_cache_to_json(cache_path, render_file, libpath=LIBPATH):
     # pylint: disable=raise-missing-from
     try:
         lib = get_lib(libpath)
-        res = lib.reference_tree_cache_to_json(cache_path.encode(), render_file.encode())
+        res = lib.reference_tree_cache_to_json(
+            cache_path.encode(), render_file.encode()
+        )
     except Exception as e:
         raise ConfigTreeError(e)
     if res == 1:

--- a/python/vyos/referencetree.py
+++ b/python/vyos/referencetree.py
@@ -25,7 +25,7 @@ class ReferenceTreeError(Exception):
 
 
 class ReferenceTree:
-    # pylint: disable=too-many-instance-attributes,raise-missing-from
+    # pylint: disable=too-many-instance-attributes,raise-missing-from,import-outside-toplevel
     def __init__(self, cache_file=reference_tree_cache, libpath=LIBPATH):
         self.__pointer = None
         self.__lib = get_lib(libpath)
@@ -61,3 +61,49 @@ class ReferenceTree:
 
     def to_json(self):
         return self.__lib.to_json_reference_tree(self.__pointer).decode()
+
+    def get_owner(self, path):
+        return self.__lib.get_owner(self.__pointer, path.encode()).decode()
+
+    def get_multi_nodes(self, tag_value_placeholder='', as_tuple=False):
+        import json
+
+        res = self.__lib.get_multi_nodes(
+            self.__pointer, tag_value_placeholder.encode()
+        ).decode()
+        sort = sorted(json.loads(res))
+        return list(map(tuple, sort)) if as_tuple else sort
+
+    def get_tag_nodes(self, tag_value_placeholder='', as_tuple=False):
+        import json
+
+        res = self.__lib.get_tag_nodes(
+            self.__pointer, tag_value_placeholder.encode()
+        ).decode()
+        sort = sorted(json.loads(res))
+        return list(map(tuple, sort)) if as_tuple else sort
+
+    def get_nodes_of_kind(self, kind, tag_value_placeholder=''):
+        import json
+
+        res = self.__lib.get_nodes_of_kind(
+            self.__pointer, kind.encode(), tag_value_placeholder.encode()
+        ).decode()
+        return sorted(json.loads(res))
+
+    def get_rdeps_of_kind(self, kind, tag_value_placeholder=''):
+        import json
+
+        res = self.__lib.get_rdeps_of_kind(
+            self.__pointer, kind.encode(), tag_value_placeholder.encode()
+        ).decode()
+        return sorted(json.loads(res))
+
+    def get_rdeps_of_kind_data(self, kind, tag_value_placeholder='', as_tuple=True):
+        import json
+
+        res = self.__lib.get_rdeps_of_kind_data(
+            self.__pointer, kind.encode(), tag_value_placeholder.encode()
+        ).decode()
+        sort = sorted(json.loads(res))
+        return list(map(tuple, sort)) if as_tuple else sort


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Add bindings and wrappers for reference tree utils.

A collection of simple utilities to collect paths of the reference tree conditionally. This has two immediate applications:
(1) organize reverse dependency data for interfaces (T7886); support for an XML dependency element is included.
(2) replace cloud-init functions that walk the legacy template directory:
https://github.com/vyos/vyos-cloud-init/blob/rolling/cloudinit/config/cc_vyos_userdata.py#L39-L74

The applications to T7886 will be discussed in a pending PR; as a replacement to walking the template directory, the performance improvement is evident below (let alone the simplification of code). The function `legacy_get_multi_nodes` is copied from the cloud-init link above; performance is compared with/without instantiation of ReferenceTree:

```
vyos@vyos:~$ ipython3
Python 3.11.2 (main, May 12 2026, 05:17:27) [GCC 12.2.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.5.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import re
   ...: 
   ...: from pathlib import Path
   ...: 
   ...: TEMPLATES_DIR = '/opt/vyatta/share/vyatta-cfg/templates/'
   ...: 
   ...: def legacy_get_multi_nodes():
   ...:     try:
   ...:         multi_nodes = []
   ...:         # search for node.def files
   ...:         node_def_files = Path(TEMPLATES_DIR).rglob('node.def')
   ...:         # prepare filter to match multi node files
   ...:         regex_filter = re.compile(r'^multi:.*$', re.MULTILINE)
   ...:         # add each node.def with multi mark to list
   ...:         for node_def_file in node_def_files:
   ...:             file_content = node_def_file.read_text()
   ...:             if regex_filter.search(file_content):
   ...:                 current_multi_path = node_def_file.relative_to(
   ...:                     TEMPLATES_DIR).parent.parts
   ...:                 multi_nodes.append(current_multi_path)
   ...:         return multi_nodes
   ...:     except Exception as err:
   ...:         print(f'Failed to find multi nodes: {err}')
   ...: 

In [2]: from vyos.referencetree import ReferenceTree
   ...: def reference_tree_get_multi_nodes():
   ...:     rt = ReferenceTree()
   ...:     out = rt.get_multi_nodes(tag_value_placeholder='node.tag', as_tuple=True)
   ...: 

In [3]: %timeit out = legacy_get_multi_nodes()
375 ms ± 3.34 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [4]: %timeit out = reference_tree_get_multi_nodes()
93.7 ms ± 1.16 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [5]: rt = ReferenceTree()
   ...: def inited_reference_tree_get_multi_nodes():
   ...:     out = rt.get_multi_nodes(tag_value_placeholder='node.tag', as_tuple=True)
   ...: 

In [6]: %timeit out = inited_reference_tree_get_multi_nodes()
925 µs ± 9.11 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)

In [7]: legacy_multi = legacy_get_multi_nodes()

In [8]: reftree_multi = rt.get_multi_nodes(tag_value_placeholder='node.tag', as_tuple=True)

In [9]: set(legacy_multi) - set(reftree_multi)
Out[9]: set()

In [10]: set(reftree_multi) - set(legacy_multi)
Out[10]: 
{('protocols', 'eigrp', 'network'),
 ('protocols', 'eigrp', 'passive-interface'),
 ('protocols', 'eigrp', 'redistribute'),
 ('vrf', 'name', 'node.tag', 'protocols', 'eigrp', 'network'),
 ('vrf', 'name', 'node.tag', 'protocols', 'eigrp', 'passive-interface'),
 ('vrf', 'name', 'node.tag', 'protocols', 'eigrp', 'redistribute')}
```

The final set diff is due to the exclusion of eigrp templates in
https://github.com/vyos/vyos-1x/blob/rolling/Makefile#L46-L49

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

https://github.com/vyos/vyos1x-config/pull/92

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [X] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
