### PR TITLE
sysctl: T9283: stop low-level Kernel messages on the console

### DIFF
--- a/src/etc/sysctl.d/30-vyos-router.conf
+++ b/src/etc/sysctl.d/30-vyos-router.conf
@@ -11,6 +11,11 @@ kernel.panic=60
 # Send all core files to /var/core/core.program.pid.time
 kernel.core_pattern=/var/core/core-%e-%p-%t
 
+# Stop low-level kernel messages from reaching the console. Fields are
+# console_loglevel, default_message_loglevel, minimum_console_loglevel
+# and default_console_loglevel
+kernel.printk=4 4 1 7
+
 # ARP configuration
 #  arp_filter - allow multiple network interfaces on same subnet
 #  arp_announce - avoid local addresses no on target's subnet


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

kernel.printk was set to "4 4 1 7" by the vyos-build image build hook 08-sysconf.chroot, which rewrote the Debian conffile /etc/sysctl.conf during ISO assembly. Move the setting to where the remaining kernel.* defaults live so the image build no longer has to touch a Debian conffile and the hook can be dropped.


## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9283

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* https://github.com/vyos/vyos-build/pull/1292
* https://github.com/vyos/vyos-build/pull/1293

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
