### PR TITLE
configtree: T9307: serialize libvyosconfig calls across threads

### DIFF
--- a/python/vyos/configtree.py
+++ b/python/vyos/configtree.py
@@ -16,6 +16,7 @@ import os
 import re
 import json
 import logging
+import threading
 
 from ctypes import cdll, c_char_p, c_void_p, c_int, c_bool
 from functools import lru_cache
@@ -99,6 +100,64 @@ _PROTOTYPES = {
 }
 
 
+# libvyosconfig is not safe for concurrent use: two threads inside it at once
+# (for example two from_string calls, or from_string racing destroy) corrupt the
+# shared parser state and crash the process. ctypes releases the GIL for the
+# duration of each foreign call, so threads in one Python process really do
+# enter the library concurrently; vyos-http-api does, running configure
+# operations in a threadpool while other requests are served on the event loop.
+#
+# Every entry point is therefore serialized on one process-wide lock. It is an
+# RLock because a call made while holding it can trigger garbage collection,
+# and ConfigTree.__del__ then calls destroy on the same thread.
+_LIB_LOCK = threading.RLock()
+
+# The library reports failures through a single global error buffer
+# (error_message in libvyosconfig/lib/bindings.ml), which each of the entry
+# points below resets on entry and sets on failure. The buffer is read right
+# after such a call, while the lock is still held, and kept per thread, so
+# get_error() returns the calling thread's own error rather than whatever
+# another thread's call left behind.
+_LIB_ERROR = threading.local()
+
+_ERROR_REPORTING = frozenset(
+    {
+        'copy_node',
+        'create_node',
+        'delete_node',
+        'delete_value',
+        'diff_compare',
+        'diff_show',
+        'diff_tree',
+        'from_string',
+        'mask_exclusive',
+        'mask_inclusive',
+        'read_internal',
+        'read_internal_string',
+        'read_internal_string_reference_tree',
+        'reference_tree_to_json',
+        'rename_node',
+        'set_add_value',
+        'set_leaf',
+        'set_replace_value',
+        'set_tag',
+        'set_valueless',
+        'subtree_from_partial',
+        'subtree_values_of_path',
+        'tree_merge',
+        'tree_union',
+        'validate_tree_filter',
+        'write_internal',
+        'write_internal_reference_tree',
+    }
+)
+
+# destroy can run from ConfigTree.__del__ between a failed call and the
+# caller's get_error(), so it must leave the captured error alone. Any other
+# call clears it, and get_error() then reads the buffer directly as before.
+_PRESERVES_ERROR = frozenset({'destroy'})
+
+
 class _Lib:
     """Lazily resolving, prototype-declaring wrapper around libvyosconfig.
 
@@ -107,6 +166,8 @@ class _Lib:
     Resolution stays lazy on purpose: not every build of the library exports
     every entry point, and the previous per-instance binding code only failed
     on symbols that were actually used.
+
+    Every call is made under _LIB_LOCK; see the comment above it.
     """
 
     # pylint: disable=too-few-public-methods
@@ -114,7 +175,7 @@ class _Lib:
     def __init__(self, libpath):
         self.__dict__['_lib'] = cdll.LoadLibrary(libpath)
 
-    def __getattr__(self, name):
+    def _raw(self, name):
         try:
             argtypes, restype = _PROTOTYPES[name]
         except KeyError:
@@ -125,8 +186,42 @@ class _Lib:
         func.argtypes = argtypes
         if restype is not None:
             func.restype = restype
-        setattr(self, name, func)
         return func
+
+    def __getattr__(self, name):
+        func = self._raw(name)
+        raw_get_error = self._raw('get_error')
+        reports_error = name in _ERROR_REPORTING
+        preserves_error = name in _PRESERVES_ERROR
+        # Bound locally so a wrapper reached from __del__ during interpreter
+        # shutdown does not depend on module globals still being set.
+        lock = _LIB_LOCK
+        error = _LIB_ERROR
+
+        if name == 'get_error':
+
+            def get_error():
+                msg = getattr(error, 'msg', None)
+                if msg is not None:
+                    return msg
+                with lock:
+                    return raw_get_error()
+
+            wrapper = get_error
+        else:
+
+            def wrapper(*args):
+                with lock:
+                    result = func(*args)
+                    if reports_error:
+                        error.msg = raw_get_error()
+                    elif not preserves_error:
+                        error.msg = None
+                return result
+
+        wrapper.__name__ = name
+        setattr(self, name, wrapper)
+        return wrapper
 
 
 @lru_cache(maxsize=None)

--- a/src/tests/test_config_tree.py
+++ b/src/tests/test_config_tree.py
@@ -22,6 +22,7 @@ import unittest
 from unittest import TestCase
 
 from vyos.configtree import ConfigTree
+from vyos.configtree import get_lib
 from vyos.referencetree import ReferenceTree
 from vyos.derivedtree import subtree_from_list_of_partial_paths
 
@@ -83,6 +84,82 @@ class TestInitialSetup(TestCase):
         t = threading.Thread(target=task)
         t.start()
         t.join()
+
+    def test_concurrent_parse_threads(self):
+        # libvyosconfig is not safe for concurrent entry; without the lock in
+        # vyos.configtree, parsing from several threads at once corrupts the
+        # parser state and crashes the process with SIGSEGV.
+        config_str = self.ct.to_string()
+        deadline = time.time() + 5
+
+        def task():
+            while time.time() < deadline:
+                ct = ConfigTree(config_str)
+                self.assertEqual(self.ct, ct)
+                del ct
+
+        threads = [threading.Thread(target=task) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    def test_parse_error_per_thread(self):
+        # The library reports errors through one global buffer. Each thread
+        # must see the error for its own failed call, not text left behind by
+        # another thread's call.
+        config_str = self.ct.to_string()
+        invalid_str = 'interfaces {\n    ethernet eth0 {\n        address \n'
+        deadline = time.time() + 5
+
+        def valid_task():
+            while time.time() < deadline:
+                ConfigTree(config_str)
+
+        def invalid_task():
+            while time.time() < deadline:
+                with self.assertRaisesRegex(ValueError, 'Syntax error'):
+                    ConfigTree(invalid_str)
+
+        threads = [
+            threading.Thread(target=valid_task),
+            threading.Thread(target=invalid_task),
+            threading.Thread(target=valid_task),
+            threading.Thread(target=invalid_task),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    def test_parse_error_survives_destroy(self):
+        # ConfigTree.__del__ can call destroy between a failed call and the
+        # caller's get_error(); that must not replace the captured error.
+        config_str = self.ct.to_string().encode()
+        lib = get_lib()
+        deadline = time.time() + 5
+
+        def valid_task():
+            while time.time() < deadline:
+                ConfigTree(config_str.decode())
+
+        def error_task():
+            while time.time() < deadline:
+                tree = lib.from_string(config_str)
+                self.assertIsNotNone(tree)
+                self.assertIsNone(lib.from_string(b'interfaces {\n    address \n'))
+                lib.destroy(tree)
+                self.assertIn('Syntax error', lib.get_error().decode())
+
+        threads = [
+            threading.Thread(target=valid_task),
+            threading.Thread(target=error_task),
+            threading.Thread(target=valid_task),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Change summary

libvyosconfig is not safe for concurrent entry, and ctypes releases the GIL for each foreign call, so two threads in one process can be inside the library at once and crash it with SIGSEGV. vyos-http-api does this when a configure operation, which runs in the threadpool since T7090, overlaps a `/retrieve` served on the event loop. This serialises every libvyosconfig call on one process-wide `RLock` in the `_Lib` wrapper in `python/vyos/configtree.py`, and keeps the library's error text per thread so `get_error()` returns the caller's own error.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)

* https://vyos.dev/T9307
* https://vyos.dev/T6069 (same crash for concurrent configure requests, fixed by building Config() under the configure lock)
* https://vyos.dev/T5006 (same crash for concurrent retrieve requests)
* https://vyos.dev/T7090 (background configure operations, which run Config() in the threadpool)

## Related PR(s)

None.

## How to test / Smoketest result

Unit tests, run as CI runs it (full suite via the package build):

```
$ PYTHONPATH=python/ python3 -m nose2 -v
```

214 tests, all pass, including three new ones in `src/tests/test_config_tree.py` (concurrent parse, per-thread error text, error text surviving a `destroy`).

A standalone reproducer (`reproduce.py`, attached to T9307 and inlined below) builds and drops `ConfigTree` objects from two threads while two more parse an invalid config, in a child process. On a stock VyOS 2026.09.11-1436-rolling router it reports "child process killed by SIGSEGV" (exit 1); with this patch it reports "107140 ConfigTree operations from 4 threads in 20s, 0 errors" (exit 0).

<details>
<summary>reproduce.py (expand to view)</summary>

```python
#!/usr/bin/env python3
#
# Minimal reproduction for concurrent entry into libvyosconfig.
#
# vyos-http-api runs configure operations in a threadpool
# (_configure_op -> run_in_threadpool(_execute_configure_op)), and that
# workflow builds Config(), which parses the running and session configs via
# ConfigTree(...) -> libvyosconfig from_string. retrieve_op is served on the
# event loop and also builds ConfigTree(res). ctypes releases the GIL for each
# foreign call, so both threads are inside the OCaml library at once, which
# corrupts the parser state and kills the process with SIGSEGV.
#
# This script drives the same library path directly: several threads build
# ConfigTree objects from the default config, compare them, and drop them (so
# ConfigTree.__del__ -> destroy runs too), while other threads parse an invalid
# config and check the error text. The work runs in a child process so a
# segfault is reported instead of killing the script.
#
# Run as root on a VyOS instance:
#   python3 reproduce.py
#
# Stock image: "child process killed by SIGSEGV". Exit code 1.
# With the patched python/vyos/configtree.py in place: "0 errors". Exit code 0.

import signal
import subprocess
import sys
import threading
import time

CONFIG = '/opt/vyatta/etc/config.boot.default'
INVALID = 'interfaces {\n    ethernet eth0 {\n        address \n'
THREADS = 4
SECONDS = 20


def child():
    from vyos.configtree import ConfigTree

    config = open(CONFIG).read()
    reference = ConfigTree(config)
    deadline = time.time() + SECONDS
    errors = []
    counts = [0] * THREADS

    def valid(idx):
        while time.time() < deadline:
            tree = ConfigTree(config)
            if tree != reference:
                errors.append('parsed tree differs from reference')
            del tree
            counts[idx] += 1

    def invalid(idx):
        while time.time() < deadline:
            try:
                ConfigTree(INVALID)
                errors.append('invalid config parsed without error')
            except ValueError as e:
                if 'Syntax error' not in str(e):
                    errors.append(f'unexpected error text: {str(e)[:80]!r}')
            counts[idx] += 1

    threads = [
        threading.Thread(target=valid if i % 2 == 0 else invalid, args=(i,))
        for i in range(THREADS)
    ]
    for t in threads:
        t.start()
    for t in threads:
        t.join()

    print(f'{sum(counts)} ConfigTree operations from {THREADS} threads in {SECONDS}s')
    for e in sorted(set(errors))[:5]:
        print(f'  {e}')
    print(f'{len(errors)} errors')
    return 1 if errors else 0


def main():
    if sys.argv[1:] == ['--child']:
        return child()
    proc = subprocess.run([sys.executable, __file__, '--child'])
    if proc.returncode < 0:
        name = signal.Signals(-proc.returncode).name
        print(f'child process killed by {name}')
        return 1
    return proc.returncode


if __name__ == '__main__':
    sys.exit(main())
```

</details>

Router validation: I deployed the patch as a hotpatch on my home-edge router, where an automation tool configures it over the REST API while a local service polls `/retrieve`. 90 seconds of 3 clients looping on `/retrieve` and 1 on a no-op `/configure` killed the stock service 8 times (88 of 106 requests got 502); with the patch, 0 restarts and 0 502s. The lock is held for one library call, and `/retrieve` throughput was unchanged (10 requests in 30s stock, 11 patched).

## Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/rolling/CONTRIBUTING.md) document
- [x] I have linked this PR to one or more Phabricator Task(s) (T9307)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/rolling/smoketest/scripts/cli) if applicable (not run)
- [x] I have thoroughly reviewed, understood, and tested the code contained in the PR, including any code produced by GenAI tools
- [x] My commit headlines contain a valid Task id (T9307)
- [ ] My change requires a change to the documentation (not required)
- [ ] I have updated the documentation accordingly (not required)
