### PR TITLE
T9258: Improve blackbox-exporter ICMP smoketest for VRF binding

### DIFF
--- a/smoketest/scripts/cli/test_service_monitoring_prometheus.py
+++ b/smoketest/scripts/cli/test_service_monitoring_prometheus.py
@@ -228,6 +228,8 @@ class TestMonitoringPrometheus(VyOSUnitTestSHIM.TestCase):
 
         # VRF + ICMP should use setpriv with net_raw capabilities
         self.cli_set(['vrf', 'name', vrf_name, 'table', '1111'])
+        # Move the listen interface into the VRF so the exporter can bind
+        self.cli_set(['interfaces', 'dummy', listen_if, 'vrf', vrf_name])
         self.cli_set(be_path + ['vrf', vrf_name])
         self.cli_set(
             be_path
@@ -242,7 +244,11 @@ class TestMonitoringPrometheus(VyOSUnitTestSHIM.TestCase):
         self.assertIn('--inh-caps=+net_raw', file_content)
         self.assertNotIn('AmbientCapabilities=CAP_NET_RAW', file_content)
 
+        # Ensure the exporter actually started under setpriv in the VRF
+        self.assertTrue(process_named_running(BLACKBOX_EXPORTER_PROCESS_NAME))
+
         # Cleanup VRF
+        self.cli_delete(['interfaces', 'dummy', listen_if, 'vrf'])
         self.cli_delete(['vrf', 'name', vrf_name])
 
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): smoketest improvement

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T9258
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
vyos@vyos:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_monitoring
test_05_blackbox_exporter_with_icmp (__main__.TestMonitoringPrometheus.test_05_blackbox_exporter_with_icmp) ... ok

----------------------------------------------------------------------
Ran 1 test in 25.003s

OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
