### PR TITLE
vpp: T9161: Enforce NIC MTU limit and apply MTU to VLAN sub-interfaces

### DIFF
--- a/interface-definitions/vpp_interface_loopback.xml.in
+++ b/interface-definitions/vpp_interface_loopback.xml.in
@@ -23,6 +23,9 @@
               #include <include/interface/address-ipv4-ipv6.xml.i>
               #include <include/interface/mac.xml.i>
               #include <include/interface/mtu-68-16000.xml.i>
+              <leafNode name="mtu">
+                <defaultValue>1500</defaultValue>
+              </leafNode>
               #include <include/vpp/vif.xml.i>
             </children>
           </tagNode>

--- a/python/vyos/ifconfig/vpp/bond.py
+++ b/python/vyos/ifconfig/vpp/bond.py
@@ -160,8 +160,11 @@ class VPPBondInterface(Interface, VPPInterface):
             if member not in members:
                 self.add_member(interface=member)
 
+        # Apply all settings to the lcp pair (kernel) interface first: creating
+        # the kernel VLANs is what makes linux-cp create the matching VPP
+        # sub-interfaces and their taps, which the VPP-specific settings below
+        # (MTU sync to those taps) then depend on.
+        super().update(config)
+
         # Apply VPP-specific interface settings
         VPPInterface.update(self, config)
-
-        # Apply all settings to the lcp pair (kernel) interface
-        super().update(config)

--- a/python/vyos/ifconfig/vpp/interface.py
+++ b/python/vyos/ifconfig/vpp/interface.py
@@ -55,22 +55,44 @@ class VPPInterface:
             if lcp_name:
                 self.vpp.iface_rxmode(lcp_name, rx_mode)
 
-    def set_mtu_vpp(self, mtu):
-        # Set MTU for the VPP interface
-        self.vpp.set_iface_mtu(self.vpp_ifname, mtu)
+    def set_mtu_vpp(self, config):
+        """Set the MTU on this interface and its VLAN sub-interfaces.
 
-        # Set MTU for the LCP pair interface
-        lcp_pair = self.vpp.lcp_pair_find(vpp_name_hw=self.vpp_ifname)
-        if lcp_pair:
-            lcp_name = lcp_pair.get('vpp_name_kernel')
-            if lcp_name:
-                self.vpp.set_iface_mtu(lcp_name, mtu)
+        The MTU is set on both the dataplane interface and its LCP tap. The
+        tap is created with MTU 0, so it always needs setting. A VLAN
+        sub-interface uses its own MTU if set, otherwise it inherits the
+        parent MTU.
+        """
+        parent_mtu = config.get('mtu')
+        if not parent_mtu:
+            return
+
+        # Fetch all LCP pairs
+        lcp_tap_map = {
+            pair.get('vpp_name_hw'): pair.get('vpp_name_kernel')
+            for pair in self.vpp.lcp_pairs_list()
+        }
+
+        # Parent: always set the dataplane interface, plus its tap if present.
+        self.vpp.set_iface_mtu(self.vpp_ifname, int(parent_mtu))
+        parent_tap = lcp_tap_map.get(self.vpp_ifname)
+        if parent_tap:
+            self.vpp.set_iface_mtu(parent_tap, int(parent_mtu))
+
+        # VLAN sub-interfaces: set the sub-interface and its tap once linux-cp
+        # has created the tap.
+        for vlan_id, vlan_config in config.get('vif', {}).items():
+            vlan_ifname = f'{self.vpp_ifname}.{vlan_id}'
+            lcp_name = lcp_tap_map.get(vlan_ifname)
+            if not lcp_name:
+                continue
+            mtu = int(vlan_config.get('mtu') or parent_mtu)
+            self.vpp.set_iface_mtu(vlan_ifname, mtu)
+            self.vpp.set_iface_mtu(lcp_name, mtu)
 
     def update(self, config):
-        # Set MTU
-        if 'mtu' in config:
-            mtu = int(config['mtu'])
-            self.set_mtu_vpp(mtu)
+        # Set MTU on the interface, its VLAN sub-interfaces, and their LCP taps
+        self.set_mtu_vpp(config)
 
         # Set rx-mode
         rx_mode = config.get('vpp_settings', {}).get('interface_rx_mode')

--- a/python/vyos/ifconfig/vpp/loopback.py
+++ b/python/vyos/ifconfig/vpp/loopback.py
@@ -106,7 +106,10 @@ class VPPLoopbackInterface(Interface, VPPInterface):
         # Add loopback interface
         self.add()
 
-        VPPInterface.update(self, config)
-
-        # Apply all settings to the lcp pair (kernel) interface
+        # Apply all settings to the lcp pair (kernel) interface first: creating
+        # the kernel VLANs is what makes linux-cp create the matching VPP
+        # sub-interfaces and their taps, which the VPP-specific settings below
+        # (MTU sync to those taps) then depend on.
         super().update(config)
+
+        VPPInterface.update(self, config)

--- a/python/vyos/vpp/control_vpp.py
+++ b/python/vyos/vpp/control_vpp.py
@@ -535,6 +535,40 @@ class VPPControl:
         return self.__vpp_api_client.api.sw_interface_set_mtu(**api_call_args)
 
     @_Decorators.api_call
+    def get_iface_max_mtu(self, iface_name_vpp: str) -> int | None:
+        """Return the maximum L3 MTU an interface's NIC can accept.
+
+        Derived from the driver limits in 'show hardware-interfaces': 'max mtu'
+        (rte_eth_dev_info.max_mtu) plus 'driver frame overhead'. The NIC is owned
+        by the VPP dataplane, so only VPP knows its real limit - the kernel side
+        is an LCP tap that reports its own, much larger max MTU and does not
+        reflect the physical NIC.
+
+        Args:
+            iface_name_vpp (str): Name of an interface in VPP
+
+        Returns:
+            int | None: maximum L3 MTU or None
+        """
+        hw_info = self.cli_cmd(f'show hardware-interfaces {iface_name_vpp}').reply or ''
+        max_mtu = re.search(r'max mtu:\s*(\d+)', hw_info)
+        if not max_mtu:
+            return None
+
+        max_mtu = int(max_mtu.group(1))
+        overhead = re.search(r'driver frame overhead:\s*(\d+)', hw_info)
+        if not overhead:
+            # Without the driver frame overhead the L3 limit is unknown.
+            return None
+
+        # VPP programs the NIC with (L3 MTU + hi->frame_overhead -
+        # driver_frame_overhead); hi->frame_overhead for a DPDK Ethernet
+        # interface is Ethernet header (14) + two QinQ VLAN tags (8) = 22. So the
+        # largest settable L3 MTU is (max_mtu + driver_frame_overhead - 22).
+        l2_frame_overhead = 14 + 8
+        return max_mtu + int(overhead.group(1)) - l2_frame_overhead
+
+    @_Decorators.api_call
     def get_sw_if_dev_type(self, ifname: str) -> int | None:
         """Find interface device type by interface name in VPP
 

--- a/smoketest/scripts/cli/test_vpp.py
+++ b/smoketest/scripts/cli/test_vpp.py
@@ -183,9 +183,51 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         normalized_out = re.sub(r'\s+', ' ', out)
         self.assertIn(f'tap4096 2 up {mtu}/0/0/0', normalized_out)
 
+        # VLAN sub-interface's MTU must reach both the VPP dataplane
+        # sub-interface and its LCP tap
+        vlan = '10'
+        vlan_mtu = '1400'
+
+        self.cli_set(['interfaces', 'ethernet', interface, 'vif', vlan])
+        self.cli_commit()
+
+        _, out = rc_cmd('sudo vppctl show interface')
+        normalized_out = re.sub(r'\s+', ' ', out)
+        self.assertRegex(normalized_out, rf'{interface}.{vlan} \d+ \S+ {mtu}/0/0/0')
+        self.assertRegex(normalized_out, rf'tap4096.{vlan} \d+ \S+ {mtu}/0/0/0')
+
+        self.cli_set(
+            ['interfaces', 'ethernet', interface, 'vif', vlan, 'mtu', vlan_mtu]
+        )
+        self.cli_commit()
+
+        _, out = rc_cmd('sudo vppctl show interface')
+        normalized_out = re.sub(r'\s+', ' ', out)
+        self.assertRegex(
+            normalized_out, rf'{interface}.{vlan} \d+ \S+ {vlan_mtu}/0/0/0'
+        )
+        self.assertRegex(normalized_out, rf'tap4096.{vlan} \d+ \S+ {vlan_mtu}/0/0/0')
+
         # delete mtu settings
+        self.cli_delete(['interfaces', 'ethernet', interface, 'vif', vlan])
         self.cli_delete(['interfaces', 'ethernet', interface, 'mtu'])
         self.cli_commit()
+
+        # An MTU larger than the NIC's maximum must be rejected at verify.
+        # The NIC maximum is driver-specific, so read it from VPP and set
+        # one above it. Skip when VPP does not report a maximum (a build without
+        # the 'max mtu' hardware-interface field cannot enforce the limit) or
+        # when it exceeds the CLI range, which has its own validation.
+        nic_max_mtu = VPPControl().get_iface_max_mtu(interface)
+        if nic_max_mtu is not None and nic_max_mtu < 16000:
+            over_mtu = nic_max_mtu + 1
+            self.cli_set(['interfaces', 'ethernet', interface, 'mtu', str(over_mtu)])
+            with self.assertRaisesRegex(
+                ConfigSessionError,
+                f'MTU {over_mtu} exceeds the maximum {nic_max_mtu}',
+            ):
+                self.cli_commit()
+            self.cli_discard()
 
         # A custom MAC address must reach the VPP dataplane, and removing it must
         # restore the hardware address (hw-id). Rejection of drivers that cannot
@@ -447,6 +489,43 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
         self.assertIn(f'Ethernet address {mac}', out)
         self.assertEqual(mac, Interface(interface_loopback).get_mac())
 
+        # MTU must reach the VPP dataplane for the loopback and its
+        # VLAN sub-interfaces. A vif without its own MTU inherits the parent's; a
+        # vif with an explicit MTU uses that.
+        mtu = '2500'
+        vif_mtu = '1400'
+
+        self.cli_set(loopback_path + [interface_loopback, 'mtu', mtu])
+        self.cli_set(loopback_path + [interface_loopback, 'vif', '10'])
+        self.cli_commit()
+
+        _, out = rc_cmd('sudo vppctl show interface')
+        normalized_out = re.sub(r'\s+', ' ', out)
+        # parent loopback and its lcp carries its configured MTU
+        self.assertRegex(normalized_out, rf'loop11 \d+ \S+ {mtu}/')
+        self.assertRegex(normalized_out, rf'tap4097 \d+ \S+ {mtu}/')
+        # vif without its own MTU inherits the parent's (sub-interface and tap)
+        self.assertRegex(normalized_out, rf'loop11.10 \d+ \S+ {mtu}/')
+        self.assertRegex(normalized_out, rf'tap4097.10 \d+ \S+ {mtu}/')
+
+        # Set the vif MTU bigger than the parent's MTU.
+        # This must raise a ConfigError.
+        self.cli_set(
+            loopback_path
+            + [interface_loopback, 'vif', '10', 'mtu', str(int(mtu) + 100)]
+        )
+        with self.assertRaises(ConfigSessionError):
+            self.cli_commit()
+
+        self.cli_set(loopback_path + [interface_loopback, 'vif', '10', 'mtu', vif_mtu])
+        self.cli_commit()
+
+        _, out = rc_cmd('sudo vppctl show interface')
+        normalized_out = re.sub(r'\s+', ' ', out)
+        # vif with an explicit MTU uses it (sub-interface and tap)
+        self.assertRegex(normalized_out, rf'loop11.10 \d+ \S+ {vif_mtu}/')
+        self.assertRegex(normalized_out, rf'tap4097.10 \d+ \S+ {vif_mtu}/')
+
         # delete loopback interface
         self.cli_delete(loopback_path + [interface_loopback])
         self.cli_commit()
@@ -524,6 +603,27 @@ class TestVPP(VyOSUnitTestSHIM.TestCase):
             r'BondEthernet23\s+\d+\s+up',
             "Interface BondEthernet23 is not in the expected state 'up'.",
         )
+
+        # MTU must be set on VLAN sub-interfaces and taps (vif inherits parent
+        # unless set).
+        mtu = '2500'
+        vif_mtu = '1400'
+        self.cli_set(bond_path + [interface_bond, 'mtu', mtu])
+        self.cli_set(bond_path + [interface_bond, 'vif', vlans[1], 'mtu', vif_mtu])
+        self.cli_commit()
+
+        _, out = rc_cmd('sudo vppctl show interface')
+        normalized_out = re.sub(r'\s+', ' ', out)
+        # parent bond carries its configured MTU
+        self.assertRegex(normalized_out, rf'BondEthernet23 \d+ \S+ {mtu}/')
+        # vif without its own MTU inherits the parent's (sub-interface and tap)
+        self.assertRegex(normalized_out, rf'BondEthernet23.{vlans[0]} \d+ \S+ {mtu}/')
+        self.assertRegex(normalized_out, rf'tap4097.123 \d+ \S+ {mtu}/')
+        # vif with an explicit MTU uses it (sub-interface and tap)
+        self.assertRegex(
+            normalized_out, rf'BondEthernet23.{vlans[1]} \d+ \S+ {vif_mtu}/'
+        )
+        self.assertRegex(normalized_out, rf'tap4097.456 \d+ \S+ {vif_mtu}/')
 
         # delete vpp interface vlan
         self.cli_delete(bond_path + [interface_bond, 'vif'])

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -42,6 +42,7 @@ from vyos.frrender import FRRender
 from vyos.frrender import get_frrender_dict
 from vyos.ifconfig import EthernetIf
 from vyos.ifconfig import BondIf
+from vyos.ifconfig import Interface
 from vyos.utils.dict import dict_search
 from vyos.utils.dict import dict_to_paths_values
 from vyos.utils.dict import dict_set
@@ -165,6 +166,15 @@ def get_config(config=None):
                 ethernet['mtu'] = str(max_mtu)
         except Exception:
             pass
+        # For a VPP-bound interface the max MTU read above is the LCP tap's, not
+        # the dataplane NIC's, so clamp the default to the real NIC limit instead
+        # - otherwise the default would be rejected at commit.
+        if conf.exists(['vpp', 'settings', 'interface', ifname]) and (
+            is_systemd_service_running('vpp.service')
+        ):
+            vpp_max_mtu = VPPControl().get_iface_max_mtu(ifname)
+            if vpp_max_mtu is not None and vpp_max_mtu < int(ethernet['mtu']):
+                ethernet['mtu'] = str(vpp_max_mtu)
 
     if 'is_bond_member' in ethernet:
         update_bond_options(conf, ethernet)
@@ -385,6 +395,31 @@ def verify_vpp_remove_vif(ethernet: dict):
     for vlan in vlan_names:
         verify_vpp_remove_interface(vlan, vpp_config)
 
+def verify_vpp_mtu(ethernet: dict):
+    """Reject an MTU larger than the NIC can handle on a VPP-bound interface.
+
+    Otherwise, the kernel accepts the MTU while the VPP dataplane caps it at the
+    NIC limit, leaving the two out of sync (T9161).
+    """
+    ifname = ethernet['ifname']
+    if 'mtu' not in ethernet:
+        return
+    if dict_search(f'vpp.settings.interface.{ifname}', ethernet) is None:
+        return
+    if not is_systemd_service_running('vpp.service'):
+        return
+
+    max_mtu = VPPControl().get_iface_max_mtu(ifname)
+    if max_mtu is None:
+        return
+
+    mtu = int(ethernet['mtu'])
+    if mtu > max_mtu:
+        raise ConfigError(
+            f'Interface MTU {mtu} exceeds the maximum {max_mtu} '
+            'supported by the VPP dataplane'
+        )
+
 def verify(ethernet):
     verify_flowtable(ethernet)
     verify_vpp_remove_vif(ethernet)
@@ -408,6 +443,7 @@ def verify(ethernet):
         and dict_search(f'vpp.settings.interface.{ifname}', ethernet) is not None
     ):
         verify_vpp_mac_change_supported(ifname)
+    verify_vpp_mtu(ethernet)
     verify_coalesce(ethernet, ethtool)
 
     if 'is_bond_member' in ethernet:
@@ -491,14 +527,10 @@ def apply(ethernet):
                 vpp_api.disable_icmpv6_ra_punt(dhcp_ifname)
 
         # If the interface is managed by the VPP DPDK driver, synchronize runtime
-        # parameters between Linux and the corresponding VPP LCP interface
-        # Find LCP pair
-        lcp_pair = vpp_api.lcp_pair_find(vpp_name_hw=ifname)
-        # Sync MTU to VPP LCP pair interface
-        if lcp_pair:
-            lcp_name = lcp_pair.get('vpp_name_kernel')
-            mtu = e.get_mtu()
-            vpp_api.set_iface_mtu(lcp_name, mtu)
+        # parameters between Linux and the corresponding VPP LCP interfaces.
+        # Sync MTU to the VPP LCP taps for the parent and its VLAN
+        # sub-interfaces (linux-cp creates sub-interface taps with MTU 0).
+        sync_vpp_lcp_mtu(ethernet, vpp_api)
 
         sync_vpp_lcp_vrf_tables(ethernet, vpp_api)
 
@@ -512,6 +544,36 @@ def apply(ethernet):
         vpp_api.set_promisc(ifname, enable=needs_promisc)
 
     return None
+
+
+def sync_vpp_lcp_mtu(ethernet: dict, vpp_api: VPPControl) -> None:
+    """Sync each VPP interface's MTU to its dataplane sub-interface and LCP tap.
+
+    A VPP VLAN sub-interface keeps the parent MTU on the dataplane, and its
+    LCP tap is created with MTU 0. Neither matches the real kernel MTU (the
+    sub-interface's own if set, else the parent's). Read the kernel MTU and
+    set it on both, so the kernel, dataplane and tap agree. Q-in-Q (vif-c)
+    is skipped, because VPP does not support it (T9161).
+    """
+    ifnames = [ethernet['ifname']]
+    ifnames += [vlan_conf['ifname'] for vlan_conf in ethernet.get('vif', {}).values()]
+    ifnames += [vlan_conf['ifname'] for vlan_conf in ethernet.get('vif_s', {}).values()]
+
+    # Fetch all LCP pairs once and index by VPP (hardware) name; lcp_pair_find()
+    # dumps every pair on each call, so avoid calling it per interface.
+    lcp_tap_map = {
+        pair.get('vpp_name_hw'): pair.get('vpp_name_kernel')
+        for pair in vpp_api.lcp_pairs_list()
+    }
+    for iface in ifnames:
+        lcp_name = lcp_tap_map.get(iface)
+        if not lcp_name:
+            continue
+        mtu = Interface(iface).get_mtu()
+        # The dataplane sub-interface and the tap both need setting: the former
+        # otherwise keeps the parent-inherited MTU, the latter stays at 0.
+        vpp_api.set_iface_mtu(iface, mtu)
+        vpp_api.set_iface_mtu(lcp_name, mtu)
 
 
 def sync_vpp_lcp_vrf_tables(ethernet: dict, vpp_api: VPPControl) -> None:

--- a/src/conf_mode/vpp_interfaces_bonding.py
+++ b/src/conf_mode/vpp_interfaces_bonding.py
@@ -23,6 +23,7 @@ from vyos.configdict import is_node_changed
 from vyos.configdict import leaf_node_changed
 from vyos.configdep import set_dependents, call_dependents
 from vyos.configverify import verify_mtu_ipv6
+from vyos.configverify import verify_vlan_config
 from vyos import ConfigError
 from vyos.utils.assertion import assert_mac
 from vyos.utils.dict import dict_search
@@ -81,6 +82,13 @@ def get_config(config=None) -> dict:
     base = ['interfaces', 'vpp', 'bonding']
 
     ifname, config = get_interface_dict(conf, base)
+
+    # A VLAN sub-interface inherits the parent MTU when its own is unset; set it
+    # explicitly so a removed sub-interface MTU reverts to the parent instead of
+    # keeping its previous value.
+    if 'mtu' in config:
+        for vlan in config.get('vif', {}).values():
+            vlan.setdefault('mtu', config['mtu'])
 
     # Get pppoe-server interfaces
     config['pppoe_ifaces'] = conf.list_nodes(['service', 'pppoe-server', 'interface'])
@@ -238,6 +246,8 @@ def verify(config):
         verify_vpp_remove_interface(vif_iface, config.get('vpp'))
 
     verify_mtu_ipv6(config)
+    # Validate VLAN sub-interfaces, incl. MTU against the parent
+    verify_vlan_config(config)
 
 
 def generate(config):

--- a/src/conf_mode/vpp_interfaces_loopback.py
+++ b/src/conf_mode/vpp_interfaces_loopback.py
@@ -20,6 +20,7 @@ from vyos import ConfigError
 
 from vyos.config import Config
 from vyos.configdict import get_interface_dict
+from vyos.configverify import verify_vlan_config
 from vyos.configdep import set_dependents, call_dependents
 from vyos.utils.process import is_systemd_service_active
 
@@ -49,6 +50,13 @@ def get_config(config=None) -> dict:
     if not conf.exists(['vpp']) and not conf.exists(base):
         config['remove_vpp'] = True
         return config
+
+    # A VLAN sub-interface inherits the parent MTU when its own is unset; set it
+    # explicitly so a removed sub-interface MTU reverts to the parent instead of
+    # keeping its previous value.
+    if 'mtu' in config:
+        for vlan in config.get('vif', {}).values():
+            vlan.setdefault('mtu', config['mtu'])
 
     # Get 'vpp settings' config
     config['vpp_settings'] = conf.get_config_dict(
@@ -104,6 +112,9 @@ def verify(config):
     for vif_remove in config.get('vif_remove', []):
         vif_iface = f'{config["ifname"]}.{vif_remove}'
         verify_vpp_remove_interface(vif_iface, config['vpp'])
+
+    # Validate VLAN sub-interfaces, incl. MTU against the parent
+    verify_vlan_config(config)
 
     return None
 


### PR DESCRIPTION
On a VPP-bound interface the MTU limit is the NIC's, which only VPP knows (the kernel side is an LCP tap reporting a meaningless larger max). Reject at commit an MTU larger than that limit, read from VPP's 'show hardware-interfaces' (max mtu + driver frame overhead), so the kernel and dataplane cannot silently end up with different MTUs.

Also apply a VLAN sub-interface's MTU to its VPP dataplane sub-interface and its linux-cp tap (created with MTU 0), not just the parent; a sub-interface without its own MTU inherits the parent's. Covers ethernet (vif/vif-s) and VPP bond/loopback (vif).

<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T9161
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
https://github.com/VyOS-Networks/vpp/pull/80 — merge only after that patch is in the VPP build. Without it, `show hardware-interfaces` has no `max mtu/driver frame overhead` fields, so the MTU-limit check is skipped
## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
1. VLAN sub-interface MTU reaches the dataplane tap
A vif inherits the parent MTU, and it must now reach the LCP tap (linux-cp creates it with MTU 0).  tap4096.10 row — MTU 0 → 1500:
```
set vpp settings interface eth1
set interfaces ethernet eth1 vif 10
commit
```
Before:
```
vyos@vyos# run show interfaces vpp | grep eth1.10
          eth1.10      dpdk                  00:00:00:00:00:00   1500  up
eth1.10   tap4096.10   virtio                00:00:00:00:00:00      0  up
[edit]
```
After:
```
vyos@vyos# run show interfaces vpp | grep eth1.10
          eth1.10      dpdk                  00:00:00:00:00:00   1500  up
eth1.10   tap4096.10   virtio                00:00:00:00:00:00   1500  up
[edit]
```
2. An MTU above the NIC limit is rejected at commit
Before, the kernel tap took 10000 while the dataplane stayed at 1500 — a silent mismatch. After, it's rejected during verify with a clear message naming the NIC maximum
Before:
```
vyos@vyos# set interfaces ethernet eth1 mtu 10000
[edit]
vyos@vyos# commit
[edit]
vyos@vyos# run show interfaces ethernet 
Codes: S - State, L - Link, u - Up, D - Down, A - Admin Down
Interface        IP Address                        S/L  Description
---------        ----------                        ---  -----------
eth0             -                                 u/D  
eth1             -                                 u/u  
eth1.10          -                                 u/u  
eth2             -                                 u/D  
eth3             10.217.32.112/24                  u/u  
[edit]
vyos@vyos# run show interfaces vpp
Kernel    Dataplane    Type    IP Address    MAC                  MTU  State
--------  -----------  ------  ------------  -----------------  -----  -------
          eth1         dpdk                  0c:66:5a:18:00:01   1500  up
          eth1.10      dpdk                  00:00:00:00:00:00   1500  up
          local0       local                 00:00:00:00:00:00      0  down
eth1      tap4096      virtio                02:fe:43:69:e3:a4  10000  up
eth1.10   tap4096.10   virtio                00:00:00:00:00:00      0  up
[edit]
```
After:
```
vyos@vyos# set interfaces ethernet eth1 mtu 10000
[edit]
vyos@vyos# commit
[ interfaces ethernet eth1 ]
Interface MTU 10000 exceeds the maximum 9706 supported by the VPP
dataplane
[[interfaces ethernet eth1]] failed
Commit failed
[edit]
```
3. Bond/loopback VLAN sub-interface MTU reaches the tap
Same as (1) for VPP-native interfaces — the vppbond1.10 tap (tap4097.10) goes 0 → 1500:
```
set interfaces vpp bonding vppbond1 member interface eth1
set interfaces vpp bonding vppbond1 vif 10 
commit
```
Before:
```
vyos@vyos# run show interfaces vpp
Kernel       Dataplane         Type    IP Address    MAC                  MTU  State
-----------  ----------------  ------  ------------  -----------------  -----  -------
             BondEthernet1     bond                  02:fe:71:3c:8f:10   1500  up
             BondEthernet1.10  bond                  00:00:00:00:00:00   1500  up
             eth1              dpdk                  0c:66:5a:18:00:01   1500  up
             local0            local                 00:00:00:00:00:00      0  down
eth1         tap4096           virtio                02:fe:43:69:e3:a4   1500  up
vppbond1     tap4097           virtio                02:fe:89:bf:f0:aa   1500  up
vppbond1.10  tap4097.10        virtio                00:00:00:00:00:00      0  up
[edit]
```
After:
```
vyos@vyos# run show interfaces vpp
Kernel       Dataplane         Type    IP Address    MAC                  MTU  State
-----------  ----------------  ------  ------------  -----------------  -----  -------
             BondEthernet1     bond                  02:fe:98:dc:d3:af   1500  up
             BondEthernet1.10  bond                  00:00:00:00:00:00   1500  up
             eth1              dpdk                  0c:9f:c1:cd:00:01   1500  up
             local0            local                 00:00:00:00:00:00      0  down
eth1         tap4096           virtio                02:fe:3b:0a:89:6f   1500  up
vppbond1     tap4097           virtio                02:fe:65:91:8d:82   1500  up
vppbond1.10  tap4097.10        virtio                00:00:00:00:00:00   1500  up
[edit]
```
4. A bond/loopback vif MTU above the parent is rejected cleanly
Before, this slipped past verify and blew up in apply with a traceback (ip link … mtu 5000 failed). After, it's caught at verify with a clear error:
Before:
```
vyos@vyos# set interfaces vpp bonding vppbond1 vif 10 mtu 5000
[edit]
vyos@vyos# commit
[ interfaces vpp bonding vppbond1 ]
Traceback (most recent call last):
  File "/usr/libexec/vyos/services/vyos-configd", line 157, in run_script
    script.apply(c)
  File "/usr/libexec/vyos/conf_mode/vpp_interfaces_bonding.py", line 233, in apply
    bond.update(config)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/vpp/bond.py", line 150, in update
    super().update(config)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 2113, in update
    vlan.update(vif_config)
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 1923, in update
    self.set_mtu(config.get('mtu'))
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/interface.py", line 502, in set_mtu
    return self.set_interface('mtu', mtu)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/control.py", line 197, in set_interface
    return self._set_command(self.config, name, value)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/control.py", line 124, in _set_command
    return self._command_set[name].get('format', lambda _: _)(self._cmd(cmd))
                                                              ^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/ifconfig/control.py", line 66, in _cmd
    return cmd(command, self.debug, env=env)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/vyos/utils/process.py", line 209, in cmd
    raise OSError(code, feedback)
FileNotFoundError: [Errno 2] failed to run command: None ip link set dev vppbond1.10 mtu 5000
returned: 
exit code: 2

[[interfaces vpp bonding vppbond1]] failed
Commit failed
[edit]
vyos@vyos# 
```
After:
```
vyos@vyos# set interfaces vpp bonding vppbond1 vif 10 mtu 5000
[edit]
vyos@vyos# commit
[ interfaces vpp bonding vppbond1 ]
Interface MTU "5000" too high, parent interface MTU is "1500"!
[[interfaces vpp bonding vppbond1]] failed
Commit failed
[edit]
vyos@vyos# 
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
