### PR TITLE
ospfv3: T7265: add point-to-multipoint network type support

### DIFF
--- a/interface-definitions/include/ospfv3/protocol-common-config.xml.i
+++ b/interface-definitions/include/ospfv3/protocol-common-config.xml.i
@@ -188,20 +188,24 @@
       <properties>
         <help>Network type</help>
         <completionHelp>
-          <list>broadcast point-to-point</list>
+          <list>broadcast point-to-multipoint point-to-point</list>
         </completionHelp>
         <valueHelp>
           <format>broadcast</format>
           <description>Broadcast network type</description>
         </valueHelp>
         <valueHelp>
+          <format>point-to-multipoint</format>
+          <description>Point-to-multipoint network type</description>
+        </valueHelp>
+        <valueHelp>
           <format>point-to-point</format>
           <description>Point-to-point network type</description>
         </valueHelp>
         <constraint>
-          <regex>(broadcast|point-to-point)</regex>
+          <regex>(broadcast|point-to-multipoint|point-to-point)</regex>
         </constraint>
-        <constraintErrorMessage>Must be broadcast or point-to-point</constraintErrorMessage>
+        <constraintErrorMessage>Must be broadcast, point-to-multipoint or point-to-point</constraintErrorMessage>
       </properties>
     </leafNode>
     #include <include/isis/passive.xml.i>

--- a/smoketest/scripts/cli/test_protocols_ospfv3.py
+++ b/smoketest/scripts/cli/test_protocols_ospfv3.py
@@ -340,5 +340,26 @@ class TestProtocolsOSPFv3(VyOSUnitTestSHIM.TestCase):
         for router_id in router_ids:
             self.assertIn(f' graceful-restart helper enable {router_id}', frrconfig)
 
+
+    def test_ospfv3_10_network_type_point_to_multipoint(self):
+        interfaces = Section.interfaces('ethernet')
+        for interface in interfaces:
+            self.cli_set(base_path + ['interface', interface, 'network', 'point-to-multipoint'])
+
+        # commit changes
+        self.cli_commit()
+
+        # Verify FRR ospfd configuration
+        frrconfig = self.getFRRconfig('router ospf6', stop_section='^exit')
+        self.assertIn(f'router ospf6', frrconfig)
+
+        for interface in interfaces:
+            if_config = self.getFRRconfig(f'interface {interface}', stop_section='^exit')
+            self.assertIn(f' ipv6 ospf6 network point-to-multipoint', if_config)
+
+        # Cleanup interfaces
+        self.cli_delete(base_path + ['interface'])
+        self.cli_commit()
+
 if __name__ == '__main__':
     unittest.main(verbosity=2, failfast=VyOSUnitTestSHIM.TestCase.debug_on())


### PR DESCRIPTION
## Summary

- Adds `point-to-multipoint` as a valid value for `set protocols ospfv3 interface <if> network`, matching what's already supported for OSPFv2 (`broadcast`, `non-broadcast`, `point-to-multipoint`, `point-to-point`).
- FRR's `ospf6d` already supports `ipv6 ospf6 network point-to-multipoint`, and VyOS's `ospf6d.frr.j2` template already passes the configured `network` value through verbatim — so this is purely a CLI validation gap, not a missing capability in FRR.
- Addresses part of [T7265](https://vyos.dev/T7265). That ticket also asks for `non-broadcast` and static-neighbor configuration for OSPFv3; both are left out here to keep this change narrowly scoped, and can follow in a separate PR.

## Motivation

On a multi-access (broadcast) OSPFv3 segment with more than two routers, only the DR/BDR form full adjacencies with every neighbor; DROther-to-DROther pairs stay in `2-Way` and rely on the DR to relay LSAs between them. After a reboot, this adds a noticeable delay before OSPFv3-dependent recursive BGP next-hops resolve and routes get installed into the RIB. `point-to-multipoint` avoids the DR/BDR election entirely and forms full adjacencies with every neighbor directly, same as it already does for OSPFv2 today.

## Testing

Since this repo requires the full VyOS build/smoketest environment for FRR-integration tests, I validated the CLI definition itself end-to-end using the repo's own tooling:

```
scripts/transclude-template interface-definitions/protocols_ospfv3.xml.in > build/interface-definitions/protocols_ospfv3.xml
python3 -c "from lxml import etree; \
  schema = etree.RelaxNG(etree.parse('schema/interface_definition.rng')); \
  print(schema.validate(etree.parse('build/interface-definitions/protocols_ospfv3.xml')))"
# -> True

scripts/build-command-templates build/interface-definitions/protocols_ospfv3.xml schema/interface_definition.rng /tmp/out
cat /tmp/out/protocols/ospfv3/interface/node.tag/network/node.def
```

which produced the expected legacy template:

```
type: txt
help: Network type
val_help: broadcast; Broadcast network type
val_help: point-to-multipoint; Point-to-multipoint network type
val_help: point-to-point; Point-to-point network type
allowed: echo "broadcast point-to-multipoint point-to-point"
syntax:expression: exec "${vyos_libexec_dir}/validate-value --regex '(broadcast|point-to-multipoint|point-to-point)'   --value '$VAR(@)'"; "Must be broadcast, point-to-multipoint or point-to-point"
```

I also added `test_ospfv3_10_network_type_point_to_multipoint` to `smoketest/scripts/cli/test_protocols_ospfv3.py`, mirroring the existing `point-to-point` interface test, for CI to exercise in the full smoketest environment.

## Test plan

- [x] `interface-definitions/protocols_ospfv3.xml.in` builds and validates against `schema/interface_definition.rng`
- [x] Generated legacy CLI template accepts `point-to-multipoint` with the expected `ipv6 ospf6 network point-to-multipoint` FRR output path (verified via the unchanged `ospf6d.frr.j2` template logic)
- [ ] Full smoketest suite (`test_protocols_ospfv3.py`) — needs the CI build environment; added `test_ospfv3_10_network_type_point_to_multipoint` for this
