### PR TITLE
podman: T9297: Encapsulate quadlet key/value parameters

### DIFF
--- a/smoketest/scripts/cli/test_container.py
+++ b/smoketest/scripts/cli/test_container.py
@@ -78,6 +78,10 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
 
     def test_basic(self):
         cont_name = 'c1'
+        env_key = 'TestKey'
+        env_key1 = 'TestKey1'
+        env_value = 'TestValue,*'
+        env_value1 = 'Test Spaced Values'
 
         self.cli_set(['interfaces', 'ethernet', 'eth0', 'address', '10.0.2.15/24'])
         self.cli_set(['protocols', 'static', 'route', '0.0.0.0/0',
@@ -92,6 +96,8 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         self.cli_set(base_path + ['name', cont_name, 'log-driver', 'journald'])
         self.cli_set(base_path + ['name', cont_name, 'allow-host-cgroups'])
         self.cli_set(base_path + ['name', cont_name, 'stop-timeout', '1'])
+        self.cli_set(base_path + ['name', cont_name, 'environment', env_key, 'value', env_value])
+        self.cli_set(base_path + ['name', cont_name, 'environment', env_key1, 'value', env_value1])
         # commit changes
         self.cli_commit()
 
@@ -105,6 +111,8 @@ class TestContainer(VyOSUnitTestSHIM.TestCase):
         self.assertEqual(l['HostConfig']['LogConfig']['Type'], 'journald')
         self.assertEqual(l['Config']['Healthcheck']['Test'], ['NONE'])
         self.assertEqual(l['HostConfig']['CgroupMode'], 'host')
+        self.assertIn(f'{env_key}={env_value}', l['Config']['Env'])
+        self.assertIn(f'{env_key1}={env_value1}', l['Config']['Env'])
 
         # cleanup
         self.cli_delete(['interfaces', 'ethernet', 'eth0', 'address'])

--- a/src/conf_mode/container.py
+++ b/src/conf_mode/container.py
@@ -473,7 +473,7 @@ def generate_quadlet_options(name, container_config, host_ident, network_config)
 
     if 'environment' in container_config:
         for k, v in container_config['environment'].items():
-            out.append(f'Environment={k}={v["value"]}')
+            out.append(f'Environment={k}="{v["value"]}"')
 
     if 'health_check' in container_config:
         if 'command' in container_config['health_check']:
@@ -499,7 +499,7 @@ def generate_quadlet_options(name, container_config, host_ident, network_config)
 
     if 'label' in container_config:
         for k, v in container_config['label'].items():
-            out.append(f'Label={k}={v["value"]}')
+            out.append(f'Label={k}="{v["value"]}"')
 
     if 'name_server' in container_config:
         for ns in container_config['name_server']:
@@ -570,7 +570,7 @@ def generate_quadlet_options(name, container_config, host_ident, network_config)
 
     if 'sysctl' in container_config and 'parameter' in container_config['sysctl']:
         for k, v in container_config['sysctl']['parameter'].items():
-            out.append(f'Sysctl={k}={v["value"]}')
+            out.append(f'Sysctl={k}="{v["value"]}"')
 
     if 'tmpfs' in container_config:
         for tmpfs_config in container_config['tmpfs'].values():


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change summary
<!--- Provide a general summary of your changes in the Title above -->
Encapsulate quadlet key/value parameters in quotes

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->

## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## How to test / Smoketest result
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backticks
```
like this
```

Or provide the output of the smoketest

```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->
```
Running Testcase (1/1): /usr/libexec/vyos/tests/smoke/cli/test_container.py
DEBUG - test_api_socket (__main__.TestContainer.test_api_socket) ... ok
DEBUG - test_basic (__main__.TestContainer.test_basic) ... ok
DEBUG - test_colliding_host_interface_names (__main__.TestContainer.test_colliding_host_interface_names) ... ok
DEBUG - test_cpu_limit (__main__.TestContainer.test_cpu_limit) ... ok
DEBUG - test_dual_stack_network (__main__.TestContainer.test_dual_stack_network) ... ok
DEBUG - test_healthcheck (__main__.TestContainer.test_healthcheck) ... ok
DEBUG - test_ipv4_network (__main__.TestContainer.test_ipv4_network) ... ok
DEBUG - test_ipv6_network (__main__.TestContainer.test_ipv6_network) ... ok
DEBUG - test_long_name_host_interface_uniqueness (__main__.TestContainer.test_long_name_host_interface_uniqueness) ... ok
DEBUG - test_name_server (__main__.TestContainer.test_name_server) ... ok
DEBUG - test_network_mtu (__main__.TestContainer.test_network_mtu) ... ok
DEBUG - test_network_types (__main__.TestContainer.test_network_types) ... ok
DEBUG - test_network_vrf (__main__.TestContainer.test_network_vrf) ... ok
DEBUG - test_no_name_server (__main__.TestContainer.test_no_name_server) ... ok
DEBUG - test_uid_gid (__main__.TestContainer.test_uid_gid) ... ok
DEBUG - test_user_defined_mac (__main__.TestContainer.test_user_defined_mac) ... ok
DEBUG - 
DEBUG - ----------------------------------------------------------------------
DEBUG - Ran 16 tests in 99.266s
DEBUG - 
DEBUG - OK
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s)
- [x] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
