### PR TITLE
monitoring: T9260: relay local frr_exporter metrics via Telegraf

### DIFF
--- a/data/config-mode-dependencies/vyos-1x.json
+++ b/data/config-mode-dependencies/vyos-1x.json
@@ -146,5 +146,8 @@
     },
     "system_sflow": {
         "vpp_sflow": ["vpp_sflow"]
+    },
+    "service_monitoring_prometheus": {
+        "frr_exporter": ["service_monitoring_telegraf"]
     }
 }

--- a/data/templates/telegraf/telegraf.j2
+++ b/data/templates/telegraf/telegraf.j2
@@ -140,6 +140,15 @@
   server = "unixgram:///run/telegraf/telegraf_syslog.sock"
   best_effort = true
   syslog_standard = "RFC3164"
+{% if frr_metrics is vyos_defined %}
+### Local FRR exporter relay (T9260) ###
+[[inputs.prometheus]]
+  ## Local Prometheus frr-exporter endpoint, relayed through Telegraf
+  urls = ["http://{{ frr_metrics.address | bracketize_ipv6 }}:{{ frr_metrics.port }}/metrics"]
+  metric_version = {{ frr_metrics.metric_version }}
+  name_override = "frr"
+### End local FRR exporter relay ###
+{% endif %}
 {% if influxdb is vyos_defined %}
 [[inputs.exec]]
   commands = [

--- a/interface-definitions/service_monitoring_telegraf.xml.in
+++ b/interface-definitions/service_monitoring_telegraf.xml.in
@@ -168,6 +168,12 @@
                   #include <include/url-http-https.xml.i>
                 </children>
               </node>
+              <leafNode name="frr-metrics">
+                <properties>
+                  <help>Import FRR routing metrics into Telegraf</help>
+                  <valueless/>
+                </properties>
+              </leafNode>
               <node name="loki">
                 <properties>
                   <help>Output plugin Loki</help>

--- a/smoketest/scripts/cli/test_service_monitoring_telegraf.py
+++ b/smoketest/scripts/cli/test_service_monitoring_telegraf.py
@@ -25,6 +25,7 @@ from vyos.utils.file import read_file
 PROCESS_NAME = 'telegraf'
 TELEGRAF_CONF = '/run/telegraf/telegraf.conf'
 base_path = ['service', 'monitoring', 'telegraf']
+prometheus_base_path = ['service', 'monitoring', 'prometheus']
 org = 'log@in.local'
 token = 'GuRJc12tIzfjnYdKRAIYbxdWd2aTpOT9PVYNddzDnFV4HkAcD7u7-kndTFXjGuXzJN6TTxmrvPODB4mnFcseDV=='
 port = '8888'
@@ -117,6 +118,74 @@ class TestMonitoringTelegraf(VyOSUnitTestSHIM.TestCase):
         with self.assertRaises(ConfigSessionError):
             self.cli_commit()
         self.cli_delete(base_path + ['global-tag', 'incomplete-tag'])
+        self.cli_commit()
+
+    def test_05_frr_metrics_requires_frr_exporter(self):
+        # frr-metrics can not be enabled unless the Prometheus frr-exporter
+        # is configured
+        self.cli_set(base_path + ['prometheus-client'])
+        self.cli_set(base_path + ['frr-metrics'])
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+        self.cli_delete(base_path + ['frr-metrics'])
+        # commit again to leave a valid, running config for tearDown()
+        self.cli_commit()
+
+    def test_06_frr_metrics(self):
+        frr_exporter_port = '9342'
+        self.cli_set(base_path + ['prometheus-client'])
+        self.cli_set(prometheus_base_path + ['frr-exporter'])
+        self.cli_set(base_path + ['frr-metrics'])
+
+        # commit changes
+        self.cli_commit()
+
+        config = read_file(TELEGRAF_CONF)
+        self.assertIn(f'[[inputs.prometheus]]', config)
+        self.assertIn(
+            f'urls = ["http://127.0.0.1:{frr_exporter_port}/metrics"]', config
+        )
+        self.assertIn(f'metric_version = 2', config)
+        self.assertIn(f'name_override = "frr"', config)
+
+        # frr-metrics must be removed together with frr-exporter, otherwise
+        # the next commit fails verification and leaves telegraf stopped
+        self.cli_delete(base_path + ['frr-metrics'])
+        self.cli_delete(prometheus_base_path)
+        self.cli_commit()
+
+    def test_07_frr_metrics_tracks_frr_exporter_changes(self):
+        # T9260 regression test: changing frr-exporter's listen-address or
+        # port alone - without touching "service monitoring telegraf" at
+        # all - must still refresh the scrape URL Telegraf renders, since
+        # Telegraf's own conf-mode script is not otherwise re-run when only
+        # frr-exporter's subtree changes
+        new_listen_address = '127.0.0.2'
+        new_port = '9999'
+
+        self.cli_set(base_path + ['prometheus-client'])
+        self.cli_set(prometheus_base_path + ['frr-exporter'])
+        self.cli_set(base_path + ['frr-metrics'])
+        self.cli_commit()
+
+        config = read_file(TELEGRAF_CONF)
+        self.assertIn('urls = ["http://127.0.0.1:9342/metrics"]', config)
+
+        # Only touch the Prometheus frr-exporter subtree
+        self.cli_set(
+            prometheus_base_path
+            + ['frr-exporter', 'listen-address', new_listen_address]
+        )
+        self.cli_set(prometheus_base_path + ['frr-exporter', 'port', new_port])
+        self.cli_commit()
+
+        config = read_file(TELEGRAF_CONF)
+        self.assertIn(
+            f'urls = ["http://{new_listen_address}:{new_port}/metrics"]', config
+        )
+
+        self.cli_delete(base_path + ['frr-metrics'])
+        self.cli_delete(prometheus_base_path)
         self.cli_commit()
 
 

--- a/src/conf_mode/service_monitoring_prometheus.py
+++ b/src/conf_mode/service_monitoring_prometheus.py
@@ -19,6 +19,8 @@ import os
 from sys import exit
 
 from vyos.config import Config
+from vyos.configdep import call_dependents
+from vyos.configdep import set_dependents
 from vyos.configdict import is_node_changed
 from vyos.configdict import node_changed
 from vyos.configdiff import Diff
@@ -48,6 +50,19 @@ def get_config(config=None):
     else:
         conf = Config()
     base = ['service', 'monitoring', 'prometheus']
+
+    # T9260: Telegraf's local "frr-metrics" relay reads frr-exporter's
+    # listen-address/port/vrf straight out of this config tree. The commit
+    # system only re-runs Telegraf's own conf-mode script when Telegraf's
+    # own subtree changes, so without an explicit dependency Telegraf would
+    # keep rendering a stale scrape URL whenever only frr-exporter changes
+    # (or is removed) in a commit that doesn't touch "service monitoring
+    # telegraf" at all.
+    if conf.exists(base + ['frr-exporter']) or is_node_changed(
+        conf, base + ['frr-exporter']
+    ):
+        set_dependents('frr_exporter', conf)
+
     if not conf.exists(base):
         return None
 
@@ -208,6 +223,9 @@ def apply(monitoring):
             call(f'systemctl stop {blackbox_exporter_systemd_service}')
 
     if not monitoring:
+        # T9260: still refresh dependents (e.g. Telegraf's frr-metrics
+        # relay) even when the whole prometheus tree was removed
+        call_dependents()
         return
 
     if 'node_exporter' in monitoring:
@@ -233,6 +251,13 @@ def apply(monitoring):
             systemd_action = 'restart'
 
         call(f'systemctl {systemd_action} {blackbox_exporter_systemd_service}')
+
+    # T9260: refresh Telegraf's local frr-exporter relay, if any dependent
+    # was registered in get_config(). Deliberately not swallowed: if
+    # frr-exporter was just removed while Telegraf's "frr-metrics" is still
+    # enabled, Telegraf's own verify() must fail the commit rather than
+    # silently leaving a stale/broken scrape URL behind.
+    call_dependents()
 
 
 if __name__ == '__main__':

--- a/src/conf_mode/service_monitoring_telegraf.py
+++ b/src/conf_mode/service_monitoring_telegraf.py
@@ -29,6 +29,7 @@ from vyos.template import render
 from vyos.utils.process import call
 from vyos.utils.permission import chown
 from vyos.utils.process import cmdl
+from vyos.xml_ref import default_value
 from vyos import ConfigError
 from vyos import airbag
 airbag.enable()
@@ -117,6 +118,50 @@ def get_config(config=None):
     if not conf.exists(base + ['loki']):
         del monitoring['loki']
 
+    # T9260: relay the local Prometheus frr-exporter endpoint through
+    # Telegraf's inputs.prometheus plugin, so FRR routing state can reach the
+    # already configured Telegraf outputs without an external Prometheus
+    # scraper having to be given inbound access to the router.
+    if 'frr_metrics' in monitoring:
+        frr_exporter_base = ['service', 'monitoring', 'prometheus', 'frr-exporter']
+        if not conf.exists(frr_exporter_base):
+            # frr_exporter isn't configured/running - nothing to relay
+            monitoring['frr_metrics'] = {'not_configured': True}
+        else:
+            frr_exporter = conf.get_config_dict(
+                frr_exporter_base,
+                key_mangling=('-', '_'),
+                get_first_key=True,
+                with_recursive_defaults=True,
+            )
+
+            # frr_exporter listens on all addresses when no listen-address is
+            # configured, so a loopback scrape is always possible in that case
+            address = '127.0.0.1'
+            if 'listen_address' in frr_exporter:
+                address = frr_exporter['listen_address'][0]
+
+            # Keep the Prometheus input in sync with the prometheus-client
+            # output metric_version, when that output is configured
+            if 'prometheus_client' in monitoring:
+                metric_version = monitoring['prometheus_client']['metric_version']
+            else:
+                metric_version = default_value(
+                    base + ['prometheus-client', 'metric-version']
+                )
+
+            monitoring['frr_metrics'] = {
+                'address': address,
+                'port': frr_exporter['port'],
+                'metric_version': metric_version,
+            }
+
+            # frr_exporter runs under "ip vrf exec" when a VRF is set - if
+            # Telegraf runs in a different VRF (or none), the loopback
+            # scrape will not reach it
+            if frr_exporter.get('vrf') != monitoring.get('vrf'):
+                monitoring['frr_metrics']['vrf_mismatch'] = {}
+
     return monitoring
 
 def verify(monitoring):
@@ -181,6 +226,20 @@ def verify(monitoring):
                 raise ConfigError(
                     f'Authentication "username" and "password" are mandatory!'
                 )
+
+    # Verify local FRR metrics relay
+    if 'frr_metrics' in monitoring:
+        if 'not_configured' in monitoring['frr_metrics']:
+            raise ConfigError(
+                '"service monitoring prometheus frr-exporter" must be '
+                'configured before FRR metrics can be relayed via Telegraf!'
+            )
+
+        if 'vrf_mismatch' in monitoring['frr_metrics']:
+            raise ConfigError(
+                'Telegraf and the Prometheus frr-exporter must run in the '
+                'same VRF for FRR metrics to be relayed locally!'
+            )
 
     return None
 


### PR DESCRIPTION

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
FRR routing state was only available through the Prometheus frr-exporter, a pull target. Operators who push everything else out via Telegraf had to run an external Prometheus server and open inbound access to the router just to scrape routing state.

Add a dedicated "service monitoring telegraf frr-metrics" node. When set, Telegraf uses inputs.prometheus to scrape the already-running local frr-exporter and re-emits the metrics through whatever Telegraf outputs are already configured (InfluxDB, ADX, Loki, Splunk, etc.).

CLI configurable option:
```
set service monitoring telegraf frr-metrics
```


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T9260

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

### 1. Happy path - default listen-address

```
set service monitoring prometheus frr-exporter
set service monitoring telegraf prometheus-client
set service monitoring telegraf frr-metrics

set protocols bgp address-family ipv4-unicast network 100.64.14.0/24
set protocols bgp neighbor 192.0.2.16 address-family ipv4-unicast
set protocols bgp neighbor 192.0.2.16 remote-as '65001'
set protocols bgp system-as '65001'

commit
```

Check the generated Telegraf config:

```
cat /run/telegraf/telegraf.conf | grep -A4 'inputs.prometheus'
```

Expected:

```
### Local FRR exporter relay (T9260) ###
[[inputs.prometheus]]
  ## Local Prometheus frr-exporter endpoint, relayed through Telegraf
  urls = ["http://127.0.0.1:9342/metrics"]
  metric_version = 2
  name_override = "frr"
```

Confirm Telegraf is actually scraping it and the metrics show up under the
`frr` measurement, via the Prometheus client output added above:

```
curl -s http://127.0.0.1:9273/metrics | grep ^frr_ | head

vyos@r14# curl -s http://127.0.0.1:9273/metrics | grep ^frr_ | head
frr_frr_bfd_peer_count{host="r14",url="http://127.0.0.1:9342/metrics"} 0
frr_frr_bgp_peer_groups_count_total{afi="ipv4",host="r14",local_as="65001",safi="unicast",url="http://127.0.0.1:9342/metrics",vrf="default"} 0
frr_frr_bgp_peer_groups_memory_bytes{afi="ipv4",host="r14",local_as="65001",safi="unicast",url="http://127.0.0.1:9342/metrics",vrf="default"} 0
frr_frr_bgp_peer_message_received_total{afi="ipv4",host="r14",local_as="65001",peer="192.0.2.16",peer_as="65001",safi="unicast",url="http://127.0.0.1:9342/metrics",vrf="default"} 0
frr_frr_bgp_peer_message_sent_total{afi="ipv4",host="r14",local_as="65001",peer="192.0.2.16",peer_as="65001",safi="unicast",url="http://127.0.0.1:9342/metrics",vrf="default"} 0
frr_frr_bgp_peer_prefixes_advertised_count_total{afi="ipv4",host="r14",local_as="65001",peer="192.0.2.16",peer_as="65001",safi="unicast",url="http://127.0.0.1:9342/metrics",vrf="default"} 0
frr_frr_bgp_peer_prefixes_received_count_total{afi="ipv4",host="r14",local_as="65001",peer="192.0.2.16",peer_as="65001",safi="unicast",url="http://127.0.0.1:9342/metrics",vrf="default"} 0
frr_frr_bgp_peer_state{afi="ipv4",host="r14",local_as="65001",peer="192.0.2.16",peer_as="65001",safi="unicast",url="http://127.0.0.1:9342/metrics",vrf="default"} 0
frr_frr_bgp_peer_uptime_seconds{afi="ipv4",host="r14",local_as="65001",peer="192.0.2.16",peer_as="65001",safi="unicast",url="http://127.0.0.1:9342/metrics",vrf="default"} 0
frr_frr_bgp_peers_count_total{afi="ipv4",host="r14",local_as="65001",safi="unicast",url="http://127.0.0.1:9342/metrics",vrf="default"} 1
[edit]
vyos@r14# 

```

Clean up:

```
delete service monitoring 
commit
```

### 2. Error path - frr-metrics without frr-exporter configured

```
set service monitoring telegraf frr-metrics
commit
```

Expected: commit is rejected, e.g.

```
"service monitoring prometheus frr-exporter" must be configured before FRR
metrics can be relayed via Telegraf!

Commit failed
```

Clean up:

```
delete service monitoring
commit
```

### 3. Error path - VRF mismatch

```
set vrf name mgmt table 1000
set service monitoring prometheus frr-exporter vrf mgmt
set service monitoring telegraf frr-metrics
commit
```

Expected: commit is rejected because Telegraf itself is not in VRF `mgmt`:

```
Telegraf and the Prometheus frr-exporter must run in the same VRF for FRR
metrics to be relayed locally!

Commit failed
```

Fix by aligning the VRFs:

```
set service monitoring telegraf vrf mgmt
commit
```

Clean up:

```
delete service monitoring telegraf
delete service monitoring prometheus frr-exporter
delete vrf name mgmt
commit
```

### 4. Non-default frr-exporter listen-address/port

```
set service monitoring prometheus frr-exporter listen-address 127.0.0.2
set service monitoring prometheus frr-exporter port 9999
set service monitoring telegraf frr-metrics
commit

cat /run/telegraf/telegraf.conf | grep 'urls ='
```

Expected:

```
  urls = ["http://127.0.0.2:9999/metrics"]
```

Clean up:

```
delete service monitoring 
commit
```


Smoketests
```
vyos@r14:~$ /usr/libexec/vyos/tests/smoke/cli/test_service_monitoring_telegraf.py
test_01_basic_config (__main__.TestMonitoringTelegraf.test_01_basic_config) ... ok
test_02_loki (__main__.TestMonitoringTelegraf.test_02_loki) ... ok
test_03_global_tags (__main__.TestMonitoringTelegraf.test_03_global_tags) ... ok
test_04_global_tag_no_value (__main__.TestMonitoringTelegraf.test_04_global_tag_no_value) ... ok
test_05_frr_metrics_requires_frr_exporter (__main__.TestMonitoringTelegraf.test_05_frr_metrics_requires_frr_exporter) ... ok
test_06_frr_metrics (__main__.TestMonitoringTelegraf.test_06_frr_metrics) ... ok
test_07_frr_metrics_tracks_frr_exporter_changes (__main__.TestMonitoringTelegraf.test_07_frr_metrics_tracks_frr_exporter_changes) ... ok

----------------------------------------------------------------------
Ran 7 tests in 15.743s

OK
vyos@r14:~$ 

```
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
