### PR TITLE
boot: T9232: run executable files in post-config.d from the stock bootup script

### DIFF
--- a/debian/vyos-1x.postinst
+++ b/debian/vyos-1x.postinst
@@ -199,12 +199,23 @@ if [ ! -x $POSTCONFIG_SCRIPT ]; then
     mkdir -p $(dirname $POSTCONFIG_SCRIPT)
     touch $POSTCONFIG_SCRIPT
     chmod 755 $POSTCONFIG_SCRIPT
-    cat <<EOF >>$POSTCONFIG_SCRIPT
+    # Quoted heredoc: the runner references $DIR / $script / $?.
+    # Existing custom /config scripts are not replaced (test -x above).
+    cat <<'EOF' >>$POSTCONFIG_SCRIPT
 #!/bin/sh
 # This script is executed at boot time after VyOS configuration is fully applied.
 # Any modifications required to work around unfixed bugs
 # or use services not available through the VyOS CLI system can be placed here.
+#
+# Executable files in /config/scripts/post-config.d/ are run in name order
+# (same idea as post-upgrade.d). Failures are logged; boot continues.
 
+DIR=/config/scripts/post-config.d
+[ -d "$DIR" ] || exit 0
+for script in "$DIR"/*; do
+    [ -f "$script" ] && [ -x "$script" ] || continue
+    "$script" || logger -t vyos-postconfig "post-config.d/$(basename "$script") failed (exit $?)"
+done
 EOF
 fi
 

--- a/debian/vyos-1x.postinst
+++ b/debian/vyos-1x.postinst
@@ -194,14 +194,14 @@ EOF
 fi
 
 # create /opt/vyatta/etc/config/scripts/vyos-postconfig-bootup.script
+# Refresh comments-only stock (old empty template) on upgrade so restore
+# and first-boot copies pick up the post-config.d runner. Leave any file
+# that has real commands (operator customizations) untouched.
 POSTCONFIG_SCRIPT=/opt/vyatta/etc/config/scripts/vyos-postconfig-bootup.script
-if [ ! -x $POSTCONFIG_SCRIPT ]; then
-    mkdir -p $(dirname $POSTCONFIG_SCRIPT)
-    touch $POSTCONFIG_SCRIPT
-    chmod 755 $POSTCONFIG_SCRIPT
+mkdir -p $(dirname $POSTCONFIG_SCRIPT)
+if [ ! -f $POSTCONFIG_SCRIPT ] || ! grep -qvE '^[[:space:]]*(#|$)' $POSTCONFIG_SCRIPT; then
     # Quoted heredoc: the runner references $DIR / $script / $?.
-    # Existing custom /config scripts are not replaced (test -x above).
-    cat <<'EOF' >>$POSTCONFIG_SCRIPT
+    cat <<'EOF' >$POSTCONFIG_SCRIPT
 #!/bin/sh
 # This script is executed at boot time after VyOS configuration is fully applied.
 # Any modifications required to work around unfixed bugs
@@ -217,6 +217,7 @@ for script in "$DIR"/*; do
     "$script" || logger -t vyos-postconfig "post-config.d/$(basename "$script") failed (exit $?)"
 done
 EOF
+    chmod 755 $POSTCONFIG_SCRIPT
 fi
 
 # symlink destination is deleted during ISO assembly - this generates some noise

--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -251,13 +251,17 @@ run_preconfig_script ()
 # restore if missing post-config script
 restore_if_missing_postconfig_script ()
 {
-    if [ ! -x ${vyatta_sysconfdir}/config/scripts/vyos-postconfig-bootup.script ]; then
-        mkdir -p ${vyatta_sysconfdir}/config/scripts
-        chgrp ${GROUP} ${vyatta_sysconfdir}/config/scripts
-        chmod 775 ${vyatta_sysconfdir}/config/scripts
-        cp ${vyos_rootfs_dir}/opt/vyatta/etc/config/scripts/vyos-postconfig-bootup.script ${vyatta_sysconfdir}/config/scripts/
-        chgrp ${GROUP} ${vyatta_sysconfdir}/config/scripts/vyos-postconfig-bootup.script
-        chmod 750 ${vyatta_sysconfdir}/config/scripts/vyos-postconfig-bootup.script
+    local dst=${vyatta_sysconfdir}/config/scripts/vyos-postconfig-bootup.script
+    local src=${vyos_rootfs_dir}/opt/vyatta/etc/config/scripts/vyos-postconfig-bootup.script
+    mkdir -p ${vyatta_sysconfdir}/config/scripts
+    chgrp ${GROUP} ${vyatta_sysconfdir}/config/scripts
+    chmod 775 ${vyatta_sysconfdir}/config/scripts
+    # Missing, or old comments-only stock (no real commands) — copy the
+    # image runner. Operator scripts with commands are left alone.
+    if [ ! -f "$dst" ] || ! grep -qvE '^[[:space:]]*(#|$)' "$dst"; then
+        cp "$src" "$dst"
+        chgrp ${GROUP} "$dst"
+        chmod 750 "$dst"
     fi
 }
 


### PR DESCRIPTION
## Change summary

Stock `/config/scripts/vyos-postconfig-bootup.script` is created empty (comment header only). `/config/scripts/post-config.d/` is **never run**.

That is inconsistent with `/config/scripts/post-upgrade.d/`, which `vyos-router` already executes via `run-parts` after an upgrade. Operators who drop executable hooks in `post-config.d/` (Debian-style, same idea as `post-upgrade.d`) find they never run unless they replace the stock bootup script.

The stock script created by `debian/vyos-1x.postinst` now iterates regular, executable files in `/config/scripts/post-config.d/` in name order. Failures are logged (`logger -t vyos-postconfig`); boot continues.

Not `run-parts`: the default name filter rejects dots, so `foo.sh` would never run.

On upgrade, a **comments-only** stock file (the old empty template) is replaced so `restore_if_missing_postconfig_script` copies the runner. Any bootup script that contains real commands (operator customizations) is left alone. Quoted heredoc so `$DIR` / `$script` are not expanded at install time.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
* https://vyos.dev/T9232

## Related PR(s)
* https://github.com/vyos/vyos-documentation/pull/2217

## How to test / Smoketest result

No CLI smoketest covers the bootup script. Manual check on a stock image:

```bash
# After installing this image (or after boot restore of a comments-only stock script):
grep post-config.d /config/scripts/vyos-postconfig-bootup.script

mkdir -p /config/scripts/post-config.d
cat >/config/scripts/post-config.d/zz-marker.sh <<'EOF'
#!/bin/sh
logger -t post-config-d "ran zz-marker"
EOF
chmod +x /config/scripts/post-config.d/zz-marker.sh
reboot
# After boot:
journalctl -t post-config-d
```

Custom `/config/scripts/vyos-postconfig-bootup.script` files that already contain commands must be left unchanged across package install / reboot.

## Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
