### PR TITLE
T9273: Add Telegraf global_tags option configurable

### DIFF
--- a/data/templates/telegraf/telegraf.j2
+++ b/data/templates/telegraf/telegraf.j2
@@ -14,6 +14,12 @@
   logfile = ""
   hostname = "{{ hostname }}"
   omit_hostname = false
+{% if global_tag is vyos_defined %}
+[global_tags]
+{%     for tag, tag_config in global_tag.items() %}
+  {{ tag }} = "{{ tag_config.value }}"
+{%     endfor %}
+{% endif %}
 {% if azure_data_explorer is vyos_defined %}
 ### Azure Data Explorer ###
 [[outputs.azure_data_explorer]]

--- a/interface-definitions/service_monitoring_telegraf.xml.in
+++ b/interface-definitions/service_monitoring_telegraf.xml.in
@@ -13,6 +13,26 @@
               <priority>1280</priority>
             </properties>
             <children>
+              <tagNode name="global-tag">
+                <properties>
+                  <help>Global tag applied to every metric collected by this agent</help>
+                  <constraint>
+                    #include <include/constraint/alpha-numeric-hyphen-underscore.xml.i>
+                  </constraint>
+                  <constraintErrorMessage>Tag name is limited to alphanumerical characters and can contain hyphens and underscores</constraintErrorMessage>
+                </properties>
+                <children>
+                  <leafNode name="value">
+                    <properties>
+                      <help>Value of this global tag</help>
+                      <valueHelp>
+                        <format>txt</format>
+                        <description>Tag value</description>
+                      </valueHelp>
+                    </properties>
+                  </leafNode>
+                </children>
+              </tagNode>
               <node name="influxdb">
                 <properties>
                   <help>Output plugin InfluxDB</help>

--- a/smoketest/scripts/cli/test_service_monitoring_telegraf.py
+++ b/smoketest/scripts/cli/test_service_monitoring_telegraf.py
@@ -91,6 +91,34 @@ class TestMonitoringTelegraf(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'username = "{loki_username}"', config)
         self.assertIn(f'password = "{loki_password}"', config)
 
+    def test_03_global_tags(self):
+        tags = {
+            'role': 'edge-router',
+            'site-id': 'fra01',
+        }
+
+        for tag, value in tags.items():
+            self.cli_set(base_path + ['global-tag', tag, 'value', value])
+        self.cli_set(base_path + ['prometheus-client'])
+
+        # commit changes
+        self.cli_commit()
+
+        config = read_file(TELEGRAF_CONF)
+
+        self.assertIn(f'[global_tags]', config)
+        for tag, value in tags.items():
+            self.assertIn(f'{tag} = "{value}"', config)
+
+    def test_04_global_tag_no_value(self):
+        self.cli_set(base_path + ['prometheus-client'])
+        self.cli_set(base_path + ['global-tag', 'incomplete-tag'])
+        # value not set - commit must fail
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(base_path + ['global-tag', 'incomplete-tag'])
+        self.cli_commit()
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())

--- a/src/conf_mode/service_monitoring_telegraf.py
+++ b/src/conf_mode/service_monitoring_telegraf.py
@@ -126,6 +126,12 @@ def verify(monitoring):
 
     verify_vrf(monitoring)
 
+    # Verify global-tag
+    if 'global_tag' in monitoring:
+        for tag, tag_config in monitoring['global_tag'].items():
+            if 'value' not in tag_config:
+                raise ConfigError(f'Global tag "{tag}" has no value assigned!')
+
     # Verify influxdb
     if 'influxdb' in monitoring:
         if 'authentication' not in monitoring['influxdb'] or \


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Adds Telegraf global_tags support - static tags stamped onto every metric.

```
set service monitoring telegraf global-tag <tag-name> value <tag-value>
```
Rendered as a [global_tags] block in telegraf.conf, applied ahead of all outputs.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T9273

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

Configure telegraf with global tags and check those values
```
set service monitoring telegraf global-tag role value 'core-router'
set service monitoring telegraf global-tag site-id value 'frank01'
set service monitoring telegraf prometheus-client
```
Expected the `role` and `site-id` in the metrics
```
vyos@r14# curl localhost:9273/metrics | tail -5
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  235k    0  235k    0     0  45.2M      0 --:--:-- --:--:-- --:--:-- 46.0M
systemd_units_sub_code{active="inactive",host="r14",load="not-found",name="plymouth-start.service",role="core-router",site_id="frank01",sub="dead"} 1
systemd_units_sub_code{active="inactive",host="r14",load="not-found",name="systemd-hwdb-update.service",role="core-router",site_id="frank01",sub="dead"} 1
systemd_units_sub_code{active="inactive",host="r14",load="not-found",name="systemd-oomd.service",role="core-router",site_id="frank01",sub="dead"} 1
systemd_units_sub_code{active="inactive",host="r14",load="not-found",name="systemd-update-done.service",role="core-router",site_id="frank01",sub="dead"} 1
systemd_units_sub_code{active="inactive",host="r14",load="not-found",name="systemd-vconsole-setup.service",role="core-router",site_id="frank01",sub="dead"} 1
[edit]
vyos@r14# 
```

Smoketests
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_monitoring_telegraf.py
test_01_basic_config (__main__.TestMonitoringTelegraf.test_01_basic_config) ... ok
test_02_loki (__main__.TestMonitoringTelegraf.test_02_loki) ... ok
test_03_global_tags (__main__.TestMonitoringTelegraf.test_03_global_tags) ... ok
test_04_global_tag_no_value (__main__.TestMonitoringTelegraf.test_04_global_tag_no_value) ... ok

----------------------------------------------------------------------
Ran 4 tests in 8.339s

OK
vyos@r14:~$ 

```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
