### PR TITLE
image: T9295: fix "writeable" typo in has_persistence docstring

### DIFF
--- a/python/vyos/system/image.py
+++ b/python/vyos/system/image.py
@@ -311,7 +311,7 @@ def has_persistence() -> bool:
 
 def if_persistence(func):
     """Decorator to call function only if persistence storage is available.
-    Without it there is no writeable GRUB configuration to operate on"""
+    Without it there is no writable GRUB configuration to operate on"""
     @wraps(func)
     def wrapper(*args, **kwargs):
         if has_persistence():


### PR DESCRIPTION
## Change summary

Fixes a docstring typo in `has_persistence()`'s decorator (`writeable` → `writable`), introduced in e94f0e47d (T9269, 2026-09-01).

This currently breaks the `typos` CI check (crate-ci/typos) on `rolling` itself and on any PR rebased past that commit, independent of what the PR actually changes — see e.g. vyos/vyos-1x#5436.

https://vyos.dev/T9295