### PR TITLE
vpp: T9305: bind PCI interfaces to vfio-pci for the general dpdk case (also fixes T9306)

### DIFF
--- a/python/vyos/vpp/control_host.py
+++ b/python/vyos/vpp/control_host.py
@@ -126,7 +126,14 @@ def load_kernel_module(module_name: str) -> None:
         module_name (str): module name
     """
     # check if a module already loaded
-    if Path(f'/sys/module/{module_name}').exists():
+    # T9306
+    # Sysfs module directories always use underscores (e.g. /sys/module/vfio_pci),
+    # even for a driver whose canonical/modprobe name has a hyphen (e.g.
+    # 'vfio-pci'). Checking the unmodified name here means this guard never matches
+    # for such modules, so load_kernel_module() always falls through to modprobe(8)
+    # even when the module is already loaded -- which is needlessly fragile anywhere
+    # modprobe execution itself is restricted (e.g. inside a container).
+    if Path(f"/sys/module/{module_name.replace('-', '_')}").exists():
         return
 
     # execute modprobe with the specified module name

--- a/src/conf_mode/vpp.py
+++ b/src/conf_mode/vpp.py
@@ -791,6 +791,34 @@ def apply(config):
                             config['persist_config'][iface]['dev_id'],
                             override_drivers[k_module],
                         )
+                    elif original_driver not in not_pci_drv:
+                        # T9305
+                        # VPP's own EAL (vlib_pci_bind_to_uio) does not bind a
+                        # PCI device to vfio-pci itself when IOMMU is active; it
+                        # only logs "Skipping PCI device ...: device is bound to
+                        # IOMMU group and vfio-pci driver is not loaded" and
+                        # leaves the device unclaimed, so no DPDK interface is
+                        # ever created and the later lcp_pair_add() crashes with
+                        # AttributeError (get_sw_if_index returns None/0).
+                        # override_drivers only covers hv_netvsc; "normal" PCI
+                        # NICs (ixgbe, i40e, virtio, ...) going the mandatory
+                        # dpdk/vfio-pci path (now that XDP is gone, T8202) need
+                        # the same explicit rebind. Skip if already vfio-pci.
+                        dev_id = config['persist_config'][iface]['dev_id']
+                        try:
+                            current_drv = (
+                                Path(f'/sys/bus/pci/devices/{dev_id}/driver')
+                                .resolve()
+                                .name
+                            )
+                        except FileNotFoundError:
+                            current_drv = None
+                        if current_drv != 'vfio-pci':
+                            control_host.override_driver(
+                                config['persist_config'][iface]['bus_id'],
+                                dev_id,
+                                'vfio-pci',
+                            )
 
         call('systemctl daemon-reload')
         call(f'systemctl restart {service_name}.service')


### PR DESCRIPTION
This PR contains two related, independently self-contained fixes found while getting VPP/DPDK working with a plain PCI NIC (Intel X552, `ixgbe`) passed through to a VyOS router.

## Commit 1 — T9305: bind PCI interfaces to vfio-pci for the general dpdk case

Configuring a "normal" PCI Ethernet NIC (Intel `ixgbe`, and presumably `i40e`/`igb`/`virtio-net`/etc. — anything not in the small `override_drivers` allow-list) under `vpp settings interface <name>` reliably failed to commit. VPP started, but never created the DPDK interface, and the conf_mode script crashed with `AttributeError: 'NoneType' object has no attribute 'retval'` inside `lcp_pair_add()`, because VPP's own DPDK/EAL layer silently skipped the PCI device at startup rather than binding it to `vfio-pci`.

This looks like a regression from the removal of AF_XDP support (T8202): `driver dpdk` + `vfio-pci` is now the only path for interfaces that aren't in the hard-coded vendor allow-list, but nothing bound the device to `vfio-pci` for any other driver.

**Fix**: adds an `elif` branch in `apply()` that explicitly binds the device to `vfio-pci` via the same `control_host.override_driver()` helper already used for the allow-listed case, skipping it if already on `vfio-pci` (idempotent re-commits).

**Testing**: verified stable across multiple restart cycles — each restart correctly re-runs `apply()`, re-binds the NIC to `vfio-pci`, and VPP comes up with the interface automatically with no manual intervention.

## Commit 2 — T9306: normalize hyphenated module names in sysfs check

`load_kernel_module()` checked `/sys/module/{module_name}` using the driver name verbatim, but Linux sysfs module directories always use underscores regardless of the module's canonical/modprobe name (e.g. `vfio-pci` shows up as `/sys/module/vfio_pci`). Because of this the guard never matched for any hyphenated module name, and `load_kernel_module()` always fell through to `modprobe(8)` even when the module was demonstrably already loaded — surfacing as a hard `PermissionError` in environments where `modprobe` execution itself is restricted.

**Fix**: normalize the module name (replace `-` with `_`) before checking `/sys/module/`, matching how the kernel actually names these directories.

**Testing**: confirmed `/sys/module/vfio-pci` does not exist while `/sys/module/vfio_pci` does on a running VPP node with `vfio-pci` loaded, and that the corrected check returns early without invoking `modprobe`.
