### PR TITLE
dhcp: T7130: add custom DHCP option 43 support

### DIFF
--- a/data/templates/dhcp-server/kea-dhcp4.conf.j2
+++ b/data/templates/dhcp-server/kea-dhcp4.conf.j2
@@ -39,13 +39,14 @@
                 "name": "wpad-url",
                 "code": 252,
                 "type": "string"
-            },
-            {
-                "name": "ubnt",
-                "code": 1,
-                "type": "ipv4-address",
-                "space": "vendor-encapsulated-options-space"
             }
+{% if shared_network_name is vyos_defined %}
+{%     set vendor_option_defs = shared_network_name | kea_vendor_option_defs %}
+{%     if vendor_option_defs != '[]' %}
+            ,
+{{ vendor_option_defs[1:-1] }}
+{%     endif %}
+{% endif %}
         ],
 {% if dynamic_dns_update is vyos_defined %}
         "dhcp-ddns": {

--- a/interface-definitions/include/dhcp/option-v4.xml.i
+++ b/interface-definitions/include/dhcp/option-v4.xml.i
@@ -237,6 +237,70 @@
         <help>Vendor Specific Options</help>
       </properties>
       <children>
+        <tagNode name="custom-option">
+          <properties>
+            <help>Custom vendor encapsulated option</help>
+            <constraint>
+              #include <include/constraint/alpha-numeric-hyphen-underscore-dot.xml.i>
+            </constraint>
+            <constraintErrorMessage>Custom vendor option name may only contain letters, numbers, dots, underscores, and hyphens</constraintErrorMessage>
+          </properties>
+          <children>
+            <leafNode name="array">
+              <properties>
+                <help>Encode multiple data values in one vendor option</help>
+                <valueless/>
+              </properties>
+            </leafNode>
+            <leafNode name="code">
+              <properties>
+                <help>Vendor encapsulated sub-option code</help>
+                <valueHelp>
+                  <format>1-254</format>
+                  <description>Vendor encapsulated sub-option code</description>
+                </valueHelp>
+                <constraint>
+                  <validator name="numeric" argument="--range 1-254"/>
+                </constraint>
+                <constraintErrorMessage>Vendor encapsulated sub-option code must be in range 1 to 254</constraintErrorMessage>
+              </properties>
+            </leafNode>
+            <leafNode name="data">
+              <properties>
+                <help>Vendor encapsulated sub-option data</help>
+                <valueHelp>
+                  <format>value</format>
+                  <description>Data formatted according to the selected type</description>
+                </valueHelp>
+                <multi/>
+              </properties>
+            </leafNode>
+            <leafNode name="type">
+              <properties>
+                <help>Vendor encapsulated sub-option data type</help>
+                <completionHelp>
+                  <list>binary boolean fqdn ipv4-address ipv6-address string uint8 uint16 uint32 int8 int16 int32</list>
+                </completionHelp>
+                <valueHelp>
+                  <format>binary</format>
+                  <description>Raw hexadecimal data</description>
+                </valueHelp>
+                <valueHelp>
+                  <format>ipv4-address</format>
+                  <description>IPv4 address</description>
+                </valueHelp>
+                <valueHelp>
+                  <format>string</format>
+                  <description>Text string</description>
+                </valueHelp>
+                <constraint>
+                  <regex>(binary|boolean|fqdn|ipv4-address|ipv6-address|string|uint8|uint16|uint32|int8|int16|int32)</regex>
+                </constraint>
+                <constraintErrorMessage>Invalid vendor encapsulated sub-option data type</constraintErrorMessage>
+              </properties>
+            </leafNode>
+          </children>
+        </tagNode>
         <node name="ubiquiti">
           <properties>
             <help>Ubiquiti specific parameters</help>

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -64,6 +64,7 @@ kea6_options = {
 }
 
 kea_ctrl_socket = '/var/run/kea/dhcp{inet}{vrf_append}-ctrl-socket'
+kea4_vendor_option_space = 'vendor-encapsulated-options-space'
 
 
 def _format_hex_string(in_str):
@@ -159,16 +160,149 @@ def kea_parse_options(config):
         config, 'vendor_option', 'ubiquiti', 'unifi_controller'
     )
     if unifi_controller:
-        options.append({'name': 'vendor-encapsulated-options'})
+        if not any(
+            option['name'] == 'vendor-encapsulated-options' for option in options
+        ):
+            options.append({'name': 'vendor-encapsulated-options'})
         options.append(
             {
                 'name': 'ubnt',
                 'data': unifi_controller,
-                'space': 'vendor-encapsulated-options-space',
+                'space': kea4_vendor_option_space,
             }
         )
 
+    custom_options = dict_search_args(config, 'vendor_option', 'custom_option')
+    if custom_options:
+        if not any(
+            option['name'] == 'vendor-encapsulated-options' for option in options
+        ):
+            options.append({'name': 'vendor-encapsulated-options'})
+        for name, option in custom_options.items():
+            data = option['data']
+            option_data = {
+                'name': name,
+                'data': ', '.join(data) if isinstance(data, list) else data,
+                'space': kea4_vendor_option_space,
+            }
+
+            if option['type'] == 'binary':
+                option_data['csv-format'] = False
+                option_data['data'] = option_data['data'].replace(
+                    ':', ''
+                ).removeprefix('0x')
+
+            options.append(option_data)
+
     return options
+
+
+def _find_custom_vendor_options(config):
+    if not isinstance(config, dict):
+        return
+
+    if 'disable' in config:
+        return
+
+    custom_options = dict_search_args(config, 'vendor_option', 'custom_option')
+    if custom_options:
+        yield from custom_options.items()
+
+    for value in config.values():
+        if isinstance(value, dict):
+            yield from _find_custom_vendor_options(value)
+
+
+def _find_unifi_vendor_options(config):
+    if not isinstance(config, dict):
+        return
+
+    if 'disable' in config:
+        return
+
+    unifi_controller = dict_search_args(
+        config, 'vendor_option', 'ubiquiti', 'unifi_controller'
+    )
+    if unifi_controller:
+        yield unifi_controller
+
+    for value in config.values():
+        if isinstance(value, dict):
+            yield from _find_unifi_vendor_options(value)
+
+
+def kea_parse_vendor_option_defs(config):
+    option_defs_by_name = {}
+    option_defs_by_code = {}
+
+    if any(_find_unifi_vendor_options(config)):
+        option_def = {
+            'name': 'ubnt',
+            'code': 1,
+            'type': 'ipv4-address',
+            'space': kea4_vendor_option_space,
+        }
+        option_defs_by_name[option_def['name']] = option_def
+        option_defs_by_code[option_def['code']] = option_def
+
+    for name, option in _find_custom_vendor_options(config):
+        option_def = {
+            'name': name,
+            'code': int(option['code']),
+            'type': option['type'],
+            'space': kea4_vendor_option_space,
+        }
+
+        if 'array' in option:
+            option_def['array'] = True
+
+        name_key = option_def['name']
+        code_key = option_def['code']
+        if (
+            name_key in option_defs_by_name
+            and option_defs_by_name[name_key] != option_def
+        ):
+            raise ConfigError(f'Conflicting DHCP vendor option definition: {name}')
+
+        if (
+            code_key in option_defs_by_code
+            and option_defs_by_code[code_key] != option_def
+        ):
+            raise ConfigError(f'Conflicting DHCP vendor option definition: {name}')
+
+        option_defs_by_name[name_key] = option_def
+        option_defs_by_code[code_key] = option_def
+
+    return list(option_defs_by_name.values())
+
+
+def verify_kea_vendor_options(config):
+    for name, option in _find_custom_vendor_options(config):
+        missing_nodes = []
+        for node in ['code', 'data', 'type']:
+            if node not in option:
+                missing_nodes.append(node.replace('_', '-'))
+
+        if missing_nodes:
+            raise ConfigError(
+                f'DHCP vendor option "{name}" requires {" and ".join(missing_nodes)}'
+            )
+
+        data = option['data']
+        if isinstance(data, list) and len(data) > 1 and 'array' not in option:
+            raise ConfigError(
+                f'DHCP vendor option "{name}" has multiple data values but array is not enabled'
+            )
+
+        if option['type'] == 'binary':
+            values = data if isinstance(data, list) else [data]
+            for value in values:
+                hex_value = value.replace(':', '').removeprefix('0x')
+                if not re.fullmatch(r'([0-9a-fA-F]{2})+', hex_value):
+                    raise ConfigError(
+                        f'DHCP vendor option "{name}" binary data must contain '
+                        'full hexadecimal octets'
+                    )
 
 
 def kea_parse_subnet(subnet, config):

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -187,10 +187,11 @@ def kea_parse_options(config):
             }
 
             if option['type'] == 'binary':
+                values = data if isinstance(data, list) else [data]
                 option_data['csv-format'] = False
-                option_data['data'] = option_data['data'].replace(
-                    ':', ''
-                ).removeprefix('0x')
+                option_data['data'] = ''.join(
+                    value.replace(':', '').removeprefix('0x') for value in values
+                )
 
             options.append(option_data)
 

--- a/python/vyos/kea.py
+++ b/python/vyos/kea.py
@@ -197,38 +197,57 @@ def kea_parse_options(config):
     return options
 
 
-def _find_custom_vendor_options(config):
+def _iter_dhcp4_option_configs(config):
     if not isinstance(config, dict):
         return
 
-    if 'disable' in config:
+    shared_networks = config.get('shared_network_name', config)
+    if not isinstance(shared_networks, dict):
         return
 
-    custom_options = dict_search_args(config, 'vendor_option', 'custom_option')
-    if custom_options:
-        yield from custom_options.items()
+    for network_config in shared_networks.values():
+        if not isinstance(network_config, dict) or 'disable' in network_config:
+            continue
 
-    for value in config.values():
-        if isinstance(value, dict):
-            yield from _find_custom_vendor_options(value)
+        if 'option' in network_config:
+            yield network_config['option']
+
+        for subnet_config in network_config.get('subnet', {}).values():
+            if not isinstance(subnet_config, dict) or 'disable' in subnet_config:
+                continue
+
+            if 'option' in subnet_config:
+                yield subnet_config['option']
+
+            for range_config in subnet_config.get('range', {}).values():
+                if isinstance(range_config, dict) and 'option' in range_config:
+                    yield range_config['option']
+
+            for host_config in subnet_config.get('static_mapping', {}).values():
+                if (
+                    isinstance(host_config, dict)
+                    and 'disable' not in host_config
+                    and 'option' in host_config
+                ):
+                    yield host_config['option']
+
+
+def _find_custom_vendor_options(config):
+    for option_config in _iter_dhcp4_option_configs(config):
+        custom_options = dict_search_args(
+            option_config, 'vendor_option', 'custom_option'
+        )
+        if custom_options:
+            yield from custom_options.items()
 
 
 def _find_unifi_vendor_options(config):
-    if not isinstance(config, dict):
-        return
-
-    if 'disable' in config:
-        return
-
-    unifi_controller = dict_search_args(
-        config, 'vendor_option', 'ubiquiti', 'unifi_controller'
-    )
-    if unifi_controller:
-        yield unifi_controller
-
-    for value in config.values():
-        if isinstance(value, dict):
-            yield from _find_unifi_vendor_options(value)
+    for option_config in _iter_dhcp4_option_configs(config):
+        unifi_controller = dict_search_args(
+            option_config, 'vendor_option', 'ubiquiti', 'unifi_controller'
+        )
+        if unifi_controller:
+            yield unifi_controller
 
 
 def kea_parse_vendor_option_defs(config):

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -1023,6 +1023,13 @@ def kea_dynamic_dns_update_domains(config, type_key):
 
     return dumps(out, indent=12)
 
+@register_filter('kea_vendor_option_defs')
+def kea_vendor_option_defs(config):
+    from vyos.kea import kea_parse_vendor_option_defs
+    from json import dumps
+
+    return dumps(kea_parse_vendor_option_defs(config), indent=12)
+
 @register_filter('kea_shared_network_json')
 def kea_shared_network_json(shared_networks):
     from vyos.kea import kea_parse_options

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -1023,6 +1023,7 @@ def kea_dynamic_dns_update_domains(config, type_key):
 
     return dumps(out, indent=12)
 
+
 @register_filter('kea_vendor_option_defs')
 def kea_vendor_option_defs(config):
     from vyos.kea import kea_parse_vendor_option_defs

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -396,6 +396,16 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
 
         self.verify_config_object(
             obj,
+            ['Dhcp4', 'option-def'],
+            {
+                'name': 'ubnt',
+                'code': 1,
+                'type': 'ipv4-address',
+                'space': 'vendor-encapsulated-options-space',
+            },
+        )
+        self.verify_config_object(
+            obj,
             ['Dhcp4', 'shared-networks', 0, 'option-data'],
             {'name': 'vendor-encapsulated-options'},
         )
@@ -406,6 +416,66 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
                 'name': 'ubnt',
                 'space': 'vendor-encapsulated-options-space',
                 'data': unifi_controller,
+            },
+        )
+        self.verify_service_running()
+
+    def test_dhcp_vendor_option_custom(self):
+        shared_net_name = 'SMOKE-1'
+
+        range_0_start = inc_ip(subnet, 10)
+        range_0_stop = inc_ip(subnet, 20)
+        range_1_start = inc_ip(subnet, 40)
+        range_1_stop = inc_ip(subnet, 50)
+        controller_1 = '192.0.2.10'
+        controller_2 = '192.0.2.11'
+
+        self.setup_single_pool_range(
+            range_0_start, range_0_stop, range_1_start, range_1_stop, shared_net_name
+        )
+
+        vendor_option = base_path + [
+            'shared-network-name',
+            shared_net_name,
+            'option',
+            'vendor-option',
+            'custom-option',
+            'cisco-wlc',
+        ]
+        self.cli_set(vendor_option + ['code', '241'])
+        self.cli_set(vendor_option + ['type', 'ipv4-address'])
+        self.cli_set(vendor_option + ['array'])
+        self.cli_set(vendor_option + ['data', controller_1])
+        self.cli_set(vendor_option + ['data', controller_2])
+
+        self.cli_commit()
+
+        config = read_file(KEA4_CONF)
+        obj = loads(config)
+
+        self.verify_config_object(
+            obj,
+            ['Dhcp4', 'option-def'],
+            {
+                'name': 'cisco-wlc',
+                'code': 241,
+                'type': 'ipv4-address',
+                'space': 'vendor-encapsulated-options-space',
+                'array': True,
+            },
+        )
+        self.verify_config_object(
+            obj,
+            ['Dhcp4', 'shared-networks', 0, 'option-data'],
+            {'name': 'vendor-encapsulated-options'},
+        )
+        self.verify_config_object(
+            obj,
+            ['Dhcp4', 'shared-networks', 0, 'option-data'],
+            {
+                'name': 'cisco-wlc',
+                'space': 'vendor-encapsulated-options-space',
+                'data': f'{controller_1}, {controller_2}',
             },
         )
         self.verify_service_running()

--- a/smoketest/scripts/cli/test_service_dhcp-server.py
+++ b/smoketest/scripts/cli/test_service_dhcp-server.py
@@ -442,11 +442,24 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
             'custom-option',
             'cisco-wlc',
         ]
+        binary_vendor_option = base_path + [
+            'shared-network-name',
+            shared_net_name,
+            'option',
+            'vendor-option',
+            'custom-option',
+            'binary-data',
+        ]
         self.cli_set(vendor_option + ['code', '241'])
         self.cli_set(vendor_option + ['type', 'ipv4-address'])
         self.cli_set(vendor_option + ['array'])
         self.cli_set(vendor_option + ['data', controller_1])
         self.cli_set(vendor_option + ['data', controller_2])
+        self.cli_set(binary_vendor_option + ['code', '242'])
+        self.cli_set(binary_vendor_option + ['type', 'binary'])
+        self.cli_set(binary_vendor_option + ['array'])
+        self.cli_set(binary_vendor_option + ['data', '0x01:02'])
+        self.cli_set(binary_vendor_option + ['data', '03:04'])
 
         self.cli_commit()
 
@@ -466,6 +479,17 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
         )
         self.verify_config_object(
             obj,
+            ['Dhcp4', 'option-def'],
+            {
+                'name': 'binary-data',
+                'code': 242,
+                'type': 'binary',
+                'space': 'vendor-encapsulated-options-space',
+                'array': True,
+            },
+        )
+        self.verify_config_object(
+            obj,
             ['Dhcp4', 'shared-networks', 0, 'option-data'],
             {'name': 'vendor-encapsulated-options'},
         )
@@ -476,6 +500,16 @@ class TestServiceDHCPServer(VyOSUnitTestSHIM.TestCase):
                 'name': 'cisco-wlc',
                 'space': 'vendor-encapsulated-options-space',
                 'data': f'{controller_1}, {controller_2}',
+            },
+        )
+        self.verify_config_object(
+            obj,
+            ['Dhcp4', 'shared-networks', 0, 'option-data'],
+            {
+                'name': 'binary-data',
+                'space': 'vendor-encapsulated-options-space',
+                'data': '01020304',
+                'csv-format': False,
             },
         )
         self.verify_service_running()

--- a/src/conf_mode/service_dhcp-server.py
+++ b/src/conf_mode/service_dhcp-server.py
@@ -27,6 +27,7 @@ from netaddr import IPRange
 
 from vyos.config import Config
 from vyos.kea import kea_test_config
+from vyos.kea import verify_kea_vendor_options
 from vyos.pki import wrap_certificate
 from vyos.pki import wrap_private_key
 from vyos.template import render
@@ -229,6 +230,8 @@ def get_config(config=None):
 
     if bool(list(dict_search_recursive(dhcp, 'ping_check'))):
         dhcp['any_ping_check'] = True
+
+    verify_kea_vendor_options(dhcp)
 
     return dhcp
 


### PR DESCRIPTION
## Summary
Adds generic DHCPv4 vendor encapsulated option support under:

`service dhcp-server ... option vendor-option custom-option <name>`

This allows DHCP option 43 sub-options such as Cisco WLC suboption 241.

## Example
```bash
set service dhcp-server shared-network-name MGMT option vendor-option custom-option cisco-wlc code 241
set service dhcp-server shared-network-name MGMT option vendor-option custom-option cisco-wlc type ipv4-address
set service dhcp-server shared-network-name MGMT option vendor-option custom-option cisco-wlc data 192.0.2.10
```
## Testing
Built a custom rolling ISO from this branch and installed it on a VyOS test system.

Verified DHCP config commits successfully.

Verified Kea renders:
```json
{
  "name": "cisco-wlc",
  "code": 241,
  "type": "ipv4-address",
  "space": "vendor-encapsulated-options-space"
}
```

Verified DHCP option 43 is sent on the wire to a Cisco AP:

```Vendor-Option (43), length 6: 241.4.192.0.2.10```

The AP receives the option as hex bytes on the wire.

Fixes: T7130
