### PR TITLE
T9244: fix regression in setting console type on install

### DIFF
--- a/python/vyos/utils/kernel.py
+++ b/python/vyos/utils/kernel.py
@@ -165,13 +165,14 @@ def get_kernel_serial_console() -> Tuple[Optional[str], Optional[str], Optional[
     command line which was used during system boot.
     """
     import re
+    from vyos.utils.file import read_file
 
     cmdline_console_re = re.compile(
-        r'(?P<console_type>tty(?:S|AMA))(?P<console_num>\d+),(?P<console_speed>\d+)'
+        r'(?:^|\s)console=(?P<console_type>tty(?:S|AMA))(?P<console_num>\d+),(?P<console_speed>\d+)(?=\s|$)'
     )
 
-    console_value = get_kernel_boot_arg('console') or ''
-    if m := cmdline_console_re.search(console_value):
+    kernel_cmdline = read_file('/proc/cmdline')
+    if m := cmdline_console_re.search(kernel_cmdline):
         return (
             m.group('console_type'),
             m.group('console_num'),


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

T8868 introduced a very useful utility `get_kernel_boot_arg` with many uses. However, its use in `get_kernel_serial_console` is not appropriate, as it searches the boot cmdline right to left --- this returns an incomplete entry, resulting in `get_kernel_serial_console` returning `(None, None, None)`. This breaks console selection during image install.

Restore original implementation, as was.

Note that as the base default is ttyS0, this was not caught in integration tests. Setting console type KVM during installation revealed the issue, and will prove the fix.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [X] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
