### PR TITLE
T9146: add initial set/call_dependents as exempt from possible cycle

### DIFF
--- a/python/vyos/configdep.py
+++ b/python/vyos/configdep.py
@@ -34,6 +34,7 @@ dependency_dir = os.path.join(directories['data'],
                               'config-mode-dependencies')
 
 dependency_list: list[typing.Callable] = []
+dependency_list_initial: list[typing.Callable] = []
 
 DEBUG = False
 
@@ -181,6 +182,15 @@ def called_as_dependent() -> bool:
             return True
     return False
 
+
+def parent_called_as_dependent() -> bool:
+    st = stack()[2:]
+    for f in st:
+        if f.filename == __file__:
+            return True
+    return False
+
+
 def graph_from_dependency_dict(d: dict) -> dict:
     g = {}
     for k in list(d):
@@ -214,3 +224,58 @@ def check_dependency_graph(dependency_dir: str = dependency_dir,
             d = dict_merge(json.load(f), d)
 
     return is_acyclic(d)
+
+
+def def_closure_initial(
+    target: str, config: 'Config', tagnode: typing.Optional[str] = None
+) -> typing.Callable:
+    def func_impl():
+        if tagnode is not None:
+            os.environ['VYOS_TAGNODE_VALUE'] = tagnode
+        run_config_mode_script(target, config)
+
+    tag_ext = f'_{tagnode}' if tagnode is not None else ''
+    func_impl.__name__ = f'{target}{tag_ext}'
+
+    return func_impl
+
+
+def set_dependents_initial(
+    target: str, config: 'Config', tagnode: typing.Optional[str] = None
+):
+    if parent_called_as_dependent():
+        return
+
+    k = caller_name()
+    lst = dependency_list_initial
+
+    func = def_closure(target, config, tagnode)
+    append_uniq(lst, func)
+
+    debug_print(
+        f'set_dependents_initial: caller {k}, current dependents {names_of(lst)}'
+    )
+
+
+def call_dependents_initial():
+    # pylint: disable=global-statement
+    global dependency_list_initial
+
+    if parent_called_as_dependent():
+        return
+
+    k = caller_name()
+    lst = dependency_list_initial
+    debug_print(
+        f'call_dependents_initial: caller {k}, remaining dependents {names_of(lst)}'
+    )
+
+    while lst:
+        f = lst.pop(0)
+        debug_print(f'calling: {f.__name__}')
+        try:
+            f()
+        except ConfigError as e:
+            s = f'dependent {f.__name__}: {str(e)}'
+            dependency_list_initial = []
+            raise ConfigError(s) from e


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Add a variant of 'initial' `set`/`call_dependents`, which only apply when the script is called natively, and not as a dependency. This allows an exemption from a possible dependency cycle as it only repeats a cycle at most once.

For example, invoking in `interface_ethernet.py`, a change to mtu would result in:

```
interface_ethernet ---------> vpp ---------> interface_ethernet
                  dep_initial        dep
```

without further repetition.

This is in DRAFT state pending further testing and discussion.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [X] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
