### PR TITLE
smoketest: T9014: guard architecture specific smoketests

### DIFF
--- a/python/vyos/utils/cpu.py
+++ b/python/vyos/utils/cpu.py
@@ -120,3 +120,55 @@ def get_available_cpus():
 def get_half_cpus():
     """ return 1/2 of the numbers of available CPUs """
     return max(1, os.cpu_count() // 2)
+
+
+# Aliases for the architecture names reported by platform.machine()
+_arch_alias = {
+    'x86_64': 'amd64',
+    'amd64': 'amd64',
+    'aarch64': 'arm64',
+    'arm64': 'arm64',
+}
+
+def _normalize_arch(arch):
+    return _arch_alias.get(arch.lower(), arch.lower())
+
+def get_cpu_arch():
+    """ Returns the normalized CPU architecture of the running system,
+        e.g. "amd64" or "arm64". Architectures we do not know about are
+        returned as reported by platform.machine()
+    """
+    import platform
+
+    return _normalize_arch(platform.machine())
+
+def cpu_arch(*architectures):
+    """ Decorator restricting a unittest TestCase or test method to a list
+        of CPU architectures. If the current architecture is not supported,
+        the test is skipped instead of failing.
+
+        Both the native names (x86_64, aarch64) and the Debian names
+        (amd64, arm64) are accepted.
+
+        Usage:
+            @cpu_arch('amd64')
+            def test_intel_modules(self):
+                ...
+
+            @cpu_arch('amd64', 'arm64')
+            class TestFoo(unittest.TestCase):
+                ...
+    """
+    import unittest
+
+    # Allow both cpu_arch('amd64', 'arm64') and cpu_arch(['amd64', 'arm64'])
+    if len(architectures) == 1 and isinstance(architectures[0], (list, tuple, set)):
+        architectures = tuple(architectures[0])
+
+    supported = {_normalize_arch(arch) for arch in architectures}
+    current = get_cpu_arch()
+
+    reason = (f'Only supported on CPU architecture: {", ".join(sorted(supported))} '
+              f'(running on {current})')
+
+    return unittest.skipUnless(current in supported, reason)

--- a/smoketest/scripts/cli/test_system_console.py
+++ b/smoketest/scripts/cli/test_system_console.py
@@ -22,10 +22,16 @@ from vyos.configsession import ConfigSessionError
 from vyos.system import disk
 from vyos.system.grub import CFG_VYOS_VARS
 from vyos.system.grub import vars_read
+from vyos.utils.cpu import get_cpu_arch
 from vyos.xml_ref import default_value
 
 base_path = ['system', 'console']
-serial_console = 'ttyS0'
+# The serial console device is platform dependent. On amd64 this is the 8250
+# UART at ttyS0, while arm64 systems use the PL011 UART exposed as ttyAMA0.
+# A device that does not exist is not a TTY and thus never becomes the Kernel
+# boot console - so we must test with the device of the running platform.
+serial_console = 'ttyAMA0' if get_cpu_arch() == 'arm64' else 'ttyS0'
+console_type = serial_console[:-1]
 default_speed = default_value(base_path + ['device', serial_console, 'speed'])
 
 def get_grub_vars() -> dict:
@@ -51,8 +57,8 @@ class TestSystemConsole(VyOSUnitTestSHIM.TestCase):
         super().tearDown()
 
     def test_multiple_kernel_consoles(self):
-        self.cli_set(base_path + ['device', 'ttyS1', 'kernel'])
-        self.cli_set(base_path + ['device', 'ttyS2', 'kernel'])
+        self.cli_set(base_path + ['device', f'{console_type}1', 'kernel'])
+        self.cli_set(base_path + ['device', f'{console_type}2', 'kernel'])
 
         # Only one console can have 'kernel'
         with self.assertRaises(ConfigSessionError):
@@ -71,8 +77,8 @@ class TestSystemConsole(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         grub_vars = get_grub_vars()
-        # We moved the Kernel boot console to ttyS0
-        self.assertEqual(grub_vars['console_type'], serial_console[:-1])
+        # We moved the Kernel boot console to the platform serial device
+        self.assertEqual(grub_vars['console_type'], console_type)
         self.assertEqual(grub_vars['console_num'], serial_console[-1])
         self.assertEqual(grub_vars['console_speed'], default_speed)
 

--- a/smoketest/scripts/cli/test_system_login.py
+++ b/smoketest/scripts/cli/test_system_login.py
@@ -34,6 +34,7 @@ from vyos.configquery import ConfigTreeQuery
 from vyos.utils.auth import DEFAULT_PASSWORD
 from vyos.utils.auth import get_current_user
 from vyos.utils.auth import get_local_passwd_entries
+from vyos.utils.cpu import cpu_arch
 from vyos.utils.process import cmdl
 from vyos.utils.file import read_file
 from vyos.utils.file import write_file
@@ -291,15 +292,31 @@ class TestSystemLogin(VyOSUnitTestSHIM.TestCase):
 
         self.cli_delete(base_path + ['user', ssh_user])
 
-    def test_radius_kernel_features(self):
-        # T2886: RADIUS requires some Kernel options to be present
+    def _verify_kernel_options(self, options: list):
         kernel_config = GzipFile('/proc/config.gz').read().decode('UTF-8')
-
-        # T2886 - RADIUS authentication - check for statically compiled options
-        options = ['CONFIG_AUDIT', 'CONFIG_AUDITSYSCALL', 'CONFIG_AUDIT_ARCH']
-
         for option in options:
             self.assertIn(f'{option}=y', kernel_config)
+
+    def test_radius_kernel_features(self):
+        # T2886: RADIUS requires some Kernel options to be present
+        # Check for statically compiled options common to all architectures
+        self._verify_kernel_options(['CONFIG_AUDIT', 'CONFIG_AUDITSYSCALL'])
+
+    # The Kernel provides the audit subsystem either as an architecture
+    # specific (CONFIG_AUDIT_ARCH) or as a generic implementation
+    # (CONFIG_AUDIT_GENERIC) - "config AUDIT_GENERIC" in lib/Kconfig depends
+    # on "!AUDIT_ARCH", thus we must test for the proper one per architecture.
+    @cpu_arch('amd64')
+    def test_radius_kernel_features_amd64(self):
+        # T2886: x86 implements its own audit code
+        self._verify_kernel_options(['CONFIG_AUDIT_ARCH'])
+
+    @cpu_arch('arm64')
+    def test_radius_kernel_features_arm64(self):
+        # T2886: arm64 has no CONFIG_AUDIT_ARCH and uses the generic
+        # implementation instead
+        self._verify_kernel_options(['CONFIG_AUDIT_GENERIC',
+                                     'CONFIG_AUDIT_ARCH_COMPAT_GENERIC'])
 
     def test_system_login_radius_ipv4(self):
         radius_servers = ['100.64.0.4', '100.64.0.5']

--- a/smoketest/scripts/system/test_kernel_options.py
+++ b/smoketest/scripts/system/test_kernel_options.py
@@ -16,14 +16,11 @@
 
 import re
 import os
-import platform
 import unittest
 
+from vyos.utils.cpu import cpu_arch
 from vyos.utils.kernel import check_kmod
 
-ARCH = platform.machine()
-IS_ARM64 = ARCH in ('aarch64', 'arm64')
-kernel = platform.release()
 class TestKernelModules(unittest.TestCase):
     """ VyOS makes use of a lot of Kernel drivers, modules and features. The
     required modules which are essential for VyOS should be tested that they are
@@ -84,8 +81,14 @@ class TestKernelModules(unittest.TestCase):
             'CONFIG_VIRTIO_NET', 'CONFIG_VIRTIO_CONSOLE',
             'CONFIG_VIRTIO', 'CONFIG_VIRTIO_PCI',
             'CONFIG_VIRTIO_BALLOON', 'CONFIG_CRYPTO_DEV_VIRTIO',
-            'CONFIG_X86_PLATFORM_DEVICES'
             ]
+        for option in options_to_check:
+            tmp = re.findall(f'{option}=(y|m)', self._config_data)
+            self.assertTrue(tmp)
+
+    @cpu_arch('amd64')
+    def test_x86_platform_devices(self):
+        options_to_check = ['CONFIG_X86_PLATFORM_DEVICES']
         for option in options_to_check:
             tmp = re.findall(f'{option}=(y|m)', self._config_data)
             self.assertTrue(tmp)
@@ -131,6 +134,7 @@ class TestKernelModules(unittest.TestCase):
             tmp = re.findall(f'{option}=y', self._config_data)
             self.assertTrue(tmp)
 
+    @cpu_arch('amd64')
     def test_amd_pstate(self):
         # AMD pstate driver required as we have "set system option kernel amd-pstate-driver"
         for option in ['CONFIG_X86_AMD_PSTATE']:
@@ -210,11 +214,8 @@ class TestKernelModules(unittest.TestCase):
             tmp = re.findall(f'{option}=(y|m)', self._config_data)
             self.assertTrue(tmp)
 
+    @cpu_arch('arm64')
     def test_arm64(self):
-        # Only required on arm64 platforms
-        if not IS_ARM64:
-            self.skipTest('Not an arm64 platform')
-
         # Marvell CN9130: CONFIG_MVPP2, CN10308
         required_options = [
             'CONFIG_MVPP2',
@@ -236,10 +237,8 @@ class TestKernelModules(unittest.TestCase):
                     tmp, msg=f'{option} must be enabled (=y or =m) on arm64'
                 )
 
+    @cpu_arch('amd64')
     def test_hypervisor_hyperv(self):
-        if IS_ARM64:
-            self.skipTest('Hyper-V only available on X86 platform')
-
         options_to_check = ['CONFIG_HYPERV_VSOCKETS', 'CONFIG_HYPERV_STORAGE',
                             'CONFIG_HYPERV_NET', 'CONFIG_HYPERV_KEYBOARD',
                             'CONFIG_HYPERV_TIMER', 'CONFIG_HYPERV_UTILS',
@@ -257,10 +256,8 @@ class TestKernelModules(unittest.TestCase):
         tmp = re.findall(r'CONFIG_HYPERV_VTL_MODE=(y|m)', self._config_data)
         self.assertFalse(tmp)
 
+    @cpu_arch('amd64')
     def test_hypervisor_vmware(self):
-        if IS_ARM64:
-            self.skipTest('VMware only available on X86 platform')
-
         options_to_check = ['CONFIG_VMWARE_VMCI_VSOCKETS', 'CONFIG_VMXNET3',
                             'CONFIG_VMWARE_BALLOON', 'CONFIG_VMWARE_VMCI',
                             'CONFIG_VMWARE_PVSCSI']

--- a/smoketest/scripts/system/test_module_load.py
+++ b/smoketest/scripts/system/test_module_load.py
@@ -15,6 +15,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+
+from vyos.utils.cpu import cpu_arch
 from vyos.utils.process import cmdl
 
 modules = {
@@ -27,22 +29,29 @@ modules = {
 }
 
 class TestKernelModules(unittest.TestCase):
-    def test_load_modules(self):
-        success = True
+    def _load_modules(self, name):
         not_found = []
-        for msk in modules:
-            not_found = []
-            ms = modules[msk]
-            for m in ms:
-                # We want to uncover all modules that fail,
-                # not fail at the first one
-                try:
-                    cmdl(['modprobe', m])
-                except:
-                    success = False
-                    not_found.append(m)
+        for module in modules[name]:
+            # We want to uncover all modules that fail,
+            # not fail at the first one
+            try:
+                cmdl(['modprobe', module])
+            except:
+                not_found.append(module)
 
-            self.assertTrue(success, 'One or more modules not found: ' + ', '.join(not_found))
+        self.assertFalse(not_found, f'One or more {name} modules not found: '
+                                    + ', '.join(not_found))
+
+    @cpu_arch('amd64')
+    def test_load_modules_intel(self):
+        self._load_modules('intel')
+
+    @cpu_arch('amd64')
+    def test_load_modules_intel_qat(self):
+        self._load_modules('intel_qat')
+
+    def test_load_modules_accel_ppp(self):
+        self._load_modules('accel_ppp')
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

VyOS ships for both amd64 and arm64, but several smoketests are only valid on one of them and fail on the other.

Add a `cpu_arch()` decorator plus `get_cpu_arch()` to `vyos.utils.cpu`. It takes a list of supported CPU architectures - a test without the decorator keeps running everywhere, a decorated test is skipped on any other architecture with a message naming both the supported and the current one. Both native (`x86_64`, `aarch64`) and Debian (`amd64`, `arm64`) names are accepted.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9014

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
