### PR TITLE
smoketest: T9014: make configtest serial console image flavor agnostic

### DIFF
--- a/debian/vyos-1x-smoketest.postinst
+++ b/debian/vyos-1x-smoketest.postinst
@@ -17,3 +17,50 @@ RADIUS_PATH="/usr/share/vyos/radius-latest.tar"
 if [[ ! -f $RADIUS_PATH ]]; then
     skopeo copy --additional-tag "$RADIUS_TAG" "docker://$RADIUS_TAG" "docker-archive:/$RADIUS_PATH"
 fi
+
+# The serial console device and its speed are defined by the image flavor -
+# amd64 uses the 8250 UART at ttyS0 while arm64 systems expose the PL011 UART
+# as ttyAMA0. Implant the flavor specific values into the configuration test
+# data once, so the test runner does not need to patch them at runtime.
+CONFIGS_DIR="/usr/libexec/vyos/tests/configs"
+FLAVOR_FILE=$(python3 -c 'from vyos.flavor import flavor_file; print(flavor_file)')
+if [ ! -f "$FLAVOR_FILE" ]; then
+    echo "E: missing image flavor file $FLAVOR_FILE"
+    exit 1
+fi
+
+SERIAL_DEVICE=$(python3 -c 'from vyos.flavor import get_image_serial_console; console_type, console_num, _ = get_image_serial_console(); print(f"{console_type}{console_num}")')
+SERIAL_SPEED=$(python3 -c 'from vyos.flavor import get_image_serial_console; print(get_image_serial_console()[2])')
+# A partially populated flavor file yields a device without instance number
+# (e.g. "ttyS" if console_num is missing) which we must not implant
+case "$SERIAL_DEVICE" in
+    tty*[0-9]) ;;
+    *)
+        echo "E: image flavor $FLAVOR_FILE defines no valid serial console device: '$SERIAL_DEVICE'"
+        exit 1
+        ;;
+esac
+case "$SERIAL_SPEED" in
+    '' | *[!0-9]*)
+        echo "E: image flavor $FLAVOR_FILE defines no valid serial console speed: '$SERIAL_SPEED'"
+        exit 1
+        ;;
+esac
+
+if [ ! -d "$CONFIGS_DIR" ] || [ ! -r "$CONFIGS_DIR" ]; then
+    echo "E: missing or unreadable configuration test data in $CONFIGS_DIR"
+    exit 1
+fi
+
+# A missing placeholder means the test data is not what we expect - bail out
+# instead of reporting a substitution that never happened
+CONFIGS=$(grep -rl -e '@SERIAL_DEVICE@' -e '@SERIAL_SPEED@' "$CONFIGS_DIR") || true
+if [ -z "$CONFIGS" ]; then
+    echo "E: no serial console placeholder found in $CONFIGS_DIR"
+    exit 1
+fi
+
+echo "$CONFIGS" | xargs sed -i \
+    -e "s/@SERIAL_DEVICE@/$SERIAL_DEVICE/g" \
+    -e "s/@SERIAL_SPEED@/$SERIAL_SPEED/g"
+echo "I: Implanted serial console $SERIAL_DEVICE,$SERIAL_SPEED into $CONFIGS_DIR"

--- a/smoketest/configs/assert/basic-api-service
+++ b/smoketest/configs/assert/basic-api-service
@@ -20,8 +20,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/basic-haproxy
+++ b/smoketest/configs/assert/basic-haproxy
@@ -35,8 +35,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/basic-ipv6
+++ b/smoketest/configs/assert/basic-ipv6
@@ -39,5 +39,5 @@ set system login user vyos authentication plaintext-password ''
 set system name-server '2001:db8::1'
 set system name-server '2001:db8::2'
 set system syslog local facility all level 'debug'
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'

--- a/smoketest/configs/assert/basic-syslog
+++ b/smoketest/configs/assert/basic-syslog
@@ -4,8 +4,8 @@ set interfaces ethernet eth1 address '172.16.33.154/24'
 set interfaces ethernet eth1 duplex 'auto'
 set interfaces ethernet eth1 speed 'auto'
 set interfaces ethernet eth1 vrf 'red'
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos-ci-test.net'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'

--- a/smoketest/configs/assert/basic-system-ip-protocol
+++ b/smoketest/configs/assert/basic-system-ip-protocol
@@ -1,5 +1,5 @@
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system ip protocol any route-map 'stub'
 set system ip protocol babel route-map 'stub'
 set system ip protocol bgp route-map 'stub'

--- a/smoketest/configs/assert/basic-vyos
+++ b/smoketest/configs/assert/basic-vyos
@@ -102,8 +102,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/basic-vyos-no-ntp
+++ b/smoketest/configs/assert/basic-vyos-no-ntp
@@ -42,8 +42,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos.ci.net'
 set system host-name 'no-ntp'
 set system login user vyos authentication encrypted-password '$6$r/Yw/07NXNY$/ZB.Rjf9jxEV.BYoDyLdH.kH14rU52pOBtrX.4S34qlPt77chflCHvpTCq9a6huLzwaMR50rEICzA5GoIRZlM0'

--- a/smoketest/configs/assert/bgp-azure-ipsec-gateway
+++ b/smoketest/configs/assert/bgp-azure-ipsec-gateway
@@ -109,8 +109,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos.net'
 set system flow-accounting netflow interface 'eth1'
 set system flow-accounting netflow interface 'vti31'

--- a/smoketest/configs/assert/bgp-bfd-communities
+++ b/smoketest/configs/assert/bgp-bfd-communities
@@ -192,8 +192,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/bgp-big-as-cloud
+++ b/smoketest/configs/assert/bgp-big-as-cloud
@@ -829,8 +829,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system flow-accounting netflow interface 'eth0.4088'
 set system flow-accounting netflow interface 'eth0.4089'
 set system flow-accounting netflow engine-id '1'

--- a/smoketest/configs/assert/bgp-dmvpn-hub
+++ b/smoketest/configs/assert/bgp-dmvpn-hub
@@ -43,8 +43,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'cpe-4'
 set system login user vyos authentication encrypted-password '$6$r/Yw/07NXNY$/ZB.Rjf9jxEV.BYoDyLdH.kH14rU52pOBtrX.4S34qlPt77chflCHvpTCq9a6huLzwaMR50rEICzA5GoIRZlM0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/bgp-dmvpn-spoke
+++ b/smoketest/configs/assert/bgp-dmvpn-spoke
@@ -49,8 +49,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'cpe-1'
 set system login user vyos authentication encrypted-password '$6$r/Yw/07NXNY$/ZB.Rjf9jxEV.BYoDyLdH.kH14rU52pOBtrX.4S34qlPt77chflCHvpTCq9a6huLzwaMR50rEICzA5GoIRZlM0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/bgp-evpn-l2vpn-leaf
+++ b/smoketest/configs/assert/bgp-evpn-l2vpn-leaf
@@ -41,8 +41,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/bgp-evpn-l2vpn-spine
+++ b/smoketest/configs/assert/bgp-evpn-l2vpn-spine
@@ -34,8 +34,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/bgp-evpn-l3vpn-pe-router
+++ b/smoketest/configs/assert/bgp-evpn-l3vpn-pe-router
@@ -88,8 +88,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos.net'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'

--- a/smoketest/configs/assert/bgp-medium-confederation
+++ b/smoketest/configs/assert/bgp-medium-confederation
@@ -63,8 +63,8 @@ set protocols bgp peer-group WDC07v6 remote-as '670'
 set protocols bgp peer-group WDC07v6 update-source 'dum0'
 set protocols bgp system-as '670'
 set system config-management commit-revisions '200'
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos.net'
 set system host-name 'vyos'
 set system ip protocol bgp route-map 'DEFAULT-ZEBRA-IN'

--- a/smoketest/configs/assert/bgp-rpki
+++ b/smoketest/configs/assert/bgp-rpki
@@ -36,8 +36,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/bgp-small-internet-exchange
+++ b/smoketest/configs/assert/bgp-small-internet-exchange
@@ -201,8 +201,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/bgp-small-ipv4-unicast
+++ b/smoketest/configs/assert/bgp-small-ipv4-unicast
@@ -23,8 +23,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos.net'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'

--- a/smoketest/configs/assert/cluster-basic
+++ b/smoketest/configs/assert/cluster-basic
@@ -12,8 +12,8 @@ set interfaces ethernet eth1 duplex 'auto'
 set interfaces ethernet eth1 speed 'auto'
 set interfaces loopback lo
 set system config-management commit-revisions '100'
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/conntrack-basic
+++ b/smoketest/configs/assert/conntrack-basic
@@ -24,8 +24,8 @@ set system conntrack modules sqlnet
 set system conntrack modules tftp
 set system conntrack table-size '262144'
 set system conntrack timeout
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos.net'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'

--- a/smoketest/configs/assert/container-simple
+++ b/smoketest/configs/assert/container-simple
@@ -12,8 +12,8 @@ set interfaces ethernet eth0 speed 'auto'
 set interfaces ethernet eth1 duplex 'auto'
 set interfaces ethernet eth1 speed 'auto'
 set system config-management commit-revisions '50'
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$r/Yw/07NXNY$/ZB.Rjf9jxEV.BYoDyLdH.kH14rU52pOBtrX.4S34qlPt77chflCHvpTCq9a6huLzwaMR50rEICzA5GoIRZlM0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/dialup-router-complex
+++ b/smoketest/configs/assert/dialup-router-complex
@@ -726,8 +726,8 @@ set system conntrack modules sqlnet
 set system conntrack modules tftp
 set system conntrack table-size '262144'
 set system conntrack timeout
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos.net'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'

--- a/smoketest/configs/assert/dialup-router-medium-vpn
+++ b/smoketest/configs/assert/dialup-router-medium-vpn
@@ -296,8 +296,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system ip arp table-size '1024'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'

--- a/smoketest/configs/assert/dialup-router-wireguard-ipv6
+++ b/smoketest/configs/assert/dialup-router-wireguard-ipv6
@@ -681,8 +681,8 @@ set system conntrack modules sqlnet
 set system conntrack modules tftp
 set system conntrack table-size '262144'
 set system conntrack timeout
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos.net'
 set system host-name 'r1'
 set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'

--- a/smoketest/configs/assert/dns-dynamic
+++ b/smoketest/configs/assert/dns-dynamic
@@ -25,8 +25,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$YuG5oKoRYQnbnxk$P2eZNlIwXJP82JFyFrF2g4ZoOZr6zgLHK.SDJVoqWDGefKkRrJijUZODAVMLeWU.9EGM48YtG9MwfuewWoOGE.'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/egp-igp-route-maps
+++ b/smoketest/configs/assert/egp-igp-route-maps
@@ -29,8 +29,8 @@ set protocols ospfv3 parameters router-id '1.1.1.1'
 set protocols ripng interface eth1
 set protocols static
 set system config-management commit-revisions '100'
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system ip protocol bgp route-map 'zebra-bgp'
 set system ip protocol isis route-map 'zebra-isis'

--- a/smoketest/configs/assert/firewall-bridged-global-options
+++ b/smoketest/configs/assert/firewall-bridged-global-options
@@ -14,8 +14,8 @@ set interfaces ethernet eth0 duplex 'auto'
 set interfaces ethernet eth0 speed 'auto'
 set interfaces ethernet eth1 duplex 'auto'
 set interfaces ethernet eth1 speed 'auto'
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos-ci-test.net'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'

--- a/smoketest/configs/assert/firewall-empty-nodes
+++ b/smoketest/configs/assert/firewall-empty-nodes
@@ -25,8 +25,8 @@ set interfaces ethernet eth0
 set interfaces ethernet eth1
 set interfaces ethernet eth2
 set interfaces loopback lo
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/firewall-groups-name
+++ b/smoketest/configs/assert/firewall-groups-name
@@ -12,7 +12,7 @@ set firewall ipv4 name TEST2 rule 20 action 'drop'
 set firewall ipv4 name TEST2 rule 20 source group network-group '!TEST_GROUP_'
 set interfaces ethernet eth0
 set interfaces loopback lo
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$QxPS.uk6mfo$9QBSo8u1FkH16gMyAVhus6fU3LOzvLR9Z9.82m3tiHFAxTtIkhaZSWssSgzt4v4dGAL8rhVQxTg0oAG9/q11h/'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/firewall-rules-address
+++ b/smoketest/configs/assert/firewall-rules-address
@@ -20,7 +20,7 @@ set firewall ipv6 name TEST2 rule 30 destination address '!2001:db8:10:15::/126'
 set firewall ipv6 name TEST2 rule 30 source address '2001:db8:10:14::1'
 set interfaces ethernet eth0
 set interfaces loopback lo
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/igmp-pim-small
+++ b/smoketest/configs/assert/igmp-pim-small
@@ -27,8 +27,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos.io'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'

--- a/smoketest/configs/assert/ipoe-server
+++ b/smoketest/configs/assert/ipoe-server
@@ -40,8 +40,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/ipv6-disable
+++ b/smoketest/configs/assert/ipv6-disable
@@ -20,8 +20,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos.net'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'

--- a/smoketest/configs/assert/isis-small
+++ b/smoketest/configs/assert/isis-small
@@ -31,8 +31,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos.io'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'

--- a/smoketest/configs/assert/nat-basic
+++ b/smoketest/configs/assert/nat-basic
@@ -77,8 +77,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos.net'
 set system host-name 'R1'
 set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'

--- a/smoketest/configs/assert/ospf-simple
+++ b/smoketest/configs/assert/ospf-simple
@@ -16,8 +16,8 @@ set protocols ospf interface eth0.666 passive
 set protocols ospf log-adjacency-changes detail
 set protocols static route 0.0.0.0/0 next-hop 193.201.42.170 distance '130'
 set system config-management commit-revisions '100'
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'lab-vyos-r1'
 set system login user vyos authentication encrypted-password '$6$R.OnGzfXSfl6J$Iba/hl9bmjBs0VPtZ2zdW.Snh/nHuvxUwi0R6ruypgW63iKEbicJH.uUst8xZCyByURblxRtjAC1lAnYfIt.b0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/ospf-small
+++ b/smoketest/configs/assert/ospf-small
@@ -65,8 +65,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos.net'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'

--- a/smoketest/configs/assert/pppoe-server
+++ b/smoketest/configs/assert/pppoe-server
@@ -39,8 +39,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/qos-basic
+++ b/smoketest/configs/assert/qos-basic
@@ -67,8 +67,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$r/Yw/07NXNY$/ZB.Rjf9jxEV.BYoDyLdH.kH14rU52pOBtrX.4S34qlPt77chflCHvpTCq9a6huLzwaMR50rEICzA5GoIRZlM0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/rip-router
+++ b/smoketest/configs/assert/rip-router
@@ -75,8 +75,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/rpki-only
+++ b/smoketest/configs/assert/rpki-only
@@ -34,8 +34,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$r/Yw/07NXNY$/ZB.Rjf9jxEV.BYoDyLdH.kH14rU52pOBtrX.4S34qlPt77chflCHvpTCq9a6huLzwaMR50rEICzA5GoIRZlM0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/static-route-basic
+++ b/smoketest/configs/assert/static-route-basic
@@ -28,8 +28,8 @@ set service ntp server 172.16.100.10
 set service ntp server 172.16.100.20
 set service ntp server 172.16.110.30
 set system config-management commit-revisions '100'
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/tunnel-broker
+++ b/smoketest/configs/assert/tunnel-broker
@@ -67,8 +67,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/vpn-openconnect-sstp
+++ b/smoketest/configs/assert/vpn-openconnect-sstp
@@ -12,8 +12,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/vpn-openvpn
+++ b/smoketest/configs/assert/vpn-openvpn
@@ -145,8 +145,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos.io'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$2Ta6TWHd/U$NmrX0x9kexCimeOcYK1MfhMpITF9ELxHcaBU/znBq.X2ukQOj61fVI2UYP/xBzP4QtiTcdkgs7WOQMHWsRymO/'

--- a/smoketest/configs/assert/vpp
+++ b/smoketest/configs/assert/vpp
@@ -11,8 +11,8 @@ set interfaces ethernet eth3
 set interfaces ethernet eth4 description 'Bonding'
 set interfaces loopback lo
 set system config-management commit-revisions '100'
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'r16'
 set system login user vyos authentication encrypted-password '$6$rounds=656000$FZBlGpWsmSrV2Rvq$YPNAPtk4k6u99FAMxR6cw4DUPCgOomwCgRZRSO5rAoJK8RlMSCkVAFVF3ozL/3mZMfxcuCnwvd5HX6f9V5KzO.'
 set system name-server '203.0.113.1'

--- a/smoketest/configs/assert/vrf-basic
+++ b/smoketest/configs/assert/vrf-basic
@@ -31,8 +31,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/vrf-bgp-pppoe-underlay
+++ b/smoketest/configs/assert/vrf-bgp-pppoe-underlay
@@ -137,8 +137,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'vyos.net'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'

--- a/smoketest/configs/assert/vrf-ospf
+++ b/smoketest/configs/assert/vrf-ospf
@@ -24,8 +24,8 @@ set system conntrack modules pptp
 set system conntrack modules sip
 set system conntrack modules sqlnet
 set system conntrack modules tftp
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system host-name 'vyos'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'
 set system login user vyos authentication plaintext-password ''

--- a/smoketest/configs/assert/wireless-basic
+++ b/smoketest/configs/assert/wireless-basic
@@ -16,8 +16,8 @@ set interfaces wireless wlan1 mode 'n'
 set interfaces wireless wlan1 ssid 'VyOS-PUBLIC'
 set interfaces wireless wlan1 type 'access-point'
 set system config-management commit-revisions '200'
-set system console device ttyS0 kernel
-set system console device ttyS0 speed '115200'
+set system console device @SERIAL_DEVICE@ kernel
+set system console device @SERIAL_DEVICE@ speed '@SERIAL_SPEED@'
 set system domain-name 'dev.vyos.net'
 set system host-name 'WR1'
 set system login user vyos authentication encrypted-password '$6$O5gJRlDYQpj$MtrCV9lxMnZPMbcxlU7.FI793MImNHznxGoMFgm3Q6QP3vfKJyOSRCt3Ka/GzFQyW1yZS4NS616NLHaIPPFHc0'

--- a/smoketest/configs/basic-api-service
+++ b/smoketest/configs/basic-api-service
@@ -46,8 +46,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/basic-haproxy
+++ b/smoketest/configs/basic-haproxy
@@ -104,8 +104,8 @@ system {
         commit-revisions "200"
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     conntrack {

--- a/smoketest/configs/basic-ipv6
+++ b/smoketest/configs/basic-ipv6
@@ -102,8 +102,8 @@ system {
         }
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos.net

--- a/smoketest/configs/basic-syslog
+++ b/smoketest/configs/basic-syslog
@@ -12,8 +12,8 @@ interfaces {
 }
 system {
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos-ci-test.net

--- a/smoketest/configs/basic-system-ip-protocol
+++ b/smoketest/configs/basic-system-ip-protocol
@@ -102,8 +102,8 @@ system {
         }
     }
     console {
-        device ttyS0 {
-            speed "115200"
+        device @SERIAL_DEVICE@ {
+            speed "@SERIAL_SPEED@"
         }
     }
     host-name "vyos"

--- a/smoketest/configs/basic-vyos
+++ b/smoketest/configs/basic-vyos
@@ -237,8 +237,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     conntrack {

--- a/smoketest/configs/basic-vyos-no-ntp
+++ b/smoketest/configs/basic-vyos-no-ntp
@@ -97,8 +97,8 @@ system {
     }
     domain-name vyos.ci.net
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name no-ntp

--- a/smoketest/configs/bgp-azure-ipsec-gateway
+++ b/smoketest/configs/bgp-azure-ipsec-gateway
@@ -261,8 +261,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos.net

--- a/smoketest/configs/bgp-bfd-communities
+++ b/smoketest/configs/bgp-bfd-communities
@@ -493,8 +493,8 @@ system {
         commit-revisions 200
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/bgp-big-as-cloud
+++ b/smoketest/configs/bgp-big-as-cloud
@@ -1808,8 +1808,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     flow-accounting {

--- a/smoketest/configs/bgp-dmvpn-hub
+++ b/smoketest/configs/bgp-dmvpn-hub
@@ -96,8 +96,8 @@ system {
         }
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name cpe-4

--- a/smoketest/configs/bgp-dmvpn-spoke
+++ b/smoketest/configs/bgp-dmvpn-spoke
@@ -120,8 +120,8 @@ system {
         }
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name cpe-1

--- a/smoketest/configs/bgp-evpn-l2vpn-leaf
+++ b/smoketest/configs/bgp-evpn-l2vpn-leaf
@@ -101,8 +101,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/bgp-evpn-l2vpn-spine
+++ b/smoketest/configs/bgp-evpn-l2vpn-spine
@@ -81,8 +81,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/bgp-evpn-l3vpn-pe-router
+++ b/smoketest/configs/bgp-evpn-l3vpn-pe-router
@@ -167,8 +167,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos.net

--- a/smoketest/configs/bgp-medium-confederation
+++ b/smoketest/configs/bgp-medium-confederation
@@ -216,8 +216,8 @@ system {
         commit-revisions 200
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos.net

--- a/smoketest/configs/bgp-rpki
+++ b/smoketest/configs/bgp-rpki
@@ -92,8 +92,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/bgp-small-internet-exchange
+++ b/smoketest/configs/bgp-small-internet-exchange
@@ -457,8 +457,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/bgp-small-ipv4-unicast
+++ b/smoketest/configs/bgp-small-ipv4-unicast
@@ -46,8 +46,8 @@ system {
         commit-revisions 200
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos.net

--- a/smoketest/configs/cluster-basic
+++ b/smoketest/configs/cluster-basic
@@ -32,8 +32,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/conntrack-basic
+++ b/smoketest/configs/conntrack-basic
@@ -44,8 +44,8 @@ system {
         }
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos.net

--- a/smoketest/configs/container-simple
+++ b/smoketest/configs/container-simple
@@ -32,8 +32,8 @@ system {
         commit-revisions 50
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/dialup-router-complex
+++ b/smoketest/configs/dialup-router-complex
@@ -1461,8 +1461,8 @@ system {
         }
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos.net

--- a/smoketest/configs/dialup-router-medium-vpn
+++ b/smoketest/configs/dialup-router-medium-vpn
@@ -631,8 +631,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/dialup-router-wireguard-ipv6
+++ b/smoketest/configs/dialup-router-wireguard-ipv6
@@ -1444,8 +1444,8 @@ system {
         }
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos.net

--- a/smoketest/configs/dns-dynamic
+++ b/smoketest/configs/dns-dynamic
@@ -45,8 +45,8 @@ system {
         }
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/egp-igp-route-maps
+++ b/smoketest/configs/egp-igp-route-maps
@@ -95,8 +95,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/firewall-bridged-global-options
+++ b/smoketest/configs/firewall-bridged-global-options
@@ -39,8 +39,8 @@ interfaces {
 }
 system {
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos-ci-test.net

--- a/smoketest/configs/firewall-empty-nodes
+++ b/smoketest/configs/firewall-empty-nodes
@@ -129,8 +129,8 @@ interfaces {
 }
 system {
     console {
-        device ttyS0 {
-            speed "115200"
+        device @SERIAL_DEVICE@ {
+            speed "@SERIAL_SPEED@"
         }
     }
     host-name "vyos"

--- a/smoketest/configs/firewall-groups-name
+++ b/smoketest/configs/firewall-groups-name
@@ -54,8 +54,8 @@ interfaces {
 }
 system {
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/firewall-rules-address
+++ b/smoketest/configs/firewall-rules-address
@@ -68,8 +68,8 @@ interfaces {
 }
 system {
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name "vyos"

--- a/smoketest/configs/igmp-pim-small
+++ b/smoketest/configs/igmp-pim-small
@@ -43,8 +43,8 @@ system {
         commit-revisions 200
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos.io

--- a/smoketest/configs/ipoe-server
+++ b/smoketest/configs/ipoe-server
@@ -76,8 +76,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/ipv6-disable
+++ b/smoketest/configs/ipv6-disable
@@ -40,8 +40,8 @@ system {
         commit-revisions 200
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos.net

--- a/smoketest/configs/isis-small
+++ b/smoketest/configs/isis-small
@@ -89,8 +89,8 @@ system {
         }
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos.io

--- a/smoketest/configs/nat-basic
+++ b/smoketest/configs/nat-basic
@@ -223,8 +223,8 @@ system {
         }
     }
     console {
-        device ttyS0 {
-            speed "115200"
+        device @SERIAL_DEVICE@ {
+            speed "@SERIAL_SPEED@"
         }
     }
     domain-name "vyos.net"

--- a/smoketest/configs/no-load/bgp-small-as
+++ b/smoketest/configs/no-load/bgp-small-as
@@ -617,8 +617,8 @@ system {
         commit-revisions 200
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos.net

--- a/smoketest/configs/no-load/firewall-big
+++ b/smoketest/configs/no-load/firewall-big
@@ -43375,8 +43375,8 @@ system {
         }
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name gb-glo-sg4ng1fw27-01

--- a/smoketest/configs/no-load/pki-ipsec
+++ b/smoketest/configs/no-load/pki-ipsec
@@ -11,8 +11,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/no-load/vrf-bgp
+++ b/smoketest/configs/no-load/vrf-bgp
@@ -38,8 +38,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/ospf-simple
+++ b/smoketest/configs/ospf-simple
@@ -51,8 +51,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name lab-vyos-r1

--- a/smoketest/configs/ospf-small
+++ b/smoketest/configs/ospf-small
@@ -136,8 +136,8 @@ system {
         commit-revisions 200
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos.net

--- a/smoketest/configs/pppoe-server
+++ b/smoketest/configs/pppoe-server
@@ -66,8 +66,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/qos-basic
+++ b/smoketest/configs/qos-basic
@@ -41,8 +41,8 @@ system {
         }
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/rip-router
+++ b/smoketest/configs/rip-router
@@ -229,8 +229,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/rpki-only
+++ b/smoketest/configs/rpki-only
@@ -81,8 +81,8 @@ system {
         commit-revisions 200
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     conntrack {

--- a/smoketest/configs/static-route-basic
+++ b/smoketest/configs/static-route-basic
@@ -109,8 +109,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/tunnel-broker
+++ b/smoketest/configs/tunnel-broker
@@ -97,8 +97,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/vpn-openconnect-sstp
+++ b/smoketest/configs/vpn-openconnect-sstp
@@ -8,8 +8,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/vpn-openvpn
+++ b/smoketest/configs/vpn-openvpn
@@ -275,8 +275,8 @@ system {
         }
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos.io

--- a/smoketest/configs/vpp
+++ b/smoketest/configs/vpp
@@ -28,8 +28,8 @@ system {
         commit-revisions "100"
     }
     console {
-        device ttyS0 {
-            speed "115200"
+        device @SERIAL_DEVICE@ {
+            speed "@SERIAL_SPEED@"
         }
     }
     host-name "r16"

--- a/smoketest/configs/vrf-basic
+++ b/smoketest/configs/vrf-basic
@@ -183,8 +183,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/vrf-bgp-pppoe-underlay
+++ b/smoketest/configs/vrf-bgp-pppoe-underlay
@@ -319,8 +319,8 @@ system {
         }
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name vyos.net

--- a/smoketest/configs/vrf-ospf
+++ b/smoketest/configs/vrf-ospf
@@ -38,8 +38,8 @@ system {
         commit-revisions 100
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     host-name vyos

--- a/smoketest/configs/wireless-basic
+++ b/smoketest/configs/wireless-basic
@@ -36,8 +36,8 @@ system {
         commit-revisions "200"
     }
     console {
-        device ttyS0 {
-            speed 115200
+        device @SERIAL_DEVICE@ {
+            speed @SERIAL_SPEED@
         }
     }
     domain-name "dev.vyos.net"

--- a/src/migration-scripts/system/31-to-32
+++ b/src/migration-scripts/system/31-to-32
@@ -16,23 +16,34 @@
 # Serial
 
 from vyos.configtree import ConfigTree
+from vyos.flavor import get_image_serial_console
 from vyos.system import disk
 from vyos.system.grub import CFG_VYOS_VARS
 from vyos.system.grub import vars_read
 
-serial_console = 'ttyS0'
 base = ['system', 'console']
 
 def migrate(config: ConfigTree) -> None:
     if not config.exists(base):
         return
 
+    # The serial console device is defined by the image flavor - amd64 uses the
+    # 8250 UART at ttyS0 while arm64 systems expose the PL011 UART as ttyAMA0
+    console_type, console_num, _ = get_image_serial_console()
+    if not console_type:
+        # image flavor carries no serial console data, assume 8250 UART
+        console_type, console_num = 'ttyS', '0'
+    serial_console = f'{console_type}{console_num}'
+
     root_dir = disk.find_persistence()
     vars_file: str = f'{root_dir}/{CFG_VYOS_VARS}'
     vars_current: dict[str, str] = vars_read(vars_file)
+    # A system without persistent GRUB storage - like VyOS running inside a
+    # container - has no boot console we could detect
+    if not vars_current:
+        return
+
     # Check if VyOS installation uses serial boot console
-    if vars_current['console_type'] == 'ttyS':
-        # In the past we only supported ttyS0 as boot console, that's why we
-        # can hardcode it ...
+    if vars_current['console_type'] == console_type:
         if config.exists(base + ['device', serial_console]):
             config.set(base + ['device', serial_console, 'kernel'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

The configuration tests hardcoded `system console device ttyS0 speed 115200`, which only holds for amd64, whereas arm64 images expose the UART as `ttyAMA0`, so loading these configs produced a diff against the assert data and the tests failed.

Replace the hardcoded values in all config test inputs and their assert counterparts with the `@SERIAL_DEVICE@` and `@SERIAL_SPEED@` placeholders. The vyos-1x-smoketest postinst queries the image flavor and implants the real values once at install time, so the test runner needs no runtime patching.

Migration script 31-to-32 now derives the serial device from the flavor, too, instead of assuming `ttyS0`.

This can be observed during vyos-1x package installation while building the ISO image

```
Setting up vyos-1x-smoketest (999.0-14834-g16f1cf457-dirty) ... ...
I: Implanted serial console ttyS0,115200 into /usr/libexec/vyos/tests/configs
```
## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9014

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->
* Depends-on: https://github.com/vyos/vyos-build/pull/1295

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
