### PR TITLE
image: T5475: derive the persistence path from the overlay upperdir 

### DIFF
--- a/src/opt/vyatta/sbin/vyos-persistpath
+++ b/src/opt/vyatta/sbin/vyos-persistpath
@@ -3,15 +3,38 @@
 if grep -q -e '^overlay.*/filesystem.squashfs' /proc/mounts; then
 	# Live CD boot
 	exit 2
-	
-elif grep -q 'upperdir=/live/persistence/' /proc/mounts && egrep -q 'overlay / overlay ' /proc/mounts; then
+
+elif egrep -q 'overlay / overlay ' /proc/mounts; then
 	# union boot
-	
-	boot_device=`grep -o 'upperdir=/live/persistence/[^/]*/boot' /proc/mounts | cut -d / -f 4`
-	persist_path="/lib/live/mount/persistence/$boot_device"
-	
-	echo $persist_path
-	exit 0
+	#
+	# The root overlay's upper directory is <persistence>/boot/<image>/rw, but
+	# the location of <persistence> depends on the live-boot in use: Debian's
+	# live-boot mounts it below /run/live/persistence, optionally in a
+	# per-device sub-directory, while the retired VyOS live-boot fork used
+	# /live/persistence (reachable as /lib/live/mount/persistence once booted).
+	# Derive the root from the upperdir rather than matching one fixed layout.
+	upperdir=$(grep -E '^overlay / overlay ' /proc/mounts | head -n1 |
+		   tr ',' '\n' | sed -n 's/^upperdir=//p' | head -n1)
+
+	if [ -z "$upperdir" ]; then
+		exit 1
+	fi
+
+	# Strip the trailing /rw, the <image> and the boot component, then collapse
+	# the duplicate slashes the fork's trailing-slash paths introduced.
+	persist_path=$(dirname "$(dirname "$(dirname "$upperdir")")" | sed -e 's|//*|/|g')
+
+	# Prefer the derived path, falling back to the legacy mount points that
+	# live-boot's compatibility rbind still provides on Debian bookworm.
+	for candidate in "$persist_path" /lib/live/mount/persistence \
+					 /usr/lib/live/mount/persistence; do
+		if [ -d "$candidate/boot" ]; then
+			echo "$candidate"
+			exit 0
+		fi
+	done
+
+	exit 1
 else
 	# old style boot
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The union boot branch matched `/proc/mounts` against the literal string `upperdir=/live/persistence/`, which is the layout produced by the VyOS fork of live-boot. Debian's live-boot mounts persistence below /run/live/persistence instead, so on an image built against it the match failed, the script reported an old style boot, and every caller silently did nothing. In practice that meant /boot was never bind mounted, so GRUB updates and image management found no configuration directory, and an encrypted config volume was never unlocked.

The old code also only worked by accident. It rebuilt the path as `/lib/live/mount/persistence/$boot_device`, where the device component came from cutting the fourth slash separated field, and that field was empty solely because the fork appended a trailing slash and produced a doubled separator.

Rather than match one fixed layout, take the overlay's own upperdir and walk up three levels to strip the rw, image and boot components, then collapse any duplicate separators. The result is checked for a boot directory, falling back to the legacy mount points that live-boot's compatibility bind mount still provides on bookworm. This handles Debian's path, upstream's optional per device sub-directory and the fork's original layout alike, so it stays correct whichever live-boot the image was assembled with.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T5475

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-build/pull/1288

## How to test / Smoketest result

All smoketests passed locally

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
