### PR TITLE
ipsec: T9254: do not emit ESN transforms in IKE proposals

### DIFF
--- a/data/templates/ipsec/swanctl/l2tp.j2
+++ b/data/templates/ipsec/swanctl/l2tp.j2
@@ -2,7 +2,7 @@
 {% set l2tp_ike = ike_group[l2tp.ike_group] if l2tp.ike_group is vyos_defined else None %}
 {% set l2tp_esp = esp_group[l2tp.esp_group] if l2tp.esp_group is vyos_defined else None %}
     l2tp_remote_access {
-        proposals = {{ l2tp_ike | get_esp_ike_cipher | join(',') if l2tp_ike else l2tp_ike_default }}
+        proposals = {{ l2tp_ike | get_esp_ike_cipher(esn=False) | join(',') if l2tp_ike else l2tp_ike_default }}
         local_addrs = {{ l2tp_outside_address }}
         dpd_delay = 15s
         dpd_timeout = 45s

--- a/data/templates/ipsec/swanctl/peer.j2
+++ b/data/templates/ipsec/swanctl/peer.j2
@@ -19,7 +19,7 @@
 {% if peer_conf.childless is vyos_defined %}
         childless = {{ peer_conf.childless }}
 {% endif %}
-        proposals = {{ ike | get_esp_ike_cipher | join(',') }}
+        proposals = {{ ike | get_esp_ike_cipher(esn=False) | join(',') }}
         version = {{ ike.key_exchange[4:] if ike.key_exchange is vyos_defined else "0" }}
 {% if peer_conf.virtual_address is vyos_defined %}
         vips = {{ peer_conf.virtual_address | join(', ') }}

--- a/data/templates/ipsec/swanctl/profile.j2
+++ b/data/templates/ipsec/swanctl/profile.j2
@@ -5,7 +5,7 @@
 {% if profile_conf.bind.tunnel is vyos_defined %}
 {%     for interface in profile_conf.bind.tunnel %}
     dmvpn-{{ name }}-{{ interface }} {
-        proposals = {{ ike_group[profile_conf.ike_group] | get_esp_ike_cipher | join(',') }}
+        proposals = {{ ike_group[profile_conf.ike_group] | get_esp_ike_cipher(esn=False) | join(',') }}
         version = {{ ike.key_exchange[4:] if ike.key_exchange is vyos_defined else "0" }}
         rekey_time = {{ ike.lifetime }}s
         keyingtries = 0

--- a/data/templates/ipsec/swanctl/remote_access.j2
+++ b/data/templates/ipsec/swanctl/remote_access.j2
@@ -14,7 +14,7 @@
 {% endif %}
         remote_addrs = %any
         local_addrs = {{ rw_conf.local_address if rw_conf.local_address is not vyos_defined('any') else '%any' }} # dhcp:{{ rw_conf.dhcp_interface if rw_conf.dhcp_interface is vyos_defined else 'no' }}
-        proposals = {{ ike_group[rw_conf.ike_group] | get_esp_ike_cipher | join(',') }}
+        proposals = {{ ike_group[rw_conf.ike_group] | get_esp_ike_cipher(esn=False) | join(',') }}
         version = {{ ike.key_exchange[4:] if ike.key_exchange is vyos_defined else "0" }}
         send_certreq = no
 {% if rw_conf.authentication.always_send_cert is vyos_defined %}

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -483,7 +483,16 @@ def get_first_ike_dh_group(ike_group):
     return 'dh-group2' # Fallback on dh-group2
 
 @register_filter('get_esp_ike_cipher')
-def get_esp_ike_cipher(group_config, ike_group=None):
+def get_esp_ike_cipher(group_config, ike_group=None, esn=True):
+    """Render strongSwan proposal strings.
+
+    esn=True  : ESP/CHILD_SA proposals, where ESN transforms are meaningful
+    esn=False : IKE_SA proposals. ESN is a CHILD_SA transform (RFC 7296
+                section 3.3.2, Transform Type 5) and has no meaning in an
+                IKE_SA proposal. Emitting it there breaks interoperability
+                with implementations that reject the malformed payload
+                without replying at all (observed with Cisco FTD, T9254).
+    """
     pfs_lut = {
         'dh-group1'  : 'modp768',
         'dh-group2'  : 'modp1024',
@@ -530,10 +539,12 @@ def get_esp_ike_cipher(group_config, ike_group=None):
                     group = get_first_ike_dh_group(ike_group)
                 tmp += '-' + pfs_lut[group]
 
-            # For 'optional' and 'disabled' we need two values as
-            # proposal without '-esn'/'-noesn' is incompatible with
-            # proposals with any of them.
-            if 'esn' in proposal:
+            # ESP/CHILD_SA only. For 'optional' and 'disabled' we need two
+            # values as a proposal without '-esn'/'-noesn' is incompatible
+            # with proposals carrying any of them. This pairing is meaningless
+            # for an IKE_SA, which has no ESN transform at all - see the esn
+            # parameter above.
+            if esn and 'esn' in proposal:
                 if proposal['esn'] == 'required':
                     tmp += '-esn'
                 elif proposal['esn'] == 'optional':

--- a/smoketest/scripts/cli/test_vpn_ipsec.py
+++ b/smoketest/scripts/cli/test_vpn_ipsec.py
@@ -171,6 +171,26 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
     def tearDownPKI(self):
         self.cli_delete(['pki'])
 
+    def assertConfigLine(self, config, line):
+        """Assert that `line` occurs as a complete line in `config`.
+
+        assertIn(line, config) is a substring test, so a check for
+        'proposals = X' is also satisfied by the longer 'esp_proposals = X'.
+        Comparing against the list of stripped lines requires a whole-line
+        match, which cannot be satisfied by a longer key sharing the suffix.
+        """
+        expected = line.strip()
+        if '\n' in expected:
+            self.fail(f'assertConfigLine() expects a single line, got: {expected!r}')
+        lines = [entry.strip() for entry in config.splitlines()]
+        if expected not in lines:
+            key = expected.split('=', 1)[0].strip()
+            near = [entry for entry in lines if entry.split('=', 1)[0].strip() == key]
+            self.fail(
+                f'Line "{expected}" not found in the generated configuration'
+                + (f' - found instead: {near}' if near else '')
+            )
+
     def test_dhcp_fail_handling(self):
         # Skip process check - connection is not created for this test
         self.skip_process_check = True
@@ -246,13 +266,13 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         # Verify strongSwan configuration
         swanctl_conf = read_file(swanctl_file)
+        self.assertConfigLine(swanctl_conf, 'proposals = aes128-sha1-modp1024')
         swanctl_conf_lines = [
             f'version = 2',
             f'auth = psk',
             f'life_bytes = {life_bytes}',
             f'life_packets = {life_packets}',
             f'rekey_time = 28800s', # default value
-            f'proposals = aes128-sha1-modp1024-noesn,aes128-sha1-modp1024',
             f'esp_proposals = aes128-sha1-modp1024-noesn,aes128-sha1-modp1024',
             f'life_time = 3600s', # default value
             f'local_addrs = {local_address} # dhcp:no',
@@ -400,13 +420,13 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         # Verify strongSwan configuration
         swanctl_conf = read_file(swanctl_file)
+        self.assertConfigLine(swanctl_conf, 'proposals = aes128-sha1-modp1024')
         swanctl_conf_lines = [
             f'version = 2',
             f'auth = psk',
             f'life_bytes = {life_bytes}',
             f'life_packets = {life_packets}',
             f'rekey_time = 28800s',  # default value
-            f'proposals = aes128-sha1-modp1024-noesn,aes128-sha1-modp1024',
             f'esp_proposals = aes128-sha1-modp1024-noesn,aes128-sha1-modp1024',
             f'life_time = 3600s',  # default value
             f'local_addrs = {local_address} # dhcp:no',
@@ -479,10 +499,12 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         # Verify strongSwan configuration
         swanctl_conf = read_file(swanctl_file)
+        self.assertConfigLine(
+            swanctl_conf, 'proposals = aes128-sha1-modp1024,aes256-sha1-modp1536'
+        )
         swanctl_conf_lines = [
             'version = 2',
             'auth = psk',
-            'proposals = aes128-sha1-modp1024-noesn,aes128-sha1-modp1024,aes256-sha1-modp1536-noesn,aes256-sha1-modp1536',
             'esp_proposals = aes128-sha1-modp2048-noesn,aes128-sha1-modp2048,aes256-sha1-modp2048-noesn,aes256-sha1-modp2048',
             'life_time = 3600s',
             'mode = transport',  # ensure transport mode is used
@@ -546,10 +568,10 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         # not have a lookup key configuration - thus we shift the key by one
         # to also support a vti0 interface
         if_id = str(int(if_id) +1)
+        self.assertConfigLine(swanctl_conf, 'proposals = aes128-sha1-modp1024')
         swanctl_conf_lines = [
             f'version = 2',
             f'auth = psk',
-            f'proposals = aes128-sha1-modp1024-noesn,aes128-sha1-modp1024',
             f'esp_proposals = aes128-sha1-modp1024-noesn,aes128-sha1-modp1024',
             f'local_addrs = {local_address} # dhcp:no',
             f'mobike = no',
@@ -622,10 +644,10 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         # not have a lookup key configuration - thus we shift the key by one
         # to also support a vti0 interface
         if_id = str(int(if_id) +1)
+        self.assertConfigLine(swanctl_conf, 'proposals = aes128-sha1-modp1024')
         swanctl_conf_lines = [
             f'version = 2',
             f'auth = psk',
-            f'proposals = aes128-sha1-modp1024-noesn,aes128-sha1-modp1024',
             f'esp_proposals = aes128-sha1-modp1024-noesn,aes128-sha1-modp1024',
             f'local_addrs = {local_address} # dhcp:no',
             f'mobike = no',
@@ -758,6 +780,9 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         # Verify strongSwan configuration
         swanctl_conf = read_file(swanctl_file)
+        self.assertConfigLine(
+            swanctl_conf, 'proposals = aes256gcm128-sha384-prfsha384-ecp384'
+        )
         swanctl_conf_lines = [
             f'ppk_id = ppk-test',
             f'ppk_required = yes',
@@ -765,7 +790,6 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             f'version = 2',
             f'auth = psk',
             f'rekey_time = 86400s',
-            f'proposals = aes256gcm128-sha384-prfsha384-ecp384-noesn,aes256gcm128-sha384-prfsha384-ecp384',
             f'esp_proposals = aes256gcm128-sha384-ecp384-noesn,aes256gcm128-sha384-ecp384',
             f'life_time = 28800s',  # default value
             f'local_addrs = {local_address} # dhcp:no',
@@ -868,8 +892,8 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         swanctl_conf = read_file(swanctl_file)
+        self.assertConfigLine(swanctl_conf, 'proposals = aes256-sha1-prfsha1-modp1024')
         swanctl_lines = [
-            f'proposals = aes256-sha1-prfsha1-modp1024-noesn,aes256-sha1-prfsha1-modp1024',
             f'version = 1',
             f'rekey_time = {ike_lifetime}s',
             f'rekey_time = {esp_lifetime}s',
@@ -923,6 +947,7 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         # not have a lookup key configuration - thus we shift the key by one
         # to also support a vti0 interface
         if_id = str(int(if_id) +1)
+        self.assertConfigLine(swanctl_conf, 'proposals = aes128-sha1-modp1024')
         swanctl_lines = [
             f'{connection_name}',
             f'version = 0', # key-exchange not set - defaulting to 0 for ikev1 and ikev2
@@ -932,7 +957,6 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
             f'id = "{peer_name}"',
             f'auth = pubkey',
             f'certs = {peer_name}.pem',
-            f'proposals = aes128-sha1-modp1024-noesn,aes128-sha1-modp1024',
             f'esp_proposals = aes128-sha1-modp1024-noesn,aes128-sha1-modp1024',
             f'local_addrs = {local_address} # dhcp:no',
             f'remote_addrs = {peer_ip}',
@@ -1184,11 +1208,14 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         # verify applied configuration
         swanctl_conf = read_file(swanctl_file)
+        self.assertConfigLine(
+            swanctl_conf,
+            'proposals = aes256-sha512-modp2048,aes256-sha256-modp2048,aes256-sha256-modp1024,aes128gcm128-sha256-modp2048',
+        )
         swanctl_lines = [
             f'{conn_name}',
             f'remote_addrs = %any',
             f'local_addrs = {local_address}',
-            f'proposals = aes256-sha512-modp2048-noesn,aes256-sha512-modp2048,aes256-sha256-modp2048-noesn,aes256-sha256-modp2048,aes256-sha256-modp1024-noesn,aes256-sha256-modp1024,aes128gcm128-sha256-modp2048-noesn,aes128gcm128-sha256-modp2048',
             f'version = 2',
             f'send_certreq = no',
             f'rekey_time = {ike_lifetime}s',
@@ -1304,11 +1331,14 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         # verify applied configuration
         swanctl_conf = read_file(swanctl_file)
+        self.assertConfigLine(
+            swanctl_conf,
+            'proposals = aes256-sha512-modp2048,aes256-sha256-modp2048,aes256-sha256-modp1024,aes128gcm128-sha256-modp2048',
+        )
         swanctl_lines = [
             f'{conn_name}',
             f'remote_addrs = %any',
             f'local_addrs = {local_address}',
-            f'proposals = aes256-sha512-modp2048-noesn,aes256-sha512-modp2048,aes256-sha256-modp2048-noesn,aes256-sha256-modp2048,aes256-sha256-modp1024-noesn,aes256-sha256-modp1024,aes128gcm128-sha256-modp2048-noesn,aes128gcm128-sha256-modp2048',
             f'version = 2',
             f'send_certreq = no',
             f'rekey_time = {ike_lifetime}s',
@@ -1420,11 +1450,14 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         # verify applied configuration
         swanctl_conf = read_file(swanctl_file)
+        self.assertConfigLine(
+            swanctl_conf,
+            'proposals = aes256-sha512-modp2048,aes256-sha256-modp2048,aes256-sha256-modp1024,aes128gcm128-sha256-modp2048',
+        )
         swanctl_lines = [
             f'{conn_name}',
             f'remote_addrs = %any',
             f'local_addrs = {local_address}',
-            f'proposals = aes256-sha512-modp2048-noesn,aes256-sha512-modp2048,aes256-sha256-modp2048-noesn,aes256-sha256-modp2048,aes256-sha256-modp1024-noesn,aes256-sha256-modp1024,aes128gcm128-sha256-modp2048-noesn,aes128gcm128-sha256-modp2048',
             f'version = 2',
             f'send_certreq = no',
             f'rekey_time = {ike_lifetime}s',
@@ -1618,11 +1651,14 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         # verify applied configuration
         swanctl_conf = read_file(swanctl_file)
+        self.assertConfigLine(
+            swanctl_conf,
+            'proposals = aes256-sha512-modp2048,aes256-sha256-modp2048,aes256-sha256-modp1024,aes128gcm128-sha256-modp2048',
+        )
         swanctl_lines = [
             f'{conn_name}',
             f'remote_addrs = %any',
             f'local_addrs = {local_address}',
-            f'proposals = aes256-sha512-modp2048-noesn,aes256-sha512-modp2048,aes256-sha256-modp2048-noesn,aes256-sha256-modp2048,aes256-sha256-modp1024-noesn,aes256-sha256-modp1024,aes128gcm128-sha256-modp2048-noesn,aes128gcm128-sha256-modp2048',
             f'version = 2',
             f'send_certreq = no',
             f'rekey_time = 0s',
@@ -1731,11 +1767,14 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         # verify applied configuration
         swanctl_conf = read_file(swanctl_file)
+        self.assertConfigLine(
+            swanctl_conf,
+            'proposals = aes256-sha512-modp2048,aes256-sha256-modp2048,aes256-sha256-modp1024,aes128gcm128-sha256-modp2048',
+        )
         swanctl_lines = [
             f'{conn_name}',
             f'remote_addrs = %any',
             f'local_addrs = {local_address}',
-            f'proposals = aes256-sha512-modp2048-noesn,aes256-sha512-modp2048,aes256-sha256-modp2048-noesn,aes256-sha256-modp2048,aes256-sha256-modp1024-noesn,aes256-sha256-modp1024,aes128gcm128-sha256-modp2048-noesn,aes128gcm128-sha256-modp2048',
             f'version = 2',
             f'send_certreq = no',
             f'rekey_time = {ike_lifetime}s',
@@ -1864,11 +1903,14 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         # to also support a vti0 interface
         if_id = str(int(if_id) +1)
 
+        self.assertConfigLine(
+            swanctl_conf,
+            'proposals = aes256-sha512-modp2048,aes256-sha256-modp2048,aes256-sha256-modp1024,aes128gcm128-sha256-modp2048',
+        )
         swanctl_lines = [
             f'{conn_name}',
             f'remote_addrs = %any',
             f'local_addrs = {local_address}',
-            f'proposals = aes256-sha512-modp2048-noesn,aes256-sha512-modp2048,aes256-sha256-modp2048-noesn,aes256-sha256-modp2048,aes256-sha256-modp1024-noesn,aes256-sha256-modp1024,aes128gcm128-sha256-modp2048-noesn,aes128gcm128-sha256-modp2048',
             f'version = 2',
             f'send_certreq = no',
             f'rekey_time = {ike_lifetime}s',
@@ -2009,12 +2051,11 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
 
         # esn - default, disabled
         swanctl_conf = read_file(swanctl_file)
-        swanctl_conf_lines = [
-            f'proposals = aes256-sha512-modp2048-noesn,aes256-sha512-modp2048',
-            f'esp_proposals = aes256-sha512-modp2048-noesn,aes256-sha512-modp2048',
-        ]
-        for line in swanctl_conf_lines:
-            self.assertIn(line, swanctl_conf)
+        self.assertConfigLine(swanctl_conf, 'proposals = aes256-sha512-modp2048')
+        self.assertIn(
+            'esp_proposals = aes256-sha512-modp2048-noesn,aes256-sha512-modp2048',
+            swanctl_conf,
+        )
 
         # esn - optional
         self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '1',  'esn', 'optional'])
@@ -2022,12 +2063,11 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         swanctl_conf = read_file(swanctl_file)
-        swanctl_conf_lines = [
-            f'proposals = aes256-sha512-modp2048-esn-noesn,aes256-sha512-modp2048',
-            f'esp_proposals = aes256-sha512-modp2048-esn-noesn,aes256-sha512-modp2048',
-        ]
-        for line in swanctl_conf_lines:
-            self.assertIn(line, swanctl_conf)
+        self.assertConfigLine(swanctl_conf, 'proposals = aes256-sha512-modp2048')
+        self.assertIn(
+            'esp_proposals = aes256-sha512-modp2048-esn-noesn,aes256-sha512-modp2048',
+            swanctl_conf,
+        )
 
         # esn - required
         self.cli_set(base_path + ['ike-group', ike_group, 'proposal', '1',  'esn', 'required'])
@@ -2035,12 +2075,8 @@ class TestVPNIPsec(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         swanctl_conf = read_file(swanctl_file)
-        swanctl_conf_lines = [
-            f'proposals = aes256-sha512-modp2048-esn',
-            f'esp_proposals = aes256-sha512-modp2048-esn',
-        ]
-        for line in swanctl_conf_lines:
-            self.assertIn(line, swanctl_conf)
+        self.assertConfigLine(swanctl_conf, 'proposals = aes256-sha512-modp2048')
+        self.assertIn('esp_proposals = aes256-sha512-modp2048-esn', swanctl_conf)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Change summary**

I have two VyOS routers in an HA pair with the same configuration. One runs 2026.06.20-0050-rolling and the IPsec tunnel to a Cisco FTD comes up fine. The other ran 2026.08.14 and then 2026.08.27, and the tunnel never establishes on either.

strongSwan is the same version on both (6.0.6-1+vyos0). The difference is in the generated swanctl.conf. The newer images add -noesn variants to the proposals line, so four proposals instead of two, and the IKE_SA_INIT grows from 340 to 436 bytes.

ESN is a CHILD_SA transform (RFC 7296, Transform Type 5). It does not belong in an IKE_SA proposal. The FTD drops the packet without answering: no NO_PROPOSAL_CHOSEN, no INVALID_KE_PAYLOAD, nothing. So the tunnel never comes up and there is nothing in the logs to explain it.

The fix adds an esn parameter to get_esp_ike_cipher(), defaulting to True so ESP output does not change, and passes esn=False at the four places that render IKE proposals: peer.j2, profile.j2, remote_access.j2 and l2tp.j2. The five esp_proposals call sites are untouched.

**how-to test**

On the FTD I captured the outside interface while the affected node tried to connect. Four IKE_SA_INIT packets of 436 bytes arrived and the FTD never replied. A minute later the working node sent a 340-byte one from the same public address and got an answer in 6 ms.

I edited the proposals line in the generated swanctl.conf by hand to remove the -noesn entries and ran swanctl --load-all. The tunnel came up within seconds. Nothing else was changed. That node had not been able to establish it for weeks.

I could not run the smoketests. They need a live VyOS instance and both my routers are on the June build. I updated the proposals assertions in test_vpn_ipsec.py to match the new output but they have not been executed, so they are worth a careful look. The esp_proposals assertions are unchanged.
