### PR TITLE
static: T9278: reconcile FRR config after every DHCP lease event

### DIFF
--- a/data/templates/dhcp-client/dhcp6c-script.j2
+++ b/data/templates/dhcp-client/dhcp6c-script.j2
@@ -2,6 +2,34 @@
 # Update DNS information for DHCPv6 clients
 # should be used only if vyos-hostsd is running
 
+# This script is executed standalone by dhcp6c and can not source the dhclient
+# hook /etc/dhcp/dhclient-enter-hooks.d/01-vyos-logging, which is only pulled
+# into the dhclient-script shell. It therefore carries its own logmsg() - keep
+# the tag, the priorities and the debug flag file in sync with that file.
+LOG_TAG="dhclient-script-vyos"
+LOG_DEBUG_ENABLE="/tmp/vyos.dhclient.debug"
+
+logmsg () {
+    log_level=$1
+    shift
+
+    case ${log_level} in
+        debug)
+            # Do not even build the message when debugging is not requested
+            [ -f "${LOG_DEBUG_ENABLE}" ] || return 0
+            log_prio="daemon.debug" ;;
+        info)  log_prio="daemon.info" ;;
+        warn)  log_prio="daemon.warning" ;;
+        error) log_prio="daemon.err" ;;
+        *)
+            # Unknown level - do not lose the message, it was never a level
+            log_prio="daemon.info"
+            set -- "${log_level}" "$@" ;;
+    esac
+
+    /usr/bin/logger -e --id=$$ -p ${log_prio} -t ${LOG_TAG} "$@"
+}
+
 if /usr/bin/systemctl -q is-active vyos-hostsd; then
     hostsd_client="/usr/bin/vyos-hostsd-client"
     hostsd_changes=
@@ -23,9 +51,9 @@ if /usr/bin/systemctl -q is-active vyos-hostsd; then
     fi
 
     if [ $hostsd_changes ]; then
-        logmsg info "Applying changes via vyos-hostsd-client"
+        logmsg debug "Applying changes via vyos-hostsd-client"
         $hostsd_client --apply
     else
-        logmsg info "No changes to apply via vyos-hostsd-client"
+        logmsg debug "No changes to apply via vyos-hostsd-client"
     fi
 fi

--- a/python/vyos/defaults.py
+++ b/python/vyos/defaults.py
@@ -64,6 +64,7 @@ config_files = {
 config_status = '/tmp/vyos-config-status'
 api_config_state = '/run/http-api-state'
 frr_debug_enable = '/tmp/vyos.frr.debug'
+dhclient_debug_enable = '/tmp/vyos.dhclient.debug'
 static_route_dhcp_interfaces_path = '/tmp/static_dhcp_interfaces'
 vyos_configd_socket_path = 'ipc:///run/vyos-configd.sock'
 

--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -31,10 +31,8 @@ from vyos.config import config_dict_merge
 from vyos.configdict import get_dhcp_interfaces
 from vyos.configdict import get_pppoe_interfaces
 from vyos.defaults import frr_debug_enable
-from vyos.defaults import static_route_dhcp_interfaces_path
 from vyos.utils.dict import dict_search
 from vyos.utils.dict import dict_set_nested
-from vyos.utils.file import read_file
 from vyos.utils.file import write_file
 from vyos.utils.process import cmdl
 from vyos.utils.process import rc_cmd
@@ -692,6 +690,41 @@ def get_frrender_dict(conf: Config, argv=None) -> dict:
 
     return dict
 
+def get_dhcp_route_interfaces(config_dict) -> set:
+    """Collect all interfaces whose static route configuration is derived from a
+    DHCP lease. Two CLI constructs end up reading the DHCP lease file via the
+    "get_dhcp_router" Jinja filter and thus depend on the current lease:
+
+    - "protocols static route <prefix> dhcp-interface <ifname>"
+    - the default route implied by "interfaces <type> <ifname> address dhcp"
+
+    Both variants exist in the default VRF as well as inside any named VRF.
+    """
+    interfaces = set()
+
+    def _add_from_static(static_conf):
+        if not isinstance(static_conf, dict):
+            return
+        for prefix_options in static_conf.get('route', {}).values():
+            interfaces.update(prefix_options.get('dhcp_interface', []))
+        for ifname, if_config in static_conf.get('dhcp', {}).items():
+            # An interface explicitly opting out of the default route does not
+            # contribute a route, thus a lease change is irrelevant for it
+            if dict_search('dhcp_options.no_default_route', if_config) != None:
+                continue
+            interfaces.add(ifname)
+
+    if not isinstance(config_dict, dict):
+        return interfaces
+
+    _add_from_static(config_dict.get('static'))
+    for vrf_name in dict_search('vrf.name', config_dict) or {}:
+        _add_from_static(
+            dict_search(f'vrf.name.{vrf_name}.protocols.static', config_dict)
+        )
+
+    return interfaces
+
 class FRRender:
     cached_config_dict = {}
     cached_dhcp_gateways = {}
@@ -707,9 +740,14 @@ class FRRender:
             tmp = type(config_dict)
             raise ValueError(f'Config must be of type "dict" and not "{tmp}"!')
 
+        # T8465: the rendered configuration embeds the current DHCP gateway,
+        # which changes independently of the CLI configuration. The interface
+        # list must be derived from the configuration itself - the DHCP hook
+        # list on disk is only written by protocols_static.py, which does not
+        # run on an interface-only commit.
         dhcp_gateways = {
             interface: get_dhcp_router(interface)
-            for interface in read_file(static_route_dhcp_interfaces_path, '').split()
+            for interface in get_dhcp_route_interfaces(config_dict)
         }
 
         if (

--- a/python/vyos/frrender.py
+++ b/python/vyos/frrender.py
@@ -695,18 +695,29 @@ def get_dhcp_route_interfaces(config_dict) -> set:
     DHCP lease. Two CLI constructs end up reading the DHCP lease file via the
     "get_dhcp_router" Jinja filter and thus depend on the current lease:
 
-    - "protocols static route <prefix> dhcp-interface <ifname>"
+    - "protocols static route <prefix> dhcp-interface <ifname>", either directly
+      or below "protocols static table <id>"
     - the default route implied by "interfaces <type> <ifname> address dhcp"
 
     Both variants exist in the default VRF as well as inside any named VRF.
     """
     interfaces = set()
 
+    def _add_from_routes(route_conf):
+        if not isinstance(route_conf, dict):
+            return
+        for prefix_options in route_conf.values():
+            interfaces.update(prefix_options.get('dhcp_interface', []))
+
     def _add_from_static(static_conf):
         if not isinstance(static_conf, dict):
             return
-        for prefix_options in static_conf.get('route', {}).values():
-            interfaces.update(prefix_options.get('dhcp_interface', []))
+        _add_from_routes(static_conf.get('route'))
+        # Routes in a dedicated routing table use the same "dhcp-interface"
+        # node, thus they depend on the DHCP lease in the very same way
+        for table_config in static_conf.get('table', {}).values():
+            if isinstance(table_config, dict):
+                _add_from_routes(table_config.get('route'))
         for ifname, if_config in static_conf.get('dhcp', {}).items():
             # An interface explicitly opting out of the default route does not
             # contribute a route, thus a lease change is irrelevant for it

--- a/python/vyos/template.py
+++ b/python/vyos/template.py
@@ -431,6 +431,14 @@ def get_dhcp_router(interface):
 
     Returns None if no router is found, returns the IP address as string if
     a router is found.
+
+    The file read here is not the dhclient lease database (dhclient_<if>.leases)
+    but the per event dump written by
+    /etc/dhcp/dhclient-exit-hooks.d/03-vyos-dhclient-hook. It is intentionally
+    not removed when the DHCP client is stopped - the RELEASE/STOP event
+    rewrites it with an empty "new_routers", which is the signal that no router
+    is available. The file name is keyed on the interface only, a VRF assignment
+    does not change it.
     """
     lease_file = directories['isc_dhclient_dir'] + f'/dhclient_{interface}.lease'
     if not os.path.exists(lease_file):

--- a/smoketest/scripts/cli/test_protocols_static.py
+++ b/smoketest/scripts/cli/test_protocols_static.py
@@ -202,6 +202,39 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
         # always forward to base class
         super().tearDown()
 
+    def wait_for_dhcp_router(self, interface, timeout=30):
+        """The DHCP client is started in the background (dhclient -nw), thus a
+        commit returns before a lease was acquired. In addition, moving an
+        interface into a VRF releases and re-acquires the lease. Wait until the
+        DHCP hook reported a router for the given interface."""
+        result, router = self.wait_for_result(
+            lambda: get_dhcp_router(interface),
+            lambda tmp: tmp is not None,
+            pause=1,
+            timeout=timeout,
+        )
+        self.assertTrue(
+            result, f'No DHCP router received on interface "{interface}"'
+        )
+        return router
+
+    def assert_in_frrconfig(self, needle, timeout=30, **kwargs):
+        """Assert that needle shows up in the FRR configuration. A DHCP lease
+        event reconciles the FRR configuration asynchronously via the dhclient
+        hook, thus we can not check the configuration only once."""
+        def check():
+            frrconfig = self.getFRRconfig(**kwargs)
+            if needle in frrconfig:
+                return True
+            return frrconfig
+
+        result, frrconfig = self.wait_for_result(
+            check, True, pause=1, timeout=timeout
+        )
+        self.assertTrue(
+            result, f"Expected '{needle}' in FRR config:\n{frrconfig}"
+        )
+
     def test_01_static(self):
         self.cli_set(['vrf', 'name', 'black', 'table', '43210'])
         for route, route_config in routes.items():
@@ -605,12 +638,9 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
         self.cli_set(interface_path + ['address', 'dhcp'])
         self.cli_commit()
 
-        # Wait for dhclient to receive IP address and default gateway
-        sleep(5)
-
-        router = get_dhcp_router(interface)
-        frrconfig = self.getFRRconfig()
-        self.assertIn(rf'ip route 0.0.0.0/0 {router} {interface} tag 210 {default_distance}', frrconfig)
+        router = self.wait_for_dhcp_router(interface)
+        route_str = f'ip route 0.0.0.0/0 {router} {interface} tag 210 {default_distance}'
+        self.assert_in_frrconfig(route_str)
 
         # T6991: Default route is missing when there is no "protocols static"
         # CLI node entry
@@ -621,8 +651,7 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Re-check FRR configuration that default route is still present
-        frrconfig = self.getFRRconfig()
-        self.assertIn(rf'ip route 0.0.0.0/0 {router} {interface} tag 210 {default_distance}', frrconfig)
+        self.assert_in_frrconfig(route_str)
 
         self.cli_delete(interface_path + ['address'])
         self.cli_commit()
@@ -648,7 +677,10 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
         self.cli_set(interface_path + ['vrf', vrf])
         self.cli_commit()
 
-        router = get_dhcp_router(interface)
+        # Moving the interface into a VRF stops and restarts the DHCP client,
+        # thus the lease is released and re-acquired - we must not read the
+        # released (empty) lease information here
+        router = self.wait_for_dhcp_router(interface)
         route_str = (
             rf'ip route 0.0.0.0/0 {router} {interface} tag 210 {default_distance}'
         )
@@ -660,7 +692,7 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
             return frrconfig
 
         result, config = self.wait_for_result(
-            check_default_route, True, pause=1, timeout=10
+            check_default_route, True, pause=1, timeout=30
         )
 
         # First clean interfaces from VRF so that VRF can be deleted
@@ -695,8 +727,9 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
         # Commit configuration
         self.cli_commit()
 
-        # Wait for dhclient to receive IP address
-        sleep(5)
+        # Wait for dhclient to receive an IP address and default gateway - the
+        # dhcp-interface routes are rendered from the lease
+        router = self.wait_for_dhcp_router(dhcp_interface)
 
         # Configure static routes with dhcp-interface
         dhcp_routes = {
@@ -734,17 +767,11 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
             f'Interface {dhcp_interface} should be in hook interface list',
         )
 
-        # Get the DHCP router for verification
-        router = get_dhcp_router(dhcp_interface)
-        self.assertIsNotNone(router, 'DHCP router should be available')
-
         # Verify FRR configuration contains the static routes with DHCP router
-        frrconfig = self.getFRRconfig('ip route', end_marker='')
-
         for route in dhcp_routes.keys():
             expected_route = f'ip route {route} {router} {dhcp_interface}'
-            self.assertIn(expected_route, frrconfig, f'Static route {route} '\
-                          'with dhcp-interface should be in FRR config')
+            self.assert_in_frrconfig(expected_route, start_section='ip route',
+                                     end_marker='')
 
         # Test table-based routes with dhcp-interface
         table_id = '100'
@@ -754,15 +781,11 @@ class TestProtocolsStatic(VyOSUnitTestSHIM.TestCase):
         self.cli_commit()
 
         # Verify table route in FRR config
-        frrconfig = self.getFRRconfig('ip route', end_marker='')
         expected_table_route = (
             f'ip route {table_route} {router} {dhcp_interface} table {table_id}'
         )
-        self.assertIn(
-            expected_table_route,
-            frrconfig,
-            f'Table static route {table_route} with dhcp-interface should be in FRR config',
-        )
+        self.assert_in_frrconfig(expected_table_route,
+                                 start_section='ip route', end_marker='')
 
         # Clean up - remove DHCP configuration
         self.cli_delete(interface_path + ['address'])

--- a/src/conf_mode/protocols_static.py
+++ b/src/conf_mode/protocols_static.py
@@ -24,6 +24,7 @@ from vyos.configverify import has_frr_protocol_in_dict
 from vyos.configverify import verify_common_route_maps
 from vyos.configverify import verify_vrf
 from vyos.frrender import FRRender
+from vyos.frrender import get_dhcp_route_interfaces
 from vyos.frrender import get_frrender_dict
 from vyos.utils.dict import dict_search
 from vyos.utils.file import write_file
@@ -99,15 +100,11 @@ def generate(config_dict):
     static = vrf and dict_search(f'vrf.name.{vrf}.protocols.static',
                                  config_dict) or config_dict['static']
 
-    # Collect interfaces that have DHCP configuration for DHCP hooks
-    dhcp_interfaces = set()
-
-    # Check for DHCP interfaces in route configurations
-    if 'route' in static:
-        for prefix, prefix_options in static['route'].items():
-            if 'dhcp_interface' in prefix_options:
-                for interface_name in prefix_options['dhcp_interface']:
-                    dhcp_interfaces.add(interface_name)
+    # Collect interfaces that have DHCP configuration for DHCP hooks. This must
+    # be derived from the entire config_dict and not from the (possibly
+    # VRF-narrowed) static dict above, as DHCP_HOOK_IFLIST is a single global
+    # file - a per VRF invocation would otherwise clobber the list.
+    dhcp_interfaces = get_dhcp_route_interfaces(config_dict)
 
     # Write the interface list for DHCP hooks or clean up if empty
     if dhcp_interfaces:

--- a/src/etc/dhcp/dhclient-enter-hooks.d/01-vyos-logging
+++ b/src/etc/dhcp/dhclient-enter-hooks.d/01-vyos-logging
@@ -3,18 +3,39 @@ LOG_ENABLE="yes"
 LOG_STDERR="no"
 LOG_TAG="dhclient-script-vyos"
 
+# Tracing the individual steps of a lease event is only of interest while
+# debugging - it is silenced unless this flag file exists. Keep in sync with
+# "dhclient_debug_enable" in python/vyos/defaults.py, the file is created by
+# src/init/vyos-router when "vyos-debug" is present on the kernel command line.
+LOG_DEBUG_ENABLE="/tmp/vyos.dhclient.debug"
+
 function logmsg () {
     # log message to journal
-    case $1 in
+    local LOG_PRIO
+    local LOG_LEVEL=$1
+    shift
+
+    case ${LOG_LEVEL} in
+        debug)
+            # Do not even build the message when debugging is not requested
+            if [ ! -f "${LOG_DEBUG_ENABLE}" ] ; then
+                return 0
+            fi
+            LOG_PRIO="daemon.debug" ;;
+        info)  LOG_PRIO="daemon.info" ;;
+        warn)  LOG_PRIO="daemon.warning" ;;
         error) LOG_PRIO="daemon.err" ;;
-        info) LOG_PRIO="daemon.info" ;;
+        *)
+            # Unknown level - do not lose the message, it was never a level
+            LOG_PRIO="daemon.info"
+            set -- "${LOG_LEVEL}" "$@" ;;
     esac
 
     if [ "${LOG_ENABLE}" == "yes" ] ; then
         if [ "${LOG_STDERR}" == "yes" ] ; then
-            /usr/bin/logger -e --id=$$ -s -p ${LOG_PRIO} -t ${LOG_TAG} "${@:2}"
+            /usr/bin/logger -e --id=$$ -s -p ${LOG_PRIO} -t ${LOG_TAG} "$@"
         else
-            /usr/bin/logger -e --id=$$ -p ${LOG_PRIO} -t ${LOG_TAG} "${@:2}"
+            /usr/bin/logger -e --id=$$ -p ${LOG_PRIO} -t ${LOG_TAG} "$@"
         fi
     fi
 }

--- a/src/etc/dhcp/dhclient-enter-hooks.d/02-vyos-stopdhclient
+++ b/src/etc/dhcp/dhclient-enter-hooks.d/02-vyos-stopdhclient
@@ -17,7 +17,7 @@ if [ -z ${CONTROLLED_STOP} ] ; then
         dhclients_pids=(`ps --no-headers --format pid,args -C dhclient | awk "{ if(match(\\$0, /\s${interface}(\s|$)/) && !match(\\$0, /\s-6\s/)) printf(\"%s\n\", \\$1) }"`)
     fi
 
-    logmsg info "Current dhclient PID: $current_dhclient, Parent PID: $master_dhclient, IP version: $ipversion_arg, All dhclients for interface $interface: ${dhclients_pids[@]}"
+    logmsg debug "Current dhclient PID: $current_dhclient, Parent PID: $master_dhclient, IP version: $ipversion_arg, All dhclients for interface $interface: ${dhclients_pids[@]}"
     # stop all dhclients for current interface, except current one
     for dhclient in ${dhclients_pids[@]}; do
         if ([ $dhclient -ne $current_dhclient ] && [ $dhclient -ne $master_dhclient ]); then

--- a/src/etc/dhcp/dhclient-enter-hooks.d/03-vyos-ipwrapper
+++ b/src/etc/dhcp/dhclient-enter-hooks.d/03-vyos-ipwrapper
@@ -100,12 +100,26 @@ function iptovtysh () {
     logmsg debug "Converted vtysh command: \"$VTYSH_CMD\""
 }
 
+# Return the VRF option for a command, unless the caller already specified one.
+# 01-vyos-cleanup builds its "ip route del" with an explicit "vrf <name>", and
+# appending $VRF_OPTION on top of that produced "vrf red vrf red".
+function vrf_option () {
+    local arg
+    for arg in "$@" ; do
+        if [ "$arg" == "vrf" ] ; then
+            return 0
+        fi
+    done
+    echo "$VRF_OPTION"
+}
+
 # delete the same route from kernel before adding new one
 function delroute () {
-    logmsg debug "Checking if the route presented in kernel: $@ $VRF_OPTION"
-    if /usr/sbin/ip route show $@ $VRF_OPTION | grep -qx "$1 " ; then
-        logmsg info "Deleting IP route: \"/usr/sbin/ip route del $@ $VRF_OPTION\""
-        /usr/sbin/ip route del $@ $VRF_OPTION
+    local VRF_ARG=$(vrf_option "$@")
+    logmsg debug "Checking if the route presented in kernel: $@ $VRF_ARG"
+    if /usr/sbin/ip route show $@ $VRF_ARG | grep -qx "$1 " ; then
+        logmsg info "Deleting IP route: \"/usr/sbin/ip route del $@ $VRF_ARG\""
+        /usr/sbin/ip route del $@ $VRF_ARG
     fi
 }
 
@@ -155,7 +169,7 @@ function ip () {
         else
             # add ip route to kernel
             logmsg info "Modifying routes in kernel: \"/usr/sbin/ip $@\""
-            /usr/sbin/ip $@ $VRF_OPTION
+            /usr/sbin/ip $@ $(vrf_option "$@")
         fi
     fi
 }

--- a/src/etc/dhcp/dhclient-enter-hooks.d/03-vyos-ipwrapper
+++ b/src/etc/dhcp/dhclient-enter-hooks.d/03-vyos-ipwrapper
@@ -19,7 +19,7 @@ VRF_OPTION=$(/usr/sbin/ip --json --detail link show ${interface} | jq -r '.[0] |
 _flush_dhcp_addrs() {
     local dev="${1:-$interface}"
 
-    logmsg info "Selectively flushing only dynamic (DHCP) addresses from ${dev}"
+    logmsg debug "Selectively flushing only dynamic (DHCP) addresses from ${dev}"
 
     local addrs
     addrs=$(/usr/sbin/ip -4 -j addr show dev "${dev}" 2>&1 | jq -r '
@@ -47,10 +47,10 @@ _flush_dhcp_addrs() {
 function frr_alive () {
     /usr/lib/frr/watchfrr.sh all_status
     if [ "$?" -eq "0" ] ; then
-        logmsg info "FRR status: running"
+        logmsg debug "FRR status: running"
         return 0
     else
-        logmsg info "FRR status: not running"
+        logmsg debug "FRR status: not running"
         return 1
     fi
 }
@@ -97,12 +97,12 @@ function iptovtysh () {
     if [ "$VTYSH_ACTION" == "del" ] ; then
         VTYSH_CMD="no $VTYSH_CMD"
     fi
-    logmsg info "Converted vtysh command: \"$VTYSH_CMD\""
+    logmsg debug "Converted vtysh command: \"$VTYSH_CMD\""
 }
 
 # delete the same route from kernel before adding new one
 function delroute () {
-    logmsg info "Checking if the route presented in kernel: $@ $VRF_OPTION"
+    logmsg debug "Checking if the route presented in kernel: $@ $VRF_OPTION"
     if /usr/sbin/ip route show $@ $VRF_OPTION | grep -qx "$1 " ; then
         logmsg info "Deleting IP route: \"/usr/sbin/ip route del $@ $VRF_OPTION\""
         /usr/sbin/ip route del $@ $VRF_OPTION
@@ -114,10 +114,10 @@ function vtysh_conf () {
     # perform 10 attempts with 1 second delay for retries
     for i in {1..10} ; do
         if vtysh  -c "conf t" -c "$1" ; then
-            logmsg info "Command was executed successfully via vtysh: \"$1\""
+            logmsg debug "Command was executed successfully via vtysh: \"$1\""
             return 0
         else
-            logmsg info "Failed to send command to vtysh, retrying in 1 second"
+            logmsg warn "Failed to send command to vtysh, retrying in 1 second"
             sleep 1
         fi
     done
@@ -130,7 +130,7 @@ function ip () {
     # Intercept: ip -4 addr flush dev <interface>
     # to preserve static addresses (only remove dynamic/DHCP addresses)
     if [ "$1" = "-4" ] && [ "$2" = "addr" ] && [ "$3" = "flush" ]; then
-        logmsg info "Intercepting 'ip -4 addr flush' to preserve static addresses"
+        logmsg debug "Intercepting 'ip -4 addr flush' to preserve static addresses"
         shift 3
         local dev=""
         while [ $# -gt 0 ]; do
@@ -143,14 +143,14 @@ function ip () {
 
     # pass command to system `ip` if this is not related to routes change
     if [ "$2" != "route" ] ; then
-        logmsg info "Passing command to /usr/sbin/ip: \"$@\""
+        logmsg debug "Passing command to /usr/sbin/ip: \"$@\""
         /usr/sbin/ip $@
     else
         # if we want to work with routes, try to use FRR first
         if frr_alive ; then
             delroute ${@:4}
             iptovtysh $@
-            logmsg info "Sending command to vtysh"
+            logmsg debug "Sending command to vtysh"
             vtysh_conf "$VTYSH_CMD"
         else
             # add ip route to kernel

--- a/src/etc/dhcp/dhclient-enter-hooks.d/04-vyos-resolvconf
+++ b/src/etc/dhcp/dhclient-enter-hooks.d/04-vyos-resolvconf
@@ -23,10 +23,10 @@ if /usr/bin/systemctl -q is-active vyos-hostsd; then
         fi
 
         if [ $hostsd_changes ]; then
-            logmsg info "Applying changes via vyos-hostsd-client"
+            logmsg debug "Applying changes via vyos-hostsd-client"
             $hostsd_client --apply
         else
-            logmsg info "No changes to apply via vyos-hostsd-client"
+            logmsg debug "No changes to apply via vyos-hostsd-client"
         fi
     }
 fi

--- a/src/etc/dhcp/dhclient-exit-hooks.d/01-vyos-cleanup
+++ b/src/etc/dhcp/dhclient-exit-hooks.d/01-vyos-cleanup
@@ -108,8 +108,8 @@ if [[ $reason =~ ^(EXPIRE6|RELEASE6|STOP6)$ ]]; then
 fi
 
 if [ $hostsd_changes ]; then
-    logmsg info "Applying changes via vyos-hostsd-client"
+    logmsg debug "Applying changes via vyos-hostsd-client"
     $hostsd_client --apply
 else
-    logmsg info "No changes to apply via vyos-hostsd-client"
+    logmsg debug "No changes to apply via vyos-hostsd-client"
 fi

--- a/src/etc/dhcp/dhclient-exit-hooks.d/98-vyos-static-routes-dhclient-hook
+++ b/src/etc/dhcp/dhclient-exit-hooks.d/98-vyos-static-routes-dhclient-hook
@@ -14,12 +14,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-DHCP_HOOK_IFLIST="/tmp/static_dhcp_interfaces"
-
-# Only run if there are static routes with dhcp-interface configured
-if ! { [ -f $DHCP_HOOK_IFLIST ] && grep -qw $interface $DHCP_HOOK_IFLIST; }; then
-    return 0
-fi
+# The FRR static route configuration embeds the DHCP gateway of an interface,
+# either for "protocols static route <prefix> dhcp-interface <ifname>" or for
+# the default route implied by "interfaces <type> <ifname> address dhcp". The
+# gateway is only known at lease time, so any lease event must reconcile the
+# rendered configuration with the current lease (T8465).
 
 # Re-generate the config on the following events:
 # - BOUND: always re-generate

--- a/src/init/vyos-router
+++ b/src/init/vyos-router
@@ -590,6 +590,7 @@ start ()
         touch /tmp/vyos.ifconfig.debug
         touch /tmp/vyos.container.debug
         touch /tmp/vyos.smoketest.debug
+        touch /tmp/vyos.dhclient.debug
     fi
 
     # Cleanup PKI CAs


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The default route derived from `interfaces <type> <ifname> address dhcp` is rendered from the DHCP lease file, so it is only known at lease time. Until now the sole runtime path into FRRs `staticd` was the one-shot `vtysh` injection in `dhclient-enter-hooks.d/03-vyos-ipwrapper`. That injection races the FRR reload of the very commit which started the DHCP client: `dhclient` runs with `-nw`, thus the commit does not wait for a lease, and when BOUND arrives mid-reload this can report FRR as down. The route is then installed into the kernel only and FRR never learns about it. Nothing recovers afterwards, as `FRRender.generate()` short-circuits on an unchanged configuration dict.

The self-healing re-render used by `protocols static route <prefix> dhcp-interface` was gated on `/tmp/static_dhcp_interfaces`, which never lists plain `address dhcp` interfaces - `protocols_static.py` does not even run on an interface-only commit, as no config-mode dependency points to it.

Derive the DHCP dependent interface list from the configuration dict itself, both for the default VRF and for every named VRF, and use it for FRR change detection. Drop the interface list gate in the dhclient exit hook so any lease event requests a re-render.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9278

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result

Included in integrated smoketest suite. All passed with flying colors.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
