### PR TITLE
T9269: fix container boot failures and two config diffing regressions they exposed

### DIFF
--- a/python/vyos/utils/dict.py
+++ b/python/vyos/utils/dict.py
@@ -315,7 +315,12 @@ def dict_to_key_paths(d: dict) -> list:
     """
     def func(d, path):
         if isinstance(d, dict):
-            if not d:
+            # An empty dict is a valueless leaf node and yields the path that
+            # leads to it - but only if there is one. An empty dict at the top
+            # level means "no configuration at all", which must yield nothing
+            # instead of a single empty path: consumers join the components
+            # into a dotted option name, and '' is not an option
+            if not d and path:
                 yield path
             for k, v in d.items():
                 for r in func(v, path + [k]):

--- a/src/conf_mode/system_option.py
+++ b/src/conf_mode/system_option.py
@@ -599,11 +599,12 @@ def generate_cmdline_for_kexec(options):
 
 
 def apply(options):
+    running_as_container = image.is_running_as_container()
     kexec_required, cmdline_new = generate_cmdline_for_kexec(options)
     # T9269: a container does not own the Kernel cmdline - it belongs to the
     # host system, thus neither kexec nor a reboot would apply anything and the
     # options always compare as changed
-    if image.is_running_as_container():
+    if running_as_container:
         kexec_required = False
     if kexec_required:
         if not boot_configuration_complete() and os.getenv('VYOS_CONFIGD'):
@@ -681,12 +682,16 @@ def apply(options):
         cmdl(['systemctl', 'disable', 'root-partition-auto-resize.service'])
 
     # Time format 12|24-hour
-    if 'time_format' in options:
+    # A container has no systemd-localed to talk to - localectl(1) fails with
+    # "Access denied" and would abort this script, so skip it entirely
+    if 'time_format' in options and not running_as_container:
         time_format = time_format_to_locale.get(options['time_format'])
         cmdl(['localectl', 'set-locale', f'LC_TIME={time_format}'])
 
-    # Reload UDEV, required for USB auto suspend
-    cmdl(['udevadm', 'control', '--reload-rules'])
+    # Reload UDEV, required for USB auto suspend - a container shares the
+    # host's udev(7) instance and has no systemd-udevd of its own
+    if not running_as_container:
+        cmdl(['udevadm', 'control', '--reload-rules'])
 
     # Enable/disable dynamic debugging for kernel modules
     modules = ['wireguard']

--- a/src/migration-scripts/system/31-to-32
+++ b/src/migration-scripts/system/31-to-32
@@ -39,8 +39,9 @@ def migrate(config: ConfigTree) -> None:
     vars_file: str = f'{root_dir}/{CFG_VYOS_VARS}'
     vars_current: dict[str, str] = vars_read(vars_file)
     # A system without persistent GRUB storage - like VyOS running inside a
-    # container - has no boot console we could detect
-    if not vars_current:
+    # container - has no boot console we could detect. Neither has one whose
+    # GRUB vars carry no console_type, e.g. a flavor that bakes no console data
+    if 'console_type' not in vars_current:
         return
 
     # Check if VyOS installation uses serial boot console

--- a/src/system/vyos-net-name-resolve.py
+++ b/src/system/vyos-net-name-resolve.py
@@ -41,6 +41,7 @@ from sys import exit
 from vyos.configtree import ConfigTree
 from vyos.defaults import directories
 from vyos.migrate import ConfigMigrate
+from vyos.system.image import is_running_as_container
 from vyos.utils.process import rc_cmd
 from vyos.utils.process import run
 
@@ -613,6 +614,14 @@ def write_status(configured: dict, found: dict, missing: set, plan: dict,
 
 
 def main():
+    if is_running_as_container():
+        # A container has no NIC of its own - its interfaces are veth pairs
+        # created by the container runtime. They have no backing bus device in
+        # sysfs and their MAC is assigned by the host and regenerated on every
+        # start, so there is nothing to wait for and no hw-id worth binding.
+        logger.info('running inside a container - skipping hw-id naming pass')
+        return
+
     configured = get_configfile_interfaces()
     pending = get_pending_hwid_nodes()
 

--- a/src/tests/test_dict_search.py
+++ b/src/tests/test_dict_search.py
@@ -15,6 +15,8 @@
 from unittest import TestCase
 from vyos.utils.dict import dict_search
 from vyos.utils.dict import dict_search_recursive
+from vyos.utils.dict import dict_to_key_paths
+from vyos.utils.dict import dict_to_paths_values
 
 data = {
     'string': 'fooo',
@@ -88,3 +90,31 @@ class TestDictSearch(TestCase):
         self.assertEqual(len(tmp), 2)
         tmp = list(dict_search_recursive(data, 'address'))
         self.assertEqual(len(tmp), 3)
+
+
+class TestDictToKeyPaths(TestCase):
+    def test_valueless_leaf_node(self):
+        # An empty dict is how get_config_dict() represents a valueless node -
+        # the path leading to it must still be reported
+        self.assertEqual(list(dict_to_key_paths({'disable': {}})),
+                         [['disable']])
+        self.assertEqual(dict_to_paths_values({'disable': {}}),
+                         {'disable': {}})
+
+    def test_nested_paths(self):
+        self.assertEqual(dict_to_paths_values(data['interfaces']['ethernet']['eth1']),
+                         {'address': ['192.0.2.9/29'],
+                          'description': 'Test456',
+                          'duplex': 'auto',
+                          'hw_id': '00:00:00:00:00:02',
+                          'speed': 'auto'})
+
+    def test_empty_dict_yields_no_paths(self):
+        # An unconfigured node is an empty dict at the TOP level, which is not
+        # a valueless leaf - it must not report a single zero-component path.
+        # It used to, and since callers join the components into a dotted
+        # option name, a bare ethernet interface (as found in a container,
+        # where no hw-id is deployed) looked like it had an option named ''
+        # configured, and could not be added to a bond
+        self.assertEqual(list(dict_to_key_paths({})), [])
+        self.assertEqual(dict_to_paths_values({}), {})

--- a/src/tests/test_net_name_resolve.py
+++ b/src/tests/test_net_name_resolve.py
@@ -38,6 +38,23 @@ vyos_net_name = prepare_module(
     os.path.join(_here, '../udev/vyos_net_name'),
     'vyos_net_name')
 
+_container_patcher = None
+
+
+def setUpModule():
+    # main() deliberately short-circuits inside a container, and these tests
+    # are routinely run from one (the VyOS build container). Pin the detection
+    # off for the whole module so the naming pass under test actually runs -
+    # TestMainInContainer patches it back on locally where that is the point.
+    global _container_patcher
+    _container_patcher = mock.patch.object(
+        resolver, 'is_running_as_container', return_value=False)
+    _container_patcher.start()
+
+
+def tearDownModule():
+    _container_patcher.stop()
+
 
 class TestGetPendingHwidNodes(unittest.TestCase):
     """A node that exists under interfaces/{ethernet,wireless} but has no
@@ -1507,6 +1524,46 @@ class TestMainFirstBootBootstrap(unittest.TestCase):
         status = json.loads(resolver.status_file.read_text())
         self.assertEqual(status['pending_unresolved'], ['eth2'])
         self.assertEqual(status['reclaimed'], {})
+
+
+class TestMainInContainer(unittest.TestCase):
+    """A container owns no NIC: its interfaces are runtime-created veth
+    pairs with no backing bus device in sysfs and a host-assigned MAC that
+    changes on every start. The naming pass can therefore never resolve a
+    pending node there - it only spent both bounded hardware waits and then
+    told the user to bind an hw-id that would not survive a restart.
+    """
+
+    def setUp(self):
+        self.udev_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.udev_dir, ignore_errors=True)
+        self._orig_udev_dir = resolver.vyos_udev_dir
+        resolver.vyos_udev_dir = self.udev_dir
+        self.addCleanup(setattr, resolver, 'vyos_udev_dir', self._orig_udev_dir)
+
+        status_dir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, status_dir, ignore_errors=True)
+        self._orig_status_file = resolver.status_file
+        resolver.status_file = resolver.Path(status_dir) / 'status.json'
+        self.addCleanup(setattr, resolver, 'status_file', self._orig_status_file)
+
+    def test_naming_pass_is_skipped_entirely(self):
+        with mock.patch.object(resolver, 'is_running_as_container',
+                                return_value=True), \
+             mock.patch.object(resolver, 'get_configfile_interfaces') as configured, \
+             mock.patch.object(resolver, 'get_pending_hwid_nodes') as pending, \
+             mock.patch.object(resolver, 'discover_physical_interfaces') as discover, \
+             mock.patch.object(resolver, 'run') as run:
+            resolver.main()
+
+        configured.assert_not_called()
+        pending.assert_not_called()
+        discover.assert_not_called()
+        run.assert_not_called()
+        # no status file means vyos-router's warn_missing_interface_hardware()
+        # stays silent instead of warning about an unbindable pending node
+        self.assertFalse(resolver.status_file.exists())
+        self.assertEqual(os.listdir(self.udev_dir), [])
 
 
 class TestWriteStatus(unittest.TestCase):


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

Booting the VyOS container image under containerlab trips four unrelated assumptions about running on real hardware.

The system option script aborted with a traceback, because setting the locale needs a systemd D-Bus service no container provides, and the udev rule reload right after it fails for the same reason. Both are now skipped in a container.

The serial console migrator crashed on a GRUB variable that is absent whenever the image flavor carries no console data, so it tests for the key first.

The interface naming pass warned about an unbindable hw-id on every boot. Container interfaces are veth pairs whose MAC the host regenerates on each start, so the pass is skipped, which also drops two bounded hardware waits from boot.

Finally two config diffing bugs, both reachable outside containers, made a bare ethernet node look like it had an empty option configured, and reported an existing bond member as removed when a second one was added.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

* https://github.com/vyos/vyos-1x/pull/5437

## How to test / Smoketest result

* `make test-oci`

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
