### PR TITLE
bond: T9269: keep the bond MAC when appending a member interface

### DIFF
--- a/python/vyos/configdict.py
+++ b/python/vyos/configdict.py
@@ -133,8 +133,13 @@ def leaf_node_changed(conf, path):
             return True
         if old is None:
             return []
+        # A multi node holding a single value is a plain string in the JSON
+        # rendering of the config tree, and only becomes a list once it holds
+        # several values. Normalize before diffing, else appending a value to a
+        # single-valued multi node reports the already configured value as gone
+        # just because its representation changed from string to list
         if isinstance(old, str):
-            return [old]
+            old = [old]
         if isinstance(old, list):
             if isinstance(new, str):
                 new = [new]

--- a/python/vyos/ifconfig/bond.py
+++ b/python/vyos/ifconfig/bond.py
@@ -481,7 +481,9 @@ class BondIf(Interface):
         # Add new interfaces to the bond first before removing no longer
         # required members - this is to ensure that in theory there is always an
         # active member link
-        is_first = True
+        # T7571: Kernel 6.6 assigns a synthetic MAC instead of the first
+        # member's - adopt it ourselves, but only on an empty bond
+        adopt_member_mac = not bond_members
         for interface in dict_search('member.interface', config, default=[]):
             # Only add interface to bond if it is not already a member
             if interface in bond_members:
@@ -493,15 +495,9 @@ class BondIf(Interface):
             # configured addresses, so we can safely flush any remaining ones.
             tmp_if.flush_addrs()
 
-            # T7571: This behavior changed from Linux Kernel 5.4 (used in VyOS 1.3)
-            # to Kernel 6.6 (starting with VyOS 1.4). Previously, the MAC address of
-            # the first member interface in a bond was adopted as the bond's default MAC.
-            # In newer versions, a synthetic MAC address is assigned instead.
-            #
-            # Re-assign first underlay MAC address to the bond
-            if is_first:
+            if adopt_member_mac:
                 self.set_mac(tmp_if.get_mac())
-                is_first = False
+                adopt_member_mac = False
 
             # Assign underlying interface to logical bond
             self.add_port(interface)

--- a/smoketest/scripts/cli/test_interfaces_bonding.py
+++ b/smoketest/scripts/cli/test_interfaces_bonding.py
@@ -134,6 +134,42 @@ class BondingInterfaceTest(BasicInterfaceTest.TestCase):
             state = Interface(remove_member).get_admin_state()
             self.assertEqual('up', state)
 
+    def test_bonding_append_member(self):
+        # T9269: appending a member to a bond that already has one must not
+        # disturb the existing member. leaf_node_changed() used to report the
+        # already configured member as removed, because a multi node holding a
+        # single value renders as a plain string and only becomes a list once
+        # it holds several values - so the bond released it again right after
+        # adding the new one. The bond MAC must not move to the new member
+        # either, that only happens while the bond has no member at all.
+        if len(self._members) < 2:
+            self.skipTest('not enough member interfaces available')
+
+        first, second = self._members[0], self._members[1]
+
+        for interface in self._interfaces:
+            self.cli_set(self._base_path + [interface, 'member', 'interface', first])
+        self.cli_commit()
+
+        bond_macs = {}
+        for interface in self._interfaces:
+            slaves = read_file(f'/sys/class/net/{interface}/bonding/slaves').split()
+            self.assertEqual(slaves, [first])
+            bond_macs[interface] = Interface(interface).get_mac()
+
+        for interface in self._interfaces:
+            self.cli_set(self._base_path + [interface, 'member', 'interface', second])
+        self.cli_commit()
+
+        for interface in self._interfaces:
+            slaves = read_file(f'/sys/class/net/{interface}/bonding/slaves').split()
+            # the pre-existing member must still be enslaved and up
+            self.assertIn(first, slaves)
+            self.assertIn(second, slaves)
+            self.assertEqual(Interface(first).get_admin_state(), 'up')
+            # appending a member must not change the bond's own MAC address
+            self.assertEqual(Interface(interface).get_mac(), bond_macs[interface])
+
     def test_bonding_min_links(self):
         # configure member interfaces
         min_links = len(self._interfaces)

--- a/src/tests/test_configdict.py
+++ b/src/tests/test_configdict.py
@@ -1,0 +1,70 @@
+# Copyright (C) VyOS Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import TestCase
+from unittest.mock import patch
+
+from vyos.configdict import leaf_node_changed
+
+
+class TestLeafNodeChanged(TestCase):
+    """leaf_node_changed() reports the old value(s) of an altered leaf node.
+
+    get_value_diff() reads the JSON rendering of the config tree, where a
+    multi node holding a single value is a plain string and only becomes a
+    list once it holds several values. A caller deleting whatever comes back
+    must therefore never see a value that is still configured.
+    """
+
+    def _changed(self, new, old):
+        # leaf_node_changed() imports get_config_diff() at call time
+        with patch('vyos.configdiff.get_config_diff') as get_diff:
+            get_diff.return_value.get_value_diff.return_value = (new, old)
+            return leaf_node_changed(None, ['some', 'path'])
+
+    def test_unchanged(self):
+        self.assertIsNone(self._changed('eth1', 'eth1'))
+        self.assertIsNone(self._changed(['eth1', 'eth2'], ['eth1', 'eth2']))
+
+    def test_value_replaced(self):
+        self.assertEqual(self._changed('eth2', 'eth1'), ['eth1'])
+
+    def test_value_deleted(self):
+        self.assertEqual(self._changed(None, 'eth1'), ['eth1'])
+        self.assertEqual(self._changed(None, ['eth1', 'eth2']), ['eth1', 'eth2'])
+
+    def test_value_added(self):
+        self.assertEqual(self._changed('eth1', None), [])
+
+    def test_valueless_node(self):
+        self.assertTrue(self._changed(None, {}))
+        self.assertTrue(self._changed({}, None))
+
+    def test_appended_to_single_valued_multi_node(self):
+        # T9269: the single configured value renders as a string while the two
+        # configured values render as a list. Nothing was removed here - adding
+        # a second bond member used to release the first one because this
+        # returned ['eth1']
+        self.assertEqual(self._changed(['eth1', 'eth2'], 'eth1'), [])
+
+    def test_appended_to_multi_valued_multi_node(self):
+        self.assertEqual(self._changed(['eth1', 'eth2', 'eth3'], ['eth1', 'eth2']), [])
+
+    def test_replaced_in_multi_node(self):
+        self.assertEqual(self._changed(['eth2', 'eth3'], 'eth1'), ['eth1'])
+        self.assertEqual(self._changed(['eth1', 'eth3'], ['eth1', 'eth2']), ['eth2'])
+
+    def test_shrunk_to_single_value(self):
+        # and the reverse representation change: list back to plain string
+        self.assertEqual(self._changed('eth1', ['eth1', 'eth2']), ['eth2'])


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Commit 6ebb8cd26 (`bond: T7571: fix inconsistent MAC address behaviour`) re-assigns the first member's MAC address to the bond, as newer Kernels no longer do so themselves. The flag driving it was initialized unconditionally and an already enslaved member hits "continue" without clearing it, so the step ran again on every append and handed the bond the newly added member's address:

```
bond0  aa:c1:ab:c3:62:48
eth1   aa:c1:ab:98:48:0f
eth2   aa:c1:ab:c3:62:48
```

Only adopt a member MAC while the bond has no member at all, which is what T7571 intended.

The added smoketest covers this together with T9269 in leaf_node_changed: it commits one member, appends a second, and verifies both stay enslaved, the pre-existing member stays admin up, and the bond MAC does not move.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9269

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-1x/pull/4656

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
