### PR TITLE
configquery: T8409: resolve op-mode config paths independent of edit level

### DIFF
--- a/python/vyos/configquery.py
+++ b/python/vyos/configquery.py
@@ -39,7 +39,6 @@ from vyos.xml_ref import is_tag
 from vyos.base import Warning
 from vyos.utils.backend import vyconf_backend
 from vyos.configsource import ConfigSourceVyconfSession
-from vyos.utils.list import list_strip
 
 config_file = os.path.join(directories['config'], 'config.boot')
 
@@ -183,9 +182,9 @@ def verify_mangling(key_mangling):
         raise ValueError('key_mangling must be a tuple of two strings')
 
 
-def op_mode_run(cmd):
+def op_mode_run(cmd, env=None):
     """low-level to avoid overhead"""
-    p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, env=env)
     out = p.stdout.read()
     p.wait()
     return p.returncode, out.decode()
@@ -203,15 +202,13 @@ def op_mode_config_dict(
 
     command = ['/bin/cli-shell-api', '--show-active-only', 'showConfig']
 
-    edit_level = os.environ.get('VYATTA_EDIT_LEVEL', '')
-    if edit_level:
-        tmp = edit_level.split('/')
-        edit_path = [el for el in tmp if el]
-        relative_path = list_strip(path, edit_path)
-    else:
-        relative_path = path
+    # An op-mode script may be called from within a configuration session at
+    # an arbitrary edit level; cli-shell-api resolves the requested path
+    # relative to that level. Reset the level for the child process, so the
+    # absolute path passed by the caller is always used as is.
+    env = os.environ | {'VYATTA_EDIT_LEVEL': '/', 'VYATTA_TEMPLATE_LEVEL': '/'}
 
-    rc, out = op_mode_run(command + relative_path)
+    rc, out = op_mode_run(command + path, env=env)
 
     if rc == cli_shell_api_err.VYOS_EMPTY_CONFIG:
         out = ''


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

`op_mode_config_dict()` rewrote the absolute path passed in by the caller into one relative to `VYATTA_EDIT_LEVEL`. `list_strip()` returns an empty list as soon as a path component mismatches, so from e.g. `[edit qos policy]` the path `qos interface eth1` became the current edit level itself and `cli-shell-api` dumped an unrelated subtree:

```
[edit qos policy]
vyos@vyos# run show qos shaper interface eth1
WARNING: Specified configuration path is not valid
QoS is not applied to eth1!
```

Relative lookups are unreliable even when the edit level is a proper prefix of the path, as `cli-shell-api` validates the path against `VYATTA_TEMPLATE_LEVEL` and rejects a relative tag node value.

Keep the absolute path and reset both level variables for the child process instead.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T8409

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
