### PR TITLE
T9238: Add RADIUS blast-protection configuration support

### DIFF
--- a/data/templates/accel-ppp/config_chap_secrets_radius.j2
+++ b/data/templates/accel-ppp/config_chap_secrets_radius.j2
@@ -41,6 +41,9 @@ bind={{ authentication.radius.source_address }}
 {%     if authentication.radius.dynamic_author.server is vyos_defined %}
 dae-server={{ authentication.radius.dynamic_author.server }}:{{ authentication.radius.dynamic_author.port }},{{ authentication.radius.dynamic_author.key }}
 {%     endif %}
+{%     if authentication.radius.blast_protection is vyos_defined %}
+blast-protection=1
+{%     endif %}
 {% endif %}
 {# Both chap-secrets and radius block required the gw-ip-address #}
 {% if authentication.mode is vyos_defined('local') or authentication.mode is vyos_defined('radius') %}

--- a/interface-definitions/include/accel-ppp/radius-additions.xml.i
+++ b/interface-definitions/include/accel-ppp/radius-additions.xml.i
@@ -116,6 +116,12 @@
         <valueless/>
       </properties>
     </leafNode>
+    <leafNode name="blast-protection">
+      <properties>
+        <help>Include Message-Authenticator attribute in Access-Request</help>
+        <valueless/>
+      </properties>
+    </leafNode>
     <node name="dynamic-author">
       <properties>
         <help>Dynamic Authorization Extension/Change of Authorization server</help>

--- a/smoketest/scripts/cli/base_accel_ppp_test.py
+++ b/smoketest/scripts/cli/base_accel_ppp_test.py
@@ -343,6 +343,8 @@ class BasicAccelPPPTest:
             source_address = "1.2.3.4"
             self.set(["authentication", "radius", "source-address", source_address])
 
+            self.set(["authentication", "radius", "blast-protection"])
+
             # commit changes
             self.cli_commit()
 
@@ -367,6 +369,7 @@ class BasicAccelPPPTest:
             self.assertEqual(conf["radius"]["nas-identifier"], nas_id)
             self.assertEqual(conf["radius"]["nas-ip-address"], nas_ip)
             self.assertEqual(conf["radius"]["bind"], source_address)
+            self.assertEqual(conf["radius"]["blast-protection"], "1")
 
             server = conf["radius"]["server"].split(",")
             self.assertEqual(radius_server, server[0])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
When blast-protection is enabled, all Access-Request packets will include a Message-Authenticator attribute for protection against Blast-RADIUS attack (CVE-2024-3596)

CLI option added for pppoe, ipoe, l2tp and sstp servers:
```
set service <pppoe-server | ipoe-server> authentication radius blast-protection
set vpn <l2tp|sstp> authentication radius blast-protection
```

```
vyos@vyos# set service pppoe-server authentication radius 
Possible completions:
   accounting-interim-interval
                        Interval in seconds to send accounting information
   acct-interim-jitter  Maximum jitter value in seconds to be applied to accounting
                        information interval
   acct-timeout         Timeout for Interim-Update packets, terminate session afterwards
                        (default: 3)
   blast-protection     Include Message-Authenticator attribute in Access-Request
   called-sid-format    Format of Called-Station-Id attribute
 > dynamic-author       Dynamic Authorization Extension/Change of Authorization server
   max-try              Number of tries to send Access-Request/Accounting-Request
                        queries (default: 3)
   nas-identifier       NAS-Identifier attribute sent to RADIUS
   nas-ip-address       NAS-IP-Address attribute sent to RADIUS
   preallocate-vif      Enable attribute NAS-Port-Id in Access-Request
 > rate-limit           Upload/Download speed limits
+> server               RADIUS server configuration
   source-address       IPv4 address used to initiate connection
   timeout              Timeout in seconds to wait response from RADIUS server (default:
                        3)

```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
https://vyos.dev/T9238

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
Depends-on : https://github.com/accel-ppp/accel-ppp-ng/pull/39

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
Testing done for PPPoE and SSTP servers. Verified that Message-Authenticator field is included upon enabling the blast-protection via VyOS CLI and FreeRadius then accepts the Access-Request.

```
Sep 03 00:41:28 accel-sstp[12542]: :: send [RADIUS(1) Access-Request id=1 <Message-Authenticator 0x00000000000000000000000000000000> <User-Name "testuser"> <NAS-Identifier "vyos-sstp-test"> <NAS-IP-Address 192.168.65.18> <NAS-Port-Type Virtual> <Service-Type Framed-User> <Framed-Protocol PPP> <Calling-Station-Id "192.168.65.2"> <Called-Station-Id "192.168.65.18"> <User-Password 0xdf34bd91b9760558ab164ecbfa32bfb1>]
Sep 03 00:41:28 accel-sstp[12542]: :: recv [RADIUS(1) Access-Accept id=1 <Message-Authenticator 0xc2bca9d94716679b3e15690f6a85ffe3> <Framed-IP-Address 10.64.0.10>]
Sep 03 00:41:29 accel-sstp[12542]: ppp0:testuser: connect: ppp0 <--> sstp(192.168.65.2:53788)
Sep 03 00:41:29 accel-sstp[12542]: ppp0:testuser: testuser: authentication succeeded
Sep 03 00:41:29 (udev-worker)[14730]: Network interface NamePolicy= disabled on kernel command line.
Sep 03 00:41:29 accel-sstp[12542]: ppp0:testuser: IPV6CP: discarding packet
Sep 03 00:41:29 kernel: sstp0: renamed from ppp0
Sep 03 00:41:29 accel-sstp[12542]: sstp0:testuser: send [RADIUS(1) Accounting-Request id=1 <User-Name "testuser"> <NAS-Identifier "vyos-sstp-test"> <NAS-IP-Address 192.168.65.18> <NAS-Port 0> <NAS-Port-Id "sstp0"> <NAS-Port-Type Virtual> <Service-Type Framed-User> <Framed-Protocol PPP> <Calling-Station-Id "192.168.65.2"> <Called-Station-Id "192.168.65.18"> <Acct-Status-Type Start> <Acct-Authentic RADIUS> <Acct-Session-Id "a65ab9be93756556"> <Acct-Session-Time 0> <Acct-Input-Octets 0> <Acct-Output-Octets 0> <Acct-Input-Packets 0> <Acct-Output-Packets 0> <Acct-Input-Gigawords 0> <Acct-Output-Gigawords 0> <Framed-IP-Address 10.64.0.10>]
Sep 03 00:41:29 accel-sstp[12542]: sstp0:testuser: recv [RADIUS(1) Accounting-Response id=1]
```

SMOKETEST EXECUTED:
`sudo python3 -m unittest test_service_pppoe-server.py`

RELEVANT OUTPUT SNIPPET:
```
set service pppoe-server authentication radius called-sid-format ifname:mac
set interfaces dummy dum667 address 192.0.2.1/32
set service pppoe-server access-concentrator ACN
set service pppoe-server interface eth0
set service pppoe-server authentication local-users username vyos password vyos
set service pppoe-server authentication mode local
set service pppoe-server gateway-address 192.0.2.1
set service pppoe-server client-ip-pool SIMPLE-POOL range 192.0.2.0/24
set service pppoe-server default-pool SIMPLE-POOL
set service pppoe-server authentication mode radius
set service pppoe-server authentication radius server 192.0.2.22 key secretVyOS
set service pppoe-server authentication radius server 192.0.2.22 port 2000
set service pppoe-server authentication radius server 192.0.2.22 acct-port 3000
set service pppoe-server authentication radius acct-interim-jitter 10
set service pppoe-server authentication radius accounting-interim-interval 10
set service pppoe-server authentication radius acct-timeout 30
set service pppoe-server authentication radius dynamic-author server 4.4.4.4
set service pppoe-server authentication radius dynamic-author key testCoA
set service pppoe-server authentication radius nas-identifier VyOS-PPPoE
set service pppoe-server authentication radius nas-ip-address 7.7.7.7
set service pppoe-server authentication radius source-address 1.2.3.4
set service pppoe-server authentication radius blast-protection
commit
del service pppoe-server authentication radius server 192.0.2.22 acct-port
set service pppoe-server authentication radius server 192.0.2.22 disable-accounting
set service pppoe-server authentication radius server 192.0.2.22 backup
set service pppoe-server authentication radius server 192.0.2.22 priority 10
commit
del interfaces dummy dum667
del service pppoe-server
commit
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
