### PR TITLE
update-checker: T8497: fix command injection via crafted update server response

### DIFF
--- a/src/op_mode/image_installer.py
+++ b/src/op_mode/image_installer.py
@@ -737,10 +737,7 @@ def image_fetch(image_path: str, vrf: str = None,
 
     # Latest version gets url from configured "system update-check url"
     if image_path == 'latest':
-        command = external_latest_image_url_script
-        if vrf:
-            command = f'ip vrf exec {vrf} {command}'
-        code, output = rc_cmd(command, env=environ)
+        code, output = rc_cmd(external_latest_image_url_script, vrf=vrf, env=environ)
         if code:
             print(output)
             exit(MSG_INFO_INSTALL_EXIT)

--- a/src/system/vyos-system-update-check.py
+++ b/src/system/vyos-system-update-check.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
             url = jmespath.search('[0].url', remote_data)
             remote_version = jmespath.search('[0].version', remote_data)
             if local_version != remote_version and remote_version:
-                call(f'wall -n "Update available: {remote_version} \nUpdate URL: {url}"')
+                call(['wall', '-n', f"Update available: {remote_version} \nUpdate URL: {url}"])
                 # MOTD used in /run/motd.d/10-vyos-update
                 motd_file.parent.mkdir(exist_ok=True)
                 motd_file.write_text(f'---\n'


### PR DESCRIPTION
## Change summary

Fix several shell injections:

First is described in https://vyos.dev/T8497

Second:

1) set system update-check url .../version.json
2) add system image latest --vrf ...
3) vyos-1x/src/helpers/latest-image-url.py:13 fetches that same system update-check url
4) It returns manifest [0].url at vyos-1x/src/helpers/latest-image-url.py:17
5) vyos-1x/src/op_mode/image_installer.py:672 stores that as image_path
With VRF, vyos-1x/src/op_mode/image_installer.py:644 injects that image_path into a shell command string
 "https://attacker/vyos.iso$(touch /tmp/vyos-rce >/dev/null)"
will execute touch /tmp/vyos-rce as root during add system image latest --vrf ....

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T8497

## Related PR(s)

## How to test / Smoketest result

See change summary.

## Checklist:

- [X] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [X] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [X] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly