### PR TITLE
ethernet: T9228: only warn about unsupported NIC features when node changed

### DIFF
--- a/python/vyos/ifconfig/ethernet.py
+++ b/python/vyos/ifconfig/ethernet.py
@@ -149,11 +149,12 @@ class EthernetIf(Interface):
 
         super().remove()
 
-    def set_flow_control(self, enable):
+    def set_flow_control(self, enable, warn=True):
         """
         Changes the pause parameters of the specified Ethernet device.
 
         @param enable: true -> enable pause frames, false -> disable pause frames
+        @param warn: display a warning if the driver does not support the change
 
         Example:
         >>> from vyos.ifconfig import EthernetIf
@@ -177,7 +178,7 @@ class EthernetIf(Interface):
             # to change this setting via sysfs
             cmd = f'ethtool --pause {ifname} autoneg {enable} tx {enable} rx {enable}'
             output, code = self._popen(cmd)
-            if code:
+            if code and warn:
                 Warning(f'could not change "{ifname}" flow control setting!')
             return output
         return None
@@ -256,7 +257,22 @@ class EthernetIf(Interface):
                 'Warning: could not set speed/duplex settings: operation not permitted!'
             )
 
-    def set_gro(self, state):
+    def _set_offload(self, feature, name, state, enabled, fixed, warn):
+        """
+        Common helper for all ethtool offload features. Only alter the setting
+        if it differs from the current one - and if the driver has it pinned
+        (fixed) we can not change it at all. T9228: only tell the user about
+        the missing driver support if the CLI node was changed in this commit.
+        """
+        if enabled == state:
+            return False
+        if not fixed:
+            return self.set_interface(feature, 'on' if state else 'off')
+        if warn:
+            Warning(f'Adapter does not support changing {name} settings!')
+        return False
+
+    def set_gro(self, state, warn=True):
         """
         Enable Generic Receive Offload. State can be either True or False.
 
@@ -269,16 +285,11 @@ class EthernetIf(Interface):
             raise ValueError('Value out of range')
 
         enabled, fixed = self.ethtool.get_generic_receive_offload()
-        if enabled != state:
-            if not fixed:
-                return self.set_interface('gro', 'on' if state else 'off')
-            else:
-                print(
-                    'Adapter does not support changing generic-receive-offload settings!'
-                )
-        return False
+        return self._set_offload(
+            'gro', 'generic-receive-offload', state, enabled, fixed, warn
+        )
 
-    def set_rx(self, state):
+    def set_rx(self, state, warn=True):
         """
         Enable/Disable Receive Checksum Offload.
         State can be either True or False.
@@ -287,14 +298,9 @@ class EthernetIf(Interface):
             raise ValueError('Value out of range')
 
         enabled, fixed = self.ethtool.get_rx_checksumming()
-        if enabled != state:
-            if not fixed:
-                return self.set_interface('rx', 'on' if state else 'off')
-            else:
-                print('Adapter does not support changing rx-checksumming settings!')
-        return False
+        return self._set_offload('rx', 'rx-checksumming', state, enabled, fixed, warn)
 
-    def set_gso(self, state):
+    def set_gso(self, state, warn=True):
         """
         Enable Generic Segmentation offload. State can be either True or False.
         Example:
@@ -306,16 +312,11 @@ class EthernetIf(Interface):
             raise ValueError('Value out of range')
 
         enabled, fixed = self.ethtool.get_generic_segmentation_offload()
-        if enabled != state:
-            if not fixed:
-                return self.set_interface('gso', 'on' if state else 'off')
-            else:
-                print(
-                    'Adapter does not support changing generic-segmentation-offload settings!'
-                )
-        return False
+        return self._set_offload(
+            'gso', 'generic-segmentation-offload', state, enabled, fixed, warn
+        )
 
-    def set_hw_tc_offload(self, state):
+    def set_hw_tc_offload(self, state, warn=True):
         """
         Enable hardware TC flow offload. State can be either True or False.
         Example:
@@ -327,14 +328,11 @@ class EthernetIf(Interface):
             raise ValueError('Value out of range')
 
         enabled, fixed = self.ethtool.get_hw_tc_offload()
-        if enabled != state:
-            if not fixed:
-                return self.set_interface('hw-tc-offload', 'on' if state else 'off')
-            else:
-                print('Adapter does not support changing hw-tc-offload settings!')
-        return False
+        return self._set_offload(
+            'hw-tc-offload', 'hw-tc-offload', state, enabled, fixed, warn
+        )
 
-    def set_lro(self, state):
+    def set_lro(self, state, warn=True):
         """
         Enable Large Receive offload. State can be either True or False.
         Example:
@@ -346,14 +344,9 @@ class EthernetIf(Interface):
             raise ValueError('Value out of range')
 
         enabled, fixed = self.ethtool.get_large_receive_offload()
-        if enabled != state:
-            if not fixed:
-                return self.set_interface('lro', 'on' if state else 'off')
-            else:
-                print(
-                    'Adapter does not support changing large-receive-offload settings!'
-                )
-        return False
+        return self._set_offload(
+            'lro', 'large-receive-offload', state, enabled, fixed, warn
+        )
 
     def set_rps(self, state):
         if not isinstance(state, bool):
@@ -412,7 +405,7 @@ class EthernetIf(Interface):
 
         return True
 
-    def set_sg(self, state):
+    def set_sg(self, state, warn=True):
         """
         Enable Scatter-Gather support. State can be either True or False.
 
@@ -425,14 +418,9 @@ class EthernetIf(Interface):
             raise ValueError('Value out of range')
 
         enabled, fixed = self.ethtool.get_scatter_gather()
-        if enabled != state:
-            if not fixed:
-                return self.set_interface('sg', 'on' if state else 'off')
-            else:
-                print('Adapter does not support changing scatter-gather settings!')
-        return False
+        return self._set_offload('sg', 'scatter-gather', state, enabled, fixed, warn)
 
-    def set_tso(self, state):
+    def set_tso(self, state, warn=True):
         """
         Enable TCP segmentation offloading. State can be either True or False.
 
@@ -445,16 +433,11 @@ class EthernetIf(Interface):
             raise ValueError('Value out of range')
 
         enabled, fixed = self.ethtool.get_tcp_segmentation_offload()
-        if enabled != state:
-            if not fixed:
-                return self.set_interface('tso', 'on' if state else 'off')
-            else:
-                print(
-                    'Adapter does not support changing tcp-segmentation-offload settings!'
-                )
-        return False
+        return self._set_offload(
+            'tso', 'tcp-segmentation-offload', state, enabled, fixed, warn
+        )
 
-    def set_ring_buffer(self, rx_tx, size):
+    def set_ring_buffer(self, rx_tx, size, warn=True):
         """
         Example:
         >>> from vyos.ifconfig import EthernetIf
@@ -472,11 +455,11 @@ class EthernetIf(Interface):
         # ethtool error codes:
         #  80 - value already set
         #  81 - does not possible to set value
-        if code and code != 80:
-            print(f'could not set "{rx_tx}" ring-buffer for {ifname}')
+        if code and code != 80 and warn:
+            Warning(f'could not set "{rx_tx}" ring-buffer for {ifname}')
         return output
 
-    def set_interrupt_coalescing(self, params: dict):
+    def set_interrupt_coalescing(self, params: dict, warn=True):
         """
         Apply ethtool coalesce settings to an interface.
 
@@ -526,9 +509,11 @@ class EthernetIf(Interface):
         try:
             coalesce.set_coalesce(ifname, **params)
         except coalesce.CoalesceError as e:
-            print(f'interrupt coalescing error: {e}')
+            if warn:
+                Warning(f'interrupt coalescing error: {e}')
         except coalesce.GeneralNetlinkError as e:
-            print(f'netlink error: {e}')
+            if warn:
+                Warning(f'netlink error: {e}')
 
         return output
 
@@ -549,13 +534,14 @@ class EthernetIf(Interface):
             print(f'could not set "{rx_tx_comb}" channel for {ifname}')
         return output
 
-    def set_switchdev(self, enable):
+    def set_switchdev(self, enable, warn=True):
         ifname = self.config['ifname']
         addr, code = self._popen(
             f"ethtool -i {ifname} | grep bus-info | awk '{{print $2}}'"
         )
         if code != 0:
-            print(f'could not resolve PCIe address of {ifname}')
+            if warn:
+                Warning(f'could not resolve PCIe address of {ifname}')
             return
 
         enabled = False
@@ -569,8 +555,8 @@ class EthernetIf(Interface):
             output, code = self._popen(
                 f'/sbin/devlink dev eswitch set pci/{addr} mode switchdev'
             )
-            if code != 0:
-                print(f'{ifname} does not support switchdev mode')
+            if code != 0 and warn:
+                Warning(f'{ifname} does not support switchdev mode')
         elif not enable and enabled:
             self._cmdl(['/sbin/devlink', 'dev', 'eswitch', 'set', f'pci/{addr}', 'mode', 'legacy'])
 
@@ -580,21 +566,39 @@ class EthernetIf(Interface):
         interface setup code and provide a single point of entry when working
         on any interface."""
 
+        # T9228: Not all NIC drivers support changing all of the settings below.
+        # The configuration is always (re-)applied, but the warning about the
+        # missing driver support is only rendered if the individual CLI node was
+        # changed in this commit - and not on any unrelated change.
+        offload_changed = config.get('offload_changed', [])
+
         # disable ethernet flow control (pause frames)
         value = 'off' if 'disable_flow_control' in config else 'on'
-        self.set_flow_control(value)
+        self.set_flow_control(value, warn='flow_control_changed' in config)
 
         # GRO (generic receive offload)
-        self.set_gro(dict_search('offload.gro', config) is not None)
+        self.set_gro(
+            dict_search('offload.gro', config) is not None,
+            warn='gro' in offload_changed,
+        )
 
         # GSO (generic segmentation offload)
-        self.set_gso(dict_search('offload.gso', config) is not None)
+        self.set_gso(
+            dict_search('offload.gso', config) is not None,
+            warn='gso' in offload_changed,
+        )
 
         # GSO (generic segmentation offload)
-        self.set_hw_tc_offload(dict_search('offload.hw_tc_offload', config) is not None)
+        self.set_hw_tc_offload(
+            dict_search('offload.hw_tc_offload', config) is not None,
+            warn='hw_tc_offload' in offload_changed,
+        )
 
         # LRO (large receive offload)
-        self.set_lro(dict_search('offload.lro', config) is not None)
+        self.set_lro(
+            dict_search('offload.lro', config) is not None,
+            warn='lro' in offload_changed,
+        )
 
         # RPS - Receive Packet Steering
         self.set_rps(dict_search('offload.rps', config) is not None)
@@ -603,13 +607,20 @@ class EthernetIf(Interface):
         self.set_rfs(dict_search('offload.rfs', config) is not None)
 
         # RX (receive checksum offload)
-        self.set_rx(dict_search('offload.rx', config) is not None)
+        self.set_rx(
+            dict_search('offload.rx', config) is not None, warn='rx' in offload_changed
+        )
 
         # scatter-gather option
-        self.set_sg(dict_search('offload.sg', config) is not None)
+        self.set_sg(
+            dict_search('offload.sg', config) is not None, warn='sg' in offload_changed
+        )
 
         # TSO (TCP segmentation offloading)
-        self.set_tso(dict_search('offload.tso', config) is not None)
+        self.set_tso(
+            dict_search('offload.tso', config) is not None,
+            warn='tso' in offload_changed,
+        )
 
         # Set physical interface speed and duplex
         if 'speed_duplex_changed' in config:
@@ -621,13 +632,15 @@ class EthernetIf(Interface):
         # Set interface ring buffer
         if 'ring_buffer' in config:
             for rx_tx, size in config['ring_buffer'].items():
-                self.set_ring_buffer(rx_tx, size)
+                self.set_ring_buffer(rx_tx, size, warn='ring_buffer_changed' in config)
 
         # Set coalesce settings for the interface
         if 'interrupt_coalescing' in config:
-            self.set_interrupt_coalescing(config['interrupt_coalescing'])
+            self.set_interrupt_coalescing(
+                config['interrupt_coalescing'], warn='coalesce_changed' in config
+            )
 
-        self.set_switchdev('switchdev' in config)
+        self.set_switchdev('switchdev' in config, warn='switchdev_changed' in config)
 
         # call base class last
         super().update(config)

--- a/src/conf_mode/interfaces_ethernet.py
+++ b/src/conf_mode/interfaces_ethernet.py
@@ -25,7 +25,9 @@ from vyos.configdep import call_dependents
 from vyos.configdict import get_interface_dict
 from vyos.configdict import is_node_changed
 from vyos.configdict import is_vrf_changed
+from vyos.configdict import node_changed
 from vyos.configdict import get_flowtable_interfaces
+from vyos.configdiff import Diff
 from vyos.configverify import verify_address
 from vyos.configverify import verify_dhcpv6
 from vyos.configverify import verify_interface_exists
@@ -177,6 +179,31 @@ def get_config(config=None):
 
     tmp = is_node_changed(conf, base + [ifname, 'evpn'])
     if tmp: ethernet.update({'frr_dict' : get_frrender_dict(conf)})
+
+    # T9228: Some NIC drivers do not support changing all settings we offer on
+    # the CLI. The warning telling the user about the missing driver support is
+    # emitted while applying the configuration - which happens on every commit
+    # touching this interface. Record which nodes have been changed so the
+    # warning is only displayed if the node in question was altered, and not on
+    # any unrelated change like an interface description or IP address.
+    tmp = node_changed(
+        conf,
+        base + [ifname, 'offload'],
+        key_mangling=('-', '_'),
+        expand_nodes=Diff.ADD | Diff.DELETE,
+    )
+    if tmp:
+        ethernet.update({'offload_changed': tmp})
+
+    for node, key in {
+        'disable-flow-control': 'flow_control_changed',
+        'ring-buffer': 'ring_buffer_changed',
+        'interrupt-coalescing': 'coalesce_changed',
+        'switchdev': 'switchdev_changed',
+    }.items():
+        tmp = is_node_changed(conf, base + [ifname, node])
+        if tmp:
+            ethernet.update({key: {}})
 
     ethernet['flowtable_interfaces'] = get_flowtable_interfaces(conf)
 


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->

`EthernetIf.update()` re-applies every ethernet knob on every commit touching the interface. The capability messages (offload, flow-control, ring-buffer, coalesce, switchdev) are emitted whenever the CLI-desired state differs from what the driver reports - and on drivers where a feature is fixed (`virtio_net`, `vmxnet3`, `vif`, `veth`, ...) that is permanently true. The message is correct the first time, but it then re-appears on unrelated commits like an interface description or IP address change.

Record in interfaces_ethernet.py which of the affected CLI nodes were altered - the mechanism already used for speed_duplex_changed - and pass it to the setters via a "warn" argument. Settings are still applied unconditionally, only the message is gated.

While at it, consolidate the seven offload setters onto a common helper and use `Warning()` instead of `print()`.

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
* https://vyos.dev/T9228

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [ ] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
