### PR TITLE
system: T9291: vyos-net-name-resolve: keep no-hw-id interfaces

### DIFF
--- a/src/system/vyos-net-name-resolve.py
+++ b/src/system/vyos-net-name-resolve.py
@@ -360,7 +360,8 @@ def compute_rename_plan(configured: dict, current: dict, pending: dict = None) -
     return plan
 
 
-def unmatched_candidates(configured: dict, current: dict, existing_plan: dict) -> list:
+def unmatched_candidates(configured: dict, current: dict, existing_plan: dict,
+                          pending: dict = None) -> list:
     """Physical interfaces this boot with no configured hw-id - the pool
     both ordinary bootstrap naming and pending-node reclaim matching draw
     from. This deliberately INCLUDES squatters compute_rename_plan() is
@@ -373,12 +374,28 @@ def unmatched_candidates(configured: dict, current: dict, existing_plan: dict) -
     existing_plan still stands as the fallback - match_pending_nodes()
     (via main()'s reclaim loop) or compute_bootstrap_plan() only override
     it, they never leave a squatter un-evicted.
+
+    The one exception is a candidate whose CURRENT name is a no-hw-id
+    configured node (an entry in `pending`): with no hw-id to identify the
+    NIC, that node is name-anchored, so the NIC sitting at the node's name
+    IS the configured interface. It is already correctly placed - not
+    unconfigured hardware - and must keep its name rather than be
+    bootstrap-renumbered. Treating it as a candidate is what pushed
+    no-hw-id interfaces from eth0/eth1 to eth2/eth3 on upgrade: the node
+    names were "reserved" as pending while the NICs that already sat on
+    them were handed fresh bootstrap slots. Such a node only needs its
+    hw-id frozen in by the later rescan hint, not a rename.
     """
+    pending_names = set()
+    if pending:
+        pending_names = (pending.get('ethernet', set()) |
+                         pending.get('wireless', set()))
     return [(mac, name) for name, mac in current.items()
-            if mac not in configured]
+            if mac not in configured and name not in pending_names]
 
 
-def match_pending_nodes(pending: dict, candidates: list) -> dict:
+def match_pending_nodes(pending: dict, candidates: list,
+                        exclude_names: set = frozenset()) -> dict:
     """Match this boot's unconfigured candidates to pending (hw-id-less)
     config nodes, one type (ethernet/wireless) at a time. Conservative by
     design: only matches when there is EXACTLY ONE pending node and
@@ -401,6 +418,11 @@ def match_pending_nodes(pending: dict, candidates: list) -> dict:
     bootstrap naming (see compute_bootstrap_plan()) and gets its own
     fresh, settings-free name instead.
 
+    exclude_names names pending nodes already satisfied in place this
+    boot (their NIC is sitting at the node's name) - they are dropped
+    from matching entirely so they neither consume a candidate nor count
+    toward the cardinality that would make a genuine match ambiguous.
+
     Returns {mac: node_name} for every unambiguous match this boot.
     """
     grouped = {'ethernet': [], 'wireless': []}
@@ -410,6 +432,9 @@ def match_pending_nodes(pending: dict, candidates: list) -> dict:
 
     matched = {}
     for intf_type, nodes in pending.items():
+        if not nodes:
+            continue
+        nodes = {n for n in nodes if n not in exclude_names}
         if not nodes:
             continue
         cands = grouped.get(intf_type, [])
@@ -474,7 +499,8 @@ def compute_bootstrap_plan(configured: dict, current: dict, existing_plan: dict,
     deleting the whole node is the admin's explicit way of saying so.
     """
     plan = {}
-    candidates = unmatched_candidates(configured, current, existing_plan)
+    candidates = unmatched_candidates(configured, current, existing_plan,
+                                      pending)
     candidates = [(mac, name) for mac, name in candidates
                   if mac not in reclaimed_macs]
     if not candidates:
@@ -584,7 +610,7 @@ def sync_rescan_hints(current_state: dict, configured: dict,
 
 def write_status(configured: dict, found: dict, missing: set, plan: dict,
                   pending: dict = None, reclaimed: dict = None,
-                  candidates: list = None) -> None:
+                  candidates: list = None, satisfied: set = frozenset()) -> None:
     """candidates is the full unmatched_candidates() list evaluated this
     boot (before reclaim/bootstrap assignment) - surfaced here so a
     pending node left unresolved for lack of hardware is self-diagnosable
@@ -596,13 +622,16 @@ def write_status(configured: dict, found: dict, missing: set, plan: dict,
     pending = pending or {}
     reclaimed = reclaimed or {}
     candidates = candidates or []
+    satisfied = set(satisfied)
     all_pending = pending.get('ethernet', set()) | pending.get('wireless', set())
     status = {
         'configured': configured,
         'found': sorted(found.values()),
         'missing': {mac: configured[mac] for mac in sorted(missing)},
         'renamed': plan,
-        'pending_unresolved': sorted(all_pending - set(reclaimed.values())),
+        'pending_unresolved': sorted(
+            all_pending - set(reclaimed.values()) - satisfied),
+        'satisfied': sorted(satisfied),
         'reclaimed': reclaimed,
         'unconfigured_candidates': {name: mac for mac, name in candidates},
     }
@@ -631,9 +660,20 @@ def main():
 
     all_pending = pending.get('ethernet', set()) | pending.get('wireless', set())
 
+    # A no-hw-id configured node whose NIC is already sitting at the node's
+    # name (the normal pre-hw-id steady state, e.g. `ethernet eth0 { address
+    # ... }` with no `hw-id` leaf) is satisfied: the NIC is name-anchored
+    # there, keeps its name, and only gets its hw-id frozen in by the later
+    # rescan hint. Such nodes must not be treated as unmet "pending" work -
+    # doing so both flagged them as unresolved (boot warning) and, worse,
+    # let the bootstrap pass renumber the NIC off the very name it is
+    # configured under (eth0/eth1 -> eth2/eth3).
+    satisfied_pending = {name for name in all_pending if current.get(name)}
+
     reclaimed = {}
     candidates = []
-    if all_pending or any(mac not in configured for mac in current.values()):
+    if (all_pending - satisfied_pending) or any(
+            mac not in configured for mac in current.values()):
         # The `all_pending` half of this condition matters even when
         # `current` (from wait_for_hardware() above, bounded only on
         # already-CONFIGURED macs) shows nothing unconfigured yet: on a
@@ -652,6 +692,12 @@ def main():
             # `missing`) this boot instead of being silently skipped.
             missing = set(configured) - set(current.values())
             plan = compute_rename_plan(configured, current, pending)
+        # the settled snapshot can differ from the early one the gate
+        # above was computed from (a NIC renamed by udev in between) -
+        # re-derive which pending nodes are satisfied in place from the
+        # settled view
+        satisfied_pending = {name for name in all_pending
+                             if current.get(name)}
 
         # let a NIC that just lost its hw-id (the documented "delete
         # hw-id to force regeneration" remediation) reclaim the exact
@@ -659,8 +705,12 @@ def main():
         # under, rather than bootstrap-naming it to a new bare node and
         # orphaning that config - only when unambiguous, see
         # match_pending_nodes()
-        candidates = unmatched_candidates(configured, current, plan)
-        reclaimed = match_pending_nodes(pending, candidates)
+        candidates = unmatched_candidates(configured, current, plan, pending)
+        # a pending node whose NIC already sits at its name needs no
+        # reclaim match - it is satisfied in place; matching it would only
+        # re-derive an identity rename
+        reclaimed = match_pending_nodes(pending, candidates,
+                                        exclude_names=satisfied_pending)
         candidate_by_mac = dict(candidates)
         for mac, target in reclaimed.items():
             name = candidate_by_mac[mac]
@@ -681,7 +731,8 @@ def main():
             configured, current, plan, pending=pending,
             reclaimed_macs=set(reclaimed)))
 
-    for name in sorted(all_pending - set(reclaimed.values())):
+    for name in sorted(all_pending - set(reclaimed.values())
+                       - satisfied_pending):
         logger.warning(
             f"pending node '{name}' still has no hw-id after this boot's "
             'naming pass'
@@ -696,7 +747,8 @@ def main():
     # vyos-interface-rescan.py write the hw-id into the existing node.
     sync_rescan_hints(final_current, configured, set(applied.keys()))
     write_status(configured, current, missing, applied,
-                 pending=pending, reclaimed=reclaimed, candidates=candidates)
+                 pending=pending, reclaimed=reclaimed, candidates=candidates,
+                 satisfied=satisfied_pending)
 
 
 if __name__ == '__main__':

--- a/src/tests/test_net_name_resolve.py
+++ b/src/tests/test_net_name_resolve.py
@@ -1616,5 +1616,186 @@ class TestBootOrdering(unittest.TestCase):
         self.assertNotIn('WantedBy=', unit)
 
 
+class TestSatisfiedNoHwIdNodes(unittest.TestCase):
+    """Regression guard for the 2026.09 upgrade breakage: a config.boot
+    that configures `interfaces ethernet ethN { address ... }` WITHOUT a
+    hw-id leaf (the normal pre-hw-id steady state, no remediation
+    involved) must be left untouched when the NIC is already sitting at
+    the node's name. Before the fix such nodes were classified "pending"
+    while the NICs sitting on them were bootstrap-renumbered off to
+    fresh slots (eth0/eth1 -> eth2/eth3), leaving the running config
+    matching nothing and the box with no connectivity.
+    """
+
+    def setUp(self):
+        self.udev_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.udev_dir, ignore_errors=True)
+        self._orig_udev_dir = resolver.vyos_udev_dir
+        resolver.vyos_udev_dir = self.udev_dir
+        self.addCleanup(setattr, resolver, 'vyos_udev_dir', self._orig_udev_dir)
+
+        status_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, status_dir, ignore_errors=True)
+        self._orig_status_file = resolver.status_file
+        resolver.status_file = resolver.Path(status_dir) / 'status.json'
+        self.addCleanup(setattr, resolver, 'status_file', self._orig_status_file)
+
+    def test_satisfied_no_hwid_nodes_keep_their_names(self):
+        # regression for the 2026.09 upgrade breakage: config.boot has
+        # `ethernet eth0 { address ... }` / `ethernet eth1 { address ... }`
+        # with NO hw-id on either (the normal pre-hw-id steady state), and
+        # the cosmetic fast path already placed each NIC at its node's
+        # name. Before the fix, both nodes were classified "pending" while
+        # the NICs sitting on them were bootstrap-renumbered off to
+        # eth2/eth3 - the running config (still eth0/eth1) then matched
+        # nothing and the box lost connectivity. They must keep their
+        # names; only the rescan hint (written under eth0/eth1) is new, so
+        # the later vyos-interface-rescan.py run freezes the hw-id in
+        # place without a rename.
+        configured = {}
+        pending = {'ethernet': {'eth0', 'eth1'}, 'wireless': set()}
+        state = {'eth0': 'aa:aa:aa:aa:aa:00', 'eth1': 'bb:bb:bb:bb:bb:01'}
+
+        def fake_discover(*_a, **_kw):
+            return dict(state)
+
+        def fake_run(command, *_a, **_kw):
+            parts = command.split()
+            if 'name' in parts:
+                old = parts[parts.index('dev') + 1]
+                new = parts[parts.index('name') + 1]
+                if old in state:
+                    state[new] = state.pop(old)
+            return 0
+
+        with mock.patch.object(resolver, 'get_configfile_interfaces',
+                                return_value=configured), \
+             mock.patch.object(resolver, 'get_pending_hwid_nodes',
+                                return_value=pending), \
+             mock.patch.object(resolver, 'discover_physical_interfaces',
+                                side_effect=fake_discover), \
+             mock.patch.object(resolver, 'is_wireless_interface',
+                                return_value=False), \
+             mock.patch.object(resolver, 'run', side_effect=fake_run), \
+             mock.patch('time.sleep'):
+            resolver.main()
+
+        # no rename at all - the NICs stayed at the names they were
+        # configured under
+        self.assertEqual(state, {
+            'eth0': 'aa:aa:aa:aa:aa:00', 'eth1': 'bb:bb:bb:bb:bb:01'})
+
+        # the rescan hints go under the (unchanged) names so the hw-id
+        # gets frozen into the EXISTING nodes
+        hints = set(os.listdir(self.udev_dir))
+        self.assertEqual(hints, {'eth0', 'eth1'})
+        with open(os.path.join(self.udev_dir, 'eth0')) as f:
+            self.assertEqual(f.read(), 'aa:aa:aa:aa:aa:00')
+        with open(os.path.join(self.udev_dir, 'eth1')) as f:
+            self.assertEqual(f.read(), 'bb:bb:bb:bb:bb:01')
+
+        status = json.loads(resolver.status_file.read_text())
+        self.assertEqual(status['renamed'], {})
+        self.assertEqual(status['pending_unresolved'], [])
+        self.assertEqual(status['satisfied'], ['eth0', 'eth1'])
+
+    def test_satisfied_node_and_unconfigured_extra_nic(self):
+        # same steady state, but a THIRD NIC (unconfigured, no node in
+        # config.boot at all) shows up racily named. The satisfied node
+        # must not drag its own NIC along, and must not make the extra
+        # NIC's assignment ambiguous or blocked: it bootstrap-names into
+        # the next free slot (eth2) while eth0/eth1 are untouched.
+        configured = {}
+        pending = {'ethernet': {'eth0'}, 'wireless': set()}
+        state = {
+            'eth0': 'aa:aa:aa:aa:aa:00',
+            'eth9': 'ff:ff:ff:ff:ff:99',  # brand-new, unconfigured NIC
+        }
+
+        def fake_discover(*_a, **_kw):
+            return dict(state)
+
+        def fake_run(command, *_a, **_kw):
+            parts = command.split()
+            if 'name' in parts:
+                old = parts[parts.index('dev') + 1]
+                new = parts[parts.index('name') + 1]
+                if old in state:
+                    state[new] = state.pop(old)
+            return 0
+
+        with mock.patch.object(resolver, 'get_configfile_interfaces',
+                                return_value=configured), \
+             mock.patch.object(resolver, 'get_pending_hwid_nodes',
+                                return_value=pending), \
+             mock.patch.object(resolver, 'discover_physical_interfaces',
+                                side_effect=fake_discover), \
+             mock.patch.object(resolver, 'is_wireless_interface',
+                                return_value=False), \
+             mock.patch.object(resolver, 'pcie_distance', return_value=0), \
+             mock.patch.object(resolver, 'run', side_effect=fake_run), \
+             mock.patch('time.sleep'):
+            resolver.main()
+
+        # the extra NIC fills the lowest free slot - eth1 is unreserved
+        # (no hw-id, no node, no pending node on it), so it goes there;
+        # eth0 stays put and no slot is skipped past the gap
+        self.assertEqual(state.get('eth0'), 'aa:aa:aa:aa:aa:00')
+        self.assertEqual(state.get('eth1'), 'ff:ff:ff:ff:ff:99')
+        self.assertNotIn('eth2', state)
+        self.assertNotIn('eth9', state)
+
+        status = json.loads(resolver.status_file.read_text())
+        self.assertEqual(status['satisfied'], ['eth0'])
+        self.assertEqual(status['pending_unresolved'], [])
+
+    def test_satisfied_only_after_settle_when_udev_renames_late(self):
+        # the gate and satisfaction must be judged on the SETTLED
+        # snapshot: if udev still moves the NIC between the early
+        # snapshot and settle (exactly the multi-vendor race this code
+        # handles), a node whose NIC is NOT at its name once things have
+        # settled is genuinely unmet pending work, not satisfied.
+        configured = {'m0': 'eth2'}
+        pending = {'ethernet': {'eth0'}, 'wireless': set()}
+
+        def fake_discover(*_a, **_kw):
+            # early snapshot looks satisfied (mac0 at eth0); the settled
+            # one shows the NIC actually landed on eth1 (probe race)
+            return {'eth2': 'm0', 'eth1': 'mac0'}
+
+        state = {'eth2': 'm0', 'eth1': 'mac0'}
+
+        def fake_run(command, *_a, **_kw):
+            parts = command.split()
+            if 'name' in parts:
+                old = parts[parts.index('dev') + 1]
+                new = parts[parts.index('name') + 1]
+                if old in state:
+                    state[new] = state.pop(old)
+            return 0
+
+        with mock.patch.object(resolver, 'get_configfile_interfaces',
+                                return_value=configured), \
+             mock.patch.object(resolver, 'get_pending_hwid_nodes',
+                                return_value=pending), \
+             mock.patch.object(resolver, 'discover_physical_interfaces',
+                                side_effect=fake_discover), \
+             mock.patch.object(resolver, 'is_wireless_interface',
+                                return_value=False), \
+             mock.patch.object(resolver, 'pcie_distance', return_value=0), \
+             mock.patch.object(resolver, 'run', side_effect=fake_run), \
+             mock.patch('time.sleep'):
+            resolver.main()
+
+        # mac0 is the only candidate and eth0 the only unmet pending
+        # node - the unambiguous reclaim must still bind them
+        self.assertEqual(state.get('eth0'), 'mac0')
+
+        status = json.loads(resolver.status_file.read_text())
+        self.assertEqual(status['reclaimed'], {'mac0': 'eth0'})
+        self.assertEqual(status['satisfied'], [])
+        self.assertEqual(status['pending_unresolved'], [])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This is a vibe-AI-slop PR with a proposed fix for [T9291](https://vyos.dev/T9291)

A config.boot with 'interfaces ethernet ethN { address ... }' and no
'hw-id' leaf (the normal pre-hw-id steady state) is misclassified by
the [T3871](https://vyos.dev/T3871) naming pass: both nodes are reported as 'pending' by
get_pending_hwid_nodes(), while the NICs already sitting at those node
names are treated as unconfigured bootstrap candidates. The node names
get reserved as pending, the NICs are then handed fresh bootstrap
slots (eth0/eth1 -> eth2/eth3), and the running config - which still
references eth0/eth1 - matches nothing: complete loss of connectivity
on the 2026.06 -> 2026.09 rolling upgrade, plus the spurious
'config error on boot' and 'still has no hw-id' warnings.

Pending-node matching was designed for the 'delete interfaces
ethernet ethN hw-id' NIC-replacement remediation, where a node lost a
hw-id and its NIC must be re-identified. A node that never had a
hw-id is different: with no hw-id to identify the NIC, the node is
name-anchored - the NIC sitting at the node's name IS the configured
interface, and it only needs its hw-id frozen in by the later
vyos-interface-rescan.py pass, not a rename.

- unmatched_candidates(): exclude candidates whose current name is a
  no-hw-id configured node from the bootstrap/reclaim candidate pool
- main(): derive the set of such 'satisfied' nodes from the settled
  snapshot, exclude them from the settle-gate and from the spurious
  'still has no hw-id' warning
- match_pending_nodes(): take excluded satisfied nodes out of the
  matching so they neither consume a candidate nor add to the
  cardinality that makes a genuine match ambiguous
- write_status(): exclude satisfied nodes from pending_unresolved and
  surface them in a new 'satisfied' key (vyos-router only reads
  '.missing' and '.pending_unresolved', both unchanged in shape)

Regression tests reproduce the reported scenario (two no-hw-id nodes
keeping eth0/eth1, hints frozen in place), a satisfied node plus an
unconfigured extra NIC (fills the next free slot, no interference),
and a NIC that only settles at the node's name (still reclaimed).

All 94 tests in test_net_name_resolve pass (4 pre-existing
TestGetPendingHwidNodes errors require the built libvyosconfig.so.0
and fail identically on the unmodified tree).
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
Fixes the interface renaming bug seen with interfaces with no hw-id configured

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
[T9291](https://vyos.dev/T9291)

## How to test / Smoketest result
Tested it on the same instance I found the bug in.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
