### PR TITLE
keepalived: T9256: keep incomplete FIFO lines between reads

### DIFF
--- a/src/system/keepalived-fifo.py
+++ b/src/system/keepalived-fifo.py
@@ -150,6 +150,10 @@ class KeepalivedFifo:
     def pipe_wait(self):
         logger.debug('Message reading start')
         self.pipe_read = os.open(self.pipe_path, os.O_RDONLY | os.O_NONBLOCK)
+        # keepalived may write more than we read in one call, and a read can
+        # land in the middle of a line. Hold the incomplete trailing line here
+        # and prepend it to the next read, so only whole lines are queued.
+        buffer = ''
         while self.stopme.is_set() is False:
             # sleep a bit to not produce 100% CPU load
             time.sleep(0.250)
@@ -157,11 +161,20 @@ class KeepalivedFifo:
                 # try to read a message from PIPE
                 message = os.read(self.pipe_read, 500)
                 if message:
-                    # split PIPE content by lines and put them into queue
-                    for line in message.decode().strip().splitlines():
-                        self.message_queue.put(line)
+                    buffer += message.decode()
+                    # split PIPE content by lines and put them into queue,
+                    # keeping the last (possibly incomplete) line for later
+                    lines = buffer.split('\n')
+                    buffer = lines.pop()
+                    queued = False
+                    for line in lines:
+                        line = line.strip()
+                        if line:
+                            self.message_queue.put(line)
+                            queued = True
                     # set new message flag to start processing
-                    self.message_event.set()
+                    if queued:
+                        self.message_event.set()
             except Exception as err:
                 # ignore the "Resource temporarily unavailable" error
                 if err.errno != 11:


### PR DESCRIPTION
**Change summary**

`keepalived-fifo.py`'s `pipe_wait()` reads the notify FIFO in 500-byte chunks and discards any partial line between reads. When a VRRP transition produces more notifications than fit in one read, the boundary falls mid-line, truncating messages like `GROUP` into `ROUP` and silently dropping the transition. This keeps a residual buffer across reads and only queues complete, non-empty lines.

This is defect 2 of T9256. Defect 1 (the notify regex rejecting VRRP group/instance names containing `:`) is intentionally out of scope here - it needs a maintainer decision on regex-widening vs. reject-at-config-time, tracked separately on T9256.

**Types of changes**

- [x] Bug fix (non-breaking change which fixes an issue)

**Related Task(s)**

* https://vyos.dev/T9256

**Related PR(s)**

None.

**How to test / Smoketest result**

Running in production on an HA pair (14 VRRP instances, IPv4+IPv6, single sync group) since 2026-08-27. Before the fix, transition-script fired roughly one time in three; since the fix, every transition fires reliably in both directions.

CI integration passed on this PR (CLI smoketests, CLI smoketests VPP, config tests, config tests VPP, RAID1, TPM).

**Checklist:**

- [x] I have read the CONTRIBUTING document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components SMOKETESTS if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly

