### PR TITLE
T9240: container: Allow sharing host's cgroup namespace with container

### DIFF
--- a/interface-definitions/container.xml.in
+++ b/interface-definitions/container.xml.in
@@ -27,6 +27,12 @@
               <valueless/>
             </properties>
           </leafNode>
+          <leafNode name="allow-host-cgroups">
+            <properties>
+              <help>Allow sharing host cgroup namespace with container</help>
+              <valueless/>
+            </properties>
+          </leafNode>
           <leafNode name="capability">
             <properties>
               <help>Grant individual Linux capability to container instance</help>

--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -87,6 +87,7 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['name', cont_name, 'sysctl', 'parameter',
                                   'kernel.msgmax', 'value', '4096'])
         self.cli_set(base_path + ['name', cont_name, 'log-driver', 'journald'])
+        self.cli_set(base_path + ['name', cont_name, 'allow-host-cgroups'])
         # commit changes
         self.cli_commit()
 
@@ -104,6 +105,7 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         l = cmd_to_json(['container', 'inspect', cont_name])
         self.assertEqual(l['HostConfig']['LogConfig']['Type'], 'journald')
         self.assertEqual(l['Config']['Healthcheck']['Test'], ['NONE'])
+        self.assertEqual(l['HostConfig']['CgroupMode'], 'host')
 
     def test_healthcheck(self):
         cont_name = 'health-test'

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -475,6 +475,10 @@ def generate_run_arguments(name, container_config, host_ident, network_config):
     if 'allow_host_pid' in container_config:
       host_pid = '--pid host'
 
+    cgroupns = ''
+    if 'allow_host_cgroups' in container_config:
+      cgroupns = '--cgroupns host'
+
     name_server = []
     if 'name_server' in container_config:
         for ns in container_config['name_server']:
@@ -486,7 +490,7 @@ def generate_run_arguments(name, container_config, host_ident, network_config):
 
     container_base_cmd = f'--detach --interactive --tty --replace {capabilities} {privileged} --cpus {cpu_quota} {sysctl_opt} ' \
                          f'--memory {memory}m --shm-size {shared_memory}m --memory-swap 0 --restart {restart} --log-driver={log_driver} ' \
-                         f'--name {name} {hostname} {device} {port} {name_server} {volume} {tmpfs} {env_opt} {label} {uid} {host_pid}'
+                         f'--name {name} {hostname} {device} {port} {name_server} {volume} {tmpfs} {env_opt} {label} {uid} {host_pid} {cgroupns}'
 
     entrypoint = ''
     if 'entrypoint' in container_config:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Currently, the container instances created with podman defaults to `private` cgroup namespace (cgroup v2). Allowing to share host's cgroup namespace would, among other things, enable systemd support within container instances.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T9240

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
### Output of the smoketest
```
vyos@vyos:~$ python3 /usr/libexec/vyos/tests/smoke/cli/test_container.py 
test_api_socket (__main__.TestContainer.test_api_socket) ... ok
test_basic (__main__.TestContainer.test_basic) ... ok
test_colliding_host_interface_names (__main__.TestContainer.test_colliding_host_interface_names) ... ok
test_cpu_limit (__main__.TestContainer.test_cpu_limit) ... ok
test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... ok
test_healthcheck (__main__.TestContainer.test_healthcheck) ... ok
test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... ok
test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... ok
test_long_name_host_interface_uniqueness (__main__.TestContainer.test_long_name_host_interface_uniqueness) ... ok
test_name_server (__main__.TestContainer.test_name_server) ... ok
test_network_mtu (__main__.TestContainer.test_network_mtu) ... ok
test_network_types (__main__.TestContainer.test_network_types) ... ok
test_network_vrf (__main__.TestContainer.test_network_vrf) ... ok
test_no_name_server (__main__.TestContainer.test_no_name_server) ... ok
test_uid_gid (__main__.TestContainer.test_uid_gid) ... ok
test_user_defined_mac (__main__.TestContainer.test_user_defined_mac) ... ok

----------------------------------------------------------------------
Ran 16 tests in 716.742s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
