### PR TITLE
T9279: VPP extend num-rx and tx ring descriptiors to 32768

### DIFF
--- a/interface-definitions/vpp.xml.in
+++ b/interface-definitions/vpp.xml.in
@@ -363,11 +363,11 @@
                 <properties>
                   <help>Receive ring descriptors</help>
                   <valueHelp>
-                    <format>u32:256-16384</format>
+                    <format>u32:256-32768</format>
                     <description>Number of descriptors in receive ring</description>
                   </valueHelp>
                   <constraint>
-                    <validator name="numeric" argument="--range 256-16384"/>
+                    <validator name="numeric" argument="--range 256-32768"/>
                   </constraint>
                 </properties>
                 <defaultValue>1024</defaultValue>
@@ -376,11 +376,11 @@
                 <properties>
                   <help>Tranceive ring descriptors</help>
                   <valueHelp>
-                    <format>u32:256-8192</format>
+                    <format>u32:256-32768</format>
                     <description>Number of descriptors in tranceive ring</description>
                   </valueHelp>
                   <constraint>
-                    <validator name="numeric" argument="--range 256-8192"/>
+                    <validator name="numeric" argument="--range 256-32768"/>
                   </constraint>
                 </properties>
                 <defaultValue>1024</defaultValue>


### PR DESCRIPTION


<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Some NICs allow configuring more ring descriptors than we allow in our CLI, extend it to `32768`

```
sudo vppctl show hardware-interfaces detail eth2

  Mellanox ConnectX-4/5/6 Family
    carrier up full duplex max-frame-size 1522  promisc
    flags: admin-up promisc maybe-multiseg tx-offload intel-phdr-cksum rx-ip4-cksum
    Devargs:
    rx: queues 6 (max 1024), desc 16384 (min 0 max 32768 align 1)
    tx: queues 6 (max 1024), desc 8192 (min 0 max 32768 align 1)
```

So before this change, we had:
```
vyos@r14# set vpp settings interface eth1 num-rx-desc 
Possible completions:
   <256-16384>          Number of descriptors in receive ring
                        

      
[edit]
vyos@r14# set vpp settings interface eth1 num-tx-desc 
Possible completions:
   <256-8192>           Number of descriptors in tranceive ring
                        
```

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [x] Other (please describe): Extend number or ring-buffers

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
 * https://vyos.dev/T9279

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
